### PR TITLE
Conservation monitoring in the vof postprocess

### DIFF
--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -43,6 +43,10 @@ namespace Parameters
     // subparameter for heat_transfer
     bool viscous_dissipation;
 
+    // subparameter for free_surface
+    bool conservation_monitoring;
+    int  fluid_index;
+
     static void
     declare_parameters(ParameterHandler &prm);
     void

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -27,6 +27,7 @@
 
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/table_handler.h>
 #include <deal.II/base/timer.h>
 
 #include <deal.II/distributed/solution_transfer.h>
@@ -405,7 +406,7 @@ private:
     previous_solutions_transfer;
 
   // Conservation Analysis
-  ConvergenceTable error_table_fs;
+  TableHandler volume_table_fs;
 
   // Enable DCDD shock capturing scheme
   const bool DCDD = true;

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -17,14 +17,6 @@
 #ifndef lethe_VOF_h
 #define lethe_VOF_h
 
-#include <core/bdf.h>
-#include <core/simulation_control.h>
-
-#include <solvers/auxiliary_physics.h>
-#include <solvers/multiphysics_interface.h>
-#include <solvers/vof_assemblers.h>
-#include <solvers/vof_scratch_data.h>
-
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
@@ -41,6 +33,13 @@
 #include <deal.II/lac/trilinos_vector.h>
 
 #include <deal.II/numerics/error_estimator.h>
+
+#include <core/bdf.h>
+#include <core/simulation_control.h>
+#include <solvers/auxiliary_physics.h>
+#include <solvers/multiphysics_interface.h>
+#include <solvers/vof_assemblers.h>
+#include <solvers/vof_scratch_data.h>
 
 
 template <int dim>
@@ -163,6 +162,11 @@ public:
    * physics. It does not concern the output of the solution using the
    * DataOutObject, which is accomplished through the attach_solution_to_output
    * function
+   *
+   * @param scratch_data The scratch data which is used to store
+   * the calculated finite element information at the gauss point.
+   * See the documentation for VOFScratchData for more
+   * information
    */
   void
   postprocess(bool first_iteration) override;

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -138,6 +138,13 @@ public:
   calculate_L2_error();
 
   /**
+   * @brief Calculates the volume for the fluid phase with given fluid_index.
+   * Used for conservation monitoring.
+   */
+  double
+  calculate_volume(int fluid_index);
+
+  /**
    * @brief Carry out the operations required to finish a simulation correctly.
    */
   void

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -17,6 +17,14 @@
 #ifndef lethe_VOF_h
 #define lethe_VOF_h
 
+#include <core/bdf.h>
+#include <core/simulation_control.h>
+
+#include <solvers/auxiliary_physics.h>
+#include <solvers/multiphysics_interface.h>
+#include <solvers/vof_assemblers.h>
+#include <solvers/vof_scratch_data.h>
+
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
@@ -33,13 +41,6 @@
 #include <deal.II/lac/trilinos_vector.h>
 
 #include <deal.II/numerics/error_estimator.h>
-
-#include <core/bdf.h>
-#include <core/simulation_control.h>
-#include <solvers/auxiliary_physics.h>
-#include <solvers/multiphysics_interface.h>
-#include <solvers/vof_assemblers.h>
-#include <solvers/vof_scratch_data.h>
 
 
 template <int dim>
@@ -402,6 +403,9 @@ private:
   std::vector<
     parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>>
     previous_solutions_transfer;
+
+  // Conservation Analysis
+  ConvergenceTable error_table_fs;
 
   // Enable DCDD shock capturing scheme
   const bool DCDD = true;

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -40,6 +40,19 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
                       "false",
                       Patterns::Bool(),
                       "Viscous dissipation in heat equation <true|false>");
+
+    // subparameter for free_surface
+    prm.declare_entry(
+      "conservation monitoring",
+      "false",
+      Patterns::Bool(),
+      "Conservation monitoring in free surface calculation <true|false>");
+
+    prm.declare_entry(
+      "fluid index",
+      "0",
+      Patterns::Integer(),
+      "Index of the fluid which conservation is monitored <0|1>");
   }
   prm.leave_subsection();
 }
@@ -57,6 +70,10 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
 
     // subparameter for heat_transfer
     viscous_dissipation = prm.get_bool("viscous dissipation");
+
+    // subparameter for free_surface
+    conservation_monitoring = prm.get_bool("conservation monitoring");
+    fluid_index             = prm.get_integer("fluid index");
   }
   prm.leave_subsection();
 }

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -414,9 +414,6 @@ VOF<dim>::postprocess(bool first_iteration)
         }
     }
 
-  //  bool conservation_monitoring(true);
-  //  int  fluid_index(1);
-
   if (simulation_parameters.multiphysics.conservation_monitoring)
     {
       double volume =
@@ -431,21 +428,21 @@ VOF<dim>::postprocess(bool first_iteration)
           // Set conservation monitoring table
           if (simulation_control->is_steady())
             {
-              error_table_fs.add_value(
+              volume_table_fs.add_value(
                 "cells", this->triangulation->n_global_active_cells());
             }
           else
             {
-              error_table_fs.add_value("time",
-                                       simulation_control->get_current_time());
+              volume_table_fs.add_value("time",
+                                        simulation_control->get_current_time());
             }
-          error_table_fs.add_value("fluid_volume", volume);
-          error_table_fs.set_scientific("fluid_volume", true);
+          volume_table_fs.add_value("fluid_volume", volume);
+          volume_table_fs.set_scientific("fluid_volume", true);
 
           // Save table to free_surface_monitoring.dat
           std::string   filename = "free_surface_monitoring.dat";
           std::ofstream output(filename.c_str());
-          error_table_fs.write_text(output);
+          volume_table_fs.write_text(output);
         }
     }
 }


### PR DESCRIPTION
The surface occupied by one of the two fluids is calculated at every time step. This can be used for any simulation, and will be especially needed with wetting/peeling.

Outputs a table in free_surface_monitoring.dat. The user can choose which fluid to monitor through the `fluid index` parameter.

Checked for 2D simulations. Compatible with multiple MPI run.
