### PR TITLE
Add update ghosts mechanism to DEM

### DIFF
--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -637,7 +637,7 @@ DEMSolver<dim>::solve()
           contact_search_step)
         {
           particle_handler.sort_particles_into_subdomains_and_cells();
-          particle_handler.exchange_ghost_particles();
+          particle_handler.exchange_ghost_particles(true);
         }
       else
         particle_handler.update_ghost_particles();

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -693,9 +693,10 @@ DEMSolver<dim>::solve()
         }
       else
         {
-          locate_ghost_particles_in_cells<dim>(particle_handler,
-                                               ghost_particle_container,
-                                               ghost_adjacent_particles);
+          // This shouuld not be needed anymore BB
+          // locate_ghost_particles_in_cells<dim>(particle_handler,
+          //                                     ghost_particle_container,
+          //                                     ghost_adjacent_particles);
         }
 
       // Particle-particle contact force

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -648,9 +648,7 @@ DEMSolver<dim>::solve()
       else
         {
 #if (DEAL_II_VERSION_MINOR <= 2)
-          locate_ghost_particles_in_cells<dim>(particle_handler,
-                                               ghost_particle_container,
-                                               ghost_adjacent_particles);
+          particle_handler.exchange_ghost_particles();
 #else
           particle_handler.update_ghost_particles();
 #endif

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -637,11 +637,23 @@ DEMSolver<dim>::solve()
           contact_search_step)
         {
           particle_handler.sort_particles_into_subdomains_and_cells();
+
+#if (DEAL_II_VERSION_MINOR <= 2)
+          particle_handler.exchange_ghost_particles();
+
+#else
           particle_handler.exchange_ghost_particles(true);
+#endif
         }
       else
         {
+#if (DEAL_II_VERSION_MINOR <= 2)
+          locate_ghost_particles_in_cells<dim>(particle_handler,
+                                               ghost_particle_container,
+                                               ghost_adjacent_particles);
+#else
           particle_handler.update_ghost_particles();
+#endif
         }
 
       // Broad particle-particle contact search
@@ -693,10 +705,13 @@ DEMSolver<dim>::solve()
         }
       else
         {
-          // This shouuld not be needed anymore BB
-          // locate_ghost_particles_in_cells<dim>(particle_handler,
-          //                                     ghost_particle_container,
-          //                                     ghost_adjacent_particles);
+#if (DEAL_II_VERSION_MINOR <= 2)
+          locate_ghost_particles_in_cells<dim>(particle_handler,
+                                               ghost_particle_container,
+                                               ghost_adjacent_particles);
+#else
+          // This is not needed anymore with the update ghost mechanism
+#endif
         }
 
       // Particle-particle contact force

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -637,9 +637,10 @@ DEMSolver<dim>::solve()
           contact_search_step)
         {
           particle_handler.sort_particles_into_subdomains_and_cells();
+          particle_handler.exchange_ghost_particles();
         }
-
-      particle_handler.exchange_ghost_particles();
+      else
+        particle_handler.update_ghost_particles();
 
       // Broad particle-particle contact search
       if (particles_insertion_step || load_balancing_step ||

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -640,7 +640,9 @@ DEMSolver<dim>::solve()
           particle_handler.exchange_ghost_particles(true);
         }
       else
-        particle_handler.update_ghost_particles();
+        {
+          particle_handler.update_ghost_particles();
+        }
 
       // Broad particle-particle contact search
       if (particles_insertion_step || load_balancing_step ||


### PR DESCRIPTION
This pull request adds the update ghost mechanism to the DEM code. This mechanism makes the execution in parallel significantly more efficient (at least 5x) because it prevents the recreation of the ghost particles multimap and, instead, re-uses the particle data. To use the content of this PR, deal.II 9.3-pre must be installed with, at least, a version dating from early november.
