### PR TITLE
Fluid identification refactoring

### DIFF
--- a/applications_tests/cfd_dem_coupling_3d/dynamic_contact_search.prm
+++ b/applications_tests/cfd_dem_coupling_3d/dynamic_contact_search.prm
@@ -29,8 +29,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.00000100501
     set density                        = 997
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.prm
+++ b/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.prm
@@ -39,8 +39,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.0000008379
     set density                        = 996.7775
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/cfd_dem_coupling_3d/particle_sedimentation.prm
+++ b/applications_tests/cfd_dem_coupling_3d/particle_sedimentation.prm
@@ -30,8 +30,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.00000100501
     set density                        = 997
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/cfd_dem_coupling_3d/restart_particle_sedimentation.prm
+++ b/applications_tests/cfd_dem_coupling_3d/restart_particle_sedimentation.prm
@@ -36,8 +36,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.00000100501
     set density                        = 997
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/mms-conduction_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms-conduction_gd.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set thermal conductivity = 1
+  subsection fluid 0
+    set thermal conductivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/mms-conduction_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms-conduction_gd.prm
@@ -43,6 +43,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+
   subsection fluid 0
     set thermal conductivity = 1
   end

--- a/applications_tests/gd_navier_stokes_2d/mms2d-unstructured_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d-unstructured_gd.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-    set kinematic viscosity            = 1.000
+  subsection fluid 0
+    set kinematic viscosity            = 1.00
+  end
 end
 #---------------------------------------------------
 # Timer

--- a/applications_tests/gd_navier_stokes_2d/mms2d-unstructured_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d-unstructured_gd.prm
@@ -13,6 +13,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+
   subsection fluid 0
     set kinematic viscosity            = 1.00
   end

--- a/applications_tests/gd_navier_stokes_2d/mms2d_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d_gd.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/mms2d_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d_gd.prm
@@ -13,6 +13,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gd_navier_stokes_2d/poiseuille_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/poiseuille_gd.prm
@@ -32,6 +32,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gd_navier_stokes_2d/poiseuille_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/poiseuille_gd.prm
@@ -32,7 +32,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf1.prm
+++ b/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf1.prm
@@ -44,6 +44,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf1.prm
+++ b/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf1.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf2.prm
+++ b/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf2.prm
@@ -44,6 +44,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf2.prm
+++ b/applications_tests/gd_navier_stokes_2d/taylor-green-vortex_gd_bdf2.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/taylorcouette_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/taylorcouette_gd.prm
@@ -27,7 +27,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/taylorcouette_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/taylorcouette_gd.prm
@@ -27,6 +27,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+
   subsection fluid 0
     set kinematic viscosity            = 1.0000
   end

--- a/applications_tests/gd_navier_stokes_3d/mms3d_gd.prm
+++ b/applications_tests/gd_navier_stokes_3d/mms3d_gd.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes_3d/poiseuille3d_gd.prm
+++ b/applications_tests/gd_navier_stokes_3d/poiseuille3d_gd.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/buoyant_flow_between_parallel_plates.prm
+++ b/applications_tests/gls_navier_stokes_2d/buoyant_flow_between_parallel_plates.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set thermal expansion = 0.01
     set thermal conductivity = 1

--- a/applications_tests/gls_navier_stokes_2d/buoyant_flow_between_parallel_plates.prm
+++ b/applications_tests/gls_navier_stokes_2d/buoyant_flow_between_parallel_plates.prm
@@ -43,8 +43,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set thermal expansion = 0.01
-  set thermal conductivity = 1
+  subsection fluid 0
+    set thermal expansion = 0.01
+    set thermal conductivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/cavity_adjoint_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/cavity_adjoint_gls.prm
@@ -18,7 +18,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.002
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/cavity_adjoint_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/cavity_adjoint_gls.prm
@@ -18,6 +18,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 0.002
   end

--- a/applications_tests/gls_navier_stokes_2d/cylinder_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/cylinder_gls.prm
@@ -57,9 +57,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-    subsection fluid 0
-        set kinematic viscosity            = 1.0000
-    end
+  set number of fluids = 1
+  subsection fluid 0
+    set kinematic viscosity            = 1.0000
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/applications_tests/gls_navier_stokes_2d/cylinder_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/cylinder_gls.prm
@@ -57,7 +57,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-    set kinematic viscosity            = 1.0000
+    subsection fluid 0
+        set kinematic viscosity            = 1.0000
+    end
 end
 #---------------------------------------------------
 # Mesh

--- a/applications_tests/gls_navier_stokes_2d/ggls-stab_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/ggls-stab_gls.prm
@@ -44,8 +44,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
     set thermal conductivity           = 0.001
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/applications_tests/gls_navier_stokes_2d/ggls-stab_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/ggls-stab_gls.prm
@@ -44,6 +44,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.0
     set thermal conductivity           = 0.001

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_advection_tanh.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_advection_tanh.prm
@@ -48,6 +48,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set tracer diffusivity =0
   end

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_advection_tanh.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_advection_tanh.prm
@@ -48,7 +48,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set tracer diffusivity =0
+  subsection fluid 0
+    set tracer diffusivity =0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_diffusion_mms_2d.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set tracer diffusivity = 1
   end

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_diffusion_mms_2d.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set tracer diffusivity = 1
+  subsection fluid 0
+    set tracer diffusivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_high_pe_stab.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_high_pe_stab.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set tracer diffusivity = 0.01
+  subsection fluid 0
+    set tracer diffusivity = 0.01
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_high_pe_stab.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_high_pe_stab.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set tracer diffusivity = 0.01
   end

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_simplex_diffusion_mms_2d.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_simplex_diffusion_mms_2d.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set tracer diffusivity = 1
   end

--- a/applications_tests/gls_navier_stokes_2d/gls_tracer_simplex_diffusion_mms_2d.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_tracer_simplex_diffusion_mms_2d.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set tracer diffusivity = 1
+  subsection fluid 0
+    set tracer diffusivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/high_pe_stab_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/high_pe_stab_gls.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set thermal conductivity = 0.01
   end

--- a/applications_tests/gls_navier_stokes_2d/high_pe_stab_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/high_pe_stab_gls.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set thermal conductivity = 0.01
+  subsection fluid 0
+    set thermal conductivity = 0.01
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms-conduction_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-conduction_gls.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set thermal conductivity = 1
   end

--- a/applications_tests/gls_navier_stokes_2d/mms-conduction_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-conduction_gls.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set thermal conductivity = 1
+  subsection fluid 0
+    set thermal conductivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms-conv-bc_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-conv-bc_gls.prm
@@ -39,6 +39,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.0
   end

--- a/applications_tests/gls_navier_stokes_2d/mms-conv-bc_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-conv-bc_gls.prm
@@ -39,7 +39,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/applications_tests/gls_navier_stokes_2d/mms-transient-conduction-restart_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-transient-conduction-restart_gls.prm
@@ -62,6 +62,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set thermal conductivity = 1
   end

--- a/applications_tests/gls_navier_stokes_2d/mms-transient-conduction-restart_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-transient-conduction-restart_gls.prm
@@ -62,7 +62,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set thermal conductivity = 1
+  subsection fluid 0
+    set thermal conductivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.prm
@@ -45,7 +45,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set thermal conductivity = 1
+  subsection fluid 0
+    set thermal conductivity = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-transient-conduction_gls.prm
@@ -45,6 +45,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set thermal conductivity = 1
   end

--- a/applications_tests/gls_navier_stokes_2d/mms2d-unstructured_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d-unstructured_gls.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 #---------------------------------------------------
 # Timer

--- a/applications_tests/gls_navier_stokes_2d/mms2d-unstructured_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d-unstructured_gls.prm
@@ -13,6 +13,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
@@ -14,7 +14,7 @@ end
 #---------------------------------------------------
 subsection physical properties
     set non newtonian flow	= true
-    subsection non newtonian
+  subsection non newtonian
     	set model 		= carreau
     	subsection carreau
 	    	set viscosity_0		= 1.0
@@ -23,7 +23,7 @@ subsection physical properties
 	    	set a	      		= 2.0
 	    	set n	      		= 0.5
 	end
-    end
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms2d_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_gls.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms2d_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_gls.prm
@@ -13,6 +13,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine3.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine3.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine3.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine3.prm
@@ -13,6 +13,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine4.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine4.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine4.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_gls_simplex_refine4.prm
@@ -13,6 +13,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/mms2d_weak_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_weak_gls.prm
@@ -14,6 +14,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/mms2d_weak_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_weak_gls.prm
@@ -14,7 +14,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms_adv_diff_diss_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms_adv_diff_diss_gls.prm
@@ -43,7 +43,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms_adv_diff_diss_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms_adv_diff_diss_gls.prm
@@ -43,6 +43,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.0
   end

--- a/applications_tests/gls_navier_stokes_2d/poiseuille_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/poiseuille_gls.prm
@@ -32,6 +32,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/poiseuille_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/poiseuille_gls.prm
@@ -32,7 +32,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/rigid-body-rotation_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/rigid-body-rotation_gls.prm
@@ -27,7 +27,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/rigid-body-rotation_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/rigid-body-rotation_gls.prm
@@ -27,6 +27,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.0000
   end

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex-restart_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex-restart_gls_bdf1.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex-restart_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex-restart_gls_bdf1.prm
@@ -44,6 +44,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_bdf1.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_bdf1.prm
@@ -44,6 +44,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk2.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk2.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk2.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk2.prm
@@ -44,6 +44,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk3.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk3.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk3.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylor-green-vortex_gls_sdirk3.prm
@@ -44,6 +44,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.000
   end

--- a/applications_tests/gls_navier_stokes_2d/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylorcouette-unstructured_gls.prm
@@ -26,6 +26,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.0000
   end

--- a/applications_tests/gls_navier_stokes_2d/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylorcouette-unstructured_gls.prm
@@ -26,7 +26,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end
 end
 
 

--- a/applications_tests/gls_navier_stokes_2d/taylorcouette_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylorcouette_gls.prm
@@ -27,7 +27,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/taylorcouette_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/taylorcouette_gls.prm
@@ -27,6 +27,7 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity            = 1.0000
   end

--- a/applications_tests/gls_navier_stokes_3d/cylinder-rigid-body_gls.prm
+++ b/applications_tests/gls_navier_stokes_3d/cylinder-rigid-body_gls.prm
@@ -27,7 +27,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.0200
+  end
 end
 
 #--------------------------------------------------

--- a/applications_tests/gls_navier_stokes_3d/mms3d_gls.prm
+++ b/applications_tests/gls_navier_stokes_3d/mms3d_gls.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_3d/mms3d_gls_simplex_refine2.prm
+++ b/applications_tests/gls_navier_stokes_3d/mms3d_gls_simplex_refine2.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_3d/poiseuille3d-flow-control_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes_3d/poiseuille3d-flow-control_gls_bdf1.prm
@@ -16,7 +16,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity        = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_3d/poiseuille3d_gls.prm
+++ b/applications_tests/gls_navier_stokes_3d/poiseuille3d_gls.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_3d/poiseuille_restart.prm
+++ b/applications_tests/gls_navier_stokes_3d/poiseuille_restart.prm
@@ -23,7 +23,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0 
     set kinematic viscosity        = 1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/impeller.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/impeller.prm
@@ -44,7 +44,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/mixer_back_and_forth.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/mixer_back_and_forth.prm
@@ -70,7 +70,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/noslip_22.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/noslip_22.prm
@@ -57,7 +57,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/poiseuille_22.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/poiseuille_22.prm
@@ -56,7 +56,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/poiseuille_two_solids_22.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/poiseuille_two_solids_22.prm
@@ -42,7 +42,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/taylor_couette_nitsche_22.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/taylor_couette_nitsche_22.prm
@@ -46,7 +46,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/two-bar-mixer-restart.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/two-bar-mixer-restart.prm
@@ -69,7 +69,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/two-bar-mixer-start.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/two-bar-mixer-start.prm
@@ -70,7 +70,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_23/couette_23.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_23/couette_23.prm
@@ -56,7 +56,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_23/taylor-couette_23.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_23/taylor-couette_23.prm
@@ -45,7 +45,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_33/noslip33_simplex.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_33/noslip33_simplex.prm
@@ -51,7 +51,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_33/noslip_33.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_33/noslip_33.prm
@@ -56,7 +56,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_2d/couette2d_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/couette2d_gls.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_2d/couette2d_gls_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/couette2d_gls_poisson.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_2d/moving_ib_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/moving_ib_gls.prm
@@ -17,8 +17,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.1
-
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_2d/moving_ib_gls_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/moving_ib_gls_poisson.prm
@@ -17,8 +17,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.1
-
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_2d/moving_stokes_2d.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/moving_stokes_2d.prm
@@ -19,7 +19,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            =1
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_3d/check_point.prm
+++ b/applications_tests/gls_sharp_navier_stokes_3d/check_point.prm
@@ -18,7 +18,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.604166666666667
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_3d/moving_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes_3d/moving_stokes.prm
@@ -18,8 +18,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            =1
-
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_3d/static_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes_3d/static_stokes.prm
@@ -18,8 +18,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1
-
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_3d/steady_couette_sphere.prm
+++ b/applications_tests/gls_sharp_navier_stokes_3d/steady_couette_sphere.prm
@@ -16,7 +16,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.01
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_3d/steady_couette_sphere_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes_3d/steady_couette_sphere_poisson.prm
@@ -16,7 +16,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.01
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_vans_2d/case0_vans.prm
+++ b/applications_tests/gls_vans_2d/case0_vans.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_vans_2d/case1_vans.prm
+++ b/applications_tests/gls_vans_2d/case1_vans.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_vans_2d/case2_vans.prm
+++ b/applications_tests/gls_vans_2d/case2_vans.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_vans_2d/case3_vans.prm
+++ b/applications_tests/gls_vans_2d/case3_vans.prm
@@ -26,7 +26,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_vans_3d/packed_bed.prm
+++ b/applications_tests/gls_vans_3d/packed_bed.prm
@@ -29,8 +29,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.00001
     set density                        = 1
+  end
 end
 
 #---------------------------------------------------

--- a/examples/cfd-dem/cylindrical_packed_bed/flow_in_bed.prm
+++ b/examples/cfd-dem/cylindrical_packed_bed/flow_in_bed.prm
@@ -30,8 +30,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.00001
     set density                        = 1
+  end
 end
 
 #---------------------------------------------------

--- a/examples/cfd-dem/square_fluidized_bed/fluidized_bed.prm
+++ b/examples/cfd-dem/square_fluidized_bed/fluidized_bed.prm
@@ -31,8 +31,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.00001
     set density                        = 1
+  end
 end
 
 #---------------------------------------------------

--- a/examples/incompressible_flow/2d_ahmed_body/ahmed.prm
+++ b/examples/incompressible_flow/2d_ahmed_body/ahmed.prm
@@ -39,7 +39,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity         = 1e-3
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/examples/incompressible_flow/2d_ahmed_body_simplex/ahmed.prm
+++ b/examples/incompressible_flow/2d_ahmed_body_simplex/ahmed.prm
@@ -39,7 +39,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity         = 1e-3
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/examples/incompressible_flow/2d_flow_around_cylinder/cylinder.prm
+++ b/examples/incompressible_flow/2d_flow_around_cylinder/cylinder.prm
@@ -50,7 +50,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end 
 end
 #---------------------------------------------------
 # Mesh

--- a/examples/incompressible_flow/2d_lid_driven_cavity/cavity.prm
+++ b/examples/incompressible_flow/2d_lid_driven_cavity/cavity.prm
@@ -13,7 +13,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.000
+  end
 end
 
 #---------------------------------------------------

--- a/examples/incompressible_flow/2d_nitsche_taylor-couette/adaptative_nitsche_taylor-couette.prm
+++ b/examples/incompressible_flow/2d_nitsche_taylor-couette/adaptative_nitsche_taylor-couette.prm
@@ -46,7 +46,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/examples/incompressible_flow/2d_nitsche_taylor-couette/uniform_nitsche_taylor-couette.prm
+++ b/examples/incompressible_flow/2d_nitsche_taylor-couette/uniform_nitsche_taylor-couette.prm
@@ -46,7 +46,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0
+  end
 end
 
 #---------------------------------------------------

--- a/examples/incompressible_flow/2d_taylor-couette/taylor-couette.prm
+++ b/examples/incompressible_flow/2d_taylor-couette/taylor-couette.prm
@@ -26,7 +26,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end
 end
 
 # --------------------------------------------------

--- a/examples/incompressible_flow/3d_flow_around_sphere/sphere_0.1.prm
+++ b/examples/incompressible_flow/3d_flow_around_sphere/sphere_0.1.prm
@@ -39,7 +39,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0 
     set kinematic viscosity            = 10
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/examples/incompressible_flow/3d_flow_around_sphere/sphere_150.prm
+++ b/examples/incompressible_flow/3d_flow_around_sphere/sphere_150.prm
@@ -51,7 +51,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.006666667
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/examples/incompressible_flow/3d_flow_around_sphere/sphere_adapt.prm
+++ b/examples/incompressible_flow/3d_flow_around_sphere/sphere_adapt.prm
@@ -51,7 +51,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.006666667
+  end
 end
 #---------------------------------------------------
 # Mesh

--- a/examples/incompressible_flow/3d_periodic_hills/periodic_hills.prm
+++ b/examples/incompressible_flow/3d_periodic_hills/periodic_hills.prm
@@ -16,7 +16,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity        = 1.95E-05 # Re = 5600
+  end
 end
 
 #---------------------------------------------------

--- a/examples/incompressible_flow/3d_ribbon_mixer/ribbon_gls.prm
+++ b/examples/incompressible_flow/3d_ribbon_mixer/ribbon_gls.prm
@@ -28,7 +28,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1.0000
+  end
 end
 
 subsection timer

--- a/examples/incompressible_flow/3d_ribbon_mixer_cad_aware/ribbon_gls.prm
+++ b/examples/incompressible_flow/3d_ribbon_mixer_cad_aware/ribbon_gls.prm
@@ -27,7 +27,9 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 0.0200
+  end
 end
 
 subsection timer

--- a/examples/incompressible_flow/3d_vessels/vessels.prm
+++ b/examples/incompressible_flow/3d_vessels/vessels.prm
@@ -32,8 +32,10 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  subsection fluid 0
     set kinematic viscosity            = 1
     set tracer diffusivity             = 0.001
+  end
 end
 
 subsection timer

--- a/examples/multiphysics/warming_up_viscous_fluid/warming_up_viscous_fluid.prm
+++ b/examples/multiphysics/warming_up_viscous_fluid/warming_up_viscous_fluid.prm
@@ -42,9 +42,11 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-  set density              = 0.9
-  set kinematic viscosity    = 0.5
-  set thermal conductivity = 0.12
+  subsection fluid 0
+    set density              = 0.9
+    set kinematic viscosity    = 0.5
+    set thermal conductivity = 0.12
+  end
 # water = 1 density, 0.01 viscosity, 0.59 conductivity
 # oil = 0.9 density, 0.5 viscosity, 0.12 conductivity
 end

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -41,7 +41,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
+  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
                               const Parameters::NonLinearSolver &param);
 
 
@@ -56,7 +56,7 @@ public:
 
 template <typename VectorType>
 KinsolNewtonNonLinearSolver<VectorType>::KinsolNewtonNonLinearSolver(
-  PhysicsSolver<VectorType>         *physics_solver,
+  PhysicsSolver<VectorType> *        physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
 {}
@@ -107,7 +107,7 @@ KinsolNewtonNonLinearSolver<VectorType>::solve(const bool /*is_initial_step*/)
   };
 
   nonlinear_solver.residual = [&](const VectorType &evaluation_point_for_kinsol,
-                                  VectorType       &residual) {
+                                  VectorType &      residual) {
     solver->pcout << "Computing residual vector..." << std::endl;
     evaluation_point = evaluation_point_for_kinsol;
     solver->apply_constraints();

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -41,7 +41,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
+  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
                               const Parameters::NonLinearSolver &param);
 
 
@@ -56,14 +56,14 @@ public:
 
 template <typename VectorType>
 KinsolNewtonNonLinearSolver<VectorType>::KinsolNewtonNonLinearSolver(
-  PhysicsSolver<VectorType> *        physics_solver,
+  PhysicsSolver<VectorType>         *physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
 {}
 
 template <typename VectorType>
 void
-KinsolNewtonNonLinearSolver<VectorType>::solve(const bool /*is_initial_step*/)
+KinsolNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
 {
 #ifdef DEAL_II_WITH_SUNDIALS
   bool first_step = is_initial_step;
@@ -107,7 +107,7 @@ KinsolNewtonNonLinearSolver<VectorType>::solve(const bool /*is_initial_step*/)
   };
 
   nonlinear_solver.residual = [&](const VectorType &evaluation_point_for_kinsol,
-                                  VectorType &      residual) {
+                                  VectorType       &residual) {
     solver->pcout << "Computing residual vector..." << std::endl;
     evaluation_point = evaluation_point_for_kinsol;
     solver->apply_constraints();

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -41,7 +41,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
+  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
                               const Parameters::NonLinearSolver &param);
 
 
@@ -56,7 +56,7 @@ public:
 
 template <typename VectorType>
 KinsolNewtonNonLinearSolver<VectorType>::KinsolNewtonNonLinearSolver(
-  PhysicsSolver<VectorType>         *physics_solver,
+  PhysicsSolver<VectorType> *        physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
 {}
@@ -107,7 +107,7 @@ KinsolNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
   };
 
   nonlinear_solver.residual = [&](const VectorType &evaluation_point_for_kinsol,
-                                  VectorType       &residual) {
+                                  VectorType &      residual) {
     solver->pcout << "Computing residual vector..." << std::endl;
     evaluation_point = evaluation_point_for_kinsol;
     solver->apply_constraints();

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -41,7 +41,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
+  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
                               const Parameters::NonLinearSolver &param);
 
 
@@ -56,14 +56,14 @@ public:
 
 template <typename VectorType>
 KinsolNewtonNonLinearSolver<VectorType>::KinsolNewtonNonLinearSolver(
-  PhysicsSolver<VectorType> *        physics_solver,
+  PhysicsSolver<VectorType>         *physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
 {}
 
 template <typename VectorType>
 void
-KinsolNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
+KinsolNewtonNonLinearSolver<VectorType>::solve(const bool /*is_initial_step*/)
 {
 #ifdef DEAL_II_WITH_SUNDIALS
   bool first_step = is_initial_step;
@@ -107,7 +107,7 @@ KinsolNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
   };
 
   nonlinear_solver.residual = [&](const VectorType &evaluation_point_for_kinsol,
-                                  VectorType &      residual) {
+                                  VectorType       &residual) {
     solver->pcout << "Computing residual vector..." << std::endl;
     evaluation_point = evaluation_point_for_kinsol;
     solver->apply_constraints();

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -272,20 +272,6 @@ namespace Parameters
     PhysicalProperties()
     {}
 
-    // Monophasic simulations parameters
-    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
-    double viscosity;
-    // volumetric mass density (rho) in units of kg/m^3
-    double density;
-    // specific heat capacity (cp) in J/K/kg
-    double specific_heat;
-    // thermal conductivity (k) in W/m/K
-    double thermal_conductivity;
-    // thermal expansion coefficient (alpha) in 1/K
-    double thermal_expansion;
-    // tracer diffusivity in L^2/s
-    double tracer_diffusivity;
-
     // Non Newtonian parameters
     bool         non_newtonian_flow;
     NonNewtonian non_newtonian_parameters;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -282,7 +282,7 @@ namespace Parameters
 
     // Fluid objects for multiphasic simulations
     std::vector<Fluid>        fluids;
-    unsigned int              number_fluids;
+    unsigned int              number_of_fluids;
     static const unsigned int max_fluids = 2;
 
     void

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -46,7 +46,7 @@ public:
   HeatTransferAssemblerBase(
     std::shared_ptr<SimulationControl>   p_simulation_control,
     const Parameters::PhysicalProperties p_physical_properties,
-    const Parameters::Multiphysics &     p_multiphysics_parameters)
+    const Parameters::Multiphysics      &p_multiphysics_parameters)
     : simulation_control(p_simulation_control)
     , physical_properties(p_physical_properties)
     , multiphysics_parameters(p_multiphysics_parameters)
@@ -63,7 +63,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) = 0;
+                  StabilizedMethodsCopyData    &copy_data) = 0;
 
   /**
    * @brief assemble_matrix Interface for the call to rhs
@@ -75,14 +75,12 @@ public:
 
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) = 0;
+               StabilizedMethodsCopyData    &copy_data) = 0;
 
 protected:
   std::shared_ptr<SimulationControl>   simulation_control;
   const Parameters::PhysicalProperties physical_properties;
-  const Parameters::Multiphysics &     multiphysics_parameters;
-
-  std::vector<std::shared_ptr<SpecificHeatModel>> specific_heat_models;
+  const Parameters::Multiphysics      &multiphysics_parameters;
 };
 
 /**
@@ -104,7 +102,7 @@ public:
   HeatTransferAssemblerCore(
     std::shared_ptr<SimulationControl>   simulation_control,
     const Parameters::PhysicalProperties physical_properties,
-    const Parameters::Multiphysics &     multiphysics_parameters)
+    const Parameters::Multiphysics      &multiphysics_parameters)
     : HeatTransferAssemblerBase<dim>(simulation_control,
                                      physical_properties,
                                      multiphysics_parameters)
@@ -117,7 +115,7 @@ public:
    */
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
 
   /**
@@ -127,7 +125,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 };
 
 /**
@@ -145,18 +143,11 @@ public:
   HeatTransferAssemblerBDF(
     std::shared_ptr<SimulationControl> simulation_control,
     Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics &   multiphysics_parameters)
+    const Parameters::Multiphysics    &multiphysics_parameters)
     : HeatTransferAssemblerBase<dim>(simulation_control,
                                      physical_properties,
                                      multiphysics_parameters)
-  {
-    // if (physical_properties.enable_phase_change)
-    //   specific_heat_model = std::make_shared<PhaseChangeSpecificHeat>(
-    //     physical_properties.phase_change_parameters);
-    // else
-    //   specific_heat_model = std::make_shared<ConstantSpecificHeat>(
-    //     physical_properties.specific_heat);
-  }
+  {}
 
   /**
    * @brief assemble_matrix Assembles the matrix
@@ -166,7 +157,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -175,7 +166,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
   const bool GGLS = true;
 };
@@ -194,7 +185,7 @@ public:
   HeatTransferAssemblerRobinBC(
     std::shared_ptr<SimulationControl> simulation_control,
     Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics &   multiphysics_parameters,
+    const Parameters::Multiphysics    &multiphysics_parameters,
     const BoundaryConditions::HTBoundaryConditions<dim>
       &p_boundary_conditions_ht)
     : HeatTransferAssemblerBase<dim>(simulation_control,
@@ -211,7 +202,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -220,7 +211,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
   const BoundaryConditions::HTBoundaryConditions<dim> &boundary_conditions_ht;
 };
@@ -241,7 +232,7 @@ public:
   HeatTransferAssemblerViscousDissipation(
     std::shared_ptr<SimulationControl> simulation_control,
     Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics &   multiphysics_parameters)
+    const Parameters::Multiphysics    &multiphysics_parameters)
     : HeatTransferAssemblerBase<dim>(simulation_control,
                                      physical_properties,
                                      multiphysics_parameters)
@@ -249,7 +240,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -258,7 +249,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 };
 
 

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -46,7 +46,7 @@ public:
   HeatTransferAssemblerBase(
     std::shared_ptr<SimulationControl>   p_simulation_control,
     const Parameters::PhysicalProperties p_physical_properties,
-    const Parameters::Multiphysics      &p_multiphysics_parameters)
+    const Parameters::Multiphysics &     p_multiphysics_parameters)
     : simulation_control(p_simulation_control)
     , physical_properties(p_physical_properties)
     , multiphysics_parameters(p_multiphysics_parameters)
@@ -63,7 +63,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData    &copy_data) = 0;
+                  StabilizedMethodsCopyData &   copy_data) = 0;
 
   /**
    * @brief assemble_matrix Interface for the call to rhs
@@ -75,12 +75,12 @@ public:
 
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData    &copy_data) = 0;
+               StabilizedMethodsCopyData &   copy_data) = 0;
 
 protected:
   std::shared_ptr<SimulationControl>   simulation_control;
   const Parameters::PhysicalProperties physical_properties;
-  const Parameters::Multiphysics      &multiphysics_parameters;
+  const Parameters::Multiphysics &     multiphysics_parameters;
 };
 
 /**
@@ -102,7 +102,7 @@ public:
   HeatTransferAssemblerCore(
     std::shared_ptr<SimulationControl>   simulation_control,
     const Parameters::PhysicalProperties physical_properties,
-    const Parameters::Multiphysics      &multiphysics_parameters)
+    const Parameters::Multiphysics &     multiphysics_parameters)
     : HeatTransferAssemblerBase<dim>(simulation_control,
                                      physical_properties,
                                      multiphysics_parameters)
@@ -115,7 +115,7 @@ public:
    */
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData    &copy_data) override;
+                  StabilizedMethodsCopyData &   copy_data) override;
 
 
   /**
@@ -125,7 +125,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData    &copy_data) override;
+               StabilizedMethodsCopyData &   copy_data) override;
 };
 
 /**
@@ -143,7 +143,7 @@ public:
   HeatTransferAssemblerBDF(
     std::shared_ptr<SimulationControl> simulation_control,
     Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics    &multiphysics_parameters)
+    const Parameters::Multiphysics &   multiphysics_parameters)
     : HeatTransferAssemblerBase<dim>(simulation_control,
                                      physical_properties,
                                      multiphysics_parameters)
@@ -157,7 +157,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData    &copy_data) override;
+                  StabilizedMethodsCopyData &   copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -166,7 +166,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData    &copy_data) override;
+               StabilizedMethodsCopyData &   copy_data) override;
 
   const bool GGLS = true;
 };
@@ -185,7 +185,7 @@ public:
   HeatTransferAssemblerRobinBC(
     std::shared_ptr<SimulationControl> simulation_control,
     Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics    &multiphysics_parameters,
+    const Parameters::Multiphysics &   multiphysics_parameters,
     const BoundaryConditions::HTBoundaryConditions<dim>
       &p_boundary_conditions_ht)
     : HeatTransferAssemblerBase<dim>(simulation_control,
@@ -202,7 +202,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData    &copy_data) override;
+                  StabilizedMethodsCopyData &   copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -211,7 +211,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData    &copy_data) override;
+               StabilizedMethodsCopyData &   copy_data) override;
 
   const BoundaryConditions::HTBoundaryConditions<dim> &boundary_conditions_ht;
 };
@@ -232,7 +232,7 @@ public:
   HeatTransferAssemblerViscousDissipation(
     std::shared_ptr<SimulationControl> simulation_control,
     Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics    &multiphysics_parameters)
+    const Parameters::Multiphysics &   multiphysics_parameters)
     : HeatTransferAssemblerBase<dim>(simulation_control,
                                      physical_properties,
                                      multiphysics_parameters)
@@ -240,7 +240,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData    &copy_data) override;
+                  StabilizedMethodsCopyData &   copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -249,7 +249,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData    &copy_data) override;
+               StabilizedMethodsCopyData &   copy_data) override;
 };
 
 

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -142,7 +142,7 @@ public:
     multiphysics.parse_parameters(prm);
 
     // Check consistency of parameters parsed in different subsections
-    if (multiphysics.free_surface && physical_properties.number_fluids != 2)
+    if (multiphysics.free_surface && physical_properties.number_of_fluids != 2)
       {
         throw std::logic_error(
           "Inconsistency in .prm!\n with free surface = true\n use: number of fluids = 2");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -11,6 +11,11 @@ DeclException2(
   << "The liquidus temperature specific is below or equal to the solidus temperature."
   << "The phase change specific heat model requires that T_liquidus>T_solidus.");
 
+DeclException1(NumberOfFluidsError,
+               int,
+               << "Number of fluids: " << arg1
+               << " is not 1 (single phase simulation) or 2 (VOF simulation)");
+
 namespace Parameters
 {
   void
@@ -299,8 +304,8 @@ namespace Parameters
       cp_s            = prm.get_double("specific heat solid");
     }
 
-    if (T_liquidus <= T_solidus)
-      PhaseChangeIntervalError(T_liquidus, T_solidus);
+    Assert(T_liquidus <= T_solidus,
+           PhaseChangeIntervalError(T_liquidus, T_solidus));
 
     prm.leave_subsection();
   }
@@ -342,7 +347,7 @@ namespace Parameters
   PhysicalProperties::declare_parameters(ParameterHandler &prm)
   {
     fluids.resize(max_fluids);
-    number_fluids = 1;
+    number_of_fluids = 1;
 
     prm.enter_subsection("physical properties");
     {
@@ -388,8 +393,11 @@ namespace Parameters
       phase_change_parameters.parse_parameters(prm);
 
       // Multiphasic simulations parameters definition
-      number_fluids = prm.get_integer("number of fluids");
-      for (unsigned int i_fluid = 0; i_fluid < number_fluids; ++i_fluid)
+      number_of_fluids = prm.get_integer("number of fluids");
+      Assert(number_of_fluids == 1 || number_of_fluids == 2,
+             NumberOfFluidsError(number_of_fluids));
+
+      for (unsigned int i_fluid = 0; i_fluid < number_of_fluids; ++i_fluid)
         {
           fluids[i_fluid].parse_parameters(prm, i_fluid);
         }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -379,8 +379,6 @@ namespace Parameters
   {
     prm.enter_subsection("physical properties");
     {
-
-
       // Management of non_newtonian_flows
       non_newtonian_flow = prm.get_bool("non newtonian flow");
       non_newtonian_parameters.parse_parameters(prm);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -7,9 +7,9 @@ DeclException2(
   double,
   double,
   << "Liquidus temperature : " << arg1
-  << "is not strictly superior to Solidus temperature: " << arg2
-  << "The liquidus temperature specific is below or equal to the solidus temperature."
-  << "The phase change specific heat model requires that T_liquidus>T_solidus.");
+  << " is not strictly superior to Solidus temperature: " << arg2
+  << " The liquidus temperature specific is below or equal to the solidus temperature."
+  << " The phase change specific heat model requires that T_liquidus>T_solidus.");
 
 DeclException1(NumberOfFluidsError,
                int,
@@ -304,7 +304,7 @@ namespace Parameters
       cp_s            = prm.get_double("specific heat solid");
     }
 
-    Assert(T_liquidus <= T_solidus,
+    Assert(T_liquidus > T_solidus,
            PhaseChangeIntervalError(T_liquidus, T_solidus));
 
     prm.leave_subsection();

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -342,34 +342,10 @@ namespace Parameters
   PhysicalProperties::declare_parameters(ParameterHandler &prm)
   {
     fluids.resize(max_fluids);
-    number_fluids = 0;
+    number_fluids = 1;
 
     prm.enter_subsection("physical properties");
     {
-      // Single phase simulations parameters definition
-      prm.declare_entry("kinematic viscosity",
-                        "1",
-                        Patterns::Double(),
-                        "Kinematic viscosity");
-      prm.declare_entry("density", "1", Patterns::Double(), "Density");
-      prm.declare_entry("specific heat",
-                        "1",
-                        Patterns::Double(),
-                        "Specific heat");
-      prm.declare_entry("thermal conductivity",
-                        "1",
-                        Patterns::Double(),
-                        "Thermal conductivity");
-      prm.declare_entry("thermal expansion",
-                        "1",
-                        Patterns::Double(),
-                        "Thermal Expansion");
-
-      prm.declare_entry("tracer diffusivity",
-                        "0",
-                        Patterns::Double(),
-                        "Tracer diffusivity");
-
       prm.declare_entry("non newtonian flow",
                         "false",
                         Patterns::Bool(),
@@ -378,7 +354,7 @@ namespace Parameters
 
 
       prm.declare_entry("number of fluids",
-                        "0",
+                        "1",
                         Patterns::Integer(),
                         "Number of fluids");
 
@@ -403,13 +379,7 @@ namespace Parameters
   {
     prm.enter_subsection("physical properties");
     {
-      // Monophasic simulations parameters definition
-      viscosity            = prm.get_double("kinematic viscosity");
-      density              = prm.get_double("density");
-      specific_heat        = prm.get_double("specific heat");
-      thermal_conductivity = prm.get_double("thermal conductivity");
-      tracer_diffusivity   = prm.get_double("tracer diffusivity");
-      thermal_expansion    = prm.get_double("thermal expansion");
+
 
       // Management of non_newtonian_flows
       non_newtonian_flow = prm.get_bool("non newtonian flow");
@@ -419,21 +389,11 @@ namespace Parameters
       enable_phase_change = prm.get_bool("enable phase change");
       phase_change_parameters.parse_parameters(prm);
 
-
-      // Multiphase simulations parameters definition
+      // Multiphasic simulations parameters definition
       number_fluids = prm.get_integer("number of fluids");
       for (unsigned int i_fluid = 0; i_fluid < number_fluids; ++i_fluid)
         {
           fluids[i_fluid].parse_parameters(prm, i_fluid);
-        }
-      // Compatibility from multiphase to single phase parameter definition
-      if (number_fluids == 1)
-        {
-          viscosity            = fluids[0].viscosity;
-          density              = fluids[0].density;
-          specific_heat        = fluids[0].specific_heat;
-          thermal_conductivity = fluids[0].thermal_conductivity;
-          tracer_diffusivity   = fluids[0].tracer_diffusivity;
         }
     }
     prm.leave_subsection();

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -982,6 +982,7 @@ GLSVANSSolver<dim>::post_processing()
       this->cfd_dem_simulation_parameters.cfd_dem.inlet_boundary_id,
       this->cfd_dem_simulation_parameters.cfd_dem.outlet_boundary_id) *
     this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties
+      .fluids[0]
       .density;
 
   this->pcout << "Mass Source: " << mass_source << " s^-1" << std::endl;

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -13,7 +13,7 @@ GLSVansAssemblerCore<dim>::assemble_matrix(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -175,7 +175,7 @@ GLSVansAssemblerCore<dim>::assemble_rhs(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -481,7 +481,7 @@ GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
       // Particle's Reynolds number
       double re = 1e-1 + relative_velocity.norm() *
                            particle_properties[DEM::PropertiesIndex::dp] /
-                           physical_properties.viscosity;
+                           physical_properties.fluids[0].viscosity;
 
       // Di Felice Drag Model CD Calculation
       c_d = pow((0.63 + 4.8 / sqrt(re)), 2) *
@@ -495,7 +495,7 @@ GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
 
       beta_drag += momentum_transfer_coefficient;
 
-      drag_force = this->physical_properties.density *
+      drag_force = this->physical_properties.fluids[0].density *
                    momentum_transfer_coefficient * relative_velocity;
 
       for (int d = 0; d < dim; ++d)
@@ -545,7 +545,7 @@ GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
       // Particle's Reynolds number
       double re = 1e-1 + relative_velocity.norm() *
                            particle_properties[DEM::PropertiesIndex::dp] /
-                           physical_properties.viscosity;
+                           physical_properties.fluids[0].viscosity;
 
       // Rong Drag Model CD Calculation
       c_d =
@@ -562,7 +562,7 @@ GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
 
       beta_drag += momentum_transfer_coefficient;
 
-      drag_force = this->physical_properties.density *
+      drag_force = this->physical_properties.fluids[0].density *
                    momentum_transfer_coefficient * relative_velocity;
 
       for (int d = 0; d < dim; ++d)
@@ -609,7 +609,7 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
       // Particle's Reynolds number
       double re = 1e-1 + relative_velocity.norm() *
                            particle_properties[DEM::PropertiesIndex::dp] /
-                           physical_properties.viscosity;
+                           physical_properties.fluids[0].viscosity;
 
       // Dallavalle Drag Model CD Calculation
       c_d = pow((0.63 + 4.8 / sqrt(re)), 2);
@@ -621,7 +621,7 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
 
       beta_drag += momentum_transfer_coefficient;
 
-      drag_force = this->physical_properties.density *
+      drag_force = this->physical_properties.fluids[0].density *
                    momentum_transfer_coefficient * relative_velocity;
 
       for (int d = 0; d < dim; ++d)
@@ -661,7 +661,7 @@ GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
       for (int d = 0; d < dim; ++d)
         {
           particle_properties[DEM::PropertiesIndex::fem_force_x + d] +=
-            buoyancy_force[d] * physical_properties.density;
+            buoyancy_force[d] * physical_properties.fluids[0].density;
         }
     }
 }
@@ -698,7 +698,7 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
       for (int d = 0; d < dim; ++d)
         {
           particle_properties[DEM::PropertiesIndex::fem_force_x + d] +=
-            pressure_force[d] * physical_properties.density;
+            pressure_force[d] * physical_properties.fluids[0].density;
           undisturbed_flow_force[d] +=
             pressure_force[d] / scratch_data.cell_volume;
         }
@@ -726,7 +726,7 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
   particle_number = 0;
 
   // Viscosity
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop over particles in cell
   for (auto &particle : pic)
@@ -742,7 +742,7 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
       for (int d = 0; d < dim; ++d)
         {
           particle_properties[DEM::PropertiesIndex::fem_force_x + d] +=
-            shear_force[d] * physical_properties.density;
+            shear_force[d] * physical_properties.fluids[0].density;
           undisturbed_flow_force[d] +=
             shear_force[d] / scratch_data.cell_volume;
         }

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -768,15 +768,16 @@ GDNavierStokesSolver<dim>::set_initial_condition_fd(
     {
       this->set_nodal_values();
       double viscosity =
-        this->simulation_parameters.physical_properties.viscosity;
-      this->simulation_parameters.physical_properties.viscosity =
+        this->simulation_parameters.physical_properties.fluids[0].viscosity;
+      this->simulation_parameters.physical_properties.fluids[0].viscosity =
         this->simulation_parameters.initial_condition->viscosity;
       this->simulation_control->set_assembly_method(
         Parameters::SimulationControl::TimeSteppingMethod::steady);
       PhysicsSolver<
         TrilinosWrappers::MPI::BlockVector>::solve_non_linear_system(false);
       this->finish_time_step_fd();
-      this->simulation_parameters.physical_properties.viscosity = viscosity;
+      this->simulation_parameters.physical_properties.fluids[0].viscosity =
+        viscosity;
     }
   else
     {
@@ -841,7 +842,7 @@ GDNavierStokesSolver<dim>::setup_ILU()
   system_ilu_preconditioner = std::make_shared<
     BlockSchurPreconditioner<TrilinosWrappers::PreconditionILU>>(
     gamma,
-    this->simulation_parameters.physical_properties.viscosity,
+    this->simulation_parameters.physical_properties.fluids[0].viscosity,
     system_matrix,
     pressure_mass_matrix,
     &(*velocity_ilu_preconditioner),
@@ -956,7 +957,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   system_amg_preconditioner = std::make_shared<
     BlockSchurPreconditioner<TrilinosWrappers::PreconditionAMG>>(
     gamma,
-    this->simulation_parameters.physical_properties.viscosity,
+    this->simulation_parameters.physical_properties.fluids[0].viscosity,
     system_matrix,
     pressure_mass_matrix,
     &(*velocity_amg_preconditioner),

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -730,15 +730,16 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
     {
       this->set_nodal_values();
       double viscosity =
-        this->simulation_parameters.physical_properties.viscosity;
-      this->simulation_parameters.physical_properties.viscosity =
+        this->simulation_parameters.physical_properties.fluids[0].viscosity;
+      this->simulation_parameters.physical_properties.fluids[0].viscosity =
         this->simulation_parameters.initial_condition->viscosity;
       this->simulation_control->set_assembly_method(
         Parameters::SimulationControl::TimeSteppingMethod::steady);
       PhysicsSolver<TrilinosWrappers::MPI::Vector>::solve_non_linear_system(
         false);
       this->finish_time_step_fd();
-      this->simulation_parameters.physical_properties.viscosity = viscosity;
+      this->simulation_parameters.physical_properties.fluids[0].viscosity =
+        viscosity;
     }
   else
     {

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -200,7 +200,7 @@ GLSNitscheNavierStokesSolver<2, 3>::calculate_forces_on_solid(
   Tensor<1, 3> force; // to be changed for a vector of tensors when
   // allowing multiple solids
   const double viscosity =
-    this->simulation_parameters.physical_properties.viscosity;
+    this->simulation_parameters.physical_properties.fluids[0].viscosity;
 
   // Loop over all local particles
   auto particle = solid_ph->begin();

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -223,8 +223,9 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
   const unsigned int dofs_per_face = this->fe->dofs_per_face;
 
   int    order = this->simulation_parameters.particlesParameters->order;
-  double mu    = this->simulation_parameters.physical_properties.viscosity;
-  double rho   = this->simulation_parameters.particlesParameters->density;
+  double mu =
+    this->simulation_parameters.physical_properties.fluids[0].viscosity;
+  double rho = this->simulation_parameters.particlesParameters->density;
   double length_ratio =
     this->simulation_parameters.particlesParameters->length_ratio;
   IBStencil<dim>      stencil;

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -14,11 +14,12 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density              = this->physical_properties.density;
-  double specific_heat        = this->physical_properties.specific_heat;
-  double thermal_conductivity = this->physical_properties.thermal_conductivity;
-  double rho_cp               = density * specific_heat;
-  double alpha                = thermal_conductivity / rho_cp;
+  double density       = physical_properties.fluids[0].density;
+  double specific_heat = physical_properties.fluids[0].specific_heat;
+  double thermal_conductivity =
+    physical_properties.fluids[0].thermal_conductivity;
+  double rho_cp = density * specific_heat;
+  double alpha  = thermal_conductivity / rho_cp;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -155,10 +156,10 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
 
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double density       = this->physical_properties.density;
-      double specific_heat = this->physical_properties.specific_heat;
+      double density       = physical_properties.fluids[0].density;
+      double specific_heat = physical_properties.fluids[0].specific_heat;
       double thermal_conductivity =
-        this->physical_properties.thermal_conductivity;
+        physical_properties.fluids[0].thermal_conductivity;
 
       double rho_cp = density * specific_heat;
       double alpha  = thermal_conductivity / rho_cp;
@@ -259,8 +260,8 @@ HeatTransferAssemblerBDF<dim>::assemble_matrix(
 
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = this->physical_properties.density;
-  double specific_heat = this->physical_properties.specific_heat;
+  double density       = physical_properties.fluids[0].density;
+  double specific_heat = physical_properties.fluids[0].specific_heat;
   double rho_cp        = density * specific_heat;
 
   const double h = scratch_data.cell_size;
@@ -346,8 +347,8 @@ HeatTransferAssemblerBDF<dim>::assemble_rhs(
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = this->physical_properties.density;
-  double specific_heat = this->physical_properties.specific_heat;
+  double density       = physical_properties.fluids[0].density;
+  double specific_heat = physical_properties.fluids[0].specific_heat;
   double rho_cp        = density * specific_heat;
 
 
@@ -568,8 +569,8 @@ HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
     {
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double density   = this->physical_properties.density;
-      double viscosity = this->physical_properties.viscosity;
+      double density   = physical_properties.fluids[0].density;
+      double viscosity = physical_properties.fluids[0].viscosity;
 
       double dynamic_viscosity = viscosity * density;
 

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -10,19 +10,19 @@ template <int dim>
 void
 HeatTransferAssemblerCore<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = physical_properties.fluids[0].density;
-  double specific_heat = physical_properties.fluids[0].specific_heat;
+  double density       = this->physical_properties.fluids[0].density;
+  double specific_heat = this->physical_properties.fluids[0].specific_heat;
   double thermal_conductivity =
-    physical_properties.fluids[0].thermal_conductivity;
+    this->physical_properties.fluids[0].thermal_conductivity;
   double rho_cp = density * specific_heat;
   double alpha  = thermal_conductivity / rho_cp;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const double       h          = scratch_data.cell_size;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -128,7 +128,7 @@ template <int dim>
 void
 HeatTransferAssemblerCore<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   const auto         method = this->simulation_control->get_assembly_method();
   const unsigned int n_q_points = scratch_data.n_q_points;
@@ -156,10 +156,10 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
 
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double density       = physical_properties.fluids[0].density;
-      double specific_heat = physical_properties.fluids[0].specific_heat;
+      double density       = this->physical_properties.fluids[0].density;
+      double specific_heat = this->physical_properties.fluids[0].specific_heat;
       double thermal_conductivity =
-        physical_properties.fluids[0].thermal_conductivity;
+        this->physical_properties.fluids[0].thermal_conductivity;
 
       double rho_cp = density * specific_heat;
       double alpha  = thermal_conductivity / rho_cp;
@@ -241,10 +241,10 @@ template <int dim>
 void
 HeatTransferAssemblerBDF<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -260,8 +260,8 @@ HeatTransferAssemblerBDF<dim>::assemble_matrix(
 
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = physical_properties.fluids[0].density;
-  double specific_heat = physical_properties.fluids[0].specific_heat;
+  double density       = this->physical_properties.fluids[0].density;
+  double specific_heat = this->physical_properties.fluids[0].specific_heat;
   double rho_cp        = density * specific_heat;
 
   const double h = scratch_data.cell_size;
@@ -343,17 +343,17 @@ template <int dim>
 void
 HeatTransferAssemblerBDF<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = physical_properties.fluids[0].density;
-  double specific_heat = physical_properties.fluids[0].specific_heat;
+  double density       = this->physical_properties.fluids[0].density;
+  double specific_heat = this->physical_properties.fluids[0].specific_heat;
   double rho_cp        = density * specific_heat;
 
 
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -443,7 +443,7 @@ template <int dim>
 void
 HeatTransferAssemblerRobinBC<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
@@ -490,7 +490,7 @@ template <int dim>
 void
 HeatTransferAssemblerRobinBC<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
@@ -549,7 +549,7 @@ template <int dim>
 void
 HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   const unsigned int n_q_points = scratch_data.n_q_points;
 
@@ -569,8 +569,8 @@ HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
     {
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double density   = physical_properties.fluids[0].density;
-      double viscosity = physical_properties.fluids[0].viscosity;
+      double density   = this->physical_properties.fluids[0].density;
+      double viscosity = this->physical_properties.fluids[0].viscosity;
 
       double dynamic_viscosity = viscosity * density;
 

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -10,7 +10,7 @@ template <int dim>
 void
 HeatTransferAssemblerCore<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
@@ -22,7 +22,7 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
   double alpha  = thermal_conductivity / rho_cp;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const double       h          = scratch_data.cell_size;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -128,7 +128,7 @@ template <int dim>
 void
 HeatTransferAssemblerCore<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   const auto         method = this->simulation_control->get_assembly_method();
   const unsigned int n_q_points = scratch_data.n_q_points;
@@ -241,10 +241,10 @@ template <int dim>
 void
 HeatTransferAssemblerBDF<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -343,7 +343,7 @@ template <int dim>
 void
 HeatTransferAssemblerBDF<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
@@ -353,7 +353,7 @@ HeatTransferAssemblerBDF<dim>::assemble_rhs(
 
 
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -443,7 +443,7 @@ template <int dim>
 void
 HeatTransferAssemblerRobinBC<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
@@ -490,7 +490,7 @@ template <int dim>
 void
 HeatTransferAssemblerRobinBC<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
@@ -549,7 +549,7 @@ template <int dim>
 void
 HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData    &copy_data)
+  StabilizedMethodsCopyData &   copy_data)
 {
   const unsigned int n_q_points = scratch_data.n_q_points;
 

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -13,7 +13,7 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -159,7 +159,7 @@ GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -1169,7 +1169,7 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -1246,7 +1246,7 @@ GDNavierStokesAssemblerCore<dim>::assemble_rhs(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -1313,7 +1313,7 @@ LaplaceAssembly<dim>::assemble_matrix(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -1374,7 +1374,7 @@ LaplaceAssembly<dim>::assemble_rhs(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -1446,7 +1446,8 @@ BuoyancyAssembly<dim>::assemble_rhs(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const double thermal_expansion = physical_properties.thermal_expansion;
+  const double thermal_expansion =
+    physical_properties.fluids[0].thermal_expansion;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -1496,7 +1497,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informationshessian
   Tensor<2, dim> identity;
@@ -1580,7 +1581,7 @@ PressureBoundaryCondition<dim>::assemble_rhs(
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   Tensor<2, dim> identity;
@@ -1665,7 +1666,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   Tensor<2, dim> identity;
@@ -1771,7 +1772,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.viscosity;
+  const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
   Tensor<2, dim> identity;

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1088,11 +1088,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       if (this->simulation_parameters.post_processing.verbosity ==
           Parameters::Verbosity::verbose)
         {
-          this->pcout
-            << "Pressure drop: "
-            << this->simulation_parameters.physical_properties.density *
-                 pressure_drop
-            << " Pa" << std::endl;
+          this->pcout << "Pressure drop: "
+                      << this->simulation_parameters.physical_properties
+                             .fluids[0]
+                             .density *
+                           pressure_drop
+                      << " Pa" << std::endl;
         }
 
       // Output pressure drop to a text file from processor 0

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -434,7 +434,7 @@ calculate_forces(
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
-  double viscosity = physical_properties.viscosity;
+  double viscosity = physical_properties.fluids[0].viscosity;
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
   const FEValuesExtractors::Vector velocities(0);
@@ -553,7 +553,7 @@ calculate_torques(
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
-  double viscosity = physical_properties.viscosity;
+  double viscosity = physical_properties.fluids[0].viscosity;
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
   const FEValuesExtractors::Vector velocities(0);

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -11,7 +11,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
                                           StabilizedMethodsCopyData &copy_data)
 {
   // Scheme and physical properties
-  const double diffusivity = physical_properties.tracer_diffusivity;
+  const double diffusivity = physical_properties.fluids[0].tracer_diffusivity;
   const auto   method      = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature informations
@@ -129,7 +129,7 @@ TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim> &   scratch_data,
                                        StabilizedMethodsCopyData &copy_data)
 {
   // Scheme and physical properties
-  const double diffusivity = physical_properties.tracer_diffusivity;
+  const double diffusivity = physical_properties.fluids[0].tracer_diffusivity;
   const auto   method      = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature informations

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -100,7 +100,9 @@ RestartNavierStokes<dim>::run()
   this->setup_dofs_fd();
   this->exact_solution   = new ExactSolutionMMS<dim>;
   this->forcing_function = new MMSSineForcingFunction<dim>;
-  this->simulation_parameters.physical_properties.viscosity = 1.;
+  this->simulation_parameters.physical_properties.fluids.push_back(
+    Parameters::Fluid());
+  this->simulation_parameters.physical_properties.fluids[0].viscosity = 1.;
 
   this->simulation_control->print_progression(this->pcout);
   this->iterate();


### PR DESCRIPTION
# Description of the problem

We currently use a confusing mechanism for the physical properties of the fluid. Originally, the code was not meant to have more than a single fluid, so all properties were indicated in the physical properties section. As we introduced the VOF model, things became confusing. We have fluid 0  and fluid 1 section for the fluid properties of the two fluids, but these sections are not used when the simulation is single phase. 


# Description of the solution

This PR makes the single and multiphase simulations coherent by introducing the usage of the fluid subsection even if simulations are single phase. Consequently, even single phase simulations use the fluid 0 subsection.

# How Has This Been Tested?

All tests had to be adapted to this change in properties. Consequently, this feature is fully tested

# Future changes

The next step will be the generalisation of the properties using physical properties model and to adapt the non-newtonian solver logic to this. I prefer to do it step-by-step. Once this will be finished, we will be able to use single and vof phase change and non-newtonian flows. Since this is a major breaking PR, I prefer to make it small.


