### PR TITLE
New clang-format workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,8 +1,10 @@
+# Independent workflow to allow greater flexibility in triggers and schedules
 name: clang-format
 
 on: push
 
 env:
+  # Supports version 5 up to version 12
   CLANG_FORMAT_VERION: 6
 
 jobs:
@@ -15,6 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      # Executes the specified version of clang-format
       - name: clang-format lint
         uses: DoozyX/clang-format-lint-action@v0.12
         with:


### PR DESCRIPTION
The proposed workflow runs `clang-format` on each push. If there is no format violations, the workflow will be successful. The workflow will return an error if `clang-format`'s output is not empty.

Example: https://github.com/technophil98/lethe/runs/3969196608?check_suite_focus=true

Here we can see that some errors should be fixed in `ib_stencil.cc`.
The output if somewhat identical to the `run-clang-format.py` script.