### PR TITLE
Dem post processing

### DIFF
--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -389,11 +389,11 @@ namespace Parameters
       // Enable granular temperature post-processing
       bool calculate_granular_temperature;
 
-      // Set initial time to start post-processing calculations
-      double initial_time;
+      // Set initial step to start post-processing calculations
+      double initial_step;
 
-      // Set end time to finish post-processing calculations
-      double end_time;
+      // Set end step to finish post-processing calculations
+      double end_step;
 
       // Set post-processing output frequency
       unsigned int output_frequency;

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -395,8 +395,8 @@ namespace Parameters
       // Set end time to finish post-processing calculations
       double end_time;
 
-      // Set post-processing sampling frequency
-      unsigned int sampling_frequency;
+      // Set post-processing output frequency
+      unsigned int output_frequency;
 
       // Prefix for particles velocity output
       std::string particles_velocity_name;

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -390,10 +390,10 @@ namespace Parameters
       bool calculate_granular_temperature;
 
       // Set initial step to start post-processing calculations
-      double initial_step;
+      unsigned int initial_step;
 
       // Set end step to finish post-processing calculations
-      double end_step;
+      unsigned int end_step;
 
       // Set post-processing output frequency
       unsigned int output_frequency;

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -395,6 +395,9 @@ namespace Parameters
       // Set end time to finish post-processing calculations
       double end_time;
 
+      // Set post-processing sampling frequency
+      unsigned int sampling_frequency;
+
       // Prefix for particles velocity output
       std::string particles_velocity_name;
 

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -373,6 +373,40 @@ namespace Parameters
       parse_parameters(ParameterHandler &prm);
     };
 
+    /**
+     * @brief Lagrangian Postprocessing - Defines the parameters
+     * for the Lagrangian post-processing.
+     *
+     */
+    struct LagrangianPostProcessing
+    {
+      // A bool variable which sets-up the Lagrangian post-processing
+      bool Lagrangian_post_processing;
+
+      // Enable particles velocity post-processing
+      bool calculate_particles_average_velocity;
+
+      // Enable granular temperature post-processing
+      bool calculate_granular_temperature;
+
+      // Set initial time to start post-processing calculations
+      double initial_time;
+
+      // Set end time to finish post-processing calculations
+      double end_time;
+
+      // Prefix for particles velocity output
+      std::string particles_velocity_name;
+
+      // Prefix for granular temperature output
+      std::string granular_temperature_name;
+
+      static void
+      declare_parameters(ParameterHandler &prm);
+      void
+      parse_parameters(ParameterHandler &prm);
+    };
+
   } // namespace Lagrangian
 } // namespace Parameters
 

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -31,6 +31,7 @@
 #include <dem/locate_local_particles.h>
 #include <dem/non_uniform_insertion.h>
 #include <dem/output_force_torque_calculation.h>
+#include <dem/lagrangian_post_processing.h>
 #include <dem/particle_point_line_broad_search.h>
 #include <dem/particle_point_line_contact_force.h>
 #include <dem/particle_point_line_contact_info_struct.h>
@@ -250,6 +251,12 @@ private:
   void
   write_output_results();
 
+  /**
+   * @brief post_process_results
+   */
+  void
+  post_process_results();
+
 
   MPI_Comm                                  mpi_communicator;
   const unsigned int                        n_mpi_processes;
@@ -352,6 +359,7 @@ private:
   std::shared_ptr<PPContactForce<dim>> pp_contact_force_object;
   std::shared_ptr<PWContactForce<dim>> pw_contact_force_object;
   Visualization<dim>                   visualization_object;
+  LagrangianPostProcessing<dim>        post_processing_object;
   FindCellNeighbors<dim>               cell_neighbors_object;
   PVDHandler                           particles_pvdhandler;
   const double                         standard_deviation_multiplier;

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -26,12 +26,12 @@
 #include <dem/grid_motion.h>
 #include <dem/insertion.h>
 #include <dem/integrator.h>
+#include <dem/lagrangian_post_processing.h>
 #include <dem/localize_contacts.h>
 #include <dem/locate_ghost_particles.h>
 #include <dem/locate_local_particles.h>
 #include <dem/non_uniform_insertion.h>
 #include <dem/output_force_torque_calculation.h>
-#include <dem/lagrangian_post_processing.h>
 #include <dem/particle_point_line_broad_search.h>
 #include <dem/particle_point_line_contact_force.h>
 #include <dem/particle_point_line_contact_info_struct.h>

--- a/include/dem/dem_solver_parameters.h
+++ b/include/dem/dem_solver_parameters.h
@@ -31,18 +31,18 @@ template <int dim>
 class DEMSolverParameters
 {
 public:
-  Parameters::Mesh                                mesh;
-  Parameters::Testing                             test;
-  Parameters::Restart                             restart;
-  Parameters::Timer                               timer;
-  Parameters::SimulationControl                   simulation_control;
-  Parameters::Lagrangian::PhysicalProperties<dim> physical_properties;
-  Parameters::Lagrangian::InsertionInfo           insertion_info;
-  Parameters::Lagrangian::ModelParameters         model_parameters;
-  Parameters::Lagrangian::FloatingWalls<dim>      floating_walls;
-  Parameters::Lagrangian::BCDEM<dim>              boundary_conditions;
-  Parameters::Lagrangian::ForceTorqueOnWall<dim>  forces_torques;
-  Parameters::Lagrangian::GridMotion<dim>         grid_motion;
+  Parameters::Mesh                                 mesh;
+  Parameters::Testing                              test;
+  Parameters::Restart                              restart;
+  Parameters::Timer                                timer;
+  Parameters::SimulationControl                    simulation_control;
+  Parameters::Lagrangian::PhysicalProperties<dim>  physical_properties;
+  Parameters::Lagrangian::InsertionInfo            insertion_info;
+  Parameters::Lagrangian::ModelParameters          model_parameters;
+  Parameters::Lagrangian::FloatingWalls<dim>       floating_walls;
+  Parameters::Lagrangian::BCDEM<dim>               boundary_conditions;
+  Parameters::Lagrangian::ForceTorqueOnWall<dim>   forces_torques;
+  Parameters::Lagrangian::GridMotion<dim>          grid_motion;
   Parameters::Lagrangian::LagrangianPostProcessing post_processing;
 
   void

--- a/include/dem/dem_solver_parameters.h
+++ b/include/dem/dem_solver_parameters.h
@@ -43,6 +43,7 @@ public:
   Parameters::Lagrangian::BCDEM<dim>              boundary_conditions;
   Parameters::Lagrangian::ForceTorqueOnWall<dim>  forces_torques;
   Parameters::Lagrangian::GridMotion<dim>         grid_motion;
+  Parameters::Lagrangian::LagrangianPostProcessing post_processing;
 
   void
   declare(ParameterHandler &prm)
@@ -59,6 +60,7 @@ public:
     boundary_conditions.declare_parameters(prm);
     forces_torques.declare_parameters(prm);
     grid_motion.declare_parameters(prm);
+    post_processing.declare_parameters(prm);
   }
 
   void
@@ -76,6 +78,7 @@ public:
     boundary_conditions.parse_parameters(prm);
     forces_torques.parse_parameters(prm);
     grid_motion.parse_parameters(prm);
+    post_processing.parse_parameters(prm);
   }
 };
 

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -18,6 +18,7 @@
  */
 
 #include <dem/dem_properties.h>
+#include <dem/dem_solver_parameters.h>
 
 #include <deal.II/distributed/tria.h>
 
@@ -55,11 +56,16 @@ public:
    *
    * @param triangulation Triangulation
    * @param particle_handler Particle handler
+   * @param dem_parameters DEM parameters for setting the names of the output
+   * files
+   * @param step_number DEM step number
    */
   void
   calculate_average_particles_velocity(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const Particles::ParticleHandler<dim> &          particle_handler);
+    const Particles::ParticleHandler<dim> &          particle_handler,
+    const DEMSolverParameters<dim> &                 dem_parameters,
+    const unsigned int &                             step_number);
 
   /**
    * Carries out the calculation of the granular temperature in each local cell.
@@ -69,11 +75,16 @@ public:
    *
    * @param triangulation Triangulation
    * @param particle_handler Particle handler
+   * @param dem_parameters DEM parameters for setting the names of the output
+   * files
+   * @param step_number DEM step number
    */
   void
   calculate_average_granular_temperature(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const Particles::ParticleHandler<dim> &          particle_handler);
+    const Particles::ParticleHandler<dim> &          particle_handler,
+    const DEMSolverParameters<dim> &                 dem_parameters,
+    const unsigned int &                             step_number);
 
 private:
   /**

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -1,0 +1,94 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 - 2021 by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+
+ *
+ * Author: Shahab Golshan, Polytechnique Montreal, 2019
+ */
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include <iostream>
+#include <vector>
+
+using namespace dealii;
+
+#ifndef lagrangian_post_processing_h
+#  define lagrangian_post_processing_h
+
+/**
+ * This class deals with Lagrangian post-processing. At the moment, calculation
+ * of time-averaged particles velocity and granular temperature are added to the
+ * class.
+ *
+ * @todo Add tracer particles
+ *
+ * @author Shahab Golshan, Polytechnique Montreal 2019-
+ */
+
+template <int dim>
+class LagrangianPostProcessing
+{
+public:
+  LagrangianPostProcessing<dim>();
+
+  /**
+   * Carries out the calculation of the average particles velocity in each local
+   * cell. These values are summed up during the post-processing steps (imposed
+   * by post-processing frequency), and finally divided by the sampling counter
+   * to calculate time-averaged particles velocity distribution.
+   *
+   * @param triangulation Triangulation
+   * @param particle_handler Particle handler
+   */
+  void
+  calculate_average_particles_velocity(
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    const Particles::ParticleHandler<dim> &          particle_handler);
+
+  /**
+   * Carries out the calculation of the granular temperature in each local cell.
+   * These values are summed up during the post-processing steps (imposed by
+   * post-processing frequency), and finally divided by the sampling counter to
+   * calculate time-averaged granular temperature distribution.
+   *
+   * @param triangulation Triangulation
+   * @param particle_handler Particle handler
+   */
+  void
+  calculate_average_granular_temperature(
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    const Particles::ParticleHandler<dim> &          particle_handler);
+
+private:
+  /**
+   * Carries out the calculation of average particles velocity for a single
+   * cell. It is defined as a separate private function since the
+   * calculate_average_granular_temperature function also needs to obtain the
+   * average velocity in the cell.
+   *
+   * @param cell A single cell in the triangulation
+   * @param particle_handler
+   * @return A tensor which stores the average particles velocity in the input cell
+   */
+  Tensor<1, dim>
+  calculate_cell_average_particles_velocity(
+    const typename parallel::distributed::Triangulation<dim>::cell_iterator
+      &                                    cell,
+    const Particles::ParticleHandler<dim> &particle_handler);
+};
+
+#endif /* lagrangian_post_processing_h */

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -17,6 +17,8 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/pvd_handler.h>
+
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 
@@ -56,16 +58,11 @@ public:
    *
    * @param triangulation Triangulation
    * @param particle_handler Particle handler
-   * @param dem_parameters DEM parameters for setting the names of the output
-   * files
-   * @param step_number DEM step number
    */
   void
   calculate_average_particles_velocity(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const Particles::ParticleHandler<dim> &          particle_handler,
-    const DEMSolverParameters<dim> &                 dem_parameters,
-    const unsigned int &                             step_number);
+    const Particles::ParticleHandler<dim> &          particle_handler);
 
   /**
    * Carries out the calculation of the granular temperature in each local cell.
@@ -75,16 +72,49 @@ public:
    *
    * @param triangulation Triangulation
    * @param particle_handler Particle handler
-   * @param dem_parameters DEM parameters for setting the names of the output
-   * files
-   * @param step_number DEM step number
    */
   void
   calculate_average_granular_temperature(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const Particles::ParticleHandler<dim> &          particle_handler,
+    const Particles::ParticleHandler<dim> &          particle_handler);
+
+  /**
+   * Carries out writing the particles' average velocity distribution
+   *
+   * @param triangulation Triangulation
+   * @param grid_pvdhandler
+   * @param dem_parameters
+   * @param time Simulation time
+   * @param step_number DEM step number
+   * @param mpi_communicator
+   */
+  void
+  write_average_particles_velocity(
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    PVDHandler &                                     grid_pvdhandler,
     const DEMSolverParameters<dim> &                 dem_parameters,
-    const unsigned int &                             step_number);
+    const double &                                   time,
+    const unsigned int &                             step_number,
+    const MPI_Comm &                                 mpi_communicator);
+
+  /**
+   * Carries out writing the granular temperature distribution
+   *
+   * @param triangulation Triangulation
+   * @param grid_pvdhandler
+   * @param dem_parameters
+   * @param time Simulation time
+   * @param step_number DEM step number
+   * @param mpi_communicator
+   */
+  void
+  write_granular_temperature(
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    PVDHandler &                                     grid_pvdhandler,
+    const DEMSolverParameters<dim> &                 dem_parameters,
+    const double &                                   time,
+    const unsigned int &                             step_number,
+    const MPI_Comm &                                 mpi_communicator);
 
 private:
   /**
@@ -102,6 +132,12 @@ private:
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
       &                                    cell,
     const Particles::ParticleHandler<dim> &particle_handler);
+
+  Vector<double> velocity_average_x;
+  Vector<double> velocity_average_y;
+  Vector<double> velocity_average_z;
+
+  Vector<double> granular_temperature_average;
 };
 
 #endif /* lagrangian_post_processing_h */

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -18,8 +18,9 @@
  */
 
 #include <deal.II/distributed/tria.h>
-
 #include <deal.II/particles/particle_handler.h>
+
+#include <dem/dem_properties.h>
 
 #include <iostream>
 #include <vector>

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -17,10 +17,11 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
-#include <deal.II/distributed/tria.h>
-#include <deal.II/particles/particle_handler.h>
-
 #include <dem/dem_properties.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 #include <iostream>
 #include <vector>

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1078,12 +1078,12 @@ namespace Parameters
                           "Enable calculation of granular temperature.");
 
         prm.declare_entry("initial step",
-                          "0.0",
+                          "0",
                           Patterns::Integer(),
                           "Initial step to start Lagrangian post-processing.");
 
         prm.declare_entry("end step",
-                          "0.0",
+                          "0",
                           Patterns::Integer(),
                           "End step to finish Lagrangian post-processing.");
 

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1056,6 +1056,68 @@ namespace Parameters
       prm.leave_subsection();
     }
 
+    void
+    LagrangianPostProcessing::declare_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("post-processing");
+      {
+        prm.declare_entry(
+          "Lagrangian post processing",
+          "false",
+          Patterns::Bool(),
+          "State whether Lagrangian post-processing should be performed.");
+
+        prm.declare_entry("calculate particles average velocity",
+                          "false",
+                          Patterns::Bool(),
+                          "Enable calculation of particles average velocity.");
+
+        prm.declare_entry("calculate granular temperature",
+                          "false",
+                          Patterns::Bool(),
+                          "Enable calculation of granular temperature.");
+
+        prm.declare_entry("initial time",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial time to start Lagrangian post-processing.");
+
+        prm.declare_entry("end time",
+                          "0.0",
+                          Patterns::Double(),
+                          "End time to finish Lagrangian post-processing.");
+
+        prm.declare_entry("particles velocity name",
+                          "particles_velocity",
+                          Patterns::FileName(),
+                          "File output particles velocity.");
+
+        prm.declare_entry("granular temperature name",
+                          "granular_temperature",
+                          Patterns::FileName(),
+                          "File output granular temperature.");
+      }
+      prm.leave_subsection();
+    }
+
+    void
+    LagrangianPostProcessing::parse_parameters(ParameterHandler &prm)
+    {
+      prm.enter_subsection("post-processing");
+      {
+        Lagrangian_post_processing = prm.get_bool("Lagrangian post processing");
+        calculate_particles_average_velocity =
+          prm.get_bool("calculate particles average velocity");
+        calculate_granular_temperature =
+          prm.get_bool("calculate granular temperature");
+        initial_time              = prm.get_double("initial time");
+        end_time                  = prm.get_double("end time");
+        particles_velocity_name   = prm.get("particles velocity name");
+        granular_temperature_name = prm.get("granular temperature name");
+      }
+      prm.leave_subsection();
+    }
+
     template class PhysicalProperties<2>;
     template class PhysicalProperties<3>;
     template class ForceTorqueOnWall<2>;

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1079,12 +1079,12 @@ namespace Parameters
 
         prm.declare_entry("initial step",
                           "0.0",
-                          Patterns::Double(),
+                          Patterns::Integer(),
                           "Initial step to start Lagrangian post-processing.");
 
         prm.declare_entry("end step",
                           "0.0",
-                          Patterns::Double(),
+                          Patterns::Integer(),
                           "End step to finish Lagrangian post-processing.");
 
         prm.declare_entry("output frequency",
@@ -1115,8 +1115,8 @@ namespace Parameters
           prm.get_bool("calculate particles average velocity");
         calculate_granular_temperature =
           prm.get_bool("calculate granular temperature");
-        initial_step              = prm.get_double("initial step");
-        end_step                  = prm.get_double("end step");
+        initial_step              = prm.get_integer("initial step");
+        end_step                  = prm.get_integer("end step");
         output_frequency          = prm.get_integer("output frequency");
         particles_velocity_name   = prm.get("particles velocity output name");
         granular_temperature_name = prm.get("granular temperature output name");

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1087,6 +1087,11 @@ namespace Parameters
                           Patterns::Double(),
                           "End time to finish Lagrangian post-processing.");
 
+        prm.declare_entry("sampling frequency",
+                          "100000",
+                          Patterns::Integer(),
+                          "Post-processing sampling frequency.");
+
         prm.declare_entry("particles velocity name",
                           "particles_velocity",
                           Patterns::FileName(),
@@ -1112,6 +1117,7 @@ namespace Parameters
           prm.get_bool("calculate granular temperature");
         initial_time              = prm.get_double("initial time");
         end_time                  = prm.get_double("end time");
+        sampling_frequency        = prm.get_integer("sampling frequency");
         particles_velocity_name   = prm.get("particles velocity name");
         granular_temperature_name = prm.get("granular temperature name");
       }

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1087,10 +1087,10 @@ namespace Parameters
                           Patterns::Double(),
                           "End time to finish Lagrangian post-processing.");
 
-        prm.declare_entry("sampling frequency",
+        prm.declare_entry("output frequency",
                           "100000",
                           Patterns::Integer(),
-                          "Post-processing sampling frequency.");
+                          "Post-processing output frequency.");
 
         prm.declare_entry("particles velocity name",
                           "particles_velocity",
@@ -1117,7 +1117,7 @@ namespace Parameters
           prm.get_bool("calculate granular temperature");
         initial_time              = prm.get_double("initial time");
         end_time                  = prm.get_double("end time");
-        sampling_frequency        = prm.get_integer("sampling frequency");
+        output_frequency          = prm.get_integer("output frequency");
         particles_velocity_name   = prm.get("particles velocity name");
         granular_temperature_name = prm.get("granular temperature name");
       }

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1077,27 +1077,27 @@ namespace Parameters
                           Patterns::Bool(),
                           "Enable calculation of granular temperature.");
 
-        prm.declare_entry("initial time",
+        prm.declare_entry("initial step",
                           "0.0",
                           Patterns::Double(),
-                          "Initial time to start Lagrangian post-processing.");
+                          "Initial step to start Lagrangian post-processing.");
 
-        prm.declare_entry("end time",
+        prm.declare_entry("end step",
                           "0.0",
                           Patterns::Double(),
-                          "End time to finish Lagrangian post-processing.");
+                          "End step to finish Lagrangian post-processing.");
 
         prm.declare_entry("output frequency",
                           "100000",
                           Patterns::Integer(),
                           "Post-processing output frequency.");
 
-        prm.declare_entry("particles velocity name",
+        prm.declare_entry("particles velocity output name",
                           "particles_velocity",
                           Patterns::FileName(),
                           "File output particles velocity.");
 
-        prm.declare_entry("granular temperature name",
+        prm.declare_entry("granular temperature output name",
                           "granular_temperature",
                           Patterns::FileName(),
                           "File output granular temperature.");
@@ -1115,11 +1115,11 @@ namespace Parameters
           prm.get_bool("calculate particles average velocity");
         calculate_granular_temperature =
           prm.get_bool("calculate granular temperature");
-        initial_time              = prm.get_double("initial time");
-        end_time                  = prm.get_double("end time");
+        initial_step              = prm.get_double("initial step");
+        end_step                  = prm.get_double("end step");
         output_frequency          = prm.get_integer("output frequency");
-        particles_velocity_name   = prm.get("particles velocity name");
-        granular_temperature_name = prm.get("granular temperature name");
+        particles_velocity_name   = prm.get("particles velocity output name");
+        granular_temperature_name = prm.get("granular temperature output name");
       }
       prm.leave_subsection();
     }

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -731,6 +731,18 @@ DEMSolver<dim>::write_output_results()
 
 template <int dim>
 void
+DEMSolver<dim>::post_process_results()
+{
+  if (parameters.post_processing.calculate_particles_average_velocity)
+    post_processing_object.calculate_average_particles_velocity(
+      triangulation, particle_handler);
+  if (parameters.post_processing.calculate_granular_temperature)
+    post_processing_object.calculate_average_granular_temperature(
+      triangulation, particle_handler);
+}
+
+template <int dim>
+void
 DEMSolver<dim>::solve()
 {
   // Print simulation starting information
@@ -980,6 +992,16 @@ DEMSolver<dim>::solve()
         write_forces_torques_output_locally<dim>(
           forces_boundary_information[simulation_control->get_step_number()],
           torques_boundary_information[simulation_control->get_step_number()]);
+
+      // Post-processing
+      if (parameters.post_processing.Lagrangian_post_processing)
+        {
+          if (simulation_control->get_step_number() >=
+                parameters.post_processing.initial_step &&
+              simulation_control->get_step_number() <=
+                parameters.post_processing.end_step)
+            post_process_results();
+        }
 
       if (parameters.restart.checkpoint &&
           simulation_control->get_step_number() %

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -735,10 +735,16 @@ DEMSolver<dim>::post_process_results()
 {
   if (parameters.post_processing.calculate_particles_average_velocity)
     post_processing_object.calculate_average_particles_velocity(
-      triangulation, particle_handler);
+      triangulation,
+      particle_handler,
+      parameters,
+      simulation_control->get_step_number());
   if (parameters.post_processing.calculate_granular_temperature)
     post_processing_object.calculate_average_granular_temperature(
-      triangulation, particle_handler);
+      triangulation,
+      particle_handler,
+      parameters,
+      simulation_control->get_step_number());
 }
 
 template <int dim>
@@ -1000,7 +1006,12 @@ DEMSolver<dim>::solve()
                 parameters.post_processing.initial_step &&
               simulation_control->get_step_number() <=
                 parameters.post_processing.end_step)
-            post_process_results();
+            {
+              if (simulation_control->get_step_number() %
+                    parameters.post_processing.output_frequency ==
+                  0)
+                post_process_results();
+            }
         }
 
       if (parameters.restart.checkpoint &&

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -734,17 +734,31 @@ void
 DEMSolver<dim>::post_process_results()
 {
   if (parameters.post_processing.calculate_particles_average_velocity)
-    post_processing_object.calculate_average_particles_velocity(
-      triangulation,
-      particle_handler,
-      parameters,
-      simulation_control->get_step_number());
+    {
+      post_processing_object.calculate_average_particles_velocity(
+        triangulation, particle_handler);
+
+      post_processing_object.write_average_particles_velocity(
+        triangulation,
+        grid_pvdhandler,
+        parameters,
+        simulation_control->get_current_time(),
+        simulation_control->get_step_number(),
+        mpi_communicator);
+    }
   if (parameters.post_processing.calculate_granular_temperature)
-    post_processing_object.calculate_average_granular_temperature(
-      triangulation,
-      particle_handler,
-      parameters,
-      simulation_control->get_step_number());
+    {
+      post_processing_object.calculate_average_granular_temperature(
+        triangulation, particle_handler);
+
+      post_processing_object.write_granular_temperature(
+        triangulation,
+        grid_pvdhandler,
+        parameters,
+        simulation_control->get_current_time(),
+        simulation_control->get_step_number(),
+        mpi_communicator);
+    }
 }
 
 template <int dim>

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -1,12 +1,12 @@
 #include <dem/lagrangian_post_processing.h>
 
-#include <fstream>
-
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/lac/block_vector.h>
 
 #include <deal.II/numerics/data_out.h>
+
+#include <fstream>
 
 using namespace dealii;
 

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -1,0 +1,161 @@
+#include <dem/dem_properties.h>
+#include <dem/lagrangian_post_processing.h>
+
+
+using namespace dealii;
+
+template <int dim>
+LagrangianPostProcessing<dim>::LagrangianPostProcessing()
+{}
+
+template <int dim>
+void
+LagrangianPostProcessing<dim>::calculate_average_particles_velocity(
+  const parallel::distributed::Triangulation<dim> &triangulation,
+  const Particles::ParticleHandler<dim> &          particle_handler)
+{
+  std::vector<Tensor<1, dim>> velocity_average;
+  velocity_average.reserve(triangulation.n_cells());
+
+  // Iterating through the active cells in the trangulation
+  for (const auto &cell : triangulation.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        velocity_average[cell->global_active_cell_index()] =
+          calculate_cell_average_particles_velocity(cell, particle_handler);
+    }
+
+  // Writing output file
+}
+
+template <int dim>
+void
+LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
+  const parallel::distributed::Triangulation<dim> &triangulation,
+  const Particles::ParticleHandler<dim> &          particle_handler)
+{
+  std::vector<double> granular_temperature_average;
+  granular_temperature_average.reserve(triangulation.n_cells());
+
+  double       granular_temperature_cell = 0;
+  unsigned int particles_cell_number     = 0;
+
+  // Iterating through the active cells in the trangulation
+  for (const auto &cell : triangulation.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          // Looping through all the particles in the cell
+          // Particles in the cell
+          typename Particles::ParticleHandler<dim>::particle_iterator_range
+            particles_in_cell = particle_handler.particles_in_cell(cell);
+
+          const bool particles_exist_in_main_cell = !particles_in_cell.empty();
+          // Check to see if the cell has any particles
+          if (particles_exist_in_main_cell)
+            {
+              Tensor<1, dim> velocity_in_cell_average =
+                calculate_cell_average_particles_velocity(cell,
+                                                          particle_handler);
+
+              // Initializing velocity fluctuations
+              Tensor<1, dim> cell_velocity_fluctuation_squared_sum;
+              cell_velocity_fluctuation_squared_sum = 0;
+              Tensor<1, dim> cell_velocity_fluctuation_squared_average;
+              cell_velocity_fluctuation_squared_average = 0;
+
+              for (typename Particles::ParticleHandler<
+                     dim>::particle_iterator_range::iterator
+                     particles_in_cell_iterator = particles_in_cell.begin();
+                   particles_in_cell_iterator != particles_in_cell.end();
+                   ++particles_in_cell_iterator)
+                {
+                  auto &particle_properties =
+                    particles_in_cell_iterator->get_properties();
+
+                  cell_velocity_fluctuation_squared_sum[0] +=
+                    (particle_properties[DEM::PropertiesIndex::v_x] -
+                     velocity_in_cell_average[0]) *
+                    (particle_properties[DEM::PropertiesIndex::v_x] -
+                     velocity_in_cell_average[0]);
+                  cell_velocity_fluctuation_squared_sum[1] +=
+                    (particle_properties[DEM::PropertiesIndex::v_y] -
+                     velocity_in_cell_average[1]) *
+                    (particle_properties[DEM::PropertiesIndex::v_y] -
+                     velocity_in_cell_average[1]);
+                  if (dim == 3)
+                    cell_velocity_fluctuation_squared_sum[2] +=
+                      (particle_properties[DEM::PropertiesIndex::v_z] -
+                       velocity_in_cell_average[2]) *
+                      (particle_properties[DEM::PropertiesIndex::v_z] -
+                       velocity_in_cell_average[2]);
+
+                  particles_cell_number++;
+                }
+              // Calculate average granular temperature in the cell
+              for (int d = 0; d < dim; ++d)
+                {
+                  cell_velocity_fluctuation_squared_average[d] =
+                    cell_velocity_fluctuation_squared_sum[d] /
+                    particles_cell_number;
+                  granular_temperature_cell +=
+                    (1 / dim) * cell_velocity_fluctuation_squared_average[d];
+                }
+            }
+          granular_temperature_average[cell->global_active_cell_index()] =
+            granular_temperature_cell;
+        }
+    }
+
+  // Writing output file
+}
+
+template <int dim>
+Tensor<1, dim>
+LagrangianPostProcessing<dim>::calculate_cell_average_particles_velocity(
+  const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+  const Particles::ParticleHandler<dim> &particle_handler)
+{
+  Tensor<1, dim> velocity_cell_sum;
+  velocity_cell_sum = 0;
+  Tensor<1, dim> velocity_cell_average;
+  velocity_cell_average              = 0;
+  unsigned int particles_cell_number = 0;
+
+  // Looping through all the particles in the cell
+  // Particles in the cell
+  typename Particles::ParticleHandler<dim>::particle_iterator_range
+    particles_in_cell = particle_handler.particles_in_cell(cell);
+
+  const bool particles_exist_in_main_cell = !particles_in_cell.empty();
+
+  // Check to see if the cell has any particles
+  if (particles_exist_in_main_cell)
+    {
+      for (typename Particles::ParticleHandler<dim>::particle_iterator_range::
+             iterator particles_in_cell_iterator = particles_in_cell.begin();
+           particles_in_cell_iterator != particles_in_cell.end();
+           ++particles_in_cell_iterator)
+        {
+          auto &particle_properties =
+            particles_in_cell_iterator->get_properties();
+
+          velocity_cell_sum[0] +=
+            particle_properties[DEM::PropertiesIndex::v_x];
+          velocity_cell_sum[1] +=
+            particle_properties[DEM::PropertiesIndex::v_y];
+          if (dim == 3)
+            velocity_cell_sum[2] +=
+              particle_properties[DEM::PropertiesIndex::v_z];
+
+          particles_cell_number++;
+        }
+      // Calculate average velocity in the cell
+      for (int d = 0; d < dim; ++d)
+        velocity_cell_average[d] = velocity_cell_sum[d] / particles_cell_number;
+    }
+  return velocity_cell_average;
+}
+
+template class LagrangianPostProcessing<2>;
+template class LagrangianPostProcessing<3>;

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -2,6 +2,8 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/lac/block_vector.h>
+
 #include <deal.II/numerics/data_out.h>
 
 using namespace dealii;
@@ -14,9 +16,13 @@ template <int dim>
 void
 LagrangianPostProcessing<dim>::calculate_average_particles_velocity(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const Particles::ParticleHandler<dim> &          particle_handler)
+  const Particles::ParticleHandler<dim> &          particle_handler,
+  const DEMSolverParameters<dim> &                 dem_parameters,
+  const unsigned int &                             step_number)
 {
-  Vector<double> velocity_average(dim * triangulation.n_active_cells());
+  Vector<double> velocity_average_x(triangulation.n_active_cells());
+  Vector<double> velocity_average_y(triangulation.n_active_cells());
+  Vector<double> velocity_average_z(triangulation.n_active_cells());
 
   // Iterating through the active cells in the trangulation
   for (const auto &cell : triangulation.active_cell_iterators())
@@ -26,49 +32,62 @@ LagrangianPostProcessing<dim>::calculate_average_particles_velocity(
           Tensor<1, dim> cell_velocity_average =
             calculate_cell_average_particles_velocity(cell, particle_handler);
 
-          for (int d = 0; d < dim; ++d)
-            velocity_average[dim * cell->global_active_cell_index() + d] =
-              cell_velocity_average[d];
+          velocity_average_x[cell->global_active_cell_index()] =
+            cell_velocity_average[0];
+          velocity_average_y[cell->global_active_cell_index()] =
+            cell_velocity_average[1];
+          if (dim == 3)
+            velocity_average_z[cell->global_active_cell_index()] =
+              cell_velocity_average[2];
         }
     }
 
-  // Writing data
+  // Writing output file
   DataOut<dim> data_out;
   data_out.attach_triangulation(triangulation);
 
-  std::vector<std::string> average_solution_names(dim, "average_velocity");
-
-  std::vector<DataComponentInterpretation::DataComponentInterpretation>
-    average_data_component_interpretation(
-      dim, DataComponentInterpretation::component_is_part_of_vector);
-
-  data_out.add_data_vector(velocity_average,
-                           average_solution_names,
-                           DataOut<dim>::type_cell_data,
-                           average_data_component_interpretation);
+  std::vector<std::string> average_solution_names(1, "average_velocity_x");
+  average_solution_names.push_back("average_velocity_y");
+  if (dim == 3)
+    average_solution_names.push_back("average_velocity_z");
 
 
-  // data_out.build_patches();
-  // std::ofstream output("solution-" + std::to_string(10) + ".vtk");
-  // data_out.write_vtk(output);
+  data_out.add_data_vector(velocity_average_x,
+                           average_solution_names[0],
+                           DataOut<dim>::type_cell_data);
+  data_out.add_data_vector(velocity_average_y,
+                           average_solution_names[1],
+                           DataOut<dim>::type_cell_data);
+  if (dim == 3)
+    data_out.add_data_vector(velocity_average_z,
+                             average_solution_names[2],
+                             DataOut<dim>::type_cell_data);
+
+
+  data_out.build_patches();
+  std::ofstream output(dem_parameters.post_processing.particles_velocity_name +
+                       "-" + std::to_string(step_number) + ".vtk");
+  data_out.write_vtk(output);
 }
 
 template <int dim>
 void
 LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const Particles::ParticleHandler<dim> &          particle_handler)
+  const Particles::ParticleHandler<dim> &          particle_handler,
+  const DEMSolverParameters<dim> &                 dem_parameters,
+  const unsigned int &                             step_number)
 {
-  Vector<double> granular_temperature_average(triangulation.n_cells());
-
-  double       granular_temperature_cell(0);
-  unsigned int particles_cell_number(0);
+  Vector<double> granular_temperature_average(triangulation.n_active_cells());
 
   // Iterating through the active cells in the trangulation
   for (const auto &cell : triangulation.active_cell_iterators())
     {
       if (cell->is_locally_owned())
         {
+          double       granular_temperature_cell(0);
+          unsigned int particles_cell_number(0);
+
           // Looping through all the particles in the cell
           // Particles in the cell
           typename Particles::ParticleHandler<dim>::particle_iterator_range
@@ -115,7 +134,7 @@ LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
                     cell_velocity_fluctuation_squared_sum[d] /
                     particles_cell_number;
                   granular_temperature_cell +=
-                    (1 / dim) * cell_velocity_fluctuation_squared_average[d];
+                    (1.0 / dim) * cell_velocity_fluctuation_squared_average[d];
                 }
             }
           granular_temperature_average[cell->global_active_cell_index()] =
@@ -124,6 +143,19 @@ LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
     }
 
   // Writing output file
+  DataOut<dim> data_out;
+  data_out.attach_triangulation(triangulation);
+  std::string average_solution_names("granular_temperature");
+
+  data_out.add_data_vector(granular_temperature_average,
+                           average_solution_names,
+                           DataOut<dim>::type_cell_data);
+
+  data_out.build_patches();
+  std::ofstream output(
+    dem_parameters.post_processing.granular_temperature_name + "-" +
+    std::to_string(step_number) + ".vtk");
+  data_out.write_vtk(output);
 }
 
 template <int dim>

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -1,5 +1,7 @@
 #include <dem/lagrangian_post_processing.h>
 
+#include <fstream>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/lac/block_vector.h>

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -1,4 +1,3 @@
-#include <dem/dem_properties.h>
 #include <dem/lagrangian_post_processing.h>
 
 
@@ -37,8 +36,8 @@ LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
   std::vector<double> granular_temperature_average;
   granular_temperature_average.reserve(triangulation.n_cells());
 
-  double       granular_temperature_cell = 0;
-  unsigned int particles_cell_number     = 0;
+  double       granular_temperature_cell(0);
+  unsigned int particles_cell_number(0);
 
   // Iterating through the active cells in the trangulation
   for (const auto &cell : triangulation.active_cell_iterators())
@@ -59,10 +58,8 @@ LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
                                                           particle_handler);
 
               // Initializing velocity fluctuations
-              Tensor<1, dim> cell_velocity_fluctuation_squared_sum;
-              cell_velocity_fluctuation_squared_sum = 0;
-              Tensor<1, dim> cell_velocity_fluctuation_squared_average;
-              cell_velocity_fluctuation_squared_average = 0;
+              Tensor<1, dim> cell_velocity_fluctuation_squared_sum = Tensor<1,dim>();
+              Tensor<1, dim> cell_velocity_fluctuation_squared_average = Tensor<1,dim>();
 
               for (typename Particles::ParticleHandler<
                      dim>::particle_iterator_range::iterator
@@ -73,22 +70,14 @@ LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
                   auto &particle_properties =
                     particles_in_cell_iterator->get_properties();
 
-                  cell_velocity_fluctuation_squared_sum[0] +=
-                    (particle_properties[DEM::PropertiesIndex::v_x] -
-                     velocity_in_cell_average[0]) *
-                    (particle_properties[DEM::PropertiesIndex::v_x] -
-                     velocity_in_cell_average[0]);
-                  cell_velocity_fluctuation_squared_sum[1] +=
-                    (particle_properties[DEM::PropertiesIndex::v_y] -
-                     velocity_in_cell_average[1]) *
-                    (particle_properties[DEM::PropertiesIndex::v_y] -
-                     velocity_in_cell_average[1]);
-                  if (dim == 3)
-                    cell_velocity_fluctuation_squared_sum[2] +=
-                      (particle_properties[DEM::PropertiesIndex::v_z] -
-                       velocity_in_cell_average[2]) *
-                      (particle_properties[DEM::PropertiesIndex::v_z] -
-                       velocity_in_cell_average[2]);
+                  for (int d = 0; d < dim; ++d)
+                    {
+                      cell_velocity_fluctuation_squared_sum[d] +=
+                    (particle_properties[DEM::PropertiesIndex::v_x+d] -
+                     velocity_in_cell_average[d]) *
+                    (particle_properties[DEM::PropertiesIndex::v_x+d] -
+                     velocity_in_cell_average[d]);
+                    }
 
                   particles_cell_number++;
                 }
@@ -116,11 +105,9 @@ LagrangianPostProcessing<dim>::calculate_cell_average_particles_velocity(
   const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
   const Particles::ParticleHandler<dim> &particle_handler)
 {
-  Tensor<1, dim> velocity_cell_sum;
-  velocity_cell_sum = 0;
-  Tensor<1, dim> velocity_cell_average;
-  velocity_cell_average              = 0;
-  unsigned int particles_cell_number = 0;
+  Tensor<1, dim> velocity_cell_sum = Tensor<1,dim>();
+  Tensor<1, dim> velocity_cell_average = Tensor<1,dim>();
+  unsigned int particles_cell_number(0);
 
   // Looping through all the particles in the cell
   // Particles in the cell
@@ -140,13 +127,10 @@ LagrangianPostProcessing<dim>::calculate_cell_average_particles_velocity(
           auto &particle_properties =
             particles_in_cell_iterator->get_properties();
 
-          velocity_cell_sum[0] +=
-            particle_properties[DEM::PropertiesIndex::v_x];
-          velocity_cell_sum[1] +=
-            particle_properties[DEM::PropertiesIndex::v_y];
-          if (dim == 3)
-            velocity_cell_sum[2] +=
-              particle_properties[DEM::PropertiesIndex::v_z];
+          for (int d = 0; d < dim; ++d)
+            {
+              velocity_cell_sum[d] += particle_properties[DEM::PropertiesIndex::v_x+d];
+            }
 
           particles_cell_number++;
         }


### PR DESCRIPTION
This PR adds post-processing calculations to the DEM solver.
Now, we can calculate average velocity of particles in each cell, as well as the granular temperature distribution.
I will add post-processing of tracer particles in a future PR.