### PR TITLE
Particle line bug fix

### DIFF
--- a/applications_tests/dem_2d/circle_restart.output
+++ b/applications_tests/dem_2d/circle_restart.output
@@ -3,6 +3,9 @@ DEM time-step is 2.32182% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/circle_with_floating_walls.mpirun=1.output
+++ b/applications_tests/dem_2d/circle_with_floating_walls.mpirun=1.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 18 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/circle_with_floating_walls.mpirun=2.output
+++ b/applications_tests/dem_2d/circle_with_floating_walls.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 18 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/insert_list_2d.mpirun=2.output
+++ b/applications_tests/dem_2d/insert_list_2d.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 2 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/insert_list_2d.output
+++ b/applications_tests/dem_2d/insert_list_2d.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 2 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/packing_in_circle.mpirun=1.output
+++ b/applications_tests/dem_2d/packing_in_circle.mpirun=1.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 8 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/packing_in_circle.mpirun=2.output
+++ b/applications_tests/dem_2d/packing_in_circle.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 8 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/packing_in_square.mpirun=1.output
+++ b/applications_tests/dem_2d/packing_in_square.mpirun=1.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/packing_in_square.mpirun=2.output
+++ b/applications_tests/dem_2d/packing_in_square.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/parallel_contacts_in_circle.mpirun=2.output
+++ b/applications_tests/dem_2d/parallel_contacts_in_circle.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/rotating_in_circle.output
+++ b/applications_tests/dem_2d/rotating_in_circle.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 50 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_2d/two_types_packing_in_circle.output
+++ b/applications_tests/dem_2d/two_types_packing_in_circle.output
@@ -3,6 +3,9 @@ DEM time-step is 1.19898% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/ball_with_floating_walls.output
+++ b/applications_tests/dem_3d/ball_with_floating_walls.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/box_grid_rotation.output
+++ b/applications_tests/dem_3d/box_grid_rotation.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 100 particles of type 0 were inserted, 100 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/box_grid_slide.output
+++ b/applications_tests/dem_3d/box_grid_slide.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 100 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/force_boundary_box.output
+++ b/applications_tests/dem_3d/force_boundary_box.output
@@ -3,6 +3,9 @@ DEM time-step is 4.64363% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 *****************************************************************
 
+Reading triangulation 
+
+Finished reading triangulation 
 *****************************************************************
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
 *****************************************************************

--- a/applications_tests/dem_3d/insert_list_3d.output
+++ b/applications_tests/dem_3d/insert_list_3d.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 3 particles of type 0 were inserted, 6 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/outlet_boundary.output
+++ b/applications_tests/dem_3d/outlet_boundary.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 200 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_ball.mpirun=1.output
+++ b/applications_tests/dem_3d/packing_in_ball.mpirun=1.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_ball.mpirun=2.output
+++ b/applications_tests/dem_3d/packing_in_ball.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_ball_dynamic_contact.output
+++ b/applications_tests/dem_3d/packing_in_ball_dynamic_contact.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_ball_dynamic_load_balance.mpirun=2.output
+++ b/applications_tests/dem_3d/packing_in_ball_dynamic_load_balance.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_box.mpirun=1.output
+++ b/applications_tests/dem_3d/packing_in_box.mpirun=1.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 200 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_box.mpirun=2.output
+++ b/applications_tests/dem_3d/packing_in_box.mpirun=2.output
@@ -3,6 +3,9 @@ DEM time-step is 2.07669% of Rayleigh time step
 Starting simulation with Lethe/DEM on 2 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 200 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/packing_in_cylinder.output
+++ b/applications_tests/dem_3d/packing_in_cylinder.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 100 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/rotating_in_ball.output
+++ b/applications_tests/dem_3d/rotating_in_ball.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/sliding_in_box.output
+++ b/applications_tests/dem_3d/sliding_in_box.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 ***************************************************************** 
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/sliding_restart.output
+++ b/applications_tests/dem_3d/sliding_restart.output
@@ -3,6 +3,9 @@ DEM time-step is 1.46845% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 ***************************************************************** 
 
+Reading triangulation 
+
+Finished reading triangulation 
 id, type, dp, x, y, z 
 0 0 0.00500 0.0076 -0.0427 -0.0675
 1 0 0.00500 -0.0512 -0.0666 -0.0675

--- a/applications_tests/dem_3d/torque_boundary_box.output
+++ b/applications_tests/dem_3d/torque_boundary_box.output
@@ -3,6 +3,9 @@ DEM time-step is 4.64363% of Rayleigh time step
 Starting simulation with Lethe/DEM on 1 processors
 *****************************************************************
 
+Reading triangulation 
+
+Finished reading triangulation 
 *****************************************************************
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
 *****************************************************************

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -133,6 +133,15 @@ private:
     const std::vector<unsigned int> &                outlet_boundaries);
 
   /**
+   * Loops over all the cells to find boundary cells, find the global boundary cells with faces. Note that the boundary_cells_with_faces container only stores the local boundary cells, while global_boundary_cells_with_faces stores all the boundary cells with faces.
+   *
+   * @param triangulation Triangulation to access the information of the cells
+   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   */
+  void find_global_boundary_cells_with_faces(const parallel::distributed::Triangulation<dim> &triangulation,
+                                                                                            const std::vector<unsigned int> &                outlet_boundaries);
+
+  /**
    * Loops over all the cells to find cells which should be searched for
    * particle-line contact, boundary lines and a point locating on each line are
    * obtained
@@ -149,6 +158,15 @@ private:
   void
   find_particle_point_and_line_contact_cells(
     const parallel::distributed::Triangulation<dim> &triangulation);
+
+  /**
+   * Adds the cells with boundary lines to the boundary cells information (boundary_cells_information), First , it loops through the boundary_cells_with_lines vector, then it loops through the neighbors of boundary cells with lines, if a neighbor is a member of boundary_cells_with_faces, then it adds the neighbor cell to the boundary_cells_information with the normal vector and point of the neighbor cell.
+   *
+   * @param triangulation Triangulation to access the information of the cells
+   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   */
+  void add_cells_with_boundary_lines_to_boundary_cells(const parallel::distributed::Triangulation<dim> & triangulation,
+                                                        const std::vector<unsigned int> &                outlet_boundaries);
 
   /**
    * Loops over all the cells to find cells which should be searched for
@@ -178,6 +196,9 @@ private:
                Point<dim>>>
     boundary_cells_with_lines;
 
+  // A vector of all the local cells with boundary lines. This vector is used in add_cells_with_boundary_lines_to_boundary_cells function.
+  std::vector<typename Triangulation<dim>::active_cell_iterator> local_cells_with_boundary_lines;
+
   // Structure that contains the boundary cells which have a point
   std::unordered_map<
     std::string,
@@ -190,9 +211,13 @@ private:
     std::set<typename Triangulation<dim>::active_cell_iterator>>
     boundary_cells_for_floating_walls;
 
-  // Structure that contains the boundary cells faces
+  // Structure that contains the local boundary cells with faces
   std::vector<typename Triangulation<dim>::active_cell_iterator>
     boundary_cells_with_faces;
+
+  // Structure that contains the global boundary cells with faces
+  std::vector<typename Triangulation<dim>::active_cell_iterator>
+    global_boundary_cells_with_faces;
 
   // A map that contains updated points on boundaries and normal vectors of the
   // boundary faces. This container is used when the grid is moving. We use this

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -133,13 +133,18 @@ private:
     const std::vector<unsigned int> &                outlet_boundaries);
 
   /**
-   * Loops over all the cells to find boundary cells, find the global boundary cells with faces. Note that the boundary_cells_with_faces container only stores the local boundary cells, while global_boundary_cells_with_faces stores all the boundary cells with faces.
+   * Loops over all the cells to find boundary cells, find the global boundary
+   * cells with faces. Note that the boundary_cells_with_faces container only
+   * stores the local boundary cells, while global_boundary_cells_with_faces
+   * stores all the boundary cells with faces.
    *
    * @param triangulation Triangulation to access the information of the cells
    * @param outlet_boundaries A vector which contains the outlet boundary IDs
    */
-  void find_global_boundary_cells_with_faces(const parallel::distributed::Triangulation<dim> &triangulation,
-                                                                                            const std::vector<unsigned int> &                outlet_boundaries);
+  void
+  find_global_boundary_cells_with_faces(
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    const std::vector<unsigned int> &                outlet_boundaries);
 
   /**
    * Loops over all the cells to find cells which should be searched for
@@ -160,13 +165,21 @@ private:
     const parallel::distributed::Triangulation<dim> &triangulation);
 
   /**
-   * Adds the cells with boundary lines to the boundary cells information (boundary_cells_information), First , it loops through the boundary_cells_with_lines vector, then it loops through the neighbors of boundary cells with lines, if a neighbor is a member of boundary_cells_with_faces, then it adds the neighbor cell to the boundary_cells_information with the normal vector and point of the neighbor cell.
+   * Adds the cells with boundary lines to the boundary cells information
+   * (boundary_cells_information), First , it loops through the
+   * boundary_cells_with_lines vector, then it loops through the neighbors of
+   * boundary cells with lines, if a neighbor is a member of
+   * boundary_cells_with_faces, then it adds the neighbor cell to the
+   * boundary_cells_information with the normal vector and point of the neighbor
+   * cell.
    *
    * @param triangulation Triangulation to access the information of the cells
    * @param outlet_boundaries A vector which contains the outlet boundary IDs
    */
-  void add_cells_with_boundary_lines_to_boundary_cells(const parallel::distributed::Triangulation<dim> & triangulation,
-                                                        const std::vector<unsigned int> &                outlet_boundaries);
+  void
+  add_cells_with_boundary_lines_to_boundary_cells(
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    const std::vector<unsigned int> &                outlet_boundaries);
 
   /**
    * Loops over all the cells to find cells which should be searched for
@@ -196,8 +209,10 @@ private:
                Point<dim>>>
     boundary_cells_with_lines;
 
-  // A vector of all the local cells with boundary lines. This vector is used in add_cells_with_boundary_lines_to_boundary_cells function.
-  std::vector<typename Triangulation<dim>::active_cell_iterator> local_cells_with_boundary_lines;
+  // A vector of all the local cells with boundary lines. This vector is used in
+  // add_cells_with_boundary_lines_to_boundary_cells function.
+  std::vector<typename Triangulation<dim>::active_cell_iterator>
+    local_cells_with_boundary_lines;
 
   // Structure that contains the boundary cells which have a point
   std::unordered_map<

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -423,88 +423,90 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(const parallel::distributed::Triangulation<dim> & triangulation,
                                                                                 const std::vector<unsigned int> &                outlet_boundaries
+
                                                                                )
 {
+    std::cout << "before " << boundary_cells_information.size() << std::endl;
+    std::vector<typename Triangulation<dim>::active_cell_iterator> boundary_neighbor_cells;
+
     // First we have to store all the global (including local and non-local) cells with boundary faces in a container. Note that the boundary_cells_with_faces container only stores the local boundary cells
     find_global_boundary_cells_with_faces(triangulation, outlet_boundaries);
 
     if (!local_cells_with_boundary_lines.empty())
        {
-        for (const auto &cell_with_boundary_line : local_cells_with_boundary_lines)
+        for (auto &cell_with_boundary_line : local_cells_with_boundary_lines)
        {
-            // Define two cells, which store the two boundary cells with faces of boundary cell with line
-            typename Triangulation<dim>::active_cell_iterator cell_one;
-            typename Triangulation<dim>::active_cell_iterator cell_two;
-
-            DoFHandler<dim>    dof_handler(triangulation);
-            std::vector<typename DoFHandler<dim>::active_cell_iterator> neighbors;
-            auto cel = dof_handler.begin_active();
-
-
-
         // Each cell with boundary line must have two neighbor cells with boundary faces. We have to find these two neighbors first.
             // Finding neighbors of the cell
             std::vector<typename Triangulation<dim>::active_cell_iterator> active_neighbors;
 
-            GridTools::get_active_neighbors<DoFHandler<dim>>(
-                        cel,
-                   neighbors);
-
            GridTools::get_active_neighbors<Triangulation<dim>>(cell_with_boundary_line,
                   active_neighbors );
 
+           boundary_neighbor_cells.clear();
             // Looping through the neighbors
             for (auto &neighbor : active_neighbors)
             {
-                bool first_cell = true;
                 // If the neighbor exists in the global_boundary_cells_with_faces
                 if (std::count(global_boundary_cells_with_faces.begin(), global_boundary_cells_with_faces.end(), neighbor))
                 {
-                    if (first_cell)
-                    {cell_one = neighbor;
-                     first_cell = false;
-                    }
-                    else
-                    {
-                        cell_two = neighbor;
-                    }
+                    boundary_neighbor_cells.push_back(neighbor);
                 }
             }
 
-            // Find the information of these two cells in boundary_cells_information
-            // Looping through the faces of cell_one
-            for (int face_id = 0;
-                 face_id < int(GeometryInfo<dim>::faces_per_cell);
-                 ++face_id)
-              {
-                // Check to see if the face is not located at boundary
-                if ((cell_one->face(face_id)->at_boundary()))
+            // Find the information of every combination of two cells in boundary_cells_information
+            for (unsigned int counter_one = 0; counter_one < boundary_neighbor_cells.size(); ++counter_one)
             {
-                    // Get the normal vector of the first cell
-                Tensor<1, dim> normal_vector_one =  boundary_cells_information.at(cell_one->face_index(face_id)).normal_vector;
-
-                // Get the normal vector of the second cell
-                for (int face_id = 0;
-                     face_id < int(GeometryInfo<dim>::faces_per_cell);
-                     ++face_id)
+                for (unsigned int counter_two = 0; counter_two < boundary_neighbor_cells.size(); ++counter_two)
                 {
-                    if (cell_two->face(face_id)->at_boundary())
+                    if (counter_one > counter_two)
                     {
-                        Tensor<1, dim> normal_vector_two =  boundary_cells_information.at(cell_two->face_index(face_id)).normal_vector;
+                        for (int face_id = 0;
+                             face_id < int(GeometryInfo<dim>::faces_per_cell);
+                             ++face_id)
+                          {
+                            // Check to see if the face is not located at boundary
+                            if (boundary_neighbor_cells[counter_one]->face(face_id)->at_boundary())
+                        {
 
-                        // Check to see if the dot product of the two normal vectors is larger than a specified threshold (cos(45))
-                        if (normal_vector_one * normal_vector_two > 0.707)
-                    {
-                        // If this condition is true, add this cell to boundary_cells_information. Since the key of boundary_cells_information is the boundary face id, and this cell does not have a boundary face, we add it to the boundary_cells_information with a negative key
-                            boundary_cells_information.insert({-cell_two->face_index(face_id), boundary_cells_information.at(cell_two->face_index(face_id))});
-                        }
+                                // Get the normal vector of the first cell
+                            Tensor<1, dim> normal_vector_one =  boundary_cells_information.at(boundary_neighbor_cells[counter_one]->face_index(face_id)).normal_vector;
+
+                            // Get the normal vector of the second cell
+                            for (int face_id = 0;
+                                 face_id < int(GeometryInfo<dim>::faces_per_cell);
+                                 ++face_id)
+                            {
+
+                                if (boundary_neighbor_cells[counter_two]->face(face_id)->at_boundary())
+                                {
+                                    Tensor<1, dim> normal_vector_two =  boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id)).normal_vector;
+
+                                    // Check to see if the dot product of the two normal vectors is larger than a specified threshold (cos(45) = 0.707)
+                                    if (normal_vector_one * normal_vector_two > 0.707)
+                                {
+                                    // If this condition is true, add this cell to boundary_cells_information. Since the key of boundary_cells_information is the boundary face id, and this cell does not have a boundary face, we add it to the boundary_cells_information with a negative key
+                                       int imaginary_face_id = -1 * boundary_neighbor_cells[counter_two]->face_index(face_id);
+
+                                       // Update cell to the cell with boundary line
+                                       boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id)).cell = cell_with_boundary_line;
+                                       boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id)).global_face_id = imaginary_face_id;
+                                        boundary_cells_information.insert({imaginary_face_id, boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id))});
+
+                                    }
+                                }
+                            }
+                            }
+                            }
                     }
 
                 }
-                }
+
             }
-       }
+        }
     }
+    std::cout << "after " << boundary_cells_information.size() << std::endl;
+
 }
 
 // This function finds the triangulation cells adjacent to the floating

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -488,10 +488,10 @@ BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(c
                                        int imaginary_face_id = -1 * boundary_neighbor_cells[counter_two]->face_index(face_id);
 
                                        // Update cell to the cell with boundary line
-                                       boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id)).cell = cell_with_boundary_line;
-                                       boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id)).global_face_id = imaginary_face_id;
-                                        boundary_cells_information.insert({imaginary_face_id, boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id))});
 
+                                        boundary_cells_information.insert({imaginary_face_id, boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id))});
+                                        boundary_cells_information.at(imaginary_face_id).cell = cell_with_boundary_line;
+                                        boundary_cells_information.at(imaginary_face_id).global_face_id = imaginary_face_id;
                                     }
                                 }
                             }

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -426,7 +426,6 @@ BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(c
 
                                                                                )
 {
-    std::cout << "before " << boundary_cells_information.size() << std::endl;
     std::vector<typename Triangulation<dim>::active_cell_iterator> boundary_neighbor_cells;
 
     // First we have to store all the global (including local and non-local) cells with boundary faces in a container. Note that the boundary_cells_with_faces container only stores the local boundary cells
@@ -505,7 +504,6 @@ BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(c
             }
         }
     }
-    std::cout << "after " << boundary_cells_information.size() << std::endl;
 
 }
 

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -1,4 +1,12 @@
 #include <dem/find_boundary_cells_information.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
 
 using namespace dealii;
 
@@ -15,7 +23,9 @@ BoundaryCellsInformation<dim>::build(
   const std::vector<unsigned int> &                 outlet_boundaries)
 {
   boundary_cells_with_faces.clear();
+  global_boundary_cells_with_faces.clear();
   boundary_cells_with_lines.clear();
+  local_cells_with_boundary_lines.clear();
   boundary_cells_information.clear();
   boundary_cells_with_points.clear();
   boundary_cells_for_floating_walls.clear();
@@ -32,6 +42,9 @@ BoundaryCellsInformation<dim>::build(
   find_boundary_cells_for_floating_walls(triangulation,
                                          floating_wall_properties,
                                          maximal_cell_diameter);
+
+  // Add cells with boundary lines to boundary cells container
+  add_cells_with_boundary_lines_to_boundary_cells(triangulation, outlet_boundaries);
 }
 
 template <int dim>
@@ -41,7 +54,9 @@ BoundaryCellsInformation<dim>::build(
   const std::vector<unsigned int> &                outlet_boundaries)
 {
   boundary_cells_with_faces.clear();
+  global_boundary_cells_with_faces.clear();
   boundary_cells_with_lines.clear();
+  local_cells_with_boundary_lines.clear();
   boundary_cells_information.clear();
   boundary_cells_with_points.clear();
   boundary_cells_for_floating_walls.clear();
@@ -50,6 +65,9 @@ BoundaryCellsInformation<dim>::build(
 
   // Finding boundary cells with lines and points
   find_particle_point_and_line_contact_cells(triangulation);
+
+  // Add cells with boundary lines to boundary cells container
+  add_cells_with_boundary_lines_to_boundary_cells(triangulation, outlet_boundaries);
 }
 
 // This function finds all the boundary cells and faces in the triangulation,
@@ -309,6 +327,9 @@ BoundaryCellsInformation<dim>::find_particle_point_and_line_contact_cells(
                              std::make_tuple(cell,
                                              map_iterator.second.first,
                                              map_iterator.second.second)});
+
+                          // Add the cell to local_cells_with_boundary_lines to be used in add_cells_with_boundary_lines_to_boundary_cells
+                          local_cells_with_boundary_lines.push_back(cell);
                         }
                     }
                 }
@@ -364,6 +385,125 @@ BoundaryCellsInformation<dim>::find_particle_point_and_line_contact_cells(
                 }
             }
         }
+    }
+}
+
+template <int dim>
+void
+BoundaryCellsInformation<dim>::find_global_boundary_cells_with_faces(const parallel::distributed::Triangulation<dim> & triangulation,
+                                                                     const std::vector<unsigned int> &                outlet_boundaries)
+{
+    // Iterating over the active cells in the trangulation
+    for (const auto &cell : triangulation.active_cell_iterators())
+      {
+             // Iterating over the faces of each cell
+            for (int face_id = 0;
+                 face_id < int(GeometryInfo<dim>::faces_per_cell);
+                 ++face_id)
+              {
+                // We search to see if the boundary is defined as an outlet or
+                // not. If it is not defined as an outlet we proceed.
+                if (std::find(outlet_boundaries.begin(),
+                              outlet_boundaries.end(),
+                              cell->face(face_id)->boundary_id()) ==
+                    outlet_boundaries.end())
+                  {
+                    // Check to see if the face is located at boundary
+                    if (cell->face(face_id)->at_boundary())
+                      {
+                        global_boundary_cells_with_faces.push_back(cell);
+                      }
+                  }
+              }
+
+      }
+}
+
+template <int dim>
+void
+BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(const parallel::distributed::Triangulation<dim> & triangulation,
+                                                                                const std::vector<unsigned int> &                outlet_boundaries
+                                                                               )
+{
+    // First we have to store all the global (including local and non-local) cells with boundary faces in a container. Note that the boundary_cells_with_faces container only stores the local boundary cells
+    find_global_boundary_cells_with_faces(triangulation, outlet_boundaries);
+
+    if (!local_cells_with_boundary_lines.empty())
+       {
+        for (const auto &cell_with_boundary_line : local_cells_with_boundary_lines)
+       {
+            // Define two cells, which store the two boundary cells with faces of boundary cell with line
+            typename Triangulation<dim>::active_cell_iterator cell_one;
+            typename Triangulation<dim>::active_cell_iterator cell_two;
+
+            DoFHandler<dim>    dof_handler(triangulation);
+            std::vector<typename DoFHandler<dim>::active_cell_iterator> neighbors;
+            auto cel = dof_handler.begin_active();
+
+
+
+        // Each cell with boundary line must have two neighbor cells with boundary faces. We have to find these two neighbors first.
+            // Finding neighbors of the cell
+            std::vector<typename Triangulation<dim>::active_cell_iterator> active_neighbors;
+
+            GridTools::get_active_neighbors<DoFHandler<dim>>(
+                        cel,
+                   neighbors);
+
+           GridTools::get_active_neighbors<Triangulation<dim>>(cell_with_boundary_line,
+                  active_neighbors );
+
+            // Looping through the neighbors
+            for (auto &neighbor : active_neighbors)
+            {
+                bool first_cell = true;
+                // If the neighbor exists in the global_boundary_cells_with_faces
+                if (std::count(global_boundary_cells_with_faces.begin(), global_boundary_cells_with_faces.end(), neighbor))
+                {
+                    if (first_cell)
+                    {cell_one = neighbor;
+                     first_cell = false;
+                    }
+                    else
+                    {
+                        cell_two = neighbor;
+                    }
+                }
+            }
+
+            // Find the information of these two cells in boundary_cells_information
+            // Looping through the faces of cell_one
+            for (int face_id = 0;
+                 face_id < int(GeometryInfo<dim>::faces_per_cell);
+                 ++face_id)
+              {
+                // Check to see if the face is not located at boundary
+                if ((cell_one->face(face_id)->at_boundary()))
+            {
+                    // Get the normal vector of the first cell
+                Tensor<1, dim> normal_vector_one =  boundary_cells_information.at(cell_one->face_index(face_id)).normal_vector;
+
+                // Get the normal vector of the second cell
+                for (int face_id = 0;
+                     face_id < int(GeometryInfo<dim>::faces_per_cell);
+                     ++face_id)
+                {
+                    if (cell_two->face(face_id)->at_boundary())
+                    {
+                        Tensor<1, dim> normal_vector_two =  boundary_cells_information.at(cell_two->face_index(face_id)).normal_vector;
+
+                        // Check to see if the dot product of the two normal vectors is larger than a specified threshold (cos(45))
+                        if (normal_vector_one * normal_vector_two > 0.707)
+                    {
+                        // If this condition is true, add this cell to boundary_cells_information. Since the key of boundary_cells_information is the boundary face id, and this cell does not have a boundary face, we add it to the boundary_cells_information with a negative key
+                            boundary_cells_information.insert({-cell_two->face_index(face_id), boundary_cells_information.at(cell_two->face_index(face_id))});
+                        }
+                    }
+
+                }
+                }
+            }
+       }
     }
 }
 

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -1,11 +1,12 @@
 #include <dem/find_boundary_cells_information.h>
-#include <deal.II/grid/grid_tools.h>
+
 #include <deal.II/distributed/tria.h>
+
 #include <deal.II/dofs/dof_handler.h>
-#include <deal.II/grid/tria.h>
-#include <deal.II/dofs/dof_handler.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
 
 
 using namespace dealii;
@@ -44,7 +45,8 @@ BoundaryCellsInformation<dim>::build(
                                          maximal_cell_diameter);
 
   // Add cells with boundary lines to boundary cells container
-  add_cells_with_boundary_lines_to_boundary_cells(triangulation, outlet_boundaries);
+  add_cells_with_boundary_lines_to_boundary_cells(triangulation,
+                                                  outlet_boundaries);
 }
 
 template <int dim>
@@ -67,7 +69,8 @@ BoundaryCellsInformation<dim>::build(
   find_particle_point_and_line_contact_cells(triangulation);
 
   // Add cells with boundary lines to boundary cells container
-  add_cells_with_boundary_lines_to_boundary_cells(triangulation, outlet_boundaries);
+  add_cells_with_boundary_lines_to_boundary_cells(triangulation,
+                                                  outlet_boundaries);
 }
 
 // This function finds all the boundary cells and faces in the triangulation,
@@ -328,7 +331,9 @@ BoundaryCellsInformation<dim>::find_particle_point_and_line_contact_cells(
                                              map_iterator.second.first,
                                              map_iterator.second.second)});
 
-                          // Add the cell to local_cells_with_boundary_lines to be used in add_cells_with_boundary_lines_to_boundary_cells
+                          // Add the cell to local_cells_with_boundary_lines to
+                          // be used in
+                          // add_cells_with_boundary_lines_to_boundary_cells
                           local_cells_with_boundary_lines.push_back(cell);
                         }
                     }
@@ -390,121 +395,167 @@ BoundaryCellsInformation<dim>::find_particle_point_and_line_contact_cells(
 
 template <int dim>
 void
-BoundaryCellsInformation<dim>::find_global_boundary_cells_with_faces(const parallel::distributed::Triangulation<dim> & triangulation,
-                                                                     const std::vector<unsigned int> &                outlet_boundaries)
+BoundaryCellsInformation<dim>::find_global_boundary_cells_with_faces(
+  const parallel::distributed::Triangulation<dim> &triangulation,
+  const std::vector<unsigned int> &                outlet_boundaries)
 {
-    // Iterating over the active cells in the trangulation
-    for (const auto &cell : triangulation.active_cell_iterators())
-      {
-             // Iterating over the faces of each cell
-            for (int face_id = 0;
-                 face_id < int(GeometryInfo<dim>::faces_per_cell);
-                 ++face_id)
-              {
-                // We search to see if the boundary is defined as an outlet or
-                // not. If it is not defined as an outlet we proceed.
-                if (std::find(outlet_boundaries.begin(),
-                              outlet_boundaries.end(),
-                              cell->face(face_id)->boundary_id()) ==
-                    outlet_boundaries.end())
-                  {
-                    // Check to see if the face is located at boundary
-                    if (cell->face(face_id)->at_boundary())
-                      {
-                        global_boundary_cells_with_faces.push_back(cell);
-                      }
-                  }
-              }
-
-      }
+  // Iterating over the active cells in the trangulation
+  for (const auto &cell : triangulation.active_cell_iterators())
+    {
+      // Iterating over the faces of each cell
+      for (int face_id = 0; face_id < int(GeometryInfo<dim>::faces_per_cell);
+           ++face_id)
+        {
+          // We search to see if the boundary is defined as an outlet or
+          // not. If it is not defined as an outlet we proceed.
+          if (std::find(outlet_boundaries.begin(),
+                        outlet_boundaries.end(),
+                        cell->face(face_id)->boundary_id()) ==
+              outlet_boundaries.end())
+            {
+              // Check to see if the face is located at boundary
+              if (cell->face(face_id)->at_boundary())
+                {
+                  global_boundary_cells_with_faces.push_back(cell);
+                }
+            }
+        }
+    }
 }
 
 template <int dim>
 void
-BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(const parallel::distributed::Triangulation<dim> & triangulation,
-                                                                                const std::vector<unsigned int> &                outlet_boundaries
+BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(
+  const parallel::distributed::Triangulation<dim> &triangulation,
+  const std::vector<unsigned int> &                outlet_boundaries
 
-                                                                               )
+)
 {
-    std::vector<typename Triangulation<dim>::active_cell_iterator> boundary_neighbor_cells;
+  std::vector<typename Triangulation<dim>::active_cell_iterator>
+    boundary_neighbor_cells;
 
-    // First we have to store all the global (including local and non-local) cells with boundary faces in a container. Note that the boundary_cells_with_faces container only stores the local boundary cells
-    find_global_boundary_cells_with_faces(triangulation, outlet_boundaries);
+  // First we have to store all the global (including local and non-local) cells
+  // with boundary faces in a container. Note that the boundary_cells_with_faces
+  // container only stores the local boundary cells
+  find_global_boundary_cells_with_faces(triangulation, outlet_boundaries);
 
-    if (!local_cells_with_boundary_lines.empty())
-       {
-        for (auto &cell_with_boundary_line : local_cells_with_boundary_lines)
-       {
-        // Each cell with boundary line must have two neighbor cells with boundary faces. We have to find these two neighbors first.
-            // Finding neighbors of the cell
-            std::vector<typename Triangulation<dim>::active_cell_iterator> active_neighbors;
+  if (!local_cells_with_boundary_lines.empty())
+    {
+      for (auto &cell_with_boundary_line : local_cells_with_boundary_lines)
+        {
+          // Each cell with boundary line must have two neighbor cells with
+          // boundary faces. We have to find these two neighbors first. Finding
+          // neighbors of the cell
+          std::vector<typename Triangulation<dim>::active_cell_iterator>
+            active_neighbors;
 
-           GridTools::get_active_neighbors<Triangulation<dim>>(cell_with_boundary_line,
-                  active_neighbors );
+          GridTools::get_active_neighbors<Triangulation<dim>>(
+            cell_with_boundary_line, active_neighbors);
 
-           boundary_neighbor_cells.clear();
-            // Looping through the neighbors
-            for (auto &neighbor : active_neighbors)
+          boundary_neighbor_cells.clear();
+          // Looping through the neighbors
+          for (auto &neighbor : active_neighbors)
             {
-                // If the neighbor exists in the global_boundary_cells_with_faces
-                if (std::count(global_boundary_cells_with_faces.begin(), global_boundary_cells_with_faces.end(), neighbor))
+              // If the neighbor exists in the global_boundary_cells_with_faces
+              if (std::count(global_boundary_cells_with_faces.begin(),
+                             global_boundary_cells_with_faces.end(),
+                             neighbor))
                 {
-                    boundary_neighbor_cells.push_back(neighbor);
+                  boundary_neighbor_cells.push_back(neighbor);
                 }
             }
 
-            // Find the information of every combination of two cells in boundary_cells_information
-            for (unsigned int counter_one = 0; counter_one < boundary_neighbor_cells.size(); ++counter_one)
+          // Find the information of every combination of two cells in
+          // boundary_cells_information
+          for (unsigned int counter_one = 0;
+               counter_one < boundary_neighbor_cells.size();
+               ++counter_one)
             {
-                for (unsigned int counter_two = 0; counter_two < boundary_neighbor_cells.size(); ++counter_two)
+              for (unsigned int counter_two = 0;
+                   counter_two < boundary_neighbor_cells.size();
+                   ++counter_two)
                 {
-                    if (counter_one > counter_two)
+                  if (counter_one > counter_two)
                     {
-                        for (int face_id = 0;
-                             face_id < int(GeometryInfo<dim>::faces_per_cell);
-                             ++face_id)
-                          {
-                            // Check to see if the face is not located at boundary
-                            if (boundary_neighbor_cells[counter_one]->face(face_id)->at_boundary())
+                      for (int face_id = 0;
+                           face_id < int(GeometryInfo<dim>::faces_per_cell);
+                           ++face_id)
                         {
-
-                                // Get the normal vector of the first cell
-                            Tensor<1, dim> normal_vector_one =  boundary_cells_information.at(boundary_neighbor_cells[counter_one]->face_index(face_id)).normal_vector;
-
-                            // Get the normal vector of the second cell
-                            for (int face_id = 0;
-                                 face_id < int(GeometryInfo<dim>::faces_per_cell);
-                                 ++face_id)
+                          // Check to see if the face is not located at boundary
+                          if (boundary_neighbor_cells[counter_one]
+                                ->face(face_id)
+                                ->at_boundary())
                             {
+                              // Get the normal vector of the first cell
+                              Tensor<1, dim> normal_vector_one =
+                                boundary_cells_information
+                                  .at(boundary_neighbor_cells[counter_one]
+                                        ->face_index(face_id))
+                                  .normal_vector;
 
-                                if (boundary_neighbor_cells[counter_two]->face(face_id)->at_boundary())
+                              // Get the normal vector of the second cell
+                              for (int face_id = 0;
+                                   face_id <
+                                   int(GeometryInfo<dim>::faces_per_cell);
+                                   ++face_id)
                                 {
-                                    Tensor<1, dim> normal_vector_two =  boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id)).normal_vector;
+                                  if (boundary_neighbor_cells[counter_two]
+                                        ->face(face_id)
+                                        ->at_boundary())
+                                    {
+                                      Tensor<1, dim> normal_vector_two =
+                                        boundary_cells_information
+                                          .at(
+                                            boundary_neighbor_cells[counter_two]
+                                              ->face_index(face_id))
+                                          .normal_vector;
 
-                                    // Check to see if the dot product of the two normal vectors is larger than a specified threshold (cos(45) = 0.707)
-                                    if (normal_vector_one * normal_vector_two > 0.707)
-                                {
-                                    // If this condition is true, add this cell to boundary_cells_information. Since the key of boundary_cells_information is the boundary face id, and this cell does not have a boundary face, we add it to the boundary_cells_information with a negative key
-                                       int imaginary_face_id = -1 * boundary_neighbor_cells[counter_two]->face_index(face_id);
+                                      // Check to see if the dot product of the
+                                      // two normal vectors is larger than a
+                                      // specified threshold (cos(45) = 0.707)
+                                      if (normal_vector_one *
+                                            normal_vector_two >
+                                          0.707)
+                                        {
+                                          // If this condition is true, add this
+                                          // cell to boundary_cells_information.
+                                          // Since the key of
+                                          // boundary_cells_information is the
+                                          // boundary face id, and this cell
+                                          // does not have a boundary face, we
+                                          // add it to the
+                                          // boundary_cells_information with a
+                                          // negative key
+                                          int imaginary_face_id =
+                                            -1 *
+                                            boundary_neighbor_cells[counter_two]
+                                              ->face_index(face_id);
 
-                                       // Update cell to the cell with boundary line
+                                          // Update cell to the cell with
+                                          // boundary line
 
-                                        boundary_cells_information.insert({imaginary_face_id, boundary_cells_information.at(boundary_neighbor_cells[counter_two]->face_index(face_id))});
-                                        boundary_cells_information.at(imaginary_face_id).cell = cell_with_boundary_line;
-                                        boundary_cells_information.at(imaginary_face_id).global_face_id = imaginary_face_id;
+                                          boundary_cells_information.insert(
+                                            {imaginary_face_id,
+                                             boundary_cells_information.at(
+                                               boundary_neighbor_cells
+                                                 [counter_two]
+                                                   ->face_index(face_id))});
+                                          boundary_cells_information
+                                            .at(imaginary_face_id)
+                                            .cell = cell_with_boundary_line;
+                                          boundary_cells_information
+                                            .at(imaginary_face_id)
+                                            .global_face_id = imaginary_face_id;
+                                        }
                                     }
                                 }
                             }
-                            }
-                            }
+                        }
                     }
-
                 }
-
             }
         }
     }
-
 }
 
 // This function finds the triangulation cells adjacent to the floating

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -7,7 +7,7 @@ read_mesh(const DEMSolverParameters<dim> &           parameters,
           parallel::distributed::Triangulation<dim> &triangulation,
           double &triangulation_cell_diameter)
 {
-    pcout << "Reading triangulation " << std::endl;
+  pcout << "Reading triangulation " << std::endl;
   // GMSH input
   if (parameters.mesh.type == Parameters::Mesh::Type::gmsh)
     {

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -7,6 +7,7 @@ read_mesh(const DEMSolverParameters<dim> &           parameters,
           parallel::distributed::Triangulation<dim> &triangulation,
           double &triangulation_cell_diameter)
 {
+    pcout << "Reading triangulation " << std::endl;
   // GMSH input
   if (parameters.mesh.type == Parameters::Mesh::Type::gmsh)
     {
@@ -51,6 +52,8 @@ read_mesh(const DEMSolverParameters<dim> &           parameters,
           triangulation.refine_global(initial_refinement);
         }
     }
+
+  pcout << std::endl << "Finished reading triangulation " << std::endl;
 }
 
 template void


### PR DESCRIPTION
This PR fixes a problem in DEM simulations using some of the triangulations created with gmsh.
If the triangulation created with gmsh had a diamond-shaped cell (with a boundary line), the particles that move from this cell toward the neighbour boundary cells were recognized as particle-wall candidates with a delay; that could lead to sudden jumps (like popcorn!) when using dynamic contact detection method.
In this PR, we add these diamond-shaped cell to particle-wall candidates with an imaginary face id and normal vectors of their boundary neighbour cell. We use this imaginary face id, because these cells do not have any boundary faces.