### PR TITLE
Constructor calls model_cast() method

### DIFF
--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -184,12 +184,7 @@ public:
     : simulation_control(simulation_control)
     , physical_properties(physical_properties)
   {
-    // if (physical_properties.non_newtonian_parameters.model ==
-    // Parameters::NonNewtonian::Model::Carreau)
-    //{
-    rheological_model = std::make_shared<Carreau<dim>>(
-      physical_properties.non_newtonian_parameters);
-    //}
+    rheological_model = RheologicalModel<dim>::model_cast(physical_properties);
   }
 
   /**
@@ -427,12 +422,7 @@ public:
     , physical_properties(physical_properties)
     , gamma(gamma)
   {
-    // if (physical_properties.non_newtonian_parameters.model ==
-    // Parameters::NonNewtonian::Model::Carreau)
-    //{
-    rheological_model = std::make_shared<Carreau<dim>>(
-      physical_properties.non_newtonian_parameters);
-    //}
+    rheological_model = RheologicalModel<dim>::model_cast(physical_properties);
   }
 
   /**


### PR DESCRIPTION
# Description of the problem

The issue was very minor. In the GDNavierStokesAssemblerNonNewtonianCore and GLSNavierStokesAssemblerNonNewtonianCore constructors, we manually casted the rheological_model attribute by using a if case on the rheological model. Now that this method with the ifs already exists, we will use it.

# Description of the solution

- Change the if series with the existing method

# How Has This Been Tested?

- No tests are needed
