### PR TITLE
Fix compatibility and remove useless member variable

### DIFF
--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -257,20 +257,14 @@ private:
   ConditionalOStream                        pcout;
   DEMSolverParameters<dim>                  parameters;
   parallel::distributed::Triangulation<dim> triangulation;
-  //#  if (DEAL_II_VERSION_MINOR <= 2)
-  //  Particles::PropertyPool property_pool;
-  //#  else
-  //  Particles::PropertyPool<dim> property_pool;
-  //#  endif
-
-  MappingQGeneric<dim>                 mapping;
-  unsigned int                         contact_build_number;
-  TimerOutput                          computing_timer;
-  double                               smallest_contact_search_criterion;
-  Particles::ParticleHandler<dim, dim> particle_handler;
-  unsigned int                         contact_detection_step;
-  Tensor<1, dim>                       g;
-  double                               triangulation_cell_diameter;
+  MappingQGeneric<dim>                      mapping;
+  unsigned int                              contact_build_number;
+  TimerOutput                               computing_timer;
+  double                                    smallest_contact_search_criterion;
+  Particles::ParticleHandler<dim, dim>      particle_handler;
+  unsigned int                              contact_detection_step;
+  Tensor<1, dim>                            g;
+  double                                    triangulation_cell_diameter;
 
   // Simulation control for time stepping and I/Os
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -257,15 +257,20 @@ private:
   ConditionalOStream                        pcout;
   DEMSolverParameters<dim>                  parameters;
   parallel::distributed::Triangulation<dim> triangulation;
-  Particles::PropertyPool                   property_pool;
-  MappingQGeneric<dim>                      mapping;
-  unsigned int                              contact_build_number;
-  TimerOutput                               computing_timer;
-  double                                    smallest_contact_search_criterion;
-  Particles::ParticleHandler<dim, dim>      particle_handler;
-  unsigned int                              contact_detection_step;
-  Tensor<1, dim>                            g;
-  double                                    triangulation_cell_diameter;
+  //#  if (DEAL_II_VERSION_MINOR <= 2)
+  //  Particles::PropertyPool property_pool;
+  //#  else
+  //  Particles::PropertyPool<dim> property_pool;
+  //#  endif
+
+  MappingQGeneric<dim>                 mapping;
+  unsigned int                         contact_build_number;
+  TimerOutput                          computing_timer;
+  double                               smallest_contact_search_criterion;
+  Particles::ParticleHandler<dim, dim> particle_handler;
+  unsigned int                         contact_detection_step;
+  Tensor<1, dim>                       g;
+  double                               triangulation_cell_diameter;
 
   // Simulation control for time stepping and I/Os
   std::shared_ptr<SimulationControl> simulation_control;

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -35,7 +35,7 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
   , pcout({std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0})
   , parameters(dem_parameters)
   , triangulation(this->mpi_communicator)
-  , property_pool(DEM::get_number_properties())
+  //, property_pool(DEM::get_number_properties())
   , mapping(1)
   , contact_build_number(0)
   , computing_timer(this->mpi_communicator,
@@ -54,8 +54,6 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
   // Change the behavior of the timer for situations when you don't want outputs
   if (parameters.timer.type == Parameters::Timer::Type::none)
     computing_timer.disable_output();
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
   simulation_control = std::make_shared<SimulationControlTransientDEM>(
     parameters.simulation_control);
 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -35,7 +35,6 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
   , pcout({std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0})
   , parameters(dem_parameters)
   , triangulation(this->mpi_communicator)
-  //, property_pool(DEM::get_number_properties())
   , mapping(1)
   , contact_build_number(0)
   , computing_timer(this->mpi_communicator,


### PR DESCRIPTION
- Removes useless member variable from DEM class. This in turns enables compatibility with the later deal.II versions.