### PR TITLE
Add documentation to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ dedicated solvers like Lethe could not exist.
 Follow the instructions in the
 [wiki](https://github.com/lethe-cfd/lethe/wiki/Installation).
 
+## Documentation
+
+Documentation, tutorials, and more can be found 
+[here][https://lethe-cfd.github.io/lethe/]
+
 ## Authors
 
 Main developer:


### PR DESCRIPTION
## Description of the problem

There was no link to the sphinx documentation anywhere in the repository.

## Description of the solution

The Readme file was updated with said link 

## How Has This Been Tested?

No tests. It's just a link.

## Future changes

I don't think so

## Comments

Non
