### PR TITLE
Use a global structure to store boundary cells information for add_ce…

### DIFF
--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -201,6 +201,12 @@ private:
   // Structure that contains the necessary information for boundaries
   std::map<int, boundary_cells_info_struct<dim>> boundary_cells_information;
 
+  // A vector that contains geometrical information of all (global) boundary
+  // cells. This vector is used in
+  // add_cells_with_boundary_lines_to_boundary_cells function
+  std::map<int, boundary_cells_info_struct<dim>>
+    global_boundary_cells_information;
+
   // Structure that contains the boundary cells which have a line
   std::unordered_map<
     std::string,


### PR DESCRIPTION
Commit name: "Use a global structure to store boundary cells information for add_cells_with_boundary_lines_to_boundary_cells function"

After adding the boundary cells with lines to boundary_cells_information vector, I tested the code performance with a few parallel simulations and they worked fine, but I found a bug in a simulation today. When comparing the normal vectors of the neighbour boundary cells of cells with boundary lines, we need to read the information from a global vector; because the neighbour cells may not be owned by the same processor that owns the cell with boundary line. This problem is fixed in this PR by defining a global container for boundary cells and use the global container in add_cells_with_boundary_lines_to_boundary_cells function. It should be mentioned that particle-wall collisions are still handled using the boundary_cells_information vector (which is local).

