### PR TITLE
Fixed nasty bug with uninitialized value in simulation control

### DIFF
--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -23,6 +23,7 @@ SimulationControl::SimulationControl(Parameters::SimulationControl param)
   , output_name(param.output_name)
   , output_path(param.output_folder)
   , output_boundaries(param.output_boundaries)
+  , first_assembly(true)
 {
   time_step_vector.resize(numberTimeStepStored);
   time_step_vector[0] = param.dt;


### PR DESCRIPTION
The first assembly boolean was sometimes not initialized in steady state simulation which could lead to an MPI crash.