### PR TITLE
Dem examples

### DIFF
--- a/examples/dem/2d_packing_in_circle/packing_in_circle.prm
+++ b/examples/dem/2d_packing_in_circle/packing_in_circle.prm
@@ -5,7 +5,7 @@
 #---------------------------------------------------
 subsection simulation control
   set time step                 			 = 1e-6
-  set time end       					 = 1
+  set time end       					 = 3
   set log frequency				         = 10000
   set output frequency            			 = 10000
 end
@@ -53,11 +53,11 @@ end
 subsection insertion info
     set insertion method				= non_uniform
     set inserted number of particles at each time step  = 50
-    set insertion frequency            		 	= 200000
+    set insertion frequency            		 	= 1000000
     set insertion box minimum x            	 	= -0.05
-    set insertion box minimum y            	        = -0.05
+    set insertion box minimum y            	        = 0
     set insertion box maximum x            	        = 0.05
-    set insertion box maximum y           	 	= 0.05
+    set insertion box maximum y           	 	= 0.07
     set insertion distance threshold			= 2
     set insertion random number range			= 0.75
     set insertion random number seed			= 19

--- a/examples/dem/3d_rotating_drum/rotating_drum.prm
+++ b/examples/dem/3d_rotating_drum/rotating_drum.prm
@@ -5,7 +5,7 @@
 #---------------------------------------------------
 subsection simulation control
   set time step                 			 = 1e-6
-  set time end       					 = 10
+  set time end       					 = 15
   set log frequency				         = 1000
   set output frequency            			 = 1000
 end
@@ -53,14 +53,14 @@ end
 #---------------------------------------------------
 subsection insertion info
     set insertion method				= non_uniform
-    set inserted number of particles at each time step  = 75110
-    set insertion frequency            		 	= 200000
+    set inserted number of particles at each time step  = 37555
+    set insertion frequency            		 	= 150000
     set insertion box minimum x            	 	= -0.175
     set insertion box minimum y            	        = -0.07
-    set insertion box minimum z            	        = -0.085
+    set insertion box minimum z            	        = 0
     set insertion box maximum x            	        = 0.175
     set insertion box maximum y           	 	= 0.07
-    set insertion box maximum z            	        = 0.085
+    set insertion box maximum z            	        = 0.09
     set insertion distance threshold			= 1.575
     set insertion random number range			= 0.05
     set insertion random number seed			= 19

--- a/examples/dem/3d_rotating_drum_with_post_processing/rotating_drum_with_post_processing.prm
+++ b/examples/dem/3d_rotating_drum_with_post_processing/rotating_drum_with_post_processing.prm
@@ -5,7 +5,7 @@
 #---------------------------------------------------
 subsection simulation control
   set time step                 			 = 1e-6
-  set time end       					 = 10
+  set time end       					 = 15
   set log frequency				         = 1000
   set output frequency            			 = 1000
 end
@@ -56,14 +56,14 @@ end
 #---------------------------------------------------
 subsection insertion info
     set insertion method				= non_uniform
-    set inserted number of particles at each time step  = 75110
-    set insertion frequency            		 	= 200000
+    set inserted number of particles at each time step  = 37555
+    set insertion frequency            		 	= 150000
     set insertion box minimum x            	 	= -0.175
     set insertion box minimum y            	        = -0.07
-    set insertion box minimum z            	        = -0.085
+    set insertion box minimum z            	        = 0
     set insertion box maximum x            	        = 0.175
     set insertion box maximum y           	 	= 0.07
-    set insertion box maximum z            	        = 0.085
+    set insertion box maximum z            	        = 0.09
     set insertion distance threshold			= 1.575
     set insertion random number range			= 0.05
     set insertion random number seed			= 19
@@ -101,8 +101,8 @@ subsection post-processing
     set Lagrangian post processing			= true
     set calculate particles average velocity            = true
     set calculate granular temperature			= true
-    set initial step            			= 8500000
-    set end step       					= 9500000
+    set initial step            			= 12500000
+    set end step       					= 14500000
     set output frequency				= 1000
     set particles velocity output name   		= average_velocity
     set granular temperature output name		= granular_temperature

--- a/examples/dem/3d_silo/silo_Golshan.prm
+++ b/examples/dem/3d_silo/silo_Golshan.prm
@@ -82,7 +82,7 @@ end
 #---------------------------------------------------
 subsection mesh
 	set type = gmsh
-	set file name = ./silo.msh
+	set file name = ./silo_Golshan.msh
 end
 
 #---------------------------------------------------


### PR DESCRIPTION
This PR fixes some small issues in the DEM examples. The insertion frequency and insertion domain in packing_in_circle and rotating_drum examples are modified. Missing mesh file is added to the 3d_silo example.