### PR TITLE
Fix a bug in solid_base motion nitscher 23 solver

### DIFF
--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -525,8 +525,7 @@ SolidBase<dim, spacedim>::move_solid_triangulation(double time_step)
     {
       if (cell->is_locally_owned())
         {
-          for (unsigned int i = 0;
-               i < GeometryInfo<spacedim>::vertices_per_cell;
+          for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell;
                ++i)
             {
               if (!displacement[cell->vertex_index(i)])


### PR DESCRIPTION
The nitsche 23 solver would crash when the solid would be moved because
improper geometry info were used. The geometry info of the solid must be
of templated size <dim> and not <spacedim>