### PR TITLE
Remove usage of SIMPLEX preprocessor variable

### DIFF
--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -32,10 +32,7 @@
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/fe/fe_q.h>
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-#  include <deal.II/fe/fe_simplex_p.h>
-#endif
-
+#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/mapping_fe.h>
 #include <deal.II/fe/mapping_q.h>
 
@@ -68,7 +65,6 @@ public:
     , solution_transfer_m2(dof_handler)
     , solution_transfer_m3(dof_handler)
   {
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
     if (simulation_parameters.mesh.simplex)
       {
         // for simplex meshes
@@ -81,7 +77,6 @@ public:
         error_quadrature = std::make_shared<QGaussSimplex<dim>>(fe->degree + 2);
       }
     else
-#endif
       {
         // Usual case, for quad/hex meshes
         fe = std::make_shared<FE_Q<dim>>(

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -72,10 +72,7 @@
 
 // Fe
 #include <deal.II/fe/fe_q.h>
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-#  include <deal.II/fe/fe_simplex_p.h>
-#endif
-
+#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_fe.h>

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -65,7 +65,6 @@ public:
     , solution_transfer_m2(dof_handler)
     , solution_transfer_m3(dof_handler)
   {
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
     if (simulation_parameters.mesh.simplex)
       {
         // for simplex meshes
@@ -75,7 +74,6 @@ public:
         cell_quadrature = std::make_shared<QGaussSimplex<dim>>(fe->degree + 1);
       }
     else
-#endif
       {
         // Usual case, for quad/hex meshes
         fe = std::make_shared<FE_Q<dim>>(

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -39,7 +39,6 @@ attach_grid_to_triangulation(
         mesh_parameters.grid_type,
         mesh_parameters.grid_arguments);
     }
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
   // Simplex && GMSH input
   else if (mesh_parameters.type == Parameters::Mesh::Type::gmsh &&
            mesh_parameters.simplex)
@@ -107,7 +106,6 @@ attach_grid_to_triangulation(
           TriangulationDescription::Settings::construct_multigrid_hierarchy);
       triangulation->create_triangulation(construction_data);
     }
-#endif
 
 
   // Periodic Hills grid

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -56,7 +56,6 @@ NavierStokesBase<dim, VectorType, DofsType>::NavierStokesBase(
   , pressure_fem_degree(p_nsparam.fem_parameters.pressure_order)
   , number_quadrature_points(p_nsparam.fem_parameters.velocity_order + 1)
 {
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
   if (simulation_parameters.mesh.simplex)
     {
       // for simplex meshes
@@ -77,7 +76,6 @@ NavierStokesBase<dim, VectorType, DofsType>::NavierStokesBase(
       dof_handler.reinit(*this->triangulation);
     }
   else
-#endif
     {
       // Usual case, for quad/hex meshes
       fe = std::make_shared<FESystem<dim>>(


### PR DESCRIPTION
The DEAL_II_WITH_SIMPLEX variable has been removed since simplices are now standard.
Remove the usage of this variable.