### PR TITLE
Bug correction high order force sharp edgre

### DIFF
--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -788,16 +788,16 @@ GLSSharpNavierStokesSolver<dim>::calculate_L2_error_particles()
   TimerOutput::Scope t(this->computing_timer, "error");
   QGauss<dim>        quadrature_formula(this->number_quadrature_points + 1);
   FEValues<dim>      fe_values(*this->mapping,
-                               *this->fe,
-                               quadrature_formula,
-                               update_values | update_gradients |
-                                 update_quadrature_points | update_JxW_values);
+                          *this->fe,
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
   FEFaceValues<dim>  fe_face_values(*this->mapping,
-                                    *this->fe,
-                                    *this->face_quadrature,
-                                    update_values | update_gradients |
-                                      update_quadrature_points |
-                                      update_JxW_values);
+                                   *this->fe,
+                                   *this->face_quadrature,
+                                   update_values | update_gradients |
+                                     update_quadrature_points |
+                                     update_JxW_values);
 
   const FEValuesExtractors::Vector velocities(0);
   const FEValuesExtractors::Scalar pressure(dim);
@@ -1577,7 +1577,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index>          &local_dof_indices,
+  std::vector<types::global_dof_index> &         local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1611,8 +1611,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1634,8 +1634,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1698,8 +1698,8 @@ GLSSharpNavierStokesSolver<dim>::sharp_edge()
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>        q_formula(this->number_quadrature_points);
   FEValues<dim>      fe_values(*this->fe,
-                               q_formula,
-                               update_quadrature_points | update_JxW_values);
+                          q_formula,
+                          update_quadrature_points | update_JxW_values);
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
 
   int    order = this->simulation_parameters.particlesParameters->order;
@@ -2245,8 +2245,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2337,8 +2337,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -288,7 +288,7 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
   // Loop over all the cell
   for (const auto &cell : cell_iterator)
     {
-      if (cell->is_locally_owned() || cell->is_ghost())
+      if (cell->is_locally_owned())
         {
           // Particle id that cut the cell.
           unsigned int p;
@@ -381,9 +381,7 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
                           // extrapolate the fluid stress tensor on the IB
                           // surface.
                           if (force_eval_done[local_face_dof_indices[i]]
-                                  .first == false &&
-                              this->locally_owned_dofs.is_element(
-                                local_face_dof_indices[i]))
+                                .first == false)
                             {
                               // Only need one extrapolation by dof location;
                               if (component_i == 0)

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -515,6 +515,9 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
                       // Use the extrapolation of fluid stress tensor at the
                       // dof location of the IB surface cell to integrate the
                       // stress tensor on the surface of the IB
+                      auto local_face_tensor_old = local_face_tensor;
+                      local_face_tensor.clear();
+                      local_face_tensor.resize(local_face_dof_indices.size());
                       for (const auto &projection_cell_face :
                            local_face_dof_handler.active_cell_iterators())
                         {
@@ -522,10 +525,78 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
                             projection_cell_face);
                           std::vector<Point<dim>> q_points =
                             fe_face_projection_values.get_quadrature_points();
+                          if (this->simulation_parameters.fem_parameters
+                                .velocity_order > 1)
+                            {
+                              FullMatrix<double> interpolation_matrix(
+                                local_face_dof_indices.size(),
+                                local_face_dof_indices.size());
+                              FullMatrix<double> inv_interpolation_matrix(
+                                local_face_dof_indices.size(),
+                                local_face_dof_indices.size());
+
+                              // Define the interpolation matrix of the surface
+                              // cell
+                              for (unsigned int i = 0;
+                                   i < local_face_dof_indices.size();
+                                   ++i)
+                                {
+                                  Point<dim> point_projection =
+                                    particles[p].position +
+                                    particles[p].radius *
+                                      (support_points
+                                         [local_face_dof_indices[i]] -
+                                       particles[p].position) /
+                                      (support_points
+                                         [local_face_dof_indices[i]] -
+                                       particles[p].position)
+                                        .norm();
+
+                                  auto projected_point_unit =
+                                    local_face_map.transform_real_to_unit_cell(
+                                      projection_cell_face, point_projection);
+                                  for (unsigned int j = 0;
+                                       j < local_face_dof_indices.size();
+                                       ++j)
+                                    {
+                                      interpolation_matrix[i][j] = 0;
+                                      if (this->fe
+                                            ->face_system_to_component_index(j)
+                                            .first ==
+                                          this->fe
+                                            ->face_system_to_component_index(i)
+                                            .first)
+                                        interpolation_matrix[i][j] +=
+                                          local_face_fe.shape_value(
+                                            j, projected_point_unit);
+                                    }
+                                }
+                              inv_interpolation_matrix.invert(
+                                interpolation_matrix);
+                              // Define the value of the fluid stress tensor on
+                              // the surface cell at the DOF support points
+                              // location.
+                              for (unsigned int i = 0;
+                                   i < local_face_dof_indices.size();
+                                   ++i)
+                                {
+                                  for (unsigned int j = 0;
+                                       j < local_face_dof_indices.size();
+                                       ++j)
+                                    {
+                                      local_face_tensor[i] +=
+                                        inv_interpolation_matrix[i][j] *
+                                        local_face_tensor_old[j];
+                                    }
+                                }
+                            }
+                          else
+                            {
+                              local_face_tensor = local_face_tensor_old;
+                            }
                           for (unsigned int q = 0; q < n_q_points_face; q++)
                             {
                               // Evaluate the total surface
-
                               // Redefined the normal at the quadrature point
                               // since we dont control the orientation of the
                               // cell.
@@ -540,11 +611,9 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
                                    ++i)
                                 {
                                   const unsigned int component_i =
-                                    this->fe->system_to_component_index(i)
+                                    local_face_fe.system_to_component_index(i)
                                       .first;
-                                  if (component_i == 0 &&
-                                      this->locally_owned_dofs.is_element(
-                                        local_face_dof_indices[i]))
+                                  if (component_i == 0)
                                     {
                                       fluid_stress +=
                                         fe_face_projection_values.shape_value(
@@ -719,16 +788,16 @@ GLSSharpNavierStokesSolver<dim>::calculate_L2_error_particles()
   TimerOutput::Scope t(this->computing_timer, "error");
   QGauss<dim>        quadrature_formula(this->number_quadrature_points + 1);
   FEValues<dim>      fe_values(*this->mapping,
-                          *this->fe,
-                          quadrature_formula,
-                          update_values | update_gradients |
-                            update_quadrature_points | update_JxW_values);
+                               *this->fe,
+                               quadrature_formula,
+                               update_values | update_gradients |
+                                 update_quadrature_points | update_JxW_values);
   FEFaceValues<dim>  fe_face_values(*this->mapping,
-                                   *this->fe,
-                                   *this->face_quadrature,
-                                   update_values | update_gradients |
-                                     update_quadrature_points |
-                                     update_JxW_values);
+                                    *this->fe,
+                                    *this->face_quadrature,
+                                    update_values | update_gradients |
+                                      update_quadrature_points |
+                                      update_JxW_values);
 
   const FEValuesExtractors::Vector velocities(0);
   const FEValuesExtractors::Scalar pressure(dim);
@@ -1508,7 +1577,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index> &         local_dof_indices,
+  std::vector<types::global_dof_index>          &local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1542,8 +1611,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1565,8 +1634,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1629,8 +1698,8 @@ GLSSharpNavierStokesSolver<dim>::sharp_edge()
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>        q_formula(this->number_quadrature_points);
   FEValues<dim>      fe_values(*this->fe,
-                          q_formula,
-                          update_quadrature_points | update_JxW_values);
+                               q_formula,
+                               update_quadrature_points | update_JxW_values);
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
 
   int    order = this->simulation_parameters.particlesParameters->order;
@@ -2176,8 +2245,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2268,8 +2337,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 


### PR DESCRIPTION
# Description of the problem

The evaluation of the force on particles using the sharp interface immersed boundary adds an error in the FE system used on the surface cell. Also, the code had an error in the projection of the solution on the surface cell for high-order elements since we use a spherical manifold.

# Description of the solution
We changed the fe_system used for the evaluation on the surface cell to the correct one and added an interpolation scheme to correctly map the fluid stress tensor on the surface cell for high order elements.

# How Has This Been Tested?
No test was added as this is simply a bug correction that improves the code's robustness and improves the precision for high order elements.
