### PR TITLE
CI trigger improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,17 @@
 name: CI
 
 on:
-  # Runs on every push. If a push contains multiple commits, it will be ran on the latest one.
+  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
+    branches:    
+      # Push events on master branch
+      - master
   # Runs the workflow when a PR is opened or syncronized (new commit). Covers PRs from forks.
   # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
   pull_request_target:
+    branches:    
+      # Pull request events targetting master branch
+      - master
 
 env:
   COMPILE_JOBS: 2
@@ -14,10 +20,6 @@ jobs:
   build:
     name: Build (${{ matrix.build_type }}-deal.ii:${{ matrix.dealii_version }})
     runs-on: ubuntu-latest
-    
-    # Cancels out jobs with the same concurrency label to avoid duplicates caused by the push and pull_request trigger
-    # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
-    concurrency: build-${{ github.ref }}
 
     strategy:
       fail-fast: false
@@ -42,7 +44,6 @@ jobs:
 
           echo "Github actions is sane!"
           echo "Running ${{ matrix.build_type }} build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
-
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,14 @@ jobs:
           echo "Github actions is sane!"
           echo "Running ${{ matrix.build_type }} build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
 
+      # Only on PR
+      - uses: actions/first-interaction@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: 'Hello, thanks for opening your first issue. Welcome you to Lethe community!'
+          pr-message: 'Hello, thanks for opening your first Pull Request and taking the time to improve Lethe.'
+
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   # Runs on every push. If a push contains multiple commits, it will be ran on the latest one.
   push:
+  # Runs the workflow when a PR is opened or syncronized (new commit). Covers PRs from forks.
+  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
 
 env:
   COMPILE_JOBS: 2
@@ -11,6 +14,10 @@ jobs:
   build:
     name: Build (${{ matrix.build_type }}-deal.ii:${{ matrix.dealii_version }})
     runs-on: ubuntu-latest
+    
+    # Cancels out jobs with the same concurrency label to avoid duplicates caused by the push and pull_request trigger
+    # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+    concurrency: build-${{ github.ref }}
 
     strategy:
       fail-fast: false
@@ -38,7 +45,8 @@ jobs:
 
 
       # Checks-out Lethe with branch of triggering commit
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Compile Lethe (${{ matrix.build_type }}-deal.ii:${{ matrix.dealii_version }})
         run: |


### PR DESCRIPTION
The CI now triggers on every commit in a pull request targeting the `master` branch + every new commit in `master`. `pull_request_target` event runs the CI on the proposed code whilst using the main Lethe repo's workflows.

I also added the first-interaction action on PRs as proposed by #184 .