### PR TITLE
Periodic hills v2

### DIFF
--- a/examples/07-periodic_hills/README
+++ b/examples/07-periodic_hills/README
@@ -1,5 +1,5 @@
 Periodic hills 
 This example can be solved using the gls_navier_stokes_3d solver
 This example is a benchmark case for computing separated flow.
-This example is run using Q2-Q2 elements to demonstrate the underlying high-order mesh for the periodic hill.
+This example is run using Q2-Q2 elements to demonstrate the underlying high-order mesh for the periodic hills.
 More details : https://kbwiki.ercoftac.org/w/index.php?title=UFR_3-30_Description

--- a/examples/07-periodic_hills/periodic_hills.prm
+++ b/examples/07-periodic_hills/periodic_hills.prm
@@ -4,42 +4,47 @@
 # Simulation and IO Control
 #---------------------------------------------------
 subsection simulation control
-  set method                       = steady
+  set method                       = bdf1
   set number mesh adapt            = 0
-  set output name                  = per_hills-output
+  set output name                  = periodic_hills1-output
   set subdivision                  = 2
+  set time step                    = 0.05    
+  set output frequency             = 4     
+  set time end                     = 10
 end
 
 #---------------------------------------------------
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-    set kinematic viscosity        = 0.1
+    set kinematic viscosity        = 1E-3
 end
 
 #---------------------------------------------------
 # Mesh
 #---------------------------------------------------
 subsection mesh
-    set type                       = per_hills
-    set initial refinement         = 4
+    set type                       = periodic_hills
+    set initial refinement         = 3
+    set grid arguments 		   = 1;1;3;3;1
 end
 
 #---------------------------------------------------
-# Mesh
+# Timer
 #---------------------------------------------------
 subsection timer
     set type                       = iteration
 end
 
-# --------------------------------------------------
-# Source term
 #---------------------------------------------------
-subsection source term
+# Flow control
+#---------------------------------------------------
+subsection flow control
     set enable                     = true
-    subsection xyz
-            set Function expression = 1 ; 0 ; 0 ; 0
-    end
+    set volumetric flow rate       = -6.41025
+    set boundary id    		   = 0
+    set flow direction 		   = 0
+    set initial beta		   = 0.5
 end
 
 # --------------------------------------------------
@@ -53,15 +58,15 @@ subsection boundary conditions
         set periodic_id           = 1
         set periodic_direction    = 0
     end
-    subsection bc 2
+    subsection bc 1
         set id                    = 2
         set type                  = noslip
     end
-    subsection bc 3
+    subsection bc 2
         set id                    = 3
         set type                  = noslip
     end
-    subsection bc 4
+    subsection bc 3
         set type                  = periodic
         set id                    = 4
         set periodic_id           = 5
@@ -69,13 +74,12 @@ subsection boundary conditions
     end 
 end
 
-
 #---------------------------------------------------
 # FEM
 #---------------------------------------------------
 subsection FEM
     set velocity order            = 2
-    set pressure order            = 2
+    set pressure order            = 1
     set qmapping all              = true
 end
 
@@ -92,9 +96,8 @@ end
 # Non-Linear Solver Control
 #---------------------------------------------------
 subsection non-linear solver
-  set tolerance                   = 1e-8
+  set tolerance                   = 1e-5
   set max iterations              = 10
-  set residual precision          = 2
   set verbosity                   = verbose
 end
 

--- a/examples/07-periodic_hills/periodic_hills.prm
+++ b/examples/07-periodic_hills/periodic_hills.prm
@@ -1,4 +1,4 @@
-# Listing of Parameters
+# Listing of Parameters 
 # ---------------------
 # --------------------------------------------------
 # Simulation and IO Control

--- a/examples/07-periodic_hills/periodic_hills.prm
+++ b/examples/07-periodic_hills/periodic_hills.prm
@@ -1,4 +1,4 @@
-# Listing of Parameters 
+# Listing of Parameters
 # ---------------------
 # --------------------------------------------------
 # Simulation and IO Control

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -401,7 +401,7 @@ namespace Parameters
     {
       gmsh,
       dealii,
-      per_hills
+      periodic_hills
     };
     Type type;
 

--- a/include/core/per_hills_grid.h
+++ b/include/core/per_hills_grid.h
@@ -31,57 +31,30 @@
 using namespace dealii;
 
 /**
- * @brief PeriodicHillsGrid.The PeriodicHillsGrid class creates an hyper_rectangle and transforms it to
- * obtain the hill geometry with the hill_geometry function.
- * It also attaches a manifold to the geometry.
+ * @brief PeriodicHillsGrid. The PeriodicHillsGrid class creates an
+ * hyper_rectangle and transforms it to obtain the hill geometry with
+ * the hill_geometry function. It also attaches a manifold to the geometry.
  */
 
 template <int dim, int spacedim>
 class PeriodicHillsGrid
 {
 public:
-  /**
-   * @brief Constructor for the PeriodicHillsGrid. At the present moment, the periodic hill
-   * cannot be controlled from the parameter file. The Grid is generated as-is.
-   */
   PeriodicHillsGrid(const std::string &grid_arguments);
-
-  /**
-   * @brief The hill_geometry function calculates all the domain of the geometry with 6
-   * polynomials depending the x position. (See Hill Geometry Definition file :
-   * https://turbmodels.larc.nasa.gov/Other_LES_Data/2dhill_periodic.html)
-   * This code has nondimensionalized geometry, but the coefficients provided
-   * need a hill height of 28.
-   * This function also does a gradual shifting of the horizontal lines
-   * prior to have smaller element on the bottom of the geometry where results
-   * are more important.
-   *
-   * @param p A point in space which will be adapted to the periodic hill geometry
-   *
-   * @param param Non-linear solver parameters
-   *
-   */
   Point<spacedim>
   static hill_geometry(const Point<spacedim> &p,
-                       double alpha, double spacing_y);
-
-  /**
-   * @brief make_grid. The make_grid function generates a hyper rectangle of the size of the domain
-   * and then transforms it to the hill geometry. It also constructs the
-   * geometry manifold with FunctionManifold and finally sets the manifold.
-   *
-   * @param triangulation. The triangulation object on which the grid is generated
-   */
+                       double spacing_y,
+                       double alpha);
   void
   make_grid(Triangulation<dim, spacedim> &triangulation);
 
 private:
   std::string grid_arguments;
-  double alpha;
   double spacing_y;
   int repetitions_x;
   int repetitions_y;
   int repetitions_z;
+  double alpha;
 };
 
 /**
@@ -91,88 +64,57 @@ private:
  * documentation)
  */
 template <int dim, int spacedim>
-class periodic_hills_push_forward : public AutoDerivativeFunction<spacedim>
+class PeriodicHillsPushForward : public AutoDerivativeFunction<spacedim>
 {
 public:
-  periodic_hills_push_forward(double alpha, double spacing_y)
-    : AutoDerivativeFunction<spacedim>(1e-6, spacedim), alpha(alpha), spacing_y(spacing_y)
+  PeriodicHillsPushForward(double spacing_y, double alpha)
+    : AutoDerivativeFunction<spacedim>(1e-6, spacedim),
+    spacing_y(spacing_y),
+    alpha(alpha)
   {}
-
-  /**
-   * @brief vector_value. This function is used to construct the geometry manifold.
-   * It changes the original point (op) of the transformed hyper_rectangle
-   * with hill_geometry to a new point (np) of the hill grid with per_hills_grid
-   * function.
-   *
-   * @param p. A point in space
-   *
-   * @param values. The vector of values which will be calculated at the position p.
-   */
-
   virtual void
   vector_value(const Point<spacedim> &p, Vector<double> &values) const override;
-
-  /**
-   * @brief value. The value function does the same thing than vector_value for one component.
-   * This implementation is needed to use the gradient function inherited by
-   * AutoDerivativeFunction.
-   *
-   * @param p. An original point in space
-   *
-   * @param component. The component of the point (x=0, y=1, z=2)
-   *
-   */
   virtual double
   value(const Point<spacedim> &p, const unsigned int component) const override;
 
 private:
-  double alpha;
   double spacing_y;
+  double alpha;
 };
 
 
 template <int dim, int spacedim>
-class periodic_hills_pull_back : public AutoDerivativeFunction<spacedim>
+class PeriodicHillsPullBack : public AutoDerivativeFunction<spacedim>
 {
 public:
-  periodic_hills_pull_back(double alpha, double spacing_y)
-    : AutoDerivativeFunction<spacedim>(1e-6, spacedim), alpha(alpha), spacing_y(spacing_y)
+  PeriodicHillsPullBack(double spacing_y, double alpha)
+    : AutoDerivativeFunction<spacedim>(1e-6, spacedim),
+    spacing_y(spacing_y),
+    alpha(alpha)
   {}
-
-  /**
-   * \brief vector_value. This vector_value function is used to construct the
-   * geometry manifold. It changes the new point (np) of the hill grid to the
-   * original point (op) of the transformed hyper_rectangle grid. This function
-   * is mandatory to use FunctionManifold. First, it finds the minimum value of
-   * y depending the x position and then calculates the op with the inverse of
-   * the transformation done by hill_geometry function.
-   *
-   * \param p. A point in space.
-   *
-   * @param values. The vector of values which will be calculated at the position p.
-   */
 
   virtual void
   vector_value(const Point<spacedim> &np,
                Vector<double> &       values) const override;
 
-  /**
-   * @brief value. The value function does the same thing than vector_value for one component.
-   * This implementation is needed to use the gradient function inherited by
-   * AutoDerivativeFunction.
-   *
-   * @param p. An original point in space
-   *
-   * @param component. The component of the point (x=0, y=1, z=2)
-   *
-   */
   virtual double
   value(const Point<spacedim> &np, const unsigned int component) const override;
 
 private:
-  double alpha;
   double spacing_y;
+  double alpha;
 };
+
+/**
+ * @brief Constructor for the PeriodicHillsGrid.
+ *
+ * @param grid_arguments. A string with 5 parameters
+ *  spacing_y : allows to control the shifting of horizontal line [0 - 1]
+ *  alpha : allows to elongate the geometry while keeping the same flat region [0.5 - 3]
+ *  repetitions_x : number of separation of cells in x before refinement
+ *  repetitions_y : number of separation of cells in y before refinement
+ *  repetitions_z : number of separation of cells in z before refinement
+ */
 
 template <int dim, int spacedim>
 PeriodicHillsGrid<dim, spacedim>::PeriodicHillsGrid(const std::string &grid_arguments)
@@ -190,23 +132,32 @@ PeriodicHillsGrid<dim, spacedim>::PeriodicHillsGrid(const std::string &grid_argu
   }
 
   std::vector<double> arguments_double = dealii::Utilities::string_to_double(arguments);
-  alpha = arguments_double[0];
-  spacing_y = arguments_double[1];
+  spacing_y = arguments_double[0];
+  alpha = arguments_double[1];
   repetitions_x = arguments_double[2];
   repetitions_y = arguments_double[3];
   if (dim == 3)
     repetitions_z = arguments_double[4];
 }
 
-
+/**
+ * @brief vector_value. This function is used to construct the geometry manifold.
+ * It changes the original point (op) of the transformed hyper_rectangle
+ * with hill_geometry to a new point (np) of the hill grid with per_hills_grid
+ * function.
+ *
+ * @param p. A point in space
+ *
+ * @param values. The vector of values which will be calculated at the position p.
+ */
 template <int dim, int spacedim>
 void
-periodic_hills_push_forward<dim, spacedim>::vector_value(
+PeriodicHillsPushForward<dim, spacedim>::vector_value(
   const Point<spacedim> &op,
   Vector<double> &       values) const
 {
   const Point<spacedim> np =
-    PeriodicHillsGrid<dim, spacedim>::hill_geometry(op, alpha, spacing_y);
+    PeriodicHillsGrid<dim, spacedim>::hill_geometry(op, spacing_y, alpha);
 
   std::cout << "Push foward x : " << op[0] << " to " << np[0] << std::endl;
 
@@ -217,33 +168,122 @@ periodic_hills_push_forward<dim, spacedim>::vector_value(
     values(2) = np[2];
 }
 
-
+/**
+ * @brief value. The value function does the same thing than vector_value for one component.
+ * This implementation is needed to use the gradient function inherited by
+ * AutoDerivativeFunction.
+ *
+ * @param op. An original point in space
+ *
+ * @param component. The component of the point (x=0, y=1, z=2)
+ */
 template <int dim, int spacedim>
 double
-periodic_hills_push_forward<dim, spacedim>::value(
+PeriodicHillsPushForward<dim, spacedim>::value(
   const Point<spacedim> &op,
   const unsigned int     component) const
 {
   const Point<spacedim> np =
-    PeriodicHillsGrid<dim, spacedim>::hill_geometry(op, alpha, spacing_y);
+    PeriodicHillsGrid<dim, spacedim>::hill_geometry(op, spacing_y, alpha);
   return np[component];
 }
 
-
+/**
+ * \brief vector_value. This vector_value function is used to construct the
+ * geometry manifold. It changes the new point (np) of the hill grid to the
+ * original point (op) of the transformed hyper_rectangle grid. This function
+ * is mandatory to use FunctionManifold. First, it finds the minimum value of
+ * y depending the x position and then calculates the op with the inverse of
+ * the transformation done by hill_geometry function.
+ *
+ * \param np. A point in space.
+ *
+ * @param values. The vector of values which will be calculated at the position p.
+ */
 template <int dim, int spacedim>
 void
-periodic_hills_pull_back<dim, spacedim>::vector_value(
+PeriodicHillsPullBack<dim, spacedim>::vector_value(
   const Point<spacedim> &np,
   Vector<double> &       values) const
 {
-  double       x = np[0];
-
-  const double max_y = 3.035;
-  double       min_y;
+  double x = np[0];
+  double max_y = 3.035;
+  double max_x = 9.0;
   double flat_region_length = 5.142;
   double left_hill = 1.929;
   double right_hill = 7.071;
+  double min_y;
 
+  // Reversing elongation and shifting of x lines
+  if (x < left_hill * alpha)
+    x = (x / alpha);
+  else if (x > alpha * left_hill + flat_region_length)
+    x = (x - flat_region_length - alpha * left_hill) / alpha + right_hill;
+  else
+    x = x - (alpha * left_hill) + left_hill;
+
+  if (alpha > 1)
+    {
+      if (x <= max_x / 2)
+        x = (-(1 - 0.5) +
+             std::sqrt(std::pow((1 - 0.5), 2) - (4 * (1 / max_x) * -x))) /
+            (2 / max_x);
+      else if (x > max_x / 2 && x <= max_x)
+        x = (-(1 + 1.5) + std::sqrt(std::pow((1 + 1.5), 2) -
+                                    (4 * (-1 / max_x) * (-0.5 * max_x - x)))) /
+            (2 * -1 / max_x);
+    }
+
+  // Reversing polynomial transformation and shifting of y lines
+  if (spacedim == 2)
+  {
+    min_y = PeriodicHillsGrid<dim, spacedim>::hill_geometry(
+      Point<spacedim>(x, 0), spacing_y, alpha)[1];
+  }
+  else if (spacedim == 3)
+  {
+    min_y = PeriodicHillsGrid<dim, spacedim>::hill_geometry(
+      Point<spacedim>(x, 0, np[2]), spacing_y, alpha)[1];
+    values(2) = np[2];
+  }
+
+  double y = (np[1] - min_y) / (1 - min_y / max_y);
+
+  if (y <= max_y/2 && spacing_y != 0)
+    y = (-(1 - 0.5 * spacing_y) + std::sqrt(std::pow((1 - 0.5 * spacing_y), 2) -
+        (4 * (spacing_y / max_y) * -y)) ) / (2 * spacing_y / max_y);
+  else if (y > max_y/2 && y < max_y && spacing_y != 0)
+    y = (-(1 + 1.5 * spacing_y) + std::sqrt(std::pow((1 + 1.5 * spacing_y), 2) -
+        (4 * (-spacing_y / max_y) * (-0.5 * spacing_y * max_y - y))) )/ (2 * -spacing_y / max_y);
+
+  std::cout << "Pull back x : " << np[0] << " to " << x << std::endl;
+  values(0) = x;
+  values(1) = y;
+}
+
+/**
+ * @brief value. The value function does the same thing than vector_value for one component.
+ * This implementation is needed to use the gradient function inherited by
+ * AutoDerivativeFunction.
+ *
+ * @param p. An original point in space
+ *
+ * @param component. The component of the point (x=0, y=1, z=2)
+ *
+ */
+template <int dim, int spacedim>
+double
+PeriodicHillsPullBack<dim, spacedim>::value(
+  const Point<spacedim> &np,
+  const unsigned int     component) const
+{
+  double x = np[0];
+  double max_y = 3.035;
+  double max_x = 9.0;
+  double flat_region_length = 5.142;
+  double left_hill = 1.929;
+  double right_hill = 7.071;
+  double min_y;
 
   if (x < left_hill * alpha)
     x = (x / alpha);
@@ -252,69 +292,88 @@ periodic_hills_pull_back<dim, spacedim>::vector_value(
   else
     x = x - (alpha * left_hill) + left_hill;
 
-  std::cout << "Pull back x : " << np[0] << " to " << x << std::endl;
+  if (x <= max_x/2)
+    x = (-(1 - 0.5) + std::sqrt(std::pow((1 - 0.5), 2) -
+                                (4 * (1 / max_x) * -x)) ) / (2 / max_x);
+  else if (x > max_x/2 && x <= max_x)
+    x = (-(1 + 1.5) + std::sqrt(std::pow((1 + 1.5), 2) -
+                                (4 * (-1 / max_x) * (-0.5 * max_x - x))) )/ (2 * -1 / max_x);
 
   if (spacedim == 2)
-  {
     min_y = PeriodicHillsGrid<dim, spacedim>::hill_geometry(
-      Point<spacedim>(x, 0), alpha, spacing_y)[1];
-  }
+      Point<spacedim>(x, 0), spacing_y, alpha)[1];
   else if (spacedim == 3)
-  {
     min_y = PeriodicHillsGrid<dim, spacedim>::hill_geometry(
-      Point<spacedim>(x, 0, np[2]), alpha, spacing_y)[1];
-    values(2) = np[2];
-  }
+      Point<spacedim>(x, 0, np[2]), spacing_y, alpha)[1];
+
 
   double y = (np[1] - min_y) / (1 - min_y / max_y);
 
-  if (y <= (max_y/2))
-    y = (-(1 - 0.5 * spacing_y) + std::sqrt(std::pow((1 - 0.5 * spacing_y), 2) -
-        (4 * (spacing_y / max_y) * -y)) ) / (2 * spacing_y / max_y);
-  else if (y > (max_y/2) && y < max_y)
-    y = (-(1 + 1.5 * spacing_y) + std::sqrt(std::pow((1 + 1.5 * spacing_y), 2) -
-        (4 * (-spacing_y / max_y) * (-0.5 * spacing_y * max_y - y))) )/ (2 * -spacing_y / max_y);
-
-
-  values(0) = x;
-  values(1) = y;
-}
-
-template <int dim, int spacedim>
-double
-periodic_hills_pull_back<dim, spacedim>::value(
-  const Point<spacedim> &np,
-  const unsigned int     component) const
-{
-  const double max_y = 3.035;
-  double       min_y = PeriodicHillsGrid<dim, spacedim>::hill_geometry(
-    Point<spacedim>(np[0], 0), alpha, spacing_y)[1];
-
-  double y = (np[1] - min_y) / (1 - min_y / max_y);
-
-  if (y <= (max_y/2))
+  if (y <= max_y/2 && spacing_y != 0)
     y = (-(1 - 0.5 * spacing_y) + std::sqrt(std::pow((1 - 0.5 * spacing_y), 2) -
                                             (4 * (spacing_y / max_y) * -y)) ) / (2 * spacing_y / max_y);
-  else if (y > (max_y/2) && y < max_y)
+  else if (y > max_y/2 && y < max_y && spacing_y != 0)
     y = (-(1 + 1.5 * spacing_y) + std::sqrt(std::pow((1 + 1.5 * spacing_y), 2) -
                                             (4 * (-spacing_y / max_y) * (-0.5 * spacing_y * max_y - y))) )/ (2 * -spacing_y / max_y);
 
-
-
-  Point<spacedim> op = {np[0], y, np[2]};
+  Point<spacedim> op;
+  if (spacedim == 2)
+    op = {x, y};
+  else if (spacedim == 3)
+    op = {x, y, np[2]};
 
   return op[component];
 }
 
-
+/**
+ * @brief The hill_geometry function calculates all the domain of the geometry with 6
+ * polynomials depending the x position. (See Hill Geometry Definition file :
+ * https://turbmodels.larc.nasa.gov/Other_LES_Data/2dhill_periodic.html)
+ * This code has nondimensionalized geometry, but the coefficients provided
+ * need a hill height of 28.
+ * This function also does a gradual shifting of the horizontal lines
+ * prior to have smaller element on the bottom of the geometry where results
+ * are more important.
+ *
+ * @param p A point in space which will be adapted to the periodic hill geometry
+ *
+ * @param param Non-linear solver parameters
+ *
+ */
 template <int dim, int spacedim>
 Point<spacedim>
 PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
-                                                double alpha,
-                                                double spacing_y)
+                                                double spacing_y,
+                                                double alpha)
 {
-  const double H = 28; // Height dimension to use with polynomials
-  double       x = p[0] * H, y = p[1] * H;
+  double H = 28; // Height dimension to use with polynomials
+  double x = p[0] * H, y = p[1] * H;
+  double max_y = 3.035 * H;
+  double max_x = 9.0 * H;
+  double pos_x_left;
+  double pos_x_right;
+  double pos_y_bottom = 0;
+  double pos_y_top;
+  double pos_y;
+  double flat_region_length = 5.142 * H;
+  double left_hill = 1.929 * H;
+  double right_hill = 7.071 * H;
+
+  // Gradual spacing and swifting depending on x position if the geometry
+  // is elongated
+  if (alpha > 1)
+    {
+      if (x <= max_x / 2)
+        {
+          pos_x_left = x / -max_x + 0.5;
+          x -= pos_x_left * x;
+        }
+      else if (x > max_x / 2 && x <= max_x)
+        {
+          pos_x_right = x / max_x - 0.5;
+          x += pos_x_right * (max_x - x);
+        }
+    }
 
   // Polynomial coefficients :
   const double a1 = 2.800000000000E+01,  b1 = 0.000000000000E+00,
@@ -330,19 +389,15 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
   const double a6 = 5.639011190988E+01,  b6 = -2.010520359035E+00,
                c6 = 1.644919857549E-02,  d6 = 2.674976141766E-05;
 
-  const double max_y = 3.035 * H;
-  double       new_x = (9 * H - x);      // x for the left side of the geometry
-  double       pos_y_bottom = 0;
-  double       pos_y_top;
-  double       pos_y;
+  double       new_x = (9 * H - x); // x for the left side of the geometry
 
   // Gradual spacing and swifting depending on y position
-  if (y <= (max_y/2))
+  if (y <= max_y/2 && spacing_y != 0)
   {
     pos_y_bottom = y / -max_y + 0.5;
     y -= spacing_y * pos_y_bottom * y;
   }
-  else if (y > max_y/2 && y < max_y)
+  else if (y > max_y/2 && y < max_y && spacing_y != 0)
   {
     pos_y_top = y / max_y - 0.5;
     y += spacing_y * pos_y_top * (max_y - y);
@@ -357,26 +412,20 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
     if (y > 28 && pos_y_bottom == 0.5)
       y = 28;
   }
-
   else if (x >= 9 && x < 14)
     y += pos_y * (a2 + b2 * x + c2 * std::pow(x, 2) + d2 * std::pow(x, 3));
-
   else if (x >= 14 && x < 20)
     y += pos_y * (a3 + b3 * x + c3 * std::pow(x, 2) + d3 * std::pow(x, 3));
-
   else if (x >= 20 && x < 30)
     y += pos_y * (a4 + b4 * x + c4 * std::pow(x, 2) + d4 * std::pow(x, 3));
-
   else if (x >= 30 && x < 40)
     y += pos_y * (a5 + b5 * x + c5 * std::pow(x, 2) + d5 * std::pow(x, 3));
-
   else if (x >= 40 && x < 54)
   {
     y += pos_y * (a6 + b6 * x + c6 * std::pow(x, 2) + d6 * std::pow(x, 3));
     if (y < 0)
       y = 0;
   }
-
   else if (x <= 252 && x >= 243)
   {
     y += pos_y * (a1 + b1 * new_x + c1 * std::pow(new_x, 2) +
@@ -384,24 +433,19 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
     if (y > 28 && pos_y >= 1)
       y = 28;
   }
-
   else if (x <= 243 && x > 238)
     y += pos_y *
          (a2 + b2 * new_x + c2 * std::pow(new_x, 2) + d2 * std::pow(new_x, 3));
-
   else if (x <= 238 && x > 232)
     y += pos_y *
          (a3 + b3 * new_x + c3 * std::pow(new_x, 2) + d3 * std::pow(new_x, 3));
-
   else if (x <= 232 && x > 222)
 
     y += pos_y *
          (a4 + b4 * new_x + c4 * std::pow(new_x, 2) + d4 * std::pow(new_x, 3));
-
   else if (x <= 222 && x > 212)
     y += pos_y *
          (a5 + b5 * new_x + c5 * std::pow(new_x, 2) + d5 * std::pow(new_x, 3));
-
   else if (x <= 212 && x > 198)
   {
     y += pos_y * (a6 + b6 * new_x + c6 * std::pow(new_x, 2) +
@@ -409,20 +453,15 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
     if (y < 0)
       y = 0;
   }
-
   else
     y += 0;
 
   // Elongation of the geometry with the alpha factor
   // Note : The length of the flat region is always the same length
-  double flat_region_length = 5.142 * H;
-  double left_hill = 1.929 * H;
-  double right_hill = 7.071 * H;
-
   if (x < left_hill)
     x = alpha * x;
   else if (x > right_hill)
-    x = alpha * (x - right_hill) + flat_region_length + alpha  * left_hill;
+    x = alpha * (x - right_hill) + flat_region_length + alpha * left_hill;
   else
     x = (x - left_hill) + (alpha * left_hill);
 
@@ -436,6 +475,13 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
   return q;
 }
 
+/**
+ * @brief make_grid. The make_grid function generates a hyper rectangle of the size of the domain
+ * and then transforms it to the hill geometry. It also constructs the
+ * geometry manifold with FunctionManifold and finally sets the manifold.
+ *
+ * @param triangulation. The triangulation object on which the grid is generated
+ */
 template <int dim, int spacedim>
 void
 PeriodicHillsGrid<dim, spacedim>::make_grid(
@@ -466,13 +512,13 @@ PeriodicHillsGrid<dim, spacedim>::make_grid(
   // Transformation of the geometry with the hill geometry
   // and gradual shifting of horizontal lines :
   GridTools::transform(
-    [this](const Point<spacedim> &p) { return this->hill_geometry(p, alpha, spacing_y); },
+    [this](const Point<spacedim> &p) { return this->hill_geometry(p ,spacing_y, alpha); },
     triangulation);
 
   // Manifold construction
   static const FunctionManifold<dim, spacedim, spacedim> manifold_func(
-    std::make_unique<periodic_hills_push_forward<dim, spacedim>>(alpha, spacing_y),
-    std::make_unique<periodic_hills_pull_back<dim, spacedim>>(alpha, spacing_y));
+    std::make_unique<PeriodicHillsPushForward<dim, spacedim>>(spacing_y, alpha),
+    std::make_unique<PeriodicHillsPullBack<dim, spacedim>>(spacing_y, alpha));
   triangulation.set_manifold(1, manifold_func);
   triangulation.set_all_manifold_ids(1);
 }

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -51,9 +51,9 @@ public:
 private:
   std::string grid_arguments;
   double spacing_y;
-  int repetitions_x;
-  int repetitions_y;
-  int repetitions_z;
+  int    repetitions_x;
+  int    repetitions_y;
+  int    repetitions_z;
   double alpha;
 };
 
@@ -132,8 +132,8 @@ PeriodicHillsGrid<dim, spacedim>::PeriodicHillsGrid(const std::string &grid_argu
   }
 
   std::vector<double> arguments_double = dealii::Utilities::string_to_double(arguments);
-  spacing_y = arguments_double[0];
-  alpha = arguments_double[1];
+  spacing_y =     arguments_double[0];
+  alpha =         arguments_double[1];
   repetitions_x = arguments_double[2];
   repetitions_y = arguments_double[3];
   if (dim == 3)
@@ -158,8 +158,6 @@ PeriodicHillsPushForward<dim, spacedim>::vector_value(
 {
   const Point<spacedim> np =
     PeriodicHillsGrid<dim, spacedim>::hill_geometry(op, spacing_y, alpha);
-
-  std::cout << "Push foward x : " << op[0] << " to " << np[0] << std::endl;
 
   values(0) = np[0];
   values(1) = np[1];
@@ -224,11 +222,11 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(
 
   if (alpha > 1)
     {
-      if (x <= max_x / 2)
+      if (x < max_x / 2)
         x = (-(1 - 0.5) +
              std::sqrt(std::pow((1 - 0.5), 2) - (4 * (1 / max_x) * -x))) /
             (2 / max_x);
-      else if (x > max_x / 2 && x <= max_x)
+      else if (x > max_x / 2 && x < max_x)
         x = (-(1 + 1.5) + std::sqrt(std::pow((1 + 1.5), 2) -
                                     (4 * (-1 / max_x) * (-0.5 * max_x - x)))) /
             (2 * -1 / max_x);
@@ -256,7 +254,6 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(
     y = (-(1 + 1.5 * spacing_y) + std::sqrt(std::pow((1 + 1.5 * spacing_y), 2) -
         (4 * (-spacing_y / max_y) * (-0.5 * spacing_y * max_y - y))) )/ (2 * -spacing_y / max_y);
 
-  std::cout << "Pull back x : " << np[0] << " to " << x << std::endl;
   values(0) = x;
   values(1) = y;
 }
@@ -363,12 +360,12 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
   // is elongated
   if (alpha > 1)
     {
-      if (x <= max_x / 2)
+      if (x < max_x / 2)
         {
           pos_x_left = x / -max_x + 0.5;
           x -= pos_x_left * x;
         }
-      else if (x > max_x / 2 && x <= max_x)
+      else if (x > max_x / 2 && x < max_x)
         {
           pos_x_right = x / max_x - 0.5;
           x += pos_x_right * (max_x - x);
@@ -493,6 +490,10 @@ PeriodicHillsGrid<dim, spacedim>::make_grid(
 
   if (dim == 2)
   {
+    if (alpha != 1 && (repetitions_x > 1 || repetitions_y > 1))
+     throw std::logic_error(
+      "When parameter alpha is not 1, repetition parameters should be all set to 1");
+
     GridGenerator::subdivided_hyper_rectangle(triangulation,
                                               repetitions,
                                               Point<dim>(0.0, 0.0),
@@ -501,6 +502,9 @@ PeriodicHillsGrid<dim, spacedim>::make_grid(
   }
   else if (dim == 3)
   {
+    if (alpha != 1 && (repetitions_x > 1 || repetitions_y > 1 || repetitions_z > 1))
+      throw std::logic_error(
+        "When parameter alpha is not 1, repetition parameters should be all set to 1");
     repetitions.push_back(repetitions_z);
     GridGenerator::subdivided_hyper_rectangle(triangulation,
                                               repetitions,

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -573,5 +573,4 @@ PeriodicHillsGrid<dim, spacedim>::make_grid(
   triangulation.set_all_manifold_ids(1);
 }
 
-
 #endif

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -170,9 +170,6 @@ PeriodicHillsPushForward<dim, spacedim>::vector_value(
 
   if (spacedim == 3)
     values(2) = np[2];
-
-  // std::cout << "Push forward (x,y) : (" << op[0] << "," << op(1) << ") to ("
-  //<< np[0] << "," << np(1) << ")" << std::endl;
 }
 
 /**
@@ -273,9 +270,6 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(const Point<spacedim> &np,
 
   values(0) = x;
   values(1) = y;
-
-  // std::cout << "Pull back (x,y) : (" << np[0] << "," << np(1) << ") to ("
-  // << x << "," << y << ")" << std::endl;
 }
 
 /**
@@ -424,12 +418,12 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
   double new_x = (max_x - x); // x for the left side of the geometry
 
   // Gradual spacing and swifting depending on y position
-  if (y < max_y / 2 && spacing_y != 0)
+  if (y < max_y / 2 && (std::abs(spacing_y) > 0))
     {
       pos_y_bottom = y / -max_y + 0.5;
       y -= spacing_y * pos_y_bottom * y;
     }
-  else if (y > max_y / 2 && y < max_y && spacing_y != 0)
+  else if (y > max_y / 2 && y < max_y && (std::abs(spacing_y) > 0))
     {
       pos_y_top = y / max_y - 0.5;
       y += spacing_y * pos_y_top * (max_y - y);
@@ -495,15 +489,12 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
 
   // Elongation of the geometry with the alpha factor
   // Note : The length of the flat region is always the same length
-  if (alpha != 1)
-    {
-      if (x < left_hill)
-        x = alpha * x;
-      else if (x > right_hill)
-        x = alpha * (x - right_hill) + flat_region_length + alpha * left_hill;
-      else
-        x = (x - left_hill) + (alpha * left_hill);
-    }
+  if (x < left_hill)
+    x = alpha * x;
+  else if (x > right_hill)
+    x = alpha * (x - right_hill) + flat_region_length + alpha * left_hill;
+  else
+    x = (x - left_hill) + (alpha * left_hill);
 
   Point<spacedim> q;
   q[0] = (x / H);

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -143,7 +143,7 @@ PeriodicHillsGrid<dim, spacedim>::PeriodicHillsGrid(
     repetitions_z = arguments_double[4];
 
   if (abs(alpha - 1) < 1e-6)
-    alpha = int (alpha);
+    alpha = int(alpha);
 }
 
 /**
@@ -171,8 +171,8 @@ PeriodicHillsPushForward<dim, spacedim>::vector_value(
   if (spacedim == 3)
     values(2) = np[2];
 
-  //std::cout << "Push forward (x,y) : (" << op[0] << "," << op(1) << ") to ("
-            //<< np[0] << "," << np(1) << ")" << std::endl;
+  // std::cout << "Push forward (x,y) : (" << op[0] << "," << op(1) << ") to ("
+  //<< np[0] << "," << np(1) << ")" << std::endl;
 }
 
 /**
@@ -231,18 +231,17 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(const Point<spacedim> &np,
         x = x - (alpha * left_hill) + left_hill;
     }
 
-    if (alpha > 1)
-      {
-        if (x < max_x / 2)
-          x = (-(1 - 0.5) +
-               std::sqrt(std::pow((1 - 0.5), 2) - (4 * (1 / max_x) * -x))) /
-              (2 / max_x);
-        else if (x > max_x / 2 && x < max_x)
-          x = (-(1 + 1.5) +
-               std::sqrt(std::pow((1 + 1.5), 2) -
-                         (4 * (-1 / max_x) * (-0.5 * max_x - x)))) /
-              (2 * -1 / max_x);
-      }
+  if (alpha > 1)
+    {
+      if (x < max_x / 2)
+        x = (-(1 - 0.5) +
+             std::sqrt(std::pow((1 - 0.5), 2) - (4 * (1 / max_x) * -x))) /
+            (2 / max_x);
+      else if (x > max_x / 2 && x < max_x)
+        x = (-(1 + 1.5) + std::sqrt(std::pow((1 + 1.5), 2) -
+                                    (4 * (-1 / max_x) * (-0.5 * max_x - x)))) /
+            (2 * -1 / max_x);
+    }
 
   // Reversing polynomial transformation and shifting of y lines
   if (spacedim == 2)
@@ -261,12 +260,13 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(const Point<spacedim> &np,
 
   double y = (np[1] - min_y) / (1 - min_y / max_y);
 
-  if (y < max_y/2 && spacing_y != 0)
+  if (y < max_y / 2 && spacing_y != 0)
     y = (-(1 - 0.5 * spacing_y) + std::sqrt(std::pow((1 - 0.5 * spacing_y), 2) -
                                             (4 * (spacing_y / max_y) * -y))) /
         (2 * spacing_y / max_y);
-  else if (y > max_y/2 && y < max_y && spacing_y != 0)
-    y =  (-(1 + 1.5 * spacing_y) +
+  else if (y > max_y / 2 && y < max_y && spacing_y != 0)
+    y =
+      (-(1 + 1.5 * spacing_y) +
        std::sqrt(std::pow((1 + 1.5 * spacing_y), 2) -
                  (4 * (-spacing_y / max_y) * (-0.5 * spacing_y * max_y - y)))) /
       (2 * -spacing_y / max_y);
@@ -274,8 +274,8 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(const Point<spacedim> &np,
   values(0) = x;
   values(1) = y;
 
-  //std::cout << "Pull back (x,y) : (" << np[0] << "," << np(1) << ") to ("
-           // << x << "," << y << ")" << std::endl;
+  // std::cout << "Pull back (x,y) : (" << np[0] << "," << np(1) << ") to ("
+  // << x << "," << y << ")" << std::endl;
 }
 
 /**
@@ -318,10 +318,9 @@ PeriodicHillsPullBack<dim, spacedim>::value(const Point<spacedim> &np,
              std::sqrt(std::pow((1 - 0.5), 2) - (4 * (1 / max_x) * -x))) /
             (2 / max_x);
       else if (x > max_x / 2 && x <= max_x)
-        x =
-          (-(1 + 1.5) + std::sqrt(std::pow((1 + 1.5), 2) -
-                                  (4 * (-1 / max_x) * (-0.5 * max_x - x)))) /
-          (2 * -1 / max_x);
+        x = (-(1 + 1.5) + std::sqrt(std::pow((1 + 1.5), 2) -
+                                    (4 * (-1 / max_x) * (-0.5 * max_x - x)))) /
+            (2 * -1 / max_x);
     }
 
   if (spacedim == 2)
@@ -425,12 +424,12 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
   double new_x = (max_x - x); // x for the left side of the geometry
 
   // Gradual spacing and swifting depending on y position
-  if (y < max_y/2 && spacing_y != 0)
+  if (y < max_y / 2 && spacing_y != 0)
     {
       pos_y_bottom = y / -max_y + 0.5;
       y -= spacing_y * pos_y_bottom * y;
     }
-  else if (y > max_y/2 && y < max_y && spacing_y != 0)
+  else if (y > max_y / 2 && y < max_y && spacing_y != 0)
     {
       pos_y_top = y / max_y - 0.5;
       y += spacing_y * pos_y_top * (max_y - y);
@@ -444,7 +443,7 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
       y += pos_y * (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
 
       // Checking if y is under 28 and correction
-      y_0 = (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
+      y_0  = (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
       diff = y_0 - 28.0;
       if (diff > 0)
         y -= pos_y * diff;
@@ -467,7 +466,7 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
     {
       y += pos_y * (a1 + b1 * new_x + c1 * std::pow(new_x, 2) +
                     d1 * std::pow(new_x, 3));
-      y_0 = (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
+      y_0  = (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
       diff = y_0 - 28.0;
       if (diff > 0)
         y -= pos_y * diff;

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -171,8 +171,8 @@ PeriodicHillsPushForward<dim, spacedim>::vector_value(
   if (spacedim == 3)
     values(2) = np[2];
 
-  std::cout << "Push forward (x,y) : (" << op[0] << "," << op(1) << ") to ("
-            << np[0] << "," << np(1) << ")" << std::endl;
+  //std::cout << "Push forward (x,y) : (" << op[0] << "," << op(1) << ") to ("
+            //<< np[0] << "," << np(1) << ")" << std::endl;
 }
 
 /**
@@ -274,8 +274,8 @@ PeriodicHillsPullBack<dim, spacedim>::vector_value(const Point<spacedim> &np,
   values(0) = x;
   values(1) = y;
 
-  std::cout << "Pull back (x,y) : (" << np[0] << "," << np(1) << ") to ("
-            << x << "," << y << ")" << std::endl;
+  //std::cout << "Pull back (x,y) : (" << np[0] << "," << np(1) << ") to ("
+           // << x << "," << y << ")" << std::endl;
 }
 
 /**
@@ -379,16 +379,18 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
 {
   double H = 28; // Height dimension to use with polynomials
   double x = p[0] * H, y = p[1] * H;
-  double max_y = 3.035 * H;
-  double max_x = 9.0 * H;
-  double pos_x_left;
-  double pos_x_right;
-  double pos_y_bottom = 0;
-  double pos_y_top;
-  double pos_y;
+  double max_y              = 3.035 * H;
+  double max_x              = 9.0 * H;
   double flat_region_length = 5.142 * H;
   double left_hill          = 1.929 * H;
   double right_hill         = 7.071 * H;
+  double pos_x_left;
+  double pos_x_right;
+  double pos_y_bottom;
+  double pos_y_top;
+  double pos_y;
+  double y_0;
+  double diff;
 
   // Gradual spacing and swifting depending on x position if the geometry
   // is elongated
@@ -440,8 +442,12 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
   if (x >= 0 && x < 9)
     {
       y += pos_y * (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
-      if (y > 28 && pos_y_bottom == 0.5)
-        y = 28;
+
+      // Checking if y is under 28 and correction
+      y_0 = (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
+      diff = y_0 - 28.0;
+      if (diff > 0)
+        y -= pos_y * diff;
     }
   else if (x >= 9 && x < 14)
     y += pos_y * (a2 + b2 * x + c2 * std::pow(x, 2) + d2 * std::pow(x, 3));
@@ -457,12 +463,14 @@ PeriodicHillsGrid<dim, spacedim>::hill_geometry(const Point<spacedim> &p,
       if (y < 0)
         y = 0;
     }
-  else if (x <= 252 && x >= 243)
+  else if (x <= 252 && x > 243)
     {
       y += pos_y * (a1 + b1 * new_x + c1 * std::pow(new_x, 2) +
                     d1 * std::pow(new_x, 3));
-      if (y > 28 && pos_y_bottom == 0.5)
-        y = 28;
+      y_0 = (a1 + b1 * x + c1 * std::pow(x, 2) + d1 * std::pow(x, 3));
+      diff = y_0 - 28.0;
+      if (diff > 0)
+        y -= pos_y * diff;
     }
   else if (x <= 243 && x > 238)
     y += pos_y *

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -84,11 +84,6 @@ protected:
   // by the time
   double output_time_frequency;
 
-  // Output boundaries
-  // Control if the boundaries of the domain are outputted when writing results
-  //
-  bool output_boundaries;
-
   // Log iteration frequency
   // Controls the frequency at which status of the simulation is written to
   // the terminal
@@ -105,6 +100,11 @@ protected:
 
   // Output path
   std::string output_path;
+
+  // Output boundaries
+  // Control if the boundaries of the domain are outputted when writing results
+  //
+  bool output_boundaries;
 
   // Indicator to tell if this is the first assembly of a step
   bool first_assembly;

--- a/include/solvers/flow_control.h
+++ b/include/solvers/flow_control.h
@@ -44,7 +44,7 @@ public:
                  const Parameters::DynamicFlowControl &flow_control,
                  const Parameters::SimulationControl & simulation_control,
                  const Parameters::FEM &               fem_parameters,
-                 const double &                        step_number,
+                 const unsigned int &                  step_number,
                  const MPI_Comm &                      mpi_communicator);
   std::vector<double>
   flow_summary();
@@ -68,7 +68,7 @@ FlowControl<dim, VectorType>::calculate_beta(
   const Parameters::DynamicFlowControl &flow_control,
   const Parameters::SimulationControl & simulation_control,
   const Parameters::FEM &               fem_parameters,
-  const double &                        step_number,
+  const unsigned int &                  step_number,
   const MPI_Comm &                      mpi_communicator)
 {
   beta_n       = beta_n1;
@@ -130,7 +130,7 @@ FlowControl<dim, VectorType>::calculate_beta(
   const double dt          = simulation_control.dt;
   const double flow_rate_0 = flow_control.flow_rate;
 
-  if (step_number == 1)
+  if (step_number <= 1)
     beta_n1 = flow_control.beta_0;
   else if (step_number == 2)
     beta_n1 = beta_n - (flow_rate_0 - flow_rate_n) / (area * dt);
@@ -153,7 +153,7 @@ template <int dim, typename VectorType>
 std::vector<double>
 FlowControl<dim, VectorType>::flow_summary()
 {
-  std::vector<double> summary{area, flow_rate_n, beta_n};
+  std::vector<double> summary{area, flow_rate_n, beta_n1};
   return summary;
 }
 

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -42,7 +42,7 @@ attach_grid_to_triangulation(
   // Periodic Hills grid
   else if (mesh_parameters.type == Parameters::Mesh::Type::per_hills)
     {
-      PeriodicHillsGrid<dim, spacedim> grid;
+      PeriodicHillsGrid<dim, spacedim> grid(mesh_parameters.grid_arguments);
       grid.make_grid(*triangulation);
     }
   else

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -4,9 +4,7 @@
 // Lethe includes
 #include "core/boundary_conditions.h"
 #include "core/grids.h"
-
-// Per_Hills needed includes
-#include "core/per_hills_grid.h"
+#include "core/periodic_hills_grid.h"
 
 // Std
 #include <fstream>
@@ -40,7 +38,7 @@ attach_grid_to_triangulation(
     }
 
   // Periodic Hills grid
-  else if (mesh_parameters.type == Parameters::Mesh::Type::per_hills)
+  else if (mesh_parameters.type == Parameters::Mesh::Type::periodic_hills)
     {
       PeriodicHillsGrid<dim, spacedim> grid(mesh_parameters.grid_arguments);
       grid.make_grid(*triangulation);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -487,8 +487,15 @@ namespace Parameters
                         Patterns::Integer(),
                         "Initial refinement of the mesh");
 
-      prm.declare_entry("grid type", "hyper_cube");
-      prm.declare_entry("grid arguments", "-1 : 1 : false");
+      if (prm.get("type") == "per_hills")
+        {
+          prm.declare_entry("grid arguments", "1 ; 1 ; 1 ; 1 ; 1");
+        }
+      else
+        {
+          prm.declare_entry("grid type", "hyper_cube");
+          prm.declare_entry("grid arguments", "-1 : 1 : false");
+        }
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -473,9 +473,9 @@ namespace Parameters
     {
       prm.declare_entry("type",
                         "dealii",
-                        Patterns::Selection("gmsh|dealii|per_hills"),
+                        Patterns::Selection("gmsh|dealii|periodic_hills"),
                         "Type of mesh "
-                        "Choices are <gmsh|dealii|per_hills>.");
+                        "Choices are <gmsh|dealii|periodic_hills>.");
 
       prm.declare_entry("file name",
                         "none",
@@ -487,7 +487,7 @@ namespace Parameters
                         Patterns::Integer(),
                         "Initial refinement of the mesh");
 
-      if (prm.get("type") == "per_hills")
+      if (prm.get("type") == "periodic_hills")
         {
           prm.declare_entry("grid arguments", "1 ; 1 ; 1 ; 1 ; 1");
         }
@@ -511,8 +511,8 @@ namespace Parameters
           type = Type::gmsh;
         else if (op == "dealii")
           type = Type::dealii;
-        else if (op == "per_hills")
-          type = Type::per_hills;
+        else if (op == "periodic_hills")
+          type = Type::periodic_hills;
         else
           throw std::logic_error(
             "Error, invalid mesh type. Choices are gmsh and dealii");


### PR DESCRIPTION
Second version of periodic hills benchmark.

The geometry can be now be designed with external parameters : 
 *  spacing_y : allows to control the shifting of horizontal line [0 - 1]
 *  alpha : allows to elongate while keeping the same flat region [0.5 - 3]
 *  repetitions_x : number of separation of cells in x before refinement
 *  repetitions_y : number of separation of cells in y before refinement
 *  repetitions_z : number of separation of cells in z before refinement

Comments were moved from the class declarations to the functions. 

Some class or function names were changed and the file per_hills.h is now periodic_hills.h.