### PR TITLE
Add grid rotation in box example

### DIFF
--- a/examples/dem/3d_grid_rotation_in_box/README
+++ b/examples/dem/3d_grid_rotation_in_box/README
@@ -1,0 +1,4 @@
+grid rotation in box tutorial
+This example can be solved using the dem_3d solver
+A description of the test case can be found at the following link :
+https://github.com/lethe-cfd/lethe/wiki/Example-15-:-Rotation-in-Box

--- a/examples/dem/3d_grid_rotation_in_box/grid_rotation_box.prm
+++ b/examples/dem/3d_grid_rotation_in_box/grid_rotation_box.prm
@@ -1,0 +1,101 @@
+# Listing of Parameters
+# ---------------------
+# --------------------------------------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set time step                 			 = 1e-5
+  set time end       					 = 5
+  set log frequency				         = 1000
+  set output frequency            			 = 1000
+end
+
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+subsection timer
+    set type    					 = none
+end
+
+#---------------------------------------------------
+# Test
+#---------------------------------------------------
+subsection test
+    set enable 						 = false
+end
+
+# --------------------------------------------------
+# Model parameters
+#---------------------------------------------------
+subsection model parameters
+  set contact detection method 		   		 = dynamic
+  set dynamic contact search size coefficient	 	 = 0.9
+  set neighborhood threshold				 = 1.3
+  set particle particle contact force method             = pp_nonlinear
+  set particle wall contact force method                 = pw_nonlinear
+  set rolling resistance torque method			 = constant_resistance
+  set integration method				 = velocity_verlet
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+    set gx            		 			= 0.0
+    set gy            		 			= 0.0
+    set gz						= -9.81
+    set number of particle types	                = 1
+    	subsection particle type 0
+		set size distribution type		= uniform
+    		set diameter            	 	= 0.001
+    		set number				= 4000
+    		set density particles	 		= 1000
+    		set young modulus particles         	= 1000000
+    		set poisson ratio particles          	= 0.3
+    		set restitution coefficient particles	= 0.3
+    		set friction coefficient particles      = 0.1
+    		set rolling friction particles         	= 0.05
+	end
+    set young modulus wall            			= 1000000
+    set poisson ratio wall            			= 0.3
+    set restitution coefficient wall           		= 0.3
+    set friction coefficient wall         		= 0.1
+    set rolling friction wall         	      	  	= 0.05
+end
+
+#---------------------------------------------------
+# Insertion Info
+#---------------------------------------------------
+subsection insertion info
+    set insertion method				= non_uniform
+    set inserted number of particles at each time step  = 4000
+    set insertion frequency            		 	= 2000000
+    set insertion box minimum x            	 	= -0.019
+    set insertion box minimum y            	        = -0.019
+    set insertion box minimum z            	        = -0.01
+    set insertion box maximum x            	        = 0.019
+    set insertion box maximum y           	 	= 0.019
+    set insertion box maximum z            	        = 0.019
+    set insertion distance threshold			= 1.5
+    set insertion random number range			= 0.2
+    set insertion random number seed			= 19
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+    set type                 				= dealii
+    set grid type            				= hyper_cube
+    set grid arguments       				= -0.02 : 0.02 : false
+    set initial refinement   				= 3
+end
+
+#---------------------------------------------------
+# Grid Motion
+#---------------------------------------------------
+subsection grid motion
+    set motion type                 			= rotational
+    set grid rotational speed            		= 1
+    set grid rotational axis		            	= 0
+end


### PR DESCRIPTION
This PR adds grid rotation in box example to Lethe.
I've linked the example's wiki page to the corresponding video on Youtube so that readers can watch the animation of the simulation.