### PR TITLE
Get residual for nonlinear solver

### DIFF
--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -159,7 +159,7 @@ NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
             }
           last_alpha_res = current_res;
         }
-      
+
       global_res       = solver->get_current_residual();
       present_solution = evaluation_point;
       last_res         = current_res;

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -79,7 +79,7 @@ NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
   // defined by the physical solver and may differ from the l2_norm of the
   // residual vector. Only the global_res is compared to the tolerance in order
   // to evaluate if the nonlinear system is solved. Only current_res is used for
-  // the alpha scheme as this scheme only applied to the matrix problem.
+  // the alpha scheme as this scheme only monitors the convergence of the non-linear system of equation (the matrix problem).
 
   PhysicsSolver<VectorType> *solver = this->physics_solver;
 

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -65,19 +65,28 @@ template <typename VectorType>
 void
 NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
 {
+  double       global_res;
   double       current_res;
   double       last_res;
   bool         first_step      = is_initial_step;
   unsigned int outer_iteration = 0;
   last_res                     = 1e6;
   current_res                  = 1e6;
+  global_res                   = 1e6;
+
+  // current_res and global_res are different as one is defined based on the l2
+  // norm of the residual vector (current_res) and the other (global_res) is
+  // defined by the physical solver and may differ from the l2_norm of the
+  // residual vector. Only the global_res is compared to the tolerance in order
+  // to evaluate if the nonlinear system is solved. Only current_res is used for
+  // the alpha scheme as this scheme only applied to the matrix problem.
 
   PhysicsSolver<VectorType> *solver = this->physics_solver;
 
   auto &evaluation_point = solver->get_evaluation_point();
   auto &present_solution = solver->get_present_solution();
 
-  while ((current_res > this->params.tolerance) &&
+  while ((global_res > this->params.tolerance) &&
          outer_iteration < this->params.max_iterations)
     {
       evaluation_point = present_solution;
@@ -150,7 +159,8 @@ NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
             }
           last_alpha_res = current_res;
         }
-
+      
+      global_res       = solver->get_current_residual();
       present_solution = evaluation_point;
       last_res         = current_res;
       ++outer_iteration;

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -79,7 +79,8 @@ NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
   // defined by the physical solver and may differ from the l2_norm of the
   // residual vector. Only the global_res is compared to the tolerance in order
   // to evaluate if the nonlinear system is solved. Only current_res is used for
-  // the alpha scheme as this scheme only monitors the convergence of the non-linear system of equation (the matrix problem).
+  // the alpha scheme as this scheme only monitors the convergence of the
+  // non-linear system of equation (the matrix problem).
 
   PhysicsSolver<VectorType> *solver = this->physics_solver;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -656,7 +656,7 @@ namespace Parameters
     std::string                  ib_force_output_file;
     double                       density;
     Tensor<1, dim>               gravity;
-    double particle_nonlinear_tol;
+    double                       particle_nonlinear_tol;
 
     double alpha;
     bool   integrate_motion;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -656,6 +656,7 @@ namespace Parameters
     std::string                  ib_force_output_file;
     double                       density;
     Tensor<1, dim>               gravity;
+    double particle_nonlinear_tol;
 
     double alpha;
     bool   integrate_motion;

--- a/include/core/physics_solver.h
+++ b/include/core/physics_solver.h
@@ -112,7 +112,8 @@ public:
 
   /**
    * @brief Default way to evaluate the residual for the nonlinear solver.
-   * Some application may use more complex evaluation of the residual and override this method.
+   * Some application may use more complex evaluation of the residual and
+   * override this method.
    */
   virtual double
   get_current_residual()

--- a/include/core/physics_solver.h
+++ b/include/core/physics_solver.h
@@ -110,6 +110,17 @@ public:
   virtual AffineConstraints<double> &
   get_nonzero_constraints() = 0;
 
+  /**
+   * @brief Default way to evaluate the residual for the nonlinear solver.
+   * Some application may use more complex evaluation of the residual and override this method.
+   */
+  virtual double
+  get_current_residual()
+  {
+    auto &system_rhs = get_system_rhs();
+    return system_rhs.l2_norm();
+  }
+
   ConditionalOStream                                pcout;
   Parameters::SimulationControl::TimeSteppingMethod time_stepping_method;
 

--- a/include/solvers/gls_sharp_navier_stokes.h
+++ b/include/solvers/gls_sharp_navier_stokes.h
@@ -387,7 +387,8 @@ Return a bool that describes  if a cell contains a specific point
    *  A override of the get_current_residual to take into account the particles coupling residual.
    */
   double
-  get_current_residual()override{
+  get_current_residual()override
+  {
     double scalling =this->simulation_parameters.non_linear_solver.tolerance/this->simulation_parameters.particlesParameters.particle_nonlinear_tol;
     return std::max(this->system_rhs.l2_norm(),particle_residual*scalling);
   }

--- a/include/solvers/gls_sharp_navier_stokes.h
+++ b/include/solvers/gls_sharp_navier_stokes.h
@@ -384,13 +384,16 @@ Return a bool that describes  if a cell contains a specific point
 
   /**
    * @brief
-   *  A override of the get_current_residual to take into account the particles coupling residual.
+   *  A override of the get_current_residual to take into account the particles
+   * coupling residual.
    */
   double
-  get_current_residual()override
+  get_current_residual() override
   {
-    double scalling =this->simulation_parameters.non_linear_solver.tolerance/this->simulation_parameters.particlesParameters.particle_nonlinear_tol;
-    return std::max(this->system_rhs.l2_norm(),particle_residual*scalling);
+    double scalling =
+      this->simulation_parameters.non_linear_solver.tolerance /
+      this->simulation_parameters.particlesParameters.particle_nonlinear_tol;
+    return std::max(this->system_rhs.l2_norm(), particle_residual * scalling);
   }
 
 
@@ -438,7 +441,7 @@ private:
   const bool                   PSPG        = true;
   const double                 GLS_u_scale = 1;
   std::vector<IBParticle<dim>> particles;
-  double particle_residual;
+  double                       particle_residual;
 
   std::vector<TableHandler> table_f;
   std::vector<TableHandler> table_t;

--- a/include/solvers/gls_sharp_navier_stokes.h
+++ b/include/solvers/gls_sharp_navier_stokes.h
@@ -384,6 +384,17 @@ Return a bool that describes  if a cell contains a specific point
 
   /**
    * @brief
+   *  A override of the get_current_residual to take into account the particles coupling residual.
+   */
+  double
+  get_current_residual()override{
+    double scalling =this->simulation_parameters.non_linear_solver.tolerance/this->simulation_parameters.particlesParameters.particle_nonlinear_tol;
+    return std::max(this->system_rhs.l2_norm(),particle_residual*scalling);
+  }
+
+
+  /**
+   * @brief
    *Return a vector of cells around a cell including vertex neighbors
    *
    * @param cell , The initial cell. we want to know all the cells that share a vertex with this cell.
@@ -426,6 +437,7 @@ private:
   const bool                   PSPG        = true;
   const double                 GLS_u_scale = 1;
   std::vector<IBParticle<dim>> particles;
+  double particle_residual;
 
   std::vector<TableHandler> table_f;
   std::vector<TableHandler> table_t;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1337,7 +1337,7 @@ namespace Parameters
       gravity[1]           = prm.get_double("gravity_y");
       assemble_navier_stokes_inside =
         prm.get_bool("assemble Navier-Stokes inside particles");
-      particle_nonlinear_tol= prm.get_double("particle nonlinear tolerance");
+      particle_nonlinear_tol = prm.get_double("particle nonlinear tolerance");
 
 
       if (dim == 3)

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1235,6 +1235,11 @@ namespace Parameters
         "false",
         Patterns::Bool(),
         "Bool to define if you assemble the inside of particles with the NS equation.");
+      prm.declare_entry(
+        "particle nonlinear tolerance",
+        "1e-6",
+        Patterns::Double(),
+        "The nonlinear tolerance for the coupling of the particle dynamics and the fluid");
       prm.declare_entry("fluid density",
                         "1",
                         Patterns::Double(),
@@ -1332,6 +1337,8 @@ namespace Parameters
       gravity[1]           = prm.get_double("gravity_y");
       assemble_navier_stokes_inside =
         prm.get_bool("assemble Navier-Stokes inside particles");
+      particle_nonlinear_tol= prm.get_double("particle nonlinear tolerance");
+
 
       if (dim == 3)
         gravity[2] = prm.get_double("gravity_z");

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -782,7 +782,7 @@ GLSSharpNavierStokesSolver<dim>::integrate_particles()
   double         alpha = this->simulation_parameters.particlesParameters.alpha;
   Tensor<1, dim> g   = this->simulation_parameters.particlesParameters.gravity;
   double         rho = this->simulation_parameters.particlesParameters.density;
-
+  particle_residual=0;
   if (this->simulation_parameters.particlesParameters.integrate_motion)
     {
       Tensor<1, dim> gravity;

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -782,7 +782,7 @@ GLSSharpNavierStokesSolver<dim>::integrate_particles()
   double         alpha = this->simulation_parameters.particlesParameters.alpha;
   Tensor<1, dim> g   = this->simulation_parameters.particlesParameters.gravity;
   double         rho = this->simulation_parameters.particlesParameters.density;
-  particle_residual=0;
+  particle_residual  = 0;
   if (this->simulation_parameters.particlesParameters.integrate_motion)
     {
       Tensor<1, dim> gravity;

--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
@@ -97,10 +97,10 @@ test()
   std::sort(cells_cut.begin(),
             cells_cut.end(),
             [](typename DoFHandler<3>::active_cell_iterator cell_1,
-              typename DoFHandler<3>::active_cell_iterator cell_2) {
-    return cell_1->global_active_cell_index() <
-    cell_2->global_active_cell_index();
-  });
+               typename DoFHandler<3>::active_cell_iterator cell_2) {
+              return cell_1->global_active_cell_index() <
+                     cell_2->global_active_cell_index();
+            });
 
 
   for (unsigned int i = 0; i < cells_cut.size(); ++i)


### PR DESCRIPTION
Add a get_current_residual method in the physical solver and an override in the gls_shapr in order to take into account the particle residual. At the moment this variable is useless but upcoming change will make use of the particle residual.