### PR TITLE
Memory consumption investigation

### DIFF
--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -95,6 +95,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   auto &nonzero_constraints = this->get_nonzero_constraints();
   {
     nonzero_constraints.clear();
+    nonzero_constraints.reinit(this->locally_relevant_dofs);
 
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             nonzero_constraints);
@@ -170,6 +171,8 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
 
   {
     this->zero_constraints.clear();
+    this->zero_constraints.reinit(this->locally_relevant_dofs);
+
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             this->zero_constraints);
 

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -213,8 +213,10 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   }
   this->zero_constraints.close();
   this->pcout << "ZERO CONSTRAINTS" << std::endl;
+  sleep(10);
   MPI_Barrier(MPI_COMM_WORLD);
   this->pcout << "Init of solutions" << std::endl;
+  sleep(10);
   MPI_Barrier(MPI_COMM_WORLD);
 
   this->present_solution.reinit(this->locally_owned_dofs,
@@ -248,12 +250,18 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
 
   this->pcout << "Before sparsity pattern" << std::endl;
 
+  sleep(10);
+  MPI_Barrier(MPI_COMM_WORLD);
+
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
                                   nonzero_constraints,
                                   false);
   this->pcout << "Before distribution of sparsity pattern" << std::endl;
+
+  sleep(10);
+  MPI_Barrier(MPI_COMM_WORLD);
 
   SparsityTools::distribute_sparsity_pattern(
     dsp,
@@ -263,6 +271,9 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
 
   this->pcout << "Sparsity pattern distributed" << std::endl;
 
+  sleep(10);
+  MPI_Barrier(MPI_COMM_WORLD);
+
 
 
   system_matrix.reinit(this->locally_owned_dofs,
@@ -270,6 +281,9 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                        dsp,
                        this->mpi_communicator);
   this->pcout << "Matrix re-inited" << std::endl;
+
+  sleep(10);
+  MPI_Barrier(MPI_COMM_WORLD);
 
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -87,6 +87,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                                           this->locally_relevant_dofs);
 
   this->pcout << "Dof distributed" << std::endl;
+  MPI_Barrier(MPI_COMM_WORLD);
 
   FEValuesExtractors::Vector velocities(0);
 
@@ -161,6 +162,9 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   }
   nonzero_constraints.close();
 
+  this->pcout << "NON ZERO CONSTRAINTS" << std::endl;
+  MPI_Barrier(MPI_COMM_WORLD);
+
   {
     this->zero_constraints.clear();
     DoFTools::make_hanging_node_constraints(this->dof_handler,
@@ -208,9 +212,10 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
       }
   }
   this->zero_constraints.close();
-
+  this->pcout << "ZERO CONSTRAINTS" << std::endl;
+  MPI_Barrier(MPI_COMM_WORLD);
   this->pcout << "Init of solutions" << std::endl;
-
+  MPI_Barrier(MPI_COMM_WORLD);
 
   this->present_solution.reinit(this->locally_owned_dofs,
                                 this->locally_relevant_dofs,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -162,7 +162,10 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   }
   nonzero_constraints.close();
 
+
   this->pcout << "NON ZERO CONSTRAINTS" << std::endl;
+  this->pcout << "Memory consumption "
+              << nonzero_constraints.memory_consumption() << std::endl;
   MPI_Barrier(MPI_COMM_WORLD);
 
   {


### PR DESCRIPTION
Constraints were initially declared global instead of local. This increases significantly the memory consumption per core, preventing the launch of larger simulation. This has been fixed now. The memory footprint of Lethe is significantly reduced because of this and simulations with >150M Q1-Q1 cells are possible.
