### PR TITLE
Running ctest with parallel jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   COMPILE_JOBS: 2
+  MULTI_CORE_TESTS_REGEX: "mpirun=2"
 
 jobs:
   build:
@@ -56,11 +57,24 @@ jobs:
           cmake ../ -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           make -j${{ env.COMPILE_JOBS }}
 
+      # These tests require a single core each so we will run them in parallel
       - name: Run Lethe tests (${{ matrix.build_type }}-deal.ii:${{ matrix.dealii_version }})
         run: |
           cd build
-          ctest -V -j${{ env.COMPILE_JOBS }}
-
+          # Print the tests to be executed
+          ctest -N --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          # Run in parallel
+          ctest -V -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+      
+      # These tests require two cores each so we will run them sequencially
+      - name: Run multi-core Lethe tests (${{ matrix.build_type }}-deal.ii:${{ matrix.dealii_version }})
+        run: |
+          cd build
+          # Print the tests to be executed
+          ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          # Run sequencially
+          ctest -V --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          
   #formatting:
     #runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run Lethe tests (${{ matrix.build_type }}-deal.ii:${{ matrix.dealii_version }})
         run: |
           cd build
-          ctest -V
+          ctest -V -j${{ env.COMPILE_JOBS }}
 
   #formatting:
     #runs-on: ubuntu-latest


### PR DESCRIPTION
Since we have 2 CPUs available in Github-provided runners, I though it may be beneficial to run Lethe tests in parallel. With two tests suites ran in parallel, the « Run Lethe tests » step is executed in (almost) **half the time**: twice the cores, half the time! I have to mention that verbose logging may be harder to read when two tests are executed at the same time, but ctest prints enough info to piece everything together.

|      Build Type (1)      | Parallel (2) | Sequential (3) |
|-----------------------|------------|-------------|
| Debug-dealii-master   | 8m 20s     | 16m 50s     |
| Debug-dealii-v9.3.0   | 8m 18s     | 17m 11s     |
| Release-dealii-master | 69m 08s    | 107m 17s    |
| Release-dealii-v9.3.0 | 54m 55s    | 81m 25s     |

(1) Commit 6bbebf
(2) https://github.com/technophil98/lethe/runs/2985108214
(3) https://github.com/lethe-cfd/lethe/runs/2952152517