### PR TITLE
Fix GitHub Pages deploy trigger on push from master branch

### DIFF
--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.7
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         with:
           branch: gh-pages
           folder: doc/build/html


### PR DESCRIPTION
# Description of the problem

The GitHub Pages deploy step of the `doc-github-pages` workflow was set to run only on `main` branch. Since Lethe's repo was created with `master` as the primary branch, the step will never execute.

# Description of the solution

Change the target branch from `main` to `master`.

# How Has This Been Tested?

Tested on a forked repository: 

https://technophil98.github.io/lethe/
https://github.com/technophil98/lethe/runs/4676279363

# Future changes

N/A

# Comments

Whoopsie
