### PR TITLE
Add std::flush to print_xyz function

### DIFF
--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -117,8 +117,9 @@ BoundaryCellsInformation<dim>::find_boundary_cells_information(
                           // Storing these information into the
                           // boundary_cells_info_struct
                           boundary_cells_info_struct<dim> boundary_information;
-                          boundary_information.cell        = cell;
-                          boundary_information.boundary_id = cell->face(face_id)->boundary_id();
+                          boundary_information.cell = cell;
+                          boundary_information.boundary_id =
+                            cell->face(face_id)->boundary_id();
                           boundary_information.global_face_id =
                             cell->face_index(face_id);
                           boundary_information.normal_vector = normal_vector;

--- a/source/dem/visualization.cc
+++ b/source/dem/visualization.cc
@@ -94,6 +94,7 @@ Visualization<dim>::print_xyz(
     }
 
   pcout << "id, type, dp, x, y, z " << std::endl;
+  std::flush(std::cout);
 
   for (auto &iterator : local_particles)
     {
@@ -108,6 +109,7 @@ Visualization<dim>::print_xyz(
                 << std::setprecision(5)
                 << particle_properties[DEM::PropertiesIndex::dp] << " "
                 << std::setprecision(4) << particle_location << std::endl;
+      std::flush(std::cout);
     }
 }
 


### PR DESCRIPTION
DEM application tests use print_xyz function to print and compare the outputs at the end of the test simulations.
Sometimes, the order of processes writing particles' info using this function mixes up, which leads to failed tests.
This PR uses std::flush in print_xyz function, in order to avoid buffering in std::cout and write the header and particles' info in order.