### PR TITLE
Lethe header and indentation major cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,6 +67,17 @@ IncludeCategories:
 # config.h must always be first:
   - Regex:    "deal.II/base/config.h"
     Priority: -1
+
+# Lethe folders in a specific order
+  - Regex:    "core/.*\\.h"
+    Priority: 101
+  - Regex:    "solvers/.*\\.h"
+    Priority: 102
+  - Regex:    "dem/.*\\.h"
+    Priority: 103
+  - Regex:    "fem-dem/.*\\.h"
+    Priority: 104
+
 # deal.II folders in sorted order:
   - Regex:    "deal.II/algorithms/.*\\.h"
     Priority: 110

--- a/applications/dem_parameter_template/dem_parameter_template.cc
+++ b/applications/dem_parameter_template/dem_parameter_template.cc
@@ -1,8 +1,8 @@
 // check the read and write of simulationcontrol
 
-#include <fstream>
-
 #include "dem/dem_solver_parameters.h"
+
+#include <fstream>
 
 int
 main()

--- a/applications/gd_navier_stokes_2d/gd_navier_stokes_2d.cc
+++ b/applications/gd_navier_stokes_2d/gd_navier_stokes_2d.cc
@@ -1,6 +1,6 @@
-#include <deal.II/base/convergence_table.h>
-
 #include <solvers/gd_navier_stokes.h>
+
+#include <deal.II/base/convergence_table.h>
 
 int
 main(int argc, char *argv[])

--- a/applications/initial_conditions/initial_conditions.cc
+++ b/applications/initial_conditions/initial_conditions.cc
@@ -1,5 +1,6 @@
 #include <core/grids.h>
 #include <core/parameters.h>
+
 #include <solvers/gls_navier_stokes.h>
 
 template <int dim>

--- a/applications/initial_conditions/initial_conditions.cc
+++ b/applications/initial_conditions/initial_conditions.cc
@@ -2,6 +2,7 @@
 #include <core/parameters.h>
 
 #include <solvers/gls_navier_stokes.h>
+#include <solvers/postprocessing_cfd.h>
 
 template <int dim>
 class ExactInitialSolution : public Function<dim>

--- a/applications/navier_stokes_parameter_template/navier_stokes_parameter_template.cc
+++ b/applications/navier_stokes_parameter_template/navier_stokes_parameter_template.cc
@@ -1,8 +1,8 @@
 // check the read and write of simulationcontrol
 
-#include <fstream>
-
 #include "solvers/simulation_parameters.h"
+
+#include <fstream>
 
 int
 main()

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -20,6 +20,10 @@
 #ifndef lethe_grids_h
 #define lethe_grids_h
 
+#include <core/boundary_conditions.h>
+#include <core/manifolds.h>
+#include <core/parameters.h>
+
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/tria_base.h>
 
@@ -27,10 +31,6 @@
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
-
-#include <core/boundary_conditions.h>
-#include <core/manifolds.h>
-#include <core/parameters.h>
 
 
 

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -1,7 +1,23 @@
-//
-// Created by lucka on 2021-05-21.
-//
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Author: Lucka Barbeau, Bruno Blais, Polytechnique Montreal, 2019 -
+ */
 
+#ifndef lethe_ib_stencils_h
+#define lethe_ib_stencils_h
 
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/tensor.h>
@@ -17,10 +33,6 @@
 #include <deal.II/lac/trilinos_vector.h>
 
 #include <core/ib_particle.h>
-
-
-#ifndef lethe_ib_stencils_h
-#  define lethe_ib_stencils_h
 
 
 

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -21,17 +21,12 @@
 #define lethe_manifolds_h
 
 #include <deal.II/base/data_out_base.h>
-#include <deal.II/base/function.h>
-#include <deal.II/base/parsed_function.h>
+#include <deal.II/base/parameter_handler.h>
 
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/dofs/dof_handler.h>
-
-#include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/grid_out.h>
-#include <deal.II/grid/tria.h>
 
 #include <deal.II/numerics/data_postprocessor.h>
 
@@ -106,12 +101,7 @@ public:
     const DataPostprocessorInputs::Vector<dim> &input_data,
     std::vector<Vector<double>> &computed_quantities) const override
   {
-#if (DEAL_II_VERSION_MINOR <= 2)
-    const typename DoFHandler<dim>::cell_iterator current_cell =
-      input_data.template get_cell<DoFHandler<dim>>();
-#else
     auto current_cell = input_data.template get_cell<dim>();
-#endif
 
     for (unsigned int p = 0; p < input_data.evaluation_points.size(); ++p)
       {

--- a/include/core/nitsche.h
+++ b/include/core/nitsche.h
@@ -18,16 +18,13 @@
  */
 
 
-#include <deal.II/base/conditional_ostream.h>
-#include <deal.II/base/function.h>
-#include <deal.II/base/parameter_acceptor.h>
-#include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/parsed_function.h>
+#ifndef nitsche_h
+#define nitsche_h
 
 #include <core/parameters.h>
 
-#ifndef nitsche_h
-#  define nitsche_h
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
 
 using namespace dealii;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -26,16 +26,18 @@
  * are required.
  */
 
-#include <deal.II/base/conditional_ostream.h>
-#include <deal.II/base/function.h>
-#include <deal.II/base/parameter_acceptor.h>
-#include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/parsed_function.h>
+
+
+#ifndef lethe_parameters_h
+#define lethe_parameters_h
 
 #include <core/ib_particle.h>
 
-#ifndef lethe_parameters_h
-#  define lethe_parameters_h
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
+
+
 
 using namespace dealii;
 

--- a/include/core/parameters_cfd_dem.h
+++ b/include/core/parameters_cfd_dem.h
@@ -20,10 +20,10 @@
 #ifndef lethe_parameters_cfd_dem_h
 #define lethe_parameters_cfd_dem_h
 
-#include <deal.II/base/function.h>
+#include <core/parameters.h>
+
 #include <deal.II/base/parsed_function.h>
 
-#include <core/parameters.h>
 
 using namespace dealii;
 /**

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -1,19 +1,30 @@
-/*
- * parametersdem.h
+/* ---------------------------------------------------------------------
  *
- *  Created on: Dec 16, 2019
- *      Author: shahab
+ * Copyright (C) 2019 - 2020 by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+
+ *
+ * Author: Shahab Golshan, Bruno Blais, Polytechnique Montreal, 2019-
  */
-#include <deal.II/base/conditional_ostream.h>
-#include <deal.II/base/function.h>
-#include <deal.II/base/parameter_acceptor.h>
+
+#ifndef lethe_parameters_lagrangian_h
+#define lethe_parameters_lagrangian_h
+
+//#include <deal.II/base/conditional_ostream.h>
+//#include <deal.II/base/function.h>
 #include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/parsed_function.h>
 
 #include <string>
-
-#ifndef PARAMETERS_LAGRANGIAN_H_
-#  define PARAMETERS_LAGRANGIAN_H_
 
 using namespace dealii;
 namespace Parameters

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -28,8 +28,6 @@
 
 #include <deal.II/base/parameter_handler.h>
 
-#include <core/multiphysics.h>
-
 using namespace dealii;
 
 namespace Parameters

--- a/include/core/sdirk.h
+++ b/include/core/sdirk.h
@@ -21,9 +21,9 @@
 #ifndef lethe_sdirk_h
 #define lethe_sdirk_h
 
-#include <deal.II/lac/full_matrix.h>
-
 #include <core/parameters.h>
+
+#include <deal.II/lac/full_matrix.h>
 
 #include <vector>
 

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -21,35 +21,27 @@
 #ifndef lethe_solid_base_h
 #define lethe_solid_base_h
 
+
+// Lethe Includes
+#include <core/nitsche.h>
+#include <core/parameters.h>
+
 // Dealii Includes
 
-// Dofs
+#include <deal.II/base/function.h>
+
+#include <deal.II/distributed/tria_base.h>
+
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>
 
-// Fe
 #include <deal.II/fe/fe_q.h>
-#include <deal.II/fe/fe_system.h>
 
-// Distributed
-#include <deal.II/distributed/tria.h>
-#include <deal.II/distributed/tria_base.h>
+#include <deal.II/grid/grid_generator.h>
 
-// Particles
-#include <deal.II/particles/data_out.h>
-#include <deal.II/particles/particle_accessor.h>
 #include <deal.II/particles/particle_handler.h>
 
-// Function
-#include <deal.II/base/function.h>
 
-// Lethe Includes
-#include <core/parameters.h>
-#include <solvers/simulation_parameters.h>
-
-// Std
-#include <fstream>
-#include <iostream>
 
 using namespace dealii;
 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -17,6 +17,9 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2020 -
  */
 
+#ifndef lethe_utilities_h
+#define lethe_utilities_h
+
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/tensor.h>
 
@@ -25,11 +28,7 @@
 #include <deal.II/fe/mapping_manifold.h>
 #include <deal.II/fe/mapping_q1.h>
 
-#ifndef lethe_utilities_h
-#  define lethe_utilities_h
-
 using namespace dealii;
-
 
 template <int dim>
 typename DoFHandler<dim>::active_cell_iterator

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -17,16 +17,8 @@
  * Author: Bruno Blais, Shahab Golshan, Polytechnique Montreal, 2019-
  */
 
-#include <deal.II/base/tensor.h>
-#include <deal.II/base/timer.h>
-
-#include <deal.II/distributed/tria.h>
-
-#include <deal.II/fe/mapping_q.h>
-
-#include <deal.II/particles/particle_handler.h>
-
 #include <core/pvd_handler.h>
+
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/explicit_euler_integrator.h>
@@ -63,6 +55,15 @@
 #include <dem/velocity_verlet_integrator.h>
 #include <dem/visualization.h>
 #include <dem/write_checkpoint.h>
+
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/timer.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 #include <fstream>
 #include <iostream>

--- a/include/dem/explicit_euler_integrator.h
+++ b/include/dem/explicit_euler_integrator.h
@@ -17,10 +17,10 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_solver_parameters.h>
 #include <dem/integrator.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
 

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -17,6 +17,9 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/boundary_cells_info_struct.h>
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/distributed/tria.h>
@@ -25,9 +28,6 @@
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/grid/grid_tools.h>
-
-#include <dem/boundary_cells_info_struct.h>
-#include <dem/dem_solver_parameters.h>
 
 #include <iostream>
 #include <unordered_set>

--- a/include/dem/find_contact_detection_step.h
+++ b/include/dem/find_contact_detection_step.h
@@ -17,9 +17,9 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_properties.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 #include <vector>
 

--- a/include/dem/find_maximum_particle_size.h
+++ b/include/dem/find_maximum_particle_size.h
@@ -17,10 +17,10 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_solver_parameters.h>
 #include <dem/input_parameter_inspection.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
 

--- a/include/dem/gear3_integrator.h
+++ b/include/dem/gear3_integrator.h
@@ -17,10 +17,10 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_solver_parameters.h>
 #include <dem/integrator.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
 

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -17,6 +17,9 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/dem_properties.h>
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/data_out_base.h>
 
@@ -33,8 +36,6 @@
 #include <deal.II/particles/particle_iterator.h>
 #include <deal.II/particles/property_pool.h>
 
-#include <dem/dem_properties.h>
-#include <dem/dem_solver_parameters.h>
 #include <math.h>
 
 #include <fstream>

--- a/include/dem/integrator.h
+++ b/include/dem/integrator.h
@@ -17,9 +17,9 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_solver_parameters.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
 

--- a/include/dem/non_uniform_insertion.h
+++ b/include/dem/non_uniform_insertion.h
@@ -17,12 +17,12 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/dem_solver_parameters.h>
+#include <dem/insertion.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/particles/particle_handler.h>
-
-#include <dem/dem_solver_parameters.h>
-#include <dem/insertion.h>
 
 #ifndef nonuniform_insertion_h
 #  define nonuniform_insertion_h

--- a/include/dem/particle_point_line_fine_search.h
+++ b/include/dem/particle_point_line_fine_search.h
@@ -17,10 +17,10 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_properties.h>
 #include <dem/particle_point_line_contact_info_struct.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 #include <iostream>
 #include <vector>

--- a/include/dem/pp_broad_search.h
+++ b/include/dem/pp_broad_search.h
@@ -16,6 +16,8 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
+#include <dem/pp_contact_info_struct.h>
+
 #include <deal.II/base/timer.h>
 
 #include <deal.II/distributed/tria.h>
@@ -23,8 +25,6 @@
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/particles/particle_iterator.h>
-
-#include <dem/pp_contact_info_struct.h>
 
 #include <iostream>
 #include <vector>

--- a/include/dem/pp_contact_force.h
+++ b/include/dem/pp_contact_force.h
@@ -17,13 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
-#include <boost/range/adaptor/map.hpp>
-
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/pp_contact_info_struct.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include <boost/range/adaptor/map.hpp>
 
 using namespace dealii;
 

--- a/include/dem/pp_fine_search.h
+++ b/include/dem/pp_fine_search.h
@@ -17,15 +17,15 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/dem_properties.h>
+#include <dem/pp_contact_info_struct.h>
+
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/particle_handler.h>
 
 #include <boost/range/adaptor/map.hpp>
-
-#include <dem/dem_properties.h>
-#include <dem/pp_contact_info_struct.h>
 
 #include <iostream>
 #include <vector>

--- a/include/dem/pp_linear_force.h
+++ b/include/dem/pp_linear_force.h
@@ -17,12 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle.h>
-#include <deal.II/particles/particle_iterator.h>
-
 #include <dem/dem_solver_parameters.h>
 #include <dem/pp_contact_force.h>
 #include <dem/pp_contact_info_struct.h>
+
+#include <deal.II/particles/particle.h>
+#include <deal.II/particles/particle_iterator.h>
+
 #include <math.h>
 
 #include <iostream>

--- a/include/dem/pp_nonlinear_force.h
+++ b/include/dem/pp_nonlinear_force.h
@@ -17,12 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle.h>
-#include <deal.II/particles/particle_iterator.h>
-
 #include <dem/dem_solver_parameters.h>
 #include <dem/pp_contact_force.h>
 #include <dem/pp_contact_info_struct.h>
+
+#include <deal.II/particles/particle.h>
+#include <deal.II/particles/particle_iterator.h>
+
 #include <math.h>
 
 #include <iostream>

--- a/include/dem/pw_broad_search.h
+++ b/include/dem/pw_broad_search.h
@@ -17,14 +17,14 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/boundary_cells_info_struct.h>
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/particles/particle_iterator.h>
-
-#include <dem/boundary_cells_info_struct.h>
-#include <dem/dem_solver_parameters.h>
 
 #include <iostream>
 #include <vector>

--- a/include/dem/pw_contact_force.h
+++ b/include/dem/pw_contact_force.h
@@ -16,12 +16,13 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
-#include <boost/math/special_functions.hpp>
-#include <boost/range/adaptor/map.hpp>
-
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/pw_contact_info_struct.h>
+
+#include <boost/math/special_functions.hpp>
+#include <boost/range/adaptor/map.hpp>
+
 #include <math.h>
 
 #include <iostream>

--- a/include/dem/pw_fine_search.h
+++ b/include/dem/pw_fine_search.h
@@ -17,13 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle.h>
-#include <deal.II/particles/particle_handler.h>
-#include <deal.II/particles/particle_iterator.h>
-
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/pw_contact_info_struct.h>
+
+#include <deal.II/particles/particle.h>
+#include <deal.II/particles/particle_handler.h>
+#include <deal.II/particles/particle_iterator.h>
 
 #include <iostream>
 #include <vector>

--- a/include/dem/pw_linear_force.h
+++ b/include/dem/pw_linear_force.h
@@ -17,12 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle.h>
-
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/pw_contact_force.h>
 #include <dem/pw_contact_info_struct.h>
+
+#include <deal.II/particles/particle.h>
+
 #include <math.h>
 
 #include <iostream>

--- a/include/dem/pw_nonlinear_force.h
+++ b/include/dem/pw_nonlinear_force.h
@@ -17,12 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle.h>
-
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/pw_contact_force.h>
 #include <dem/pw_contact_info_struct.h>
+
+#include <deal.II/particles/particle.h>
+
 #include <math.h>
 
 #include <iostream>

--- a/include/dem/read_checkpoint.h
+++ b/include/dem/read_checkpoint.h
@@ -17,6 +17,10 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/pvd_handler.h>
+
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/base/timer.h>
 
 #include <deal.II/distributed/tria.h>
@@ -25,9 +29,6 @@
 
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
-
-#include <core/pvd_handler.h>
-#include <dem/dem_solver_parameters.h>
 
 #include <fstream>
 #include <iostream>

--- a/include/dem/read_mesh.h
+++ b/include/dem/read_mesh.h
@@ -17,13 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
-
-#include <dem/dem_solver_parameters.h>
 
 #include <fstream>
 #include <iostream>

--- a/include/dem/uniform_insertion.h
+++ b/include/dem/uniform_insertion.h
@@ -17,13 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/distributed/tria.h>
-
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/insertion.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 #ifndef uniform_insertion_h
 #  define uniform_insertion_h

--- a/include/dem/velocity_verlet_integrator.h
+++ b/include/dem/velocity_verlet_integrator.h
@@ -17,10 +17,10 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_solver_parameters.h>
 #include <dem/integrator.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
 

--- a/include/dem/visualization.h
+++ b/include/dem/visualization.h
@@ -17,13 +17,13 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/dem_properties.h>
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/base/data_out_base.h>
 
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/particle_handler.h>
-
-#include <dem/dem_properties.h>
-#include <dem/dem_solver_parameters.h>
 
 #include <tuple>
 #include <vector>

--- a/include/dem/write_checkpoint.h
+++ b/include/dem/write_checkpoint.h
@@ -17,6 +17,10 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/pvd_handler.h>
+
+#include <dem/dem_solver_parameters.h>
+
 #include <deal.II/base/timer.h>
 
 #include <deal.II/distributed/tria.h>
@@ -25,9 +29,6 @@
 
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
-
-#include <core/pvd_handler.h>
-#include <dem/dem_solver_parameters.h>
 
 #include <fstream>
 #include <iostream>

--- a/include/fem-dem/gls_vans.h
+++ b/include/fem-dem/gls_vans.h
@@ -20,6 +20,19 @@
 #ifndef lethe_gls_vans_h
 #define lethe_gls_vans_h
 
+#include "core/bdf.h"
+#include "core/grids.h"
+#include "core/manifolds.h"
+#include "core/time_integration_utilities.h"
+#include <core/grids.h>
+#include <core/parameters.h>
+#include <core/parameters_cfd_dem.h>
+
+#include "solvers/gls_navier_stokes.h"
+
+#include <dem/dem.h>
+#include <dem/dem_properties.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/fe/mapping_q.h>
@@ -29,18 +42,6 @@
 
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
-
-#include <core/grids.h>
-#include <core/parameters.h>
-#include <core/parameters_cfd_dem.h>
-#include <dem/dem.h>
-#include <dem/dem_properties.h>
-
-#include "core/bdf.h"
-#include "core/grids.h"
-#include "core/manifolds.h"
-#include "core/time_integration_utilities.h"
-#include "solvers/gls_navier_stokes.h"
 
 
 

--- a/include/solvers/analytical_solutions.h
+++ b/include/solvers/analytical_solutions.h
@@ -23,10 +23,10 @@
 #ifndef LETHE_ANALYTICALSOLUTIONS_H
 #define LETHE_ANALYTICALSOLUTIONS_H
 
+#include <core/parameters.h>
+
 #include <deal.II/base/function.h>
 #include <deal.II/base/parsed_function.h>
-
-#include <core/parameters.h>
 
 using namespace dealii;
 /**

--- a/include/solvers/analytical_solutions.h
+++ b/include/solvers/analytical_solutions.h
@@ -20,8 +20,8 @@
 // TODO : Refactor so the class itself is not a pointer, but contains a pointer
 //        to a function. This would be a lot more coherent...
 
-#ifndef LETHE_ANALYTICALSOLUTIONS_H
-#define LETHE_ANALYTICALSOLUTIONS_H
+#ifndef lethe_analytical_solutions_h
+#define lethe_analytical_solutions_h
 
 #include <core/parameters.h>
 

--- a/include/solvers/auxiliary_physics.h
+++ b/include/solvers/auxiliary_physics.h
@@ -20,13 +20,14 @@
 #ifndef lethe_auxiliary_physics_h
 #define lethe_auxiliary_physics_h
 
+#include <core/parameters.h>
+#include <core/physics_solver.h>
+
+#include <solvers/simulation_parameters.h>
+
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/numerics/data_out.h>
-
-#include <core/parameters.h>
-#include <core/physics_solver.h>
-#include <solvers/simulation_parameters.h>
 
 
 /**

--- a/include/solvers/auxiliary_physics.h
+++ b/include/solvers/auxiliary_physics.h
@@ -25,7 +25,7 @@
 
 #include <solvers/simulation_parameters.h>
 
-#include <deal.II/distributed/tria_base.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/numerics/data_out.h>
 

--- a/include/solvers/flow_control.h
+++ b/include/solvers/flow_control.h
@@ -17,21 +17,20 @@
  * Author: Audrey Collard-Daigneault, Polytechnique Montreal, 2020 -
  */
 
-// Base
-#include <deal.II/base/tensor.h>
-
-// Dofs
-#include <deal.II/dofs/dof_handler.h>
-
-// Fe
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/fe/mapping_q.h>
+#ifndef lethe_flow_control_h
+#define lethe_flow_control_h
 
 // Lethe includes
 #include <core/parameters.h>
 
-#ifndef lethe_flow_control_h
-#  define lethe_flow_control_h
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
+
+
 
 using namespace dealii;
 

--- a/include/solvers/free_surface.h
+++ b/include/solvers/free_surface.h
@@ -25,6 +25,12 @@
 #ifndef lethe_free_surface_h
 #define lethe_free_surface_h
 
+#include <core/bdf.h>
+#include <core/simulation_control.h>
+
+#include <solvers/auxiliary_physics.h>
+#include <solvers/multiphysics_interface.h>
+
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -38,11 +44,6 @@
 
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
-
-#include <core/bdf.h>
-#include <core/simulation_control.h>
-#include <solvers/auxiliary_physics.h>
-#include <solvers/multiphysics_interface.h>
 
 
 template <int dim>

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -21,6 +21,11 @@
 #define lethe_gd_navier_stokes_h
 
 #include <deal.II/lac/precondition_block.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_ilu.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_precondition.h>

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -20,11 +20,15 @@
 #ifndef lethe_gd_navier_stokes_h
 #define lethe_gd_navier_stokes_h
 
-#include "core/bdf.h"
-
+#include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
 
 #include "navier_stokes_base.h"
+
+
 
 using namespace dealii;
 

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -20,9 +20,10 @@
 #ifndef lethe_gd_navier_stokes_h
 #define lethe_gd_navier_stokes_h
 
+#include "core/bdf.h"
+
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 
-#include "core/bdf.h"
 #include "navier_stokes_base.h"
 
 using namespace dealii;

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -22,6 +22,7 @@
 
 #include <solvers/navier_stokes_base.h>
 
+#include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_solver.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -20,7 +20,14 @@
 #ifndef lethe_gls_navier_stokes_h
 #define lethe_gls_navier_stokes_h
 
-#include "navier_stokes_base.h"
+#include <solvers/navier_stokes_base.h>
+
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+
 
 using namespace dealii;
 

--- a/include/solvers/gls_nitsche_navier_stokes.h
+++ b/include/solvers/gls_nitsche_navier_stokes.h
@@ -21,9 +21,9 @@
 #ifndef lethe_gls_nitsche_navier_stokes_h
 #define lethe_gls_nitsche_navier_stokes_h
 
-#include <deal.II/lac/trilinos_vector.h>
-
 #include <core/solid_base.h>
+
+#include <deal.II/lac/trilinos_vector.h>
 
 #include "gls_navier_stokes.h"
 

--- a/include/solvers/gls_sharp_navier_stokes.h
+++ b/include/solvers/gls_sharp_navier_stokes.h
@@ -25,6 +25,8 @@
 
 #include <solvers/gls_navier_stokes.h>
 
+#include <deal.II/dofs/dof_tools.h>
+
 using namespace dealii;
 
 /**

--- a/include/solvers/gls_sharp_navier_stokes.h
+++ b/include/solvers/gls_sharp_navier_stokes.h
@@ -22,6 +22,7 @@
 
 #include <core/ib_particle.h>
 #include <core/ib_stencil.h>
+
 #include <solvers/gls_navier_stokes.h>
 
 using namespace dealii;

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -25,6 +25,12 @@
 #ifndef lethe_heat_transfer_h
 #define lethe_heat_transfer_h
 
+#include <core/bdf.h>
+#include <core/simulation_control.h>
+
+#include <solvers/auxiliary_physics.h>
+#include <solvers/multiphysics_interface.h>
+
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -38,11 +44,6 @@
 
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
-
-#include <core/bdf.h>
-#include <core/simulation_control.h>
-#include <solvers/auxiliary_physics.h>
-#include <solvers/multiphysics_interface.h>
 
 
 template <int dim>

--- a/include/solvers/initial_conditions.h
+++ b/include/solvers/initial_conditions.h
@@ -26,9 +26,6 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/parsed_function.h>
 
-// TODO : Refactor so the class itself is not a pointer, but contains a pointer
-//        to a function. This would be a lot more coherent...
-
 using namespace dealii;
 
 namespace Parameters

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -24,6 +24,13 @@
 #ifndef lethe_multiphysics_interface_h
 #define lethe_multiphysics_interface_h
 
+#include <core/multiphysics.h>
+#include <core/parameters_multiphysics.h>
+#include <core/simulation_control.h>
+
+#include <solvers/auxiliary_physics.h>
+#include <solvers/simulation_parameters.h>
+
 #include <deal.II/base/exceptions.h>
 
 #include <deal.II/distributed/tria_base.h>
@@ -32,12 +39,6 @@
 
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
-
-#include <core/multiphysics.h>
-#include <core/parameters_multiphysics.h>
-#include <core/simulation_control.h>
-#include <solvers/auxiliary_physics.h>
-#include <solvers/simulation_parameters.h>
 
 #include <map>
 #include <memory>

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -20,6 +20,24 @@
 #ifndef lethe_navier_stokes_base_h
 #define lethe_navier_stokes_base_h
 
+
+// Lethe Includes
+#include <core/bdf.h>
+#include <core/boundary_conditions.h>
+#include <core/manifolds.h>
+#include <core/newton_non_linear_solver.h>
+#include <core/parameters.h>
+#include <core/physics_solver.h>
+#include <core/pvd_handler.h>
+#include <core/simulation_control.h>
+
+#include <solvers/flow_control.h>
+#include <solvers/multiphysics_interface.h>
+#include <solvers/post_processors.h>
+#include <solvers/postprocessing_cfd.h>
+#include <solvers/postprocessing_velocities.h>
+#include <solvers/simulation_parameters.h>
+
 // Dealii Includes
 
 // Base
@@ -36,7 +54,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_gmres.h>
@@ -45,13 +62,6 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/lac/vector.h>
-
-// Lac - Trilinos includes
-#include <deal.II/lac/trilinos_parallel_block_vector.h>
-#include <deal.II/lac/trilinos_precondition.h>
-#include <deal.II/lac/trilinos_solver.h>
-#include <deal.II/lac/trilinos_sparse_matrix.h>
-#include <deal.II/lac/trilinos_vector.h>
 
 // Grid
 #include <deal.II/grid/grid_generator.h>
@@ -80,10 +90,7 @@
 
 // Numerics
 #include <deal.II/numerics/data_out.h>
-#include <deal.II/numerics/error_estimator.h>
-#include <deal.II/numerics/matrix_tools.h>
-#include <deal.II/numerics/solution_transfer.h>
-#include <deal.II/numerics/vector_tools.h>
+
 
 // Distributed
 #include <deal.II/distributed/fully_distributed_tria.h>
@@ -91,23 +98,6 @@
 #include <deal.II/distributed/solution_transfer.h>
 
 
-// Lethe Includes
-#include <core/bdf.h>
-#include <core/boundary_conditions.h>
-#include <core/manifolds.h>
-#include <core/newton_non_linear_solver.h>
-#include <core/parameters.h>
-#include <core/physics_solver.h>
-#include <core/pvd_handler.h>
-#include <core/simulation_control.h>
-
-#include <solvers/flow_control.h>
-#include <solvers/multiphysics_interface.h>
-#include <solvers/postprocessing_cfd.h>
-#include <solvers/postprocessing_velocities.h>
-
-#include "post_processors.h"
-#include "simulation_parameters.h"
 
 // Std
 #include <fstream>

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -100,6 +100,7 @@
 #include <core/physics_solver.h>
 #include <core/pvd_handler.h>
 #include <core/simulation_control.h>
+
 #include <solvers/flow_control.h>
 #include <solvers/multiphysics_interface.h>
 #include <solvers/postprocessing_cfd.h>

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -22,10 +22,6 @@
 
 
 // Lethe Includes
-#include <core/bdf.h>
-#include <core/boundary_conditions.h>
-#include <core/manifolds.h>
-#include <core/newton_non_linear_solver.h>
 #include <core/parameters.h>
 #include <core/physics_solver.h>
 #include <core/pvd_handler.h>
@@ -34,68 +30,34 @@
 #include <solvers/flow_control.h>
 #include <solvers/multiphysics_interface.h>
 #include <solvers/post_processors.h>
-#include <solvers/postprocessing_cfd.h>
 #include <solvers/postprocessing_velocities.h>
 #include <solvers/simulation_parameters.h>
 
 // Dealii Includes
-
-// Base
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/index_set.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/timer.h>
-#include <deal.II/base/utilities.h>
 
-// Lac
-#include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/solver_bicgstab.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/sparse_direct.h>
-#include <deal.II/lac/sparse_ilu.h>
-#include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparsity_tools.h>
-#include <deal.II/lac/vector.h>
-
-// Grid
-#include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/grid_in.h>
-#include <deal.II/grid/grid_out.h>
-#include <deal.II/grid/grid_refinement.h>
-#include <deal.II/grid/grid_tools.h>
-#include <deal.II/grid/manifold_lib.h>
-#include <deal.II/grid/tria.h>
-#include <deal.II/grid/tria_accessor.h>
-#include <deal.II/grid/tria_iterator.h>
-
-// Dofs
-#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>
-#include <deal.II/dofs/dof_renumbering.h>
-#include <deal.II/dofs/dof_tools.h>
 
-// Fe
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_system.h>
-#include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_fe.h>
 #include <deal.II/fe/mapping_q.h>
 
-// Numerics
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_refinement.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
 #include <deal.II/numerics/data_out.h>
-
-
-// Distributed
-#include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 
 
 

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -43,27 +43,15 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/fe/fe_q.h>
-#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_fe.h>
-#include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_out.h>
-#include <deal.II/grid/grid_refinement.h>
 
 #include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>
-
-
-
-// Std
-#include <fstream>
-#include <iostream>
 
 using namespace dealii;
 

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -49,7 +49,6 @@
 #include <deal.II/grid/grid_out.h>
 
 #include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/sparse_matrix.h>
 
 #include <deal.II/numerics/data_out.h>
 

--- a/include/solvers/post_processors.h
+++ b/include/solvers/post_processors.h
@@ -6,9 +6,6 @@
 // Base
 #include <deal.II/base/tensor.h>
 
-// Lac
-#include <deal.II/lac/vector.h>
-
 // Numerics
 #include <deal.II/numerics/data_postprocessor.h>
 

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -30,15 +30,11 @@
 #  include <deal.II/lac/vector.h>
 
 // Dofs
-#  include <deal.II/dofs/dof_accessor.h>
 #  include <deal.II/dofs/dof_handler.h>
 
 // Fe
-#  include <deal.II/fe/fe_q.h>
-#  include <deal.II/fe/fe_system.h>
-#  include <deal.II/fe/fe_values.h>
+#  include <deal.II/fe/fe.h>
 #  include <deal.II/fe/mapping_fe.h>
-#  include <deal.II/fe/mapping_q.h>
 
 // Lethe includes
 #  include <core/boundary_conditions.h>

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -22,14 +22,14 @@
 
 #include <core/boundary_conditions.h>
 #include <core/manifolds.h>
+#include <core/nitsche.h>
 #include <core/parameters.h>
 #include <core/parameters_cfd_dem.h>
 #include <core/parameters_multiphysics.h>
 
-#include "analytical_solutions.h"
-#include "initial_conditions.h"
-#include "nitsche.h"
-#include "source_terms.h"
+#include <solvers/analytical_solutions.h>
+#include <solvers/initial_conditions.h>
+#include <solvers/source_terms.h>
 
 template <int dim>
 class SimulationParameters

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -25,6 +25,12 @@
 #ifndef lethe_tracer_h
 #define lethe_tracer_h
 
+#include <core/bdf.h>
+#include <core/simulation_control.h>
+
+#include <solvers/auxiliary_physics.h>
+#include <solvers/multiphysics_interface.h>
+
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -38,11 +44,6 @@
 
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
-
-#include <core/bdf.h>
-#include <core/simulation_control.h>
-#include <solvers/auxiliary_physics.h>
-#include <solvers/multiphysics_interface.h>
 
 
 template <int dim>

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -1,11 +1,13 @@
+
+// Lethe includes
+#include <core/boundary_conditions.h>
+#include <core/grids.h>
+#include <core/periodic_hills_grid.h>
+
 // Deal.II includes
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
-// Lethe includes
-#include "core/boundary_conditions.h"
-#include "core/grids.h"
-#include "core/periodic_hills_grid.h"
 
 // Std
 #include <fstream>

--- a/source/core/ib_stencil.cc
+++ b/source/core/ib_stencil.cc
@@ -1,9 +1,4 @@
-//
-// Created by lucka on 2021-05-21.
-//
-
 #include <core/ib_stencil.h>
-
 
 
 template <int dim>

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -1,14 +1,12 @@
+#include <core/manifolds.h>
+
 // Dealii Includes
-// Base
 #include <deal.II/base/point.h>
 
-// Grid
 #include <deal.II/grid/manifold_lib.h>
 
 #include <deal.II/opencascade/manifold_lib.h>
 #include <deal.II/opencascade/utilities.h>
-
-#include "core/manifolds.h"
 
 namespace Parameters
 {

--- a/source/core/nitsche.cc
+++ b/source/core/nitsche.cc
@@ -17,7 +17,7 @@
  * Author: Carole-Anne Daunais, Polytechnique Montreal, 2020 -
  */
 
-#include "solvers/nitsche.h"
+#include <core/nitsche.h>
 
 namespace Parameters
 {

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -1,7 +1,7 @@
 
-#include <deal.II/base/parameter_handler.h>
-
 #include <core/parameters_multiphysics.h>
+
+#include <deal.II/base/parameter_handler.h>
 
 
 

--- a/source/core/sdirk.cc
+++ b/source/core/sdirk.cc
@@ -1,6 +1,6 @@
-#include <deal.II/lac/full_matrix.h>
-
 #include <core/sdirk.h>
+
+#include <deal.II/lac/full_matrix.h>
 
 // Matrix of coefficients for the SDIRK methods
 // The lines store the information required for each step

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -3,8 +3,6 @@
 #include <cfloat>
 #include <fstream>
 
-#include "core/parameters.h"
-
 
 SimulationControl::SimulationControl(Parameters::SimulationControl param)
   : method(param.method)

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -39,6 +39,8 @@
 
 #include <memory.h>
 
+#include <fstream>
+
 
 
 template <int dim, int spacedim>

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -16,12 +16,15 @@
  *
  * Author: Carole-Anne Daunais, Valérie Bibeau, Polytechnique Montreal, 2020-
  */
+
+
+#include <core/solid_base.h>
+
 #include <deal.II/base/bounding_box.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/fe/fe.h>
-#include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/grid/filtered_iterator.h>
@@ -35,9 +38,6 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 
-#include <core/grids.h>
-#include <core/parameters.h>
-#include <core/solid_base.h>
 #include <memory.h>
 
 

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -26,12 +26,11 @@
 
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping.h>
 
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
-
-#include <deal.II/lac/trilinos_vector.h>
 
 #include <deal.II/particles/data_out.h>
 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -16,13 +16,14 @@
  *
  * Author: Bruno Blais, Shahab Golshan, Polytechnique Montreal, 2019-
  */
+#include <core/solutions_output.h>
+
+#include <dem/dem.h>
+
 #include <deal.II/fe/mapping_q_generic.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
-
-#include <core/solutions_output.h>
-#include <dem/dem.h>
 
 template <int dim>
 DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1,4 +1,7 @@
-#include "fem-dem/gls_vans.h"
+#include <fem-dem/gls_vans.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
 
 // Constructor for class GLS_VANS
 template <int dim>

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1,5 +1,7 @@
 #include <fem-dem/gls_vans.h>
 
+#include <deal.II/dofs/dof_tools.h>
+
 #include <deal.II/numerics/vector_tools.h>
 
 

--- a/source/solvers/analytical_solutions.cc
+++ b/source/solvers/analytical_solutions.cc
@@ -17,7 +17,7 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include "solvers/analytical_solutions.h"
+#include <solvers/analytical_solutions.h>
 
 namespace AnalyticalSolutions
 {

--- a/source/solvers/free_surface.cc
+++ b/source/solvers/free_surface.cc
@@ -1,3 +1,10 @@
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+
+#include <solvers/free_surface.h>
+
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>
 
@@ -12,12 +19,6 @@
 #include <deal.II/lac/trilinos_solver.h>
 
 #include <deal.II/numerics/vector_tools.h>
-
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-#include <solvers/free_surface.h>
 
 
 template <int dim>

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -29,6 +29,8 @@
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/lac/full_matrix.h>
+
 #include <deal.II/numerics/vector_tools.h>
 
 

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -27,6 +27,7 @@
 #include <solvers/gd_navier_stokes.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/numerics/vector_tools.h>
 

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -17,14 +17,20 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include "solvers/gd_navier_stokes.h"
+#include <core/bdf.h>
+#include <core/grids.h>
+#include <core/manifolds.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
 
-#include "core/bdf.h"
-#include "core/grids.h"
-#include "core/manifolds.h"
-#include "core/sdirk.h"
-#include "core/time_integration_utilities.h"
-#include "core/utilities.h"
+#include <solvers/gd_navier_stokes.h>
+
+#include <deal.II/dofs/dof_renumbering.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+
 
 // Constructor for class GDNavierStokesSolver
 template <int dim>

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -17,15 +17,21 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include "solvers/gls_navier_stokes.h"
-
-#include "core/bdf.h"
-#include "core/grids.h"
-#include "core/manifolds.h"
-#include "core/multiphysics.h"
-#include "core/sdirk.h"
-#include "core/time_integration_utilities.h"
+#include <core/bdf.h>
+#include <core/grids.h>
+#include <core/manifolds.h>
+#include <core/multiphysics.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
 #include <core/utilities.h>
+
+#include <solvers/gls_navier_stokes.h>
+
+#include <deal.II/dofs/dof_renumbering.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+
 
 // Constructor for class GLSNavierStokesSolver
 template <int dim>

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -30,6 +30,7 @@
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_gmres.h>

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -19,14 +19,13 @@
 
 #include "solvers/gls_navier_stokes.h"
 
-#include <core/utilities.h>
-
 #include "core/bdf.h"
 #include "core/grids.h"
 #include "core/manifolds.h"
 #include "core/multiphysics.h"
 #include "core/sdirk.h"
 #include "core/time_integration_utilities.h"
+#include <core/utilities.h>
 
 // Constructor for class GLSNavierStokesSolver
 template <int dim>

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -28,6 +28,13 @@
 #include <solvers/gls_navier_stokes.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_ilu.h>
 
 #include <deal.II/numerics/vector_tools.h>
 

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -18,15 +18,15 @@
  Montreal, 2020-
  */
 
-#include "solvers/gls_nitsche_navier_stokes.h"
-
-#include "core/bdf.h"
-#include "core/grids.h"
-#include "core/manifolds.h"
-#include "core/sdirk.h"
-#include "core/time_integration_utilities.h"
+#include <core/bdf.h>
+#include <core/grids.h>
+#include <core/manifolds.h>
+#include <core/sdirk.h>
 #include <core/solutions_output.h>
+#include <core/time_integration_utilities.h>
 #include <core/utilities.h>
+
+#include <solvers/gls_nitsche_navier_stokes.h>
 
 #include <deal.II/numerics/fe_field_function.h>
 

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -20,21 +20,20 @@
 
 #include "solvers/gls_nitsche_navier_stokes.h"
 
+#include "core/bdf.h"
+#include "core/grids.h"
+#include "core/manifolds.h"
+#include "core/sdirk.h"
+#include "core/time_integration_utilities.h"
+#include <core/solutions_output.h>
+#include <core/utilities.h>
+
 #include <deal.II/numerics/fe_field_function.h>
 
 #include <deal.II/particles/data_out.h>
 
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
-
-#include <core/solutions_output.h>
-#include <core/utilities.h>
-
-#include "core/bdf.h"
-#include "core/grids.h"
-#include "core/manifolds.h"
-#include "core/sdirk.h"
-#include "core/time_integration_utilities.h"
 
 // Constructor for class GLSNitscheNavierStokesSolver
 template <int dim, int spacedim>

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -17,13 +17,16 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include "solvers/gls_sharp_navier_stokes.h"
+#include <core/bdf.h>
+#include <core/grids.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
 
-#include "core/bdf.h"
-#include "core/grids.h"
-#include "core/sdirk.h"
-#include "core/time_integration_utilities.h"
-#include "core/utilities.h"
+#include <solvers/gls_sharp_navier_stokes.h>
+
+#include <deal.II/grid/grid_tools.h>
+
 
 // Constructor for class GLSNavierStokesSolver
 template <int dim>

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -27,6 +27,9 @@
 
 #include <deal.II/grid/grid_tools.h>
 
+#include <deal.II/lac/full_matrix.h>
+
+
 
 // Constructor for class GLSNavierStokesSolver
 template <int dim>

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1,3 +1,10 @@
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+
+#include <solvers/heat_transfer.h>
+
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>
 
@@ -12,12 +19,6 @@
 #include <deal.II/lac/trilinos_solver.h>
 
 #include <deal.II/numerics/vector_tools.h>
-
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-#include <solvers/heat_transfer.h>
 
 template <int dim>
 void

--- a/source/solvers/initial_conditions.cc
+++ b/source/solvers/initial_conditions.cc
@@ -17,7 +17,7 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
-#include "solvers/initial_conditions.h"
+#include <solvers/initial_conditions.h>
 
 namespace Parameters
 {

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -1,8 +1,7 @@
-#include <solvers/multiphysics_interface.h>
-
 #include "solvers/free_surface.h"
 #include "solvers/heat_transfer.h"
 #include "solvers/tracer.h"
+#include <solvers/multiphysics_interface.h>
 
 
 template <int dim>

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -1,7 +1,7 @@
-#include "solvers/free_surface.h"
-#include "solvers/heat_transfer.h"
-#include "solvers/tracer.h"
+#include <solvers/free_surface.h>
+#include <solvers/heat_transfer.h>
 #include <solvers/multiphysics_interface.h>
+#include <solvers/tracer.h>
 
 
 template <int dim>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -32,6 +32,10 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/numerics/data_out_faces.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/solution_transfer.h>
+#include <deal.II/numerics/vector_tools.h>
 
 #include <deal.II/opencascade/manifold_lib.h>
 #include <deal.II/opencascade/utilities.h>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -17,24 +17,24 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include <deal.II/grid/tria_iterator.h>
-
-#include <deal.II/numerics/data_out_faces.h>
-
-#include <deal.II/opencascade/manifold_lib.h>
-#include <deal.II/opencascade/utilities.h>
-
+#include "core/time_integration_utilities.h"
 #include <core/grids.h>
 #include <core/sdirk.h>
 #include <core/solutions_output.h>
 #include <core/utilities.h>
+
 #include <solvers/flow_control.h>
 #include <solvers/navier_stokes_base.h>
 #include <solvers/post_processors.h>
 #include <solvers/postprocessing_cfd.h>
 #include <solvers/postprocessing_velocities.h>
 
-#include "core/time_integration_utilities.h"
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/numerics/data_out_faces.h>
+
+#include <deal.II/opencascade/manifold_lib.h>
+#include <deal.II/opencascade/utilities.h>
 
 /*
  * Constructor for the Navier-Stokes base class

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -17,10 +17,11 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include "core/time_integration_utilities.h"
+#include <core/bdf.h>
 #include <core/grids.h>
 #include <core/sdirk.h>
 #include <core/solutions_output.h>
+#include <core/time_integration_utilities.h>
 #include <core/utilities.h>
 
 #include <solvers/flow_control.h>
@@ -28,6 +29,9 @@
 #include <solvers/post_processors.h>
 #include <solvers/postprocessing_cfd.h>
 #include <solvers/postprocessing_velocities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/grid_refinement.h>
 
 #include <deal.II/grid/tria_iterator.h>
 
@@ -39,6 +43,7 @@
 
 #include <deal.II/opencascade/manifold_lib.h>
 #include <deal.II/opencascade/utilities.h>
+
 
 /*
  * Constructor for the Navier-Stokes base class

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -33,6 +33,9 @@
 #include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/grid_refinement.h>
 
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/numerics/data_out_faces.h>

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -25,6 +25,7 @@
 // Lethe includes
 #include <core/boundary_conditions.h>
 #include <core/parameters.h>
+
 #include <solvers/postprocessing_cfd.h>
 
 

--- a/source/solvers/simulation_parameters.cc
+++ b/source/solvers/simulation_parameters.cc
@@ -17,7 +17,7 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
-#include "solvers/simulation_parameters.h"
+#include <solvers/simulation_parameters.h>
 
 template class SimulationParameters<2>;
 template class SimulationParameters<3>;

--- a/source/solvers/source_terms.cc
+++ b/source/solvers/source_terms.cc
@@ -17,7 +17,7 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include "solvers/source_terms.h"
+#include <solvers/source_terms.h>
 
 // Pre-compile the 2D and 3D Navier-Stokes solver to ensure that the library is
 // valid before we actually compile the solver This greatly helps with debugging

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1,3 +1,10 @@
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+
+#include <solvers/tracer.h>
+
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>
 
@@ -14,12 +21,6 @@
 #include <deal.II/lac/trilinos_solver.h>
 
 #include <deal.II/numerics/vector_tools.h>
-
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-#include <solvers/tracer.h>
 
 
 template <int dim>

--- a/tests/core/newton_non_linear_solver_01.cc
+++ b/tests/core/newton_non_linear_solver_01.cc
@@ -8,6 +8,7 @@
 
 // Tests (with common definitions)
 #include <../tests/core/non_linear_test_system_01.h>
+
 #include <../tests/tests.h>
 
 void

--- a/tests/core/skip_newton_non_linear_solver_01.cc
+++ b/tests/core/skip_newton_non_linear_solver_01.cc
@@ -8,6 +8,7 @@
 
 // Tests (with common definitions)
 #include <../tests/core/non_linear_test_system_01.h>
+
 #include <../tests/tests.h>
 
 void

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -27,6 +27,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/solid_base.h>
+
 #include <solvers/nitsche.h>
 
 // Tests (with common definitions)

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -25,10 +25,10 @@
 #include <deal.II/particles/data_out.h>
 
 // Lethe
+#include <core/nitsche.h>
 #include <core/parameters.h>
 #include <core/solid_base.h>
 
-#include <solvers/nitsche.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -27,6 +27,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/solid_base.h>
+
 #include <solvers/nitsche.h>
 
 // Tests (with common definitions)

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -25,10 +25,9 @@
 #include <deal.II/particles/data_out.h>
 
 // Lethe
+#include <core/nitsche.h>
 #include <core/parameters.h>
 #include <core/solid_base.h>
-
-#include <solvers/nitsche.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -27,6 +27,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/solid_base.h>
+
 #include <solvers/nitsche.h>
 
 // Tests (with common definitions)

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -25,10 +25,9 @@
 #include <deal.II/particles/data_out.h>
 
 // Lethe
+#include <core/nitsche.h>
 #include <core/parameters.h>
 #include <core/solid_base.h>
-
-#include <solvers/nitsche.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -27,6 +27,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/solid_base.h>
+
 #include <solvers/nitsche.h>
 
 // Tests (with common definitions)

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -25,10 +25,11 @@
 #include <deal.II/particles/data_out.h>
 
 // Lethe
+#include <core/nitsche.h>
 #include <core/parameters.h>
 #include <core/solid_base.h>
 
-#include <solvers/nitsche.h>
+#include <solvers/simulation_parameters.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -30,6 +30,7 @@
 #include <core/parameters.h>
 #include <core/solid_base.h>
 #include <core/solutions_output.h>
+
 #include <solvers/nitsche.h>
 
 // Tests (with common definitions)

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -27,11 +27,13 @@
 #include <deal.II/particles/data_out.h>
 
 // Lethe
+#include <core/nitsche.h>
 #include <core/parameters.h>
 #include <core/solid_base.h>
 #include <core/solutions_output.h>
 
-#include <solvers/nitsche.h>
+#include <solvers/simulation_parameters.h>
+
 
 // Tests (with common definitions)
 #include <../tests/tests.h>

--- a/tests/dem/boundary_cells_and_faces.cc
+++ b/tests/dem/boundary_cells_and_faces.cc
@@ -30,6 +30,7 @@
 
 // Lethe
 #include <core/parameters_lagrangian.h>
+
 #include <dem/find_boundary_cells_information.h>
 
 // Tests

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -22,6 +22,15 @@
  * is calculated after a particle-wall collision
  */
 
+#include <dem/dem_properties.h>
+#include <dem/dem_solver_parameters.h>
+#include <dem/find_boundary_cells_information.h>
+#include <dem/pw_broad_search.h>
+#include <dem/pw_contact_force.h>
+#include <dem/pw_fine_search.h>
+#include <dem/pw_nonlinear_force.h>
+#include <dem/velocity_verlet_integrator.h>
+
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/point.h>
 
@@ -34,15 +43,6 @@
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/particles/particle_iterator.h>
-
-#include <dem/dem_properties.h>
-#include <dem/dem_solver_parameters.h>
-#include <dem/find_boundary_cells_information.h>
-#include <dem/pw_broad_search.h>
-#include <dem/pw_contact_force.h>
-#include <dem/pw_fine_search.h>
-#include <dem/pw_nonlinear_force.h>
-#include <dem/velocity_verlet_integrator.h>
 
 #include <iostream>
 #include <vector>

--- a/tests/solvers/average_velocities_01.cc
+++ b/tests/solvers/average_velocities_01.cc
@@ -36,6 +36,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/simulation_control.h>
+
 #include <solvers/postprocessing_velocities.h>
 
 // Tests

--- a/tests/solvers/average_velocities_02.cc
+++ b/tests/solvers/average_velocities_02.cc
@@ -38,6 +38,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/simulation_control.h>
+
 #include <solvers/postprocessing_velocities.h>
 
 // Tests

--- a/tests/solvers/flow_control_01.cc
+++ b/tests/solvers/flow_control_01.cc
@@ -24,6 +24,7 @@
 
 // Lethe
 #include <core/parameters.h>
+
 #include <solvers/flow_control.h>
 
 // Tests

--- a/tests/solvers/multiphysics_interface_01.cc
+++ b/tests/solvers/multiphysics_interface_01.cc
@@ -26,6 +26,7 @@
 #include <core/multiphysics.h>
 #include <core/parameters.h>
 #include <core/simulation_control.h>
+
 #include <solvers/multiphysics_interface.h>
 #include <solvers/simulation_parameters.h>
 

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -2,16 +2,21 @@
  * @brief This code checks the read and write of simulationcontrol.
  */
 
+// Lethe
+#include <core/parameters.h>
+
+#include <solvers/gls_navier_stokes.h>
+#include <solvers/postprocessing_cfd.h>
+#include <solvers/simulation_parameters.h>
+
+
 // Deal.II includes
 #include <deal.II/base/function.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/types.h>
 
-// Lethe
-#include <core/parameters.h>
+#include <deal.II/grid/grid_generator.h>
 
-#include <solvers/gls_navier_stokes.h>
-#include <solvers/simulation_parameters.h>
 
 // Tests
 #include <../tests/tests.h>

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -9,6 +9,7 @@
 
 // Lethe
 #include <core/parameters.h>
+
 #include <solvers/gls_navier_stokes.h>
 #include <solvers/simulation_parameters.h>
 

--- a/tests/solvers/reynolds_stress_01.cc
+++ b/tests/solvers/reynolds_stress_01.cc
@@ -38,6 +38,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/simulation_control.h>
+
 #include <solvers/postprocessing_velocities.h>
 
 // Tests

--- a/tests/solvers/reynolds_stress_02.cc
+++ b/tests/solvers/reynolds_stress_02.cc
@@ -38,6 +38,7 @@
 // Lethe
 #include <core/parameters.h>
 #include <core/simulation_control.h>
+
 #include <solvers/postprocessing_velocities.h>
 
 // Tests


### PR DESCRIPTION
Clean the majority of the header files in the code to minimise include statements.
Adjust the clang format file to prioritise lethe files.