### PR TITLE
fix checkpointing debug error

### DIFF
--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -118,6 +118,17 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
               &particle_handler,
               false));
 
+  // Necessary signals for checkpointing
+  triangulation.signals.pre_distributed_save.connect(std::bind(
+    &Particles::ParticleHandler<dim>::register_store_callback_function,
+    &particle_handler));
+
+  triangulation.signals.post_distributed_load.connect(
+    std::bind(&Particles::ParticleHandler<dim>::register_load_callback_function,
+              &particle_handler,
+              true));
+
+
   // Setting contact detection method (constant or dynamic)
   if (parameters.model_parameters.contact_detection_method ==
       Parameters::Lagrangian::ModelParameters::ContactDetectionMethod::constant)

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -16,11 +16,6 @@ read_checkpoint(TimerOutput &                              computing_timer,
   simulation_control->read(prefix);
   particles_pvdhandler.read(prefix);
 
-  triangulation.signals.post_distributed_load.connect(
-    std::bind(&Particles::ParticleHandler<dim>::register_load_callback_function,
-              &particle_handler,
-              true));
-
   // Gather particle serialization information
   std::string   particle_filename = prefix + ".particles";
   std::ifstream input(particle_filename.c_str());

--- a/source/dem/write_checkpoint.cc
+++ b/source/dem/write_checkpoint.cc
@@ -24,10 +24,6 @@ write_checkpoint(TimerOutput &                       computing_timer,
       particles_pvdhandler.save(prefix);
     }
 
-  triangulation.signals.pre_distributed_save.connect(std::bind(
-    &Particles::ParticleHandler<dim>::register_store_callback_function,
-    &particle_handler));
-
   std::ostringstream            oss;
   boost::archive::text_oarchive oa(oss, boost::archive::no_header);
   oa << particle_handler;

--- a/tests/core/kinsol_newton_non_linear_solver_01.cc
+++ b/tests/core/kinsol_newton_non_linear_solver_01.cc
@@ -27,7 +27,8 @@ test()
   deallog << "Creating solver" << std::endl;
 
   // Create an instantiation of the Test Class
-  std::unique_ptr<NonLinearProblemTestClass> solver = std::make_unique<NonLinearProblemTestClass>(params);
+  std::unique_ptr<NonLinearProblemTestClass> solver =
+    std::make_unique<NonLinearProblemTestClass>(params);
 
 
   deallog << "Solving non-linear system " << std::endl;


### PR DESCRIPTION
This PR fixes a bug in the checkpointing of DEM where the signals defined in the write and read functions are removed and defined in the dem constructor. This was leading to incorrect number of vectors being attached to the triangulation when saving.