### PR TITLE
Add checkpoint_step to reinitialize vector containers

### DIFF
--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -834,7 +834,7 @@ DEMSolver<dim>::solve()
       // Load balancing
       load_balance_step = (this->*check_load_balance_step)();
 
-      if (load_balance_step)
+      if (load_balance_step || checkpoint_step)
 #if DEAL_II_VERSION_GTE(10, 0, 0)
         displacement.resize(particle_handler.get_max_local_particle_index());
 #else


### PR DESCRIPTION
Previously I had added initialization of the property vector at load-balancing steps. These re initialization should also be done at checkpoint steps. This PR adds re initialization of property vectors at checkpoint steps.