### PR TITLE
Add header for Boost sign compatibility

### DIFF
--- a/source/dem/pw_fine_search.cc
+++ b/source/dem/pw_fine_search.cc
@@ -1,5 +1,8 @@
 #include <dem/pw_fine_search.h>
 
+#include <boost/math/special_functions/sign.hpp>
+
+
 using namespace dealii;
 
 template <int dim>


### PR DESCRIPTION
# Description of the problem

When using a newer version of the Boost library (in my case on Manjaro), the sign function is not located in the next.hpp header anymore but in the dedicated sign header

# Description of the solution

We now use the correct sign header

# How Has This Been Tested?

If compilation works on CI and on my machine, all should be good.

# Comments

It is good to start testing on newer version of GCC.

