### PR TITLE
Fix parallel void fraction bounding + grad-div stab for VANS

### DIFF
--- a/include/fem-dem/gls_vans.h
+++ b/include/fem-dem/gls_vans.h
@@ -184,6 +184,7 @@ private:
   const bool   PSPG        = true;
   const bool   SUPG        = true;
   const bool   DCDD        = true;
+  const bool   grad_div    = false;
   const double GLS_u_scale = 1;
 };
 

--- a/include/fem-dem/gls_vans.h
+++ b/include/fem-dem/gls_vans.h
@@ -153,6 +153,10 @@ private:
 
   // Solution of the void fraction at previous time steps
 
+  IndexSet locally_owned_dofs_voidfraction;
+
+  IndexSet locally_relevant_dofs_voidfraction;
+
   TrilinosWrappers::MPI::Vector void_fraction_m1;
   TrilinosWrappers::MPI::Vector void_fraction_m2;
   TrilinosWrappers::MPI::Vector void_fraction_m3;

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -207,7 +207,7 @@ GLSVANSSolver<dim>::calculate_void_fraction(const double time)
     {
       assemble_L2_projection_void_fraction();
       solve_L2_system_void_fraction();
-      // update_solution_and_constraints();
+      update_solution_and_constraints();
     }
 }
 
@@ -300,10 +300,9 @@ GLSVANSSolver<dim>::update_solution_and_constraints()
                   lambda(dof_index)                       = 0;
                 }
             }
-
-          void_fraction_constraints.close();
         }
     }
+  void_fraction_constraints.close();
 }
 
 template <int dim>

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1029,6 +1029,13 @@ GLSVANSSolver<dim>::assembleGLS()
                                   present_void_fraction_gradients[q]))) *
                             JxW;
 
+                          // Grad-div stabilization - Bruno test
+                          local_matrix(i, j) +=
+
+                            (div_phi_u[j] * present_void_fraction_values[q] +
+                             phi_u[j] * present_void_fraction_gradients[q]) *
+                            div_phi_u[i] * JxW;
+
                           // Mass matrix
                           if (is_bdf(scheme))
                             local_matrix(i, j) +=
@@ -1128,6 +1135,13 @@ GLSVANSSolver<dim>::assembleGLS()
                        mass_source) *
                         phi_p[i]) *
                     JxW;
+
+                  // Grad-div stabilization
+                  local_rhs(i) -= (present_void_fraction_values[q] *
+                                     present_velocity_divergence +
+                                   present_velocity_values[q] *
+                                     present_void_fraction_gradients[q]) *
+                                  div_phi_u[i] * JxW;
 
                   // Residual associated with BDF schemes
                   if (scheme == Parameters::SimulationControl::

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -969,6 +969,8 @@ GLSVANSSolver<dim>::assembleGLS()
                                    present_void_fraction_values[q];
 
 
+              double gamma = 0.05;
+
               // Matrix assembly
               if (assemble_matrix)
                 {
@@ -1031,7 +1033,7 @@ GLSVANSSolver<dim>::assembleGLS()
 
                           // Grad-div stabilization - Bruno test
                           local_matrix(i, j) +=
-
+                            gamma *
                             (div_phi_u[j] * present_void_fraction_values[q] +
                              phi_u[j] * present_void_fraction_gradients[q]) *
                             div_phi_u[i] * JxW;
@@ -1137,7 +1139,8 @@ GLSVANSSolver<dim>::assembleGLS()
                     JxW;
 
                   // Grad-div stabilization
-                  local_rhs(i) -= (present_void_fraction_values[q] *
+                  local_rhs(i) -= gamma *
+                                  (present_void_fraction_values[q] *
                                      present_velocity_divergence +
                                    present_velocity_values[q] *
                                      present_void_fraction_gradients[q]) *


### PR DESCRIPTION
This PR fixes two things:
- the issue with the parallel bounding of the void fraction
- It adds grad-div stabilization for the vans equation to ensure mass conservation when there are shocks. Right now this is disabled (the bool is set to false) because I did not want to break all the tests. If we deem that this implementation is superior, then we can enable it.
This settles my first part of this project. @tonielgeitani work on the complete stress tensor and @shahabgol work on the void fraction with smoothing will be next :)
