### PR TITLE
Transient bdf solution management

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.mpirun=2.output
+++ b/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.mpirun=2.output
@@ -8,61 +8,61 @@ Running on 2 MPI rank(s)...
 Transient iteration : 1        Time : 0.1      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.00249168
+L2 error temperature : 0.000139052
 
 *****************************************************************
 Transient iteration : 2        Time : 0.2      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.000975686
+L2 error temperature : 2.39517e-05
 
 *****************************************************************
 Transient iteration : 3        Time : 0.3      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.000117625
+L2 error temperature : 1.14834e-06
 
 *****************************************************************
 Transient iteration : 4        Time : 0.4      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 3.21803e-06
+L2 error temperature : 1.83852e-08
 
 *****************************************************************
 Transient iteration : 5        Time : 0.5      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 2.34746e-07
+L2 error temperature : 7.73849e-08
 
 *****************************************************************
 Transient iteration : 6        Time : 0.6      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 2.45504e-07
+L2 error temperature : 3.41699e-08
 
 *****************************************************************
 Transient iteration : 7        Time : 0.7      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 3.14116e-08
+L2 error temperature : 1.18031e-08
 
 *****************************************************************
 Transient iteration : 8        Time : 0.8      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 5.24096e-10
+L2 error temperature : 5.78133e-09
 
 *****************************************************************
 Transient iteration : 9        Time : 0.9      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 4.41067e-09
+L2 error temperature : 4.27673e-09
 
 *****************************************************************
 Transient iteration : 10       Time : 1        Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 4.77644e-09
+L2 error temperature : 3.69422e-09
  time  error_velocity 
 0.1000 0.0000e+00     
 0.2000 0.0000e+00     
@@ -75,13 +75,13 @@ L2 error temperature : 4.77644e-09
 0.9000 0.0000e+00     
 1.0000 0.0000e+00     
 cells error_temperature 
-256   2.4917e-03        
-256   9.7569e-04        
-256   1.1763e-04        
-256   3.2180e-06        
-256   2.3475e-07        
-256   2.4550e-07        
-256   3.1412e-08        
-256   5.2410e-10        
-256   4.4107e-09        
-256   4.7764e-09        
+256   1.3905e-04        
+256   2.3952e-05        
+256   1.1483e-06        
+256   1.8385e-08        
+256   7.7385e-08        
+256   3.4170e-08        
+256   1.1803e-08        
+256   5.7813e-09        
+256   4.2767e-09        
+256   3.6942e-09        

--- a/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.output
+++ b/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.output
@@ -8,61 +8,61 @@ Running on 1 MPI rank(s)...
 Transient iteration : 1        Time : 0.1      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.00249168
+L2 error temperature : 0.000139052
 
 *****************************************************************
 Transient iteration : 2        Time : 0.2      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.000975686
+L2 error temperature : 2.39517e-05
 
 *****************************************************************
 Transient iteration : 3        Time : 0.3      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.000117625
+L2 error temperature : 1.14834e-06
 
 *****************************************************************
 Transient iteration : 4        Time : 0.4      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 3.21803e-06
+L2 error temperature : 1.83852e-08
 
 *****************************************************************
 Transient iteration : 5        Time : 0.5      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 2.34746e-07
+L2 error temperature : 7.73849e-08
 
 *****************************************************************
 Transient iteration : 6        Time : 0.6      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 2.45504e-07
+L2 error temperature : 3.41699e-08
 
 *****************************************************************
 Transient iteration : 7        Time : 0.7      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 3.14116e-08
+L2 error temperature : 1.18031e-08
 
 *****************************************************************
 Transient iteration : 8        Time : 0.8      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 5.24096e-10
+L2 error temperature : 5.78133e-09
 
 *****************************************************************
 Transient iteration : 9        Time : 0.9      Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 4.41067e-09
+L2 error temperature : 4.27673e-09
 
 *****************************************************************
 Transient iteration : 10       Time : 1        Time step : 0.1      CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 4.77644e-09
+L2 error temperature : 3.69422e-09
  time  error_velocity 
 0.1000 0.0000e+00     
 0.2000 0.0000e+00     
@@ -75,13 +75,13 @@ L2 error temperature : 4.77644e-09
 0.9000 0.0000e+00     
 1.0000 0.0000e+00     
 cells error_temperature 
-256   2.4917e-03        
-256   9.7569e-04        
-256   1.1763e-04        
-256   3.2180e-06        
-256   2.3475e-07        
-256   2.4550e-07        
-256   3.1412e-08        
-256   5.2410e-10        
-256   4.4107e-09        
-256   4.7764e-09        
+256   1.3905e-04        
+256   2.3952e-05        
+256   1.1483e-06        
+256   1.8385e-08        
+256   7.7385e-08        
+256   3.4170e-08        
+256   1.1803e-08        
+256   5.7813e-09        
+256   4.2767e-09        
+256   3.6942e-09        

--- a/include/core/bdf.h
+++ b/include/core/bdf.h
@@ -60,4 +60,19 @@ bdf_coefficients(unsigned int order, const std::vector<double> time_steps);
 Vector<double>
 delta(unsigned int order, unsigned int n, unsigned int j, Vector<double> times);
 
+
+
+/**
+ * @brief Returns the number of previous time steps supposed by the BDF schemes implemented in Lethe.
+ *  At the moment this is hardcoded to 3, but eventually this could be made
+ * larger or smaller depending on the methods used.
+ *
+ */
+inline unsigned int
+maximum_number_of_previous_solutions()
+{
+  return 3;
+}
+
+
 #endif

--- a/include/core/sdirk.h
+++ b/include/core/sdirk.h
@@ -51,11 +51,41 @@ using namespace dealii;
  * |   b    1-b-gamma  gamma|
  * --------------------------
  *
- * Intermediary 1 step is at t+0.5 * dt
- * Intermediary 2 step is at t+0.5 * dt
+ * Intermediary 1 step is at
+ * Intermediary 2 step is at
  *
  */
 FullMatrix<double>
 sdirk_coefficients(const unsigned int order, const double time_step);
+
+
+/**
+ * @brief Returns the number of previous time steps supposed by the BDF schemes implemented in Lethe.
+ *  At the moment this is hardcoded to 3, but eventually this could be made
+ * larger or smaller depending on the methods used.
+ *
+ * @param Time-stepping scheme used
+ *
+ */
+inline unsigned int
+number_of_intermediary_stages(
+  Parameters::SimulationControl::TimeSteppingMethod method)
+{
+  unsigned int n_stages = 0;
+
+  if (method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_1 ||
+      method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_2 ||
+      method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_3 ||
+      method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33)
+    n_stages = 2;
+
+  if (method == Parameters::SimulationControl::TimeSteppingMethod::sdirk22_1 ||
+      method == Parameters::SimulationControl::TimeSteppingMethod::sdirk22_2 ||
+      method == Parameters::SimulationControl::TimeSteppingMethod::sdirk22)
+    n_stages = 1;
+
+  return n_stages;
+}
+
 
 #endif

--- a/include/core/time_integration_utilities.h
+++ b/include/core/time_integration_utilities.h
@@ -152,8 +152,6 @@ time_stepping_method_has_two_stages(
   const Parameters::SimulationControl::TimeSteppingMethod method)
 {
   return (
-    method == Parameters::SimulationControl::TimeSteppingMethod::bdf2 ||
-    method == Parameters::SimulationControl::TimeSteppingMethod::bdf3 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk22_1 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk22_2 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_1 ||
@@ -173,11 +171,36 @@ time_stepping_method_has_three_stages(
   const Parameters::SimulationControl::TimeSteppingMethod method)
 {
   return (
-    method == Parameters::SimulationControl::TimeSteppingMethod::bdf3 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_1 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_2 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33_3 ||
     method == Parameters::SimulationControl::TimeSteppingMethod::sdirk33);
+}
+
+
+/**
+ * @brief Determines if the time integration method requires an additional array
+ *
+ * @param method A time integration method
+ */
+inline bool
+time_stepping_method_uses_two_previous_solutions(
+  const Parameters::SimulationControl::TimeSteppingMethod method)
+{
+  return (method == Parameters::SimulationControl::TimeSteppingMethod::bdf2 ||
+          method == Parameters::SimulationControl::TimeSteppingMethod::bdf3);
+}
+
+/**
+ * @brief Determines if the time integration method requires two additional arrays
+ *
+ * @param method A time integration method
+ */
+inline bool
+time_stepping_method_uses_three_previous_solutions(
+  const Parameters::SimulationControl::TimeSteppingMethod method)
+{
+  return (method == Parameters::SimulationControl::TimeSteppingMethod::bdf3);
 }
 
 #endif

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -39,6 +39,7 @@
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
 
+#include <core/bdf.h>
 #include <core/simulation_control.h>
 #include <solvers/auxiliary_physics.h>
 #include <solvers/multiphysics_interface.h>
@@ -61,9 +62,6 @@ public:
     , simulation_control(p_simulation_control)
     , dof_handler(*triangulation)
     , solution_transfer(dof_handler)
-    , solution_transfer_m1(dof_handler)
-    , solution_transfer_m2(dof_handler)
-    , solution_transfer_m3(dof_handler)
   {
     if (simulation_parameters.mesh.simplex)
       {
@@ -86,6 +84,19 @@ public:
         cell_quadrature  = std::make_shared<QGauss<dim>>(fe->degree + 1);
         face_quadrature  = std::make_shared<QGauss<dim - 1>>(fe->degree + 1);
         error_quadrature = std::make_shared<QGauss<dim>>(fe->degree + 2);
+      }
+
+    // Set size of previous solutions using BDF schemes information
+    previous_solutions.resize(maximum_number_of_previous_solutions());
+
+    // Prepare previous solutions transfer
+    previous_solutions_transfer.reserve(previous_solutions.size());
+    for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+      {
+        previous_solutions_transfer.emplace_back(
+          parallel::distributed::
+            SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>(
+              this->dof_handler));
       }
   }
 
@@ -287,20 +298,15 @@ private:
   TrilinosWrappers::SparseMatrix system_matrix;
 
 
-  // Past solution vectors
-  TrilinosWrappers::MPI::Vector solution_m1;
-  TrilinosWrappers::MPI::Vector solution_m2;
-  TrilinosWrappers::MPI::Vector solution_m3;
+  // Previous solutions vectors
+  std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
 
   // Solution transfer classes
   parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
     solution_transfer;
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    solution_transfer_m1;
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    solution_transfer_m2;
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    solution_transfer_m3;
+  std::vector<
+    parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>>
+    previous_solutions_transfer;
 
   // Reference for GGLS https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.2324
   // Warning, this GGLS implementation is valid only for Linear elements

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -472,6 +472,9 @@ protected:
   // Previous solutions vectors
   std::vector<VectorType> previous_solutions;
 
+  // Intermediary solution stages for SDIRK methods
+  std::vector<VectorType> solution_stages;
+
   // Finite element order used
   const unsigned int velocity_fem_degree;
   const unsigned int pressure_fem_degree;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -471,8 +471,6 @@ protected:
 
   // Previous solutions vectors
   std::vector<VectorType> previous_solutions;
-  VectorType              solution_m2;
-  VectorType              solution_m3;
 
   // Finite element order used
   const unsigned int velocity_fem_degree;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -471,7 +471,6 @@ protected:
 
   // Previous solutions vectors
   std::vector<VectorType> previous_solutions;
-  VectorType              solution_m1;
   VectorType              solution_m2;
   VectorType              solution_m3;
 

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -446,15 +446,17 @@ protected:
   SimulationParameters<dim> simulation_parameters;
   PVDHandler                pvdhandler;
 
+  // Functions used for source term and error analysis
   Function<dim> *exact_solution;
   Function<dim> *forcing_function;
 
-  // Inlet flow rate and area
-  std::pair<double, double> flow_rate;
+
 
   // Dynamic flow control
   FlowControl<dim> flow_control;
   Tensor<1, dim>   beta;
+  // Inlet flow rate and area
+  std::pair<double, double> flow_rate;
 
   // Constraints for Dirichlet boundary conditions
   AffineConstraints<double> zero_constraints;
@@ -467,10 +469,11 @@ protected:
   VectorType                system_rhs;
   AffineConstraints<double> nonzero_constraints;
 
-  // Past solution vectors
-  VectorType solution_m1;
-  VectorType solution_m2;
-  VectorType solution_m3;
+  // Previous solutions vectors
+  std::vector<VectorType> previous_solutions;
+  VectorType              solution_m1;
+  VectorType              solution_m2;
+  VectorType              solution_m3;
 
   // Finite element order used
   const unsigned int velocity_fem_degree;
@@ -488,7 +491,6 @@ protected:
 
   // Simulation control for time stepping and I/Os
   std::shared_ptr<SimulationControl> simulation_control;
-  // SimulationControl simulationControl;
 
   // Post-processing variables
   TableHandler enstrophy_table;

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -62,9 +62,6 @@ public:
     , simulation_control(p_simulation_control)
     , dof_handler(*triangulation)
     , solution_transfer(dof_handler)
-    , solution_transfer_m1(dof_handler)
-    , solution_transfer_m2(dof_handler)
-    , solution_transfer_m3(dof_handler)
   {
     if (simulation_parameters.mesh.simplex)
       {
@@ -86,6 +83,16 @@ public:
 
     // Set size of previous solutions using BDF schemes information
     previous_solutions.resize(maximum_number_of_previous_solutions());
+
+    // Prepare previous solutions transfer
+    previous_solutions_transfer.reserve(previous_solutions.size());
+    for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+      {
+        previous_solutions_transfer.emplace_back(
+          parallel::distributed::
+            SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>(
+              this->dof_handler));
+      }
   }
 
   /**
@@ -316,12 +323,6 @@ private:
   std::vector<
     parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>>
     previous_solutions_transfer;
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    solution_transfer_m1;
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    solution_transfer_m2;
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    solution_transfer_m3;
 
   // Tracer statistics table
   TableHandler statistics_table;

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -39,6 +39,7 @@
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
 
+#include <core/bdf.h>
 #include <core/simulation_control.h>
 #include <solvers/auxiliary_physics.h>
 #include <solvers/multiphysics_interface.h>
@@ -82,6 +83,9 @@ public:
           fe->degree, simulation_parameters.fem_parameters.qmapping_all);
         cell_quadrature = std::make_shared<QGauss<dim>>(fe->degree + 1);
       }
+
+    // Set size of previous solutions using BDF schemes information
+    previous_solutions.resize(maximum_number_of_previous_solutions());
   }
 
   /**
@@ -303,14 +307,15 @@ private:
   TrilinosWrappers::SparseMatrix system_matrix;
 
 
-  // Past solution vectors
-  TrilinosWrappers::MPI::Vector solution_m1;
-  TrilinosWrappers::MPI::Vector solution_m2;
-  TrilinosWrappers::MPI::Vector solution_m3;
+  // Previous solutions vectors
+  std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
 
   // Solution transfer classes
   parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
     solution_transfer;
+  std::vector<
+    parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>>
+    previous_solutions_transfer;
   parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
     solution_transfer_m1;
   parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -634,12 +634,12 @@ GLSVANSSolver<dim>::assembleGLS()
               this->previous_solutions[0], p1_velocity_values);
 
           if (time_stepping_method_has_two_stages(scheme))
-            fe_values[velocities].get_function_values(this->solution_m2,
-                                                      p2_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[1], p2_velocity_values);
 
           if (time_stepping_method_has_three_stages(scheme))
-            fe_values[velocities].get_function_values(this->solution_m3,
-                                                      p3_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[2], p3_velocity_values);
 
           // Gather the previous time steps depending on the number of stages
           // of the time integration scheme for the void fraction

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -370,10 +370,9 @@ GLSVANSSolver<dim>::first_iteration()
       calculate_void_fraction(intermediate_time);
       PhysicsSolver<TrilinosWrappers::MPI::Vector>::solve_non_linear_system(
         Parameters::SimulationControl::TimeSteppingMethod::bdf1, false, true);
-      this->solution_m2 = this->solution_m1;
-      this->solution_m1 = this->present_solution;
-      void_fraction_m2  = void_fraction_m1;
-      void_fraction_m1  = nodal_void_fraction_relevant;
+      this->percolate_time_vectors_fd();
+      void_fraction_m2 = void_fraction_m1;
+      void_fraction_m1 = nodal_void_fraction_relevant;
 
       // Reset the time step and do a bdf 2 newton iteration using the two
       // steps to complete the full step
@@ -410,10 +409,9 @@ GLSVANSSolver<dim>::first_iteration()
 
       PhysicsSolver<TrilinosWrappers::MPI::Vector>::solve_non_linear_system(
         Parameters::SimulationControl::TimeSteppingMethod::bdf1, false, true);
-      this->solution_m2 = this->solution_m1;
-      this->solution_m1 = this->present_solution;
-      void_fraction_m2  = void_fraction_m1;
-      void_fraction_m1  = nodal_void_fraction_relevant;
+      this->percolate_time_vectors_fd();
+      void_fraction_m2 = void_fraction_m1;
+      void_fraction_m1 = nodal_void_fraction_relevant;
 
       // Reset the time step and do a bdf 2 newton iteration using the two
       // steps
@@ -425,12 +423,10 @@ GLSVANSSolver<dim>::first_iteration()
 
       PhysicsSolver<TrilinosWrappers::MPI::Vector>::solve_non_linear_system(
         Parameters::SimulationControl::TimeSteppingMethod::bdf1, false, true);
-      this->solution_m3 = this->solution_m2;
-      this->solution_m2 = this->solution_m1;
-      this->solution_m1 = this->present_solution;
-      void_fraction_m3  = void_fraction_m2;
-      void_fraction_m2  = void_fraction_m1;
-      void_fraction_m1  = nodal_void_fraction_relevant;
+      this->percolate_time_vectors_fd();
+      void_fraction_m3 = void_fraction_m2;
+      void_fraction_m2 = void_fraction_m1;
+      void_fraction_m1 = nodal_void_fraction_relevant;
 
       // Reset the time step and do a bdf 3 newton iteration using the two
       // steps to complete the full step
@@ -634,8 +630,8 @@ GLSVANSSolver<dim>::assembleGLS()
           // of the time integration scheme
           if (scheme !=
               Parameters::SimulationControl::TimeSteppingMethod::steady)
-            fe_values[velocities].get_function_values(this->solution_m1,
-                                                      p1_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[0], p1_velocity_values);
 
           if (time_stepping_method_has_two_stages(scheme))
             fe_values[velocities].get_function_values(this->solution_m2,

--- a/source/solvers/free_surface.cc
+++ b/source/solvers/free_surface.cc
@@ -186,13 +186,15 @@ FreeSurface<dim>::assemble_system(
                                                p1_phase_values);
             }
 
-          if (time_stepping_method_has_two_stages(time_stepping_method))
+          if (time_stepping_method_uses_two_previous_solutions(
+                time_stepping_method))
             {
               fe_values_fs.get_function_values(previous_solutions[1],
                                                p2_phase_values);
             }
 
-          if (time_stepping_method_has_three_stages(time_stepping_method))
+          if (time_stepping_method_uses_three_previous_solutions(
+                time_stepping_method))
             {
               fe_values_fs.get_function_values(previous_solutions[2],
                                                p3_phase_values);

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -180,8 +180,8 @@ GDNavierStokesSolver<dim>::assembleGD()
 
           if (scheme !=
               Parameters::SimulationControl::TimeSteppingMethod::steady)
-            fe_values[velocities].get_function_values(this->solution_m1,
-                                                      p1_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[0], p1_velocity_values);
 
           if (scheme ==
                 Parameters::SimulationControl::TimeSteppingMethod::bdf2 ||
@@ -584,9 +584,6 @@ GDNavierStokesSolver<dim>::setup_dofs_fd()
                       this->mpi_communicator);
     }
 
-  this->solution_m1.reinit(this->locally_owned_dofs,
-                           this->locally_relevant_dofs,
-                           this->mpi_communicator);
   this->solution_m2.reinit(this->locally_owned_dofs,
                            this->locally_relevant_dofs,
                            this->mpi_communicator);

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -186,12 +186,12 @@ GDNavierStokesSolver<dim>::assembleGD()
           if (scheme ==
                 Parameters::SimulationControl::TimeSteppingMethod::bdf2 ||
               scheme == Parameters::SimulationControl::TimeSteppingMethod::bdf3)
-            fe_values[velocities].get_function_values(this->solution_m2,
-                                                      p2_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[1], p2_velocity_values);
 
           if (scheme == Parameters::SimulationControl::TimeSteppingMethod::bdf3)
-            fe_values[velocities].get_function_values(this->solution_m3,
-                                                      p3_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[2], p3_velocity_values);
 
           if (l_forcing_function)
             l_forcing_function->vector_value_list(
@@ -584,12 +584,6 @@ GDNavierStokesSolver<dim>::setup_dofs_fd()
                       this->mpi_communicator);
     }
 
-  this->solution_m2.reinit(this->locally_owned_dofs,
-                           this->locally_relevant_dofs,
-                           this->mpi_communicator);
-  this->solution_m3.reinit(this->locally_owned_dofs,
-                           this->locally_relevant_dofs,
-                           this->mpi_communicator);
   this->newton_update.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -577,7 +577,16 @@ GDNavierStokesSolver<dim>::setup_dofs_fd()
                                 this->locally_relevant_dofs,
                                 this->mpi_communicator);
 
+  // Initialize previous solutions
   for (auto &solution : this->previous_solutions)
+    {
+      solution.reinit(this->locally_owned_dofs,
+                      this->locally_relevant_dofs,
+                      this->mpi_communicator);
+    }
+
+  // If SDIRK type of methods are used, initialize solution stages
+  for (auto &solution : this->solution_stages)
     {
       solution.reinit(this->locally_owned_dofs,
                       this->locally_relevant_dofs,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -577,6 +577,13 @@ GDNavierStokesSolver<dim>::setup_dofs_fd()
                                 this->locally_relevant_dofs,
                                 this->mpi_communicator);
 
+  for (auto &solution : this->previous_solutions)
+    {
+      solution.reinit(this->locally_owned_dofs,
+                      this->locally_relevant_dofs,
+                      this->mpi_communicator);
+    }
+
   this->solution_m1.reinit(this->locally_owned_dofs,
                            this->locally_relevant_dofs,
                            this->mpi_communicator);

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -202,13 +202,6 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                       this->mpi_communicator);
     }
 
-  this->solution_m2.reinit(this->locally_owned_dofs,
-                           this->locally_relevant_dofs,
-                           this->mpi_communicator);
-  this->solution_m3.reinit(this->locally_owned_dofs,
-                           this->locally_relevant_dofs,
-                           this->mpi_communicator);
-
   this->newton_update.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
@@ -422,12 +415,12 @@ GLSNavierStokesSolver<dim>::assembleGLS()
               this->previous_solutions[0], p1_velocity_values);
 
           if (time_stepping_method_has_two_stages(scheme))
-            fe_values[velocities].get_function_values(this->solution_m2,
-                                                      p2_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[1], p2_velocity_values);
 
           if (time_stepping_method_has_three_stages(scheme))
-            fe_values[velocities].get_function_values(this->solution_m3,
-                                                      p3_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[2], p3_velocity_values);
 
           // Loop over the quadrature points
           for (unsigned int q = 0; q < n_q_points; ++q)
@@ -1034,12 +1027,12 @@ GLSNavierStokesSolver<dim>::assembleGLSFreeSurface()
               this->previous_solutions[0], p1_velocity_values);
 
           if (time_stepping_method_has_two_stages(scheme))
-            fe_values[velocities].get_function_values(this->solution_m2,
-                                                      p2_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[1], p2_velocity_values);
 
           if (time_stepping_method_has_three_stages(scheme))
-            fe_values[velocities].get_function_values(this->solution_m3,
-                                                      p3_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[2], p3_velocity_values);
           // Loop over the quadrature points
           for (unsigned int q = 0; q < n_q_points; ++q)
             {

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -202,9 +202,6 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                       this->mpi_communicator);
     }
 
-  this->solution_m1.reinit(this->locally_owned_dofs,
-                           this->locally_relevant_dofs,
-                           this->mpi_communicator);
   this->solution_m2.reinit(this->locally_owned_dofs,
                            this->locally_relevant_dofs,
                            this->mpi_communicator);
@@ -421,8 +418,8 @@ GLSNavierStokesSolver<dim>::assembleGLS()
           // stages of the time integration scheme
           if (scheme !=
               Parameters::SimulationControl::TimeSteppingMethod::steady)
-            fe_values[velocities].get_function_values(this->solution_m1,
-                                                      p1_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[0], p1_velocity_values);
 
           if (time_stepping_method_has_two_stages(scheme))
             fe_values[velocities].get_function_values(this->solution_m2,
@@ -1033,8 +1030,8 @@ GLSNavierStokesSolver<dim>::assembleGLSFreeSurface()
           // of the time integration scheme
           if (scheme !=
               Parameters::SimulationControl::TimeSteppingMethod::steady)
-            fe_values[velocities].get_function_values(this->solution_m1,
-                                                      p1_velocity_values);
+            fe_values[velocities].get_function_values(
+              this->previous_solutions[0], p1_velocity_values);
 
           if (time_stepping_method_has_two_stages(scheme))
             fe_values[velocities].get_function_values(this->solution_m2,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -195,6 +195,13 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->present_solution.reinit(this->locally_owned_dofs,
                                 this->locally_relevant_dofs,
                                 this->mpi_communicator);
+  for (auto &solution : this->previous_solutions)
+    {
+      solution.reinit(this->locally_owned_dofs,
+                      this->locally_relevant_dofs,
+                      this->mpi_communicator);
+    }
+
   this->solution_m1.reinit(this->locally_owned_dofs,
                            this->locally_relevant_dofs,
                            this->mpi_communicator);

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -981,6 +981,10 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::read_checkpoint()
 
   system_trans_vectors.deserialize(x_system);
   this->present_solution = distributed_system;
+  for (unsigned int i = 0; i < this->previous_solutions.size(); ++i)
+    {
+      this->previous_solutions[i] = distributed_previous_solutions[i];
+    }
   this->multiphysics->read_checkpoint();
 }
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -3050,12 +3050,12 @@ GLSSharpNavierStokesSolver<dim>::assembleGLS()
                   this->previous_solutions[0], p1_velocity_values);
 
               if (time_stepping_method_has_two_stages(scheme))
-                fe_values[velocities].get_function_values(this->solution_m2,
-                                                          p2_velocity_values);
+                fe_values[velocities].get_function_values(
+                  this->previous_solutions[1], p2_velocity_values);
 
               if (time_stepping_method_has_three_stages(scheme))
-                fe_values[velocities].get_function_values(this->solution_m3,
-                                                          p3_velocity_values);
+                fe_values[velocities].get_function_values(
+                  this->previous_solutions[2], p3_velocity_values);
 
               // Loop over the quadrature points
               for (unsigned int q = 0; q < n_q_points; ++q)

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -152,7 +152,6 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
                                                               active_neighbors_set;
   std::vector<typename DoFHandler<dim>::active_cell_iterator> active_neighbors;
   MappingQ1<dim>                                              map;
-  std::pair<unsigned int, unsigned int>                       cell_vertex_map;
   const double min_cell_diameter =
     GridTools::minimal_cell_diameter(*this->triangulation);
 
@@ -3047,8 +3046,8 @@ GLSSharpNavierStokesSolver<dim>::assembleGLS()
               // stages of the time integration scheme
               if (scheme !=
                   Parameters::SimulationControl::TimeSteppingMethod::steady)
-                fe_values[velocities].get_function_values(this->solution_m1,
-                                                          p1_velocity_values);
+                fe_values[velocities].get_function_values(
+                  this->previous_solutions[0], p1_velocity_values);
 
               if (time_stepping_method_has_two_stages(scheme))
                 fe_values[velocities].get_function_values(this->solution_m2,

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -259,7 +259,8 @@ HeatTransfer<dim>::assemble_system(
                                                   p1_temperature_gradients);
             }
 
-          if (time_stepping_method_has_two_stages(time_stepping_method))
+          if (time_stepping_method_uses_two_previous_solutions(
+                time_stepping_method))
             {
               fe_values_ht.get_function_values(previous_solutions[1],
                                                p2_temperature_values);
@@ -268,7 +269,8 @@ HeatTransfer<dim>::assemble_system(
                                                   p2_temperature_gradients);
             }
 
-          if (time_stepping_method_has_three_stages(time_stepping_method))
+          if (time_stepping_method_uses_three_previous_solutions(
+                time_stepping_method))
             {
               fe_values_ht.get_function_values(previous_solutions[2],
                                                p3_temperature_values);
@@ -955,8 +957,7 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
   if (this->simulation_parameters.linear_solver.verbosity !=
       Parameters::Verbosity::quiet)
     {
-      this->pcout << "  Heat Transfer : " << std::endl
-                  << "  -Tolerance of iterative solver is : "
+      this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
@@ -994,8 +995,7 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
   if (simulation_parameters.linear_solver.verbosity !=
       Parameters::Verbosity::quiet)
     {
-      this->pcout << "  Heat Transfer : " << std::endl
-                  << "  -Iterative solver took : " << solver_control.last_step()
+      this->pcout << "  -Iterative solver took : " << solver_control.last_step()
                   << " steps " << std::endl;
     }
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -253,27 +253,27 @@ HeatTransfer<dim>::assemble_system(
           if (time_stepping_method !=
               Parameters::SimulationControl::TimeSteppingMethod::steady)
             {
-              fe_values_ht.get_function_values(this->solution_m1,
+              fe_values_ht.get_function_values(previous_solutions[0],
                                                p1_temperature_values);
-              fe_values_ht.get_function_gradients(this->solution_m1,
+              fe_values_ht.get_function_gradients(previous_solutions[0],
                                                   p1_temperature_gradients);
             }
 
           if (time_stepping_method_has_two_stages(time_stepping_method))
             {
-              fe_values_ht.get_function_values(this->solution_m2,
+              fe_values_ht.get_function_values(previous_solutions[1],
                                                p2_temperature_values);
 
-              fe_values_ht.get_function_gradients(this->solution_m2,
+              fe_values_ht.get_function_gradients(previous_solutions[1],
                                                   p2_temperature_gradients);
             }
 
           if (time_stepping_method_has_three_stages(time_stepping_method))
             {
-              fe_values_ht.get_function_values(this->solution_m3,
+              fe_values_ht.get_function_values(previous_solutions[2],
                                                p3_temperature_values);
 
-              fe_values_ht.get_function_gradients(this->solution_m3,
+              fe_values_ht.get_function_gradients(previous_solutions[2],
                                                   p3_temperature_gradients);
             }
 
@@ -692,9 +692,11 @@ template <int dim>
 void
 HeatTransfer<dim>::percolate_time_vectors()
 {
-  solution_m3 = solution_m2;
-  solution_m2 = solution_m1;
-  solution_m1 = present_solution;
+  for (unsigned int i = previous_solutions.size() - 1; i > 0; --i)
+    {
+      previous_solutions[i] = previous_solutions[i - 1];
+    }
+  previous_solutions[0] = this->present_solution;
 }
 
 template <int dim>
@@ -731,9 +733,12 @@ void
 HeatTransfer<dim>::pre_mesh_adaptation()
 {
   solution_transfer.prepare_for_coarsening_and_refinement(present_solution);
-  solution_transfer_m1.prepare_for_coarsening_and_refinement(solution_m1);
-  solution_transfer_m2.prepare_for_coarsening_and_refinement(solution_m2);
-  solution_transfer_m3.prepare_for_coarsening_and_refinement(solution_m3);
+
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      previous_solutions_transfer[i].prepare_for_coarsening_and_refinement(
+        previous_solutions[i]);
+    }
 }
 
 template <int dim>
@@ -745,27 +750,25 @@ HeatTransfer<dim>::post_mesh_adaptation()
 
   // Set up the vectors for the transfer
   TrilinosWrappers::MPI::Vector tmp(locally_owned_dofs, mpi_communicator);
-  TrilinosWrappers::MPI::Vector tmp_m1(locally_owned_dofs, mpi_communicator);
-  TrilinosWrappers::MPI::Vector tmp_m2(locally_owned_dofs, mpi_communicator);
-  TrilinosWrappers::MPI::Vector tmp_m3(locally_owned_dofs, mpi_communicator);
 
   // Interpolate the solution at time and previous time
   solution_transfer.interpolate(tmp);
-  solution_transfer_m1.interpolate(tmp_m1);
-  solution_transfer_m2.interpolate(tmp_m2);
-  solution_transfer_m3.interpolate(tmp_m3);
 
   // Distribute constraints
   nonzero_constraints.distribute(tmp);
-  nonzero_constraints.distribute(tmp_m1);
-  nonzero_constraints.distribute(tmp_m2);
-  nonzero_constraints.distribute(tmp_m3);
 
   // Fix on the new mesh
   present_solution = tmp;
-  solution_m1      = tmp_m1;
-  solution_m2      = tmp_m2;
-  solution_m3      = tmp_m3;
+
+  // Transfer previous solutions
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      TrilinosWrappers::MPI::Vector tmp_previous_solution(locally_owned_dofs,
+                                                          mpi_communicator);
+      previous_solutions_transfer[i].interpolate(tmp_previous_solution);
+      nonzero_constraints.distribute(tmp_previous_solution);
+      previous_solutions[i] = tmp_previous_solution;
+    }
 }
 
 template <int dim>
@@ -775,9 +778,10 @@ HeatTransfer<dim>::write_checkpoint()
   std::vector<const TrilinosWrappers::MPI::Vector *> sol_set_transfer;
 
   sol_set_transfer.push_back(&present_solution);
-  sol_set_transfer.push_back(&solution_m1);
-  sol_set_transfer.push_back(&solution_m2);
-  sol_set_transfer.push_back(&solution_m3);
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      sol_set_transfer.push_back(&previous_solutions[i]);
+    }
   solution_transfer.prepare_for_serialization(sol_set_transfer);
 }
 
@@ -788,27 +792,29 @@ HeatTransfer<dim>::read_checkpoint()
   auto mpi_communicator = triangulation->get_communicator();
   this->pcout << "Reading heat transfer checkpoint" << std::endl;
 
-  std::vector<TrilinosWrappers::MPI::Vector *> input_vectors(4);
+  std::vector<TrilinosWrappers::MPI::Vector *> input_vectors(
+    1 + previous_solutions.size());
   TrilinosWrappers::MPI::Vector distributed_system(locally_owned_dofs,
                                                    mpi_communicator);
-  TrilinosWrappers::MPI::Vector distributed_system_m1(locally_owned_dofs,
-                                                      mpi_communicator);
-  TrilinosWrappers::MPI::Vector distributed_system_m2(locally_owned_dofs,
-                                                      mpi_communicator);
-  TrilinosWrappers::MPI::Vector distributed_system_m3(locally_owned_dofs,
-                                                      mpi_communicator);
-
   input_vectors[0] = &distributed_system;
-  input_vectors[1] = &distributed_system_m1;
-  input_vectors[2] = &distributed_system_m2;
-  input_vectors[3] = &distributed_system_m3;
+
+
+  std::vector<TrilinosWrappers::MPI::Vector> distributed_previous_solutions;
+  distributed_previous_solutions.reserve(previous_solutions.size());
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      distributed_previous_solutions.emplace_back(
+        TrilinosWrappers::MPI::Vector(locally_owned_dofs, mpi_communicator));
+      input_vectors[i + 1] = &distributed_previous_solutions[i];
+    }
 
   solution_transfer.deserialize(input_vectors);
 
   present_solution = distributed_system;
-  solution_m1      = distributed_system_m1;
-  solution_m2      = distributed_system_m2;
-  solution_m3      = distributed_system_m3;
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      previous_solutions[i] = distributed_previous_solutions[i];
+    }
 }
 
 
@@ -830,15 +836,12 @@ HeatTransfer<dim>::setup_dofs()
                           mpi_communicator);
 
   // Previous solutions for transient schemes
-  solution_m1.reinit(locally_owned_dofs,
-                     locally_relevant_dofs,
-                     mpi_communicator);
-  solution_m2.reinit(locally_owned_dofs,
-                     locally_relevant_dofs,
-                     mpi_communicator);
-  solution_m3.reinit(locally_owned_dofs,
-                     locally_relevant_dofs,
-                     mpi_communicator);
+  for (auto &solution : this->previous_solutions)
+    {
+      solution.reinit(locally_owned_dofs,
+                      locally_relevant_dofs,
+                      mpi_communicator);
+    }
 
   system_rhs.reinit(locally_owned_dofs, mpi_communicator);
 

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -207,13 +207,15 @@ Tracer<dim>::assemble_system(
                                                    p1_tracer_values);
             }
 
-          if (time_stepping_method_has_two_stages(time_stepping_method))
+          if (time_stepping_method_uses_two_previous_solutions(
+                time_stepping_method))
             {
               fe_values_tracer.get_function_values(previous_solutions[1],
                                                    p2_tracer_values);
             }
 
-          if (time_stepping_method_has_three_stages(time_stepping_method))
+          if (time_stepping_method_uses_three_previous_solutions(
+                time_stepping_method))
             {
               fe_values_tracer.get_function_values(previous_solutions[2],
                                                    p3_tracer_values);

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -625,15 +625,8 @@ Tracer<dim>::pre_mesh_adaptation()
 {
   solution_transfer.prepare_for_coarsening_and_refinement(present_solution);
 
-  // Prepare previous solutions transfer
-  previous_solutions_transfer.clear();
-  previous_solutions_transfer.reserve(previous_solutions.size());
   for (unsigned int i = 0; i < previous_solutions.size(); ++i)
     {
-      previous_solutions_transfer.emplace_back(
-        parallel::distributed::SolutionTransfer<dim,
-                                                TrilinosWrappers::MPI::Vector>(
-          this->dof_handler));
       previous_solutions_transfer[i].prepare_for_coarsening_and_refinement(
         previous_solutions[i]);
     }

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -203,19 +203,19 @@ Tracer<dim>::assemble_system(
           if (time_stepping_method !=
               Parameters::SimulationControl::TimeSteppingMethod::steady)
             {
-              fe_values_tracer.get_function_values(this->solution_m1,
+              fe_values_tracer.get_function_values(previous_solutions[0],
                                                    p1_tracer_values);
             }
 
           if (time_stepping_method_has_two_stages(time_stepping_method))
             {
-              fe_values_tracer.get_function_values(this->solution_m2,
+              fe_values_tracer.get_function_values(previous_solutions[1],
                                                    p2_tracer_values);
             }
 
           if (time_stepping_method_has_three_stages(time_stepping_method))
             {
-              fe_values_tracer.get_function_values(this->solution_m3,
+              fe_values_tracer.get_function_values(previous_solutions[2],
                                                    p3_tracer_values);
             }
 
@@ -474,9 +474,11 @@ template <int dim>
 void
 Tracer<dim>::percolate_time_vectors()
 {
-  solution_m3 = solution_m2;
-  solution_m2 = solution_m1;
-  solution_m1 = present_solution;
+  for (unsigned int i = previous_solutions.size() - 1; i > 0; --i)
+    {
+      previous_solutions[i] = previous_solutions[i - 1];
+    }
+  previous_solutions[0] = this->present_solution;
 }
 
 template <int dim>
@@ -622,9 +624,19 @@ void
 Tracer<dim>::pre_mesh_adaptation()
 {
   solution_transfer.prepare_for_coarsening_and_refinement(present_solution);
-  solution_transfer_m1.prepare_for_coarsening_and_refinement(solution_m1);
-  solution_transfer_m2.prepare_for_coarsening_and_refinement(solution_m2);
-  solution_transfer_m3.prepare_for_coarsening_and_refinement(solution_m3);
+
+  // Prepare previous solutions transfer
+  previous_solutions_transfer.clear();
+  previous_solutions_transfer.reserve(previous_solutions.size());
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      previous_solutions_transfer.emplace_back(
+        parallel::distributed::SolutionTransfer<dim,
+                                                TrilinosWrappers::MPI::Vector>(
+          this->dof_handler));
+      previous_solutions_transfer[i].prepare_for_coarsening_and_refinement(
+        previous_solutions[i]);
+    }
 }
 
 template <int dim>
@@ -633,30 +645,27 @@ Tracer<dim>::post_mesh_adaptation()
 {
   auto mpi_communicator = triangulation->get_communicator();
 
-
   // Set up the vectors for the transfer
   TrilinosWrappers::MPI::Vector tmp(locally_owned_dofs, mpi_communicator);
-  TrilinosWrappers::MPI::Vector tmp_m1(locally_owned_dofs, mpi_communicator);
-  TrilinosWrappers::MPI::Vector tmp_m2(locally_owned_dofs, mpi_communicator);
-  TrilinosWrappers::MPI::Vector tmp_m3(locally_owned_dofs, mpi_communicator);
 
   // Interpolate the solution at time and previous time
   solution_transfer.interpolate(tmp);
-  solution_transfer_m1.interpolate(tmp_m1);
-  solution_transfer_m2.interpolate(tmp_m2);
-  solution_transfer_m3.interpolate(tmp_m3);
 
   // Distribute constraints
   nonzero_constraints.distribute(tmp);
-  nonzero_constraints.distribute(tmp_m1);
-  nonzero_constraints.distribute(tmp_m2);
-  nonzero_constraints.distribute(tmp_m3);
 
   // Fix on the new mesh
   present_solution = tmp;
-  solution_m1      = tmp_m1;
-  solution_m2      = tmp_m2;
-  solution_m3      = tmp_m3;
+
+  // Transfer previous solutions
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      TrilinosWrappers::MPI::Vector tmp_previous_solution(locally_owned_dofs,
+                                                          mpi_communicator);
+      previous_solutions_transfer[i].interpolate(tmp_previous_solution);
+      nonzero_constraints.distribute(tmp_previous_solution);
+      previous_solutions[i] = tmp_previous_solution;
+    }
 }
 
 template <int dim>
@@ -666,9 +675,10 @@ Tracer<dim>::write_checkpoint()
   std::vector<const TrilinosWrappers::MPI::Vector *> sol_set_transfer;
 
   sol_set_transfer.push_back(&present_solution);
-  sol_set_transfer.push_back(&solution_m1);
-  sol_set_transfer.push_back(&solution_m2);
-  sol_set_transfer.push_back(&solution_m3);
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      sol_set_transfer.push_back(&previous_solutions[i]);
+    }
   solution_transfer.prepare_for_serialization(sol_set_transfer);
 }
 
@@ -679,27 +689,29 @@ Tracer<dim>::read_checkpoint()
   auto mpi_communicator = triangulation->get_communicator();
   this->pcout << "Reading tracer checkpoint" << std::endl;
 
-  std::vector<TrilinosWrappers::MPI::Vector *> input_vectors(4);
+  std::vector<TrilinosWrappers::MPI::Vector *> input_vectors(
+    1 + previous_solutions.size());
   TrilinosWrappers::MPI::Vector distributed_system(locally_owned_dofs,
                                                    mpi_communicator);
-  TrilinosWrappers::MPI::Vector distributed_system_m1(locally_owned_dofs,
-                                                      mpi_communicator);
-  TrilinosWrappers::MPI::Vector distributed_system_m2(locally_owned_dofs,
-                                                      mpi_communicator);
-  TrilinosWrappers::MPI::Vector distributed_system_m3(locally_owned_dofs,
-                                                      mpi_communicator);
-
   input_vectors[0] = &distributed_system;
-  input_vectors[1] = &distributed_system_m1;
-  input_vectors[2] = &distributed_system_m2;
-  input_vectors[3] = &distributed_system_m3;
+
+
+  std::vector<TrilinosWrappers::MPI::Vector> distributed_previous_solutions;
+  distributed_previous_solutions.reserve(previous_solutions.size());
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      distributed_previous_solutions.emplace_back(
+        TrilinosWrappers::MPI::Vector(locally_owned_dofs, mpi_communicator));
+      input_vectors[i + 1] = &distributed_previous_solutions[i];
+    }
 
   solution_transfer.deserialize(input_vectors);
 
   present_solution = distributed_system;
-  solution_m1      = distributed_system_m1;
-  solution_m2      = distributed_system_m2;
-  solution_m3      = distributed_system_m3;
+  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+    {
+      previous_solutions[i] = distributed_previous_solutions[i];
+    }
 }
 
 
@@ -721,15 +733,12 @@ Tracer<dim>::setup_dofs()
                           mpi_communicator);
 
   // Previous solutions for transient schemes
-  solution_m1.reinit(locally_owned_dofs,
-                     locally_relevant_dofs,
-                     mpi_communicator);
-  solution_m2.reinit(locally_owned_dofs,
-                     locally_relevant_dofs,
-                     mpi_communicator);
-  solution_m3.reinit(locally_owned_dofs,
-                     locally_relevant_dofs,
-                     mpi_communicator);
+  for (auto &solution : this->previous_solutions)
+    {
+      solution.reinit(locally_owned_dofs,
+                      locally_relevant_dofs,
+                      mpi_communicator);
+    }
 
   system_rhs.reinit(locally_owned_dofs, mpi_communicator);
 


### PR DESCRIPTION
Fixes a lot of issue with the time management vector. Adds an std::vector mechanism for previous solutions instead of having tons of seperated vector. This is much more clean.
This PR also seperates RK stages from BDF previous steps into two separate vector.
