### PR TITLE
Migrate compute canada instructions to sphinx doc

### DIFF
--- a/doc/source/compute_canada.rst
+++ b/doc/source/compute_canada.rst
@@ -55,7 +55,7 @@ Then, we can clone and compile ``dealii``. Although Lethe always supports the ma
 
  git clone https://github.com/lethe-cfd/dealii.git
 
-We can compile ``dealii`` in the ``$HOME/dealii/build folder``, by defining path to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``:
+We can compile ``dealii`` in the ``$HOME/dealii/build folder``, by defining the paths to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``:
 
 .. code-block:: text
 
@@ -92,7 +92,7 @@ Then, we can clone and compile ``dealii``. Although Lethe always supports the ma
 
  git clone https://github.com/lethe-cfd/dealii.git
 
-We can compile ``dealii`` in the ``$HOME/dealii/build`` folder, by defining path to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``:
+We can compile ``dealii`` in the ``$HOME/dealii/build`` folder, by defining the paths to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``:
 
 .. code-block:: text
 
@@ -216,7 +216,7 @@ and use it in your ``.sh`` script (see Launching simulations below).
 Launching simulations
 ================================
 
-Simulations are sent to the scheduler via batch scripts, visit Compute Canada wiki page more information about the `scheduler <https://docs.computecanada.ca/wiki/What_is_a_scheduler%3F>`_ and `running jobs <https://docs.computecanada.ca/wiki/Running_jobs>`_. For your convenience, an example of ``job.sh`` used on Beluga is given below:
+Simulations are sent to the scheduler via batch scripts. Visit the Compute Canada wiki page for more information about the `scheduler <https://docs.computecanada.ca/wiki/What_is_a_scheduler%3F>`_ and `running jobs <https://docs.computecanada.ca/wiki/Running_jobs>`_. For your convenience, an example of ``job.sh`` used on Beluga is given below:
 
 .. code-block:: text
 

--- a/doc/source/compute_canada.rst
+++ b/doc/source/compute_canada.rst
@@ -1,0 +1,270 @@
+########################################
+Running Lethe on Compute Canada clusters
+########################################
+
+
+
+================================
+Setting-up the folder structure
+================================
+
+In your ``$HOME``, create a "dealii" folder and a "lethe" folder, each containing "build" and "inst" folders:
+
+.. code-block:: text
+
+ mkdir -p {dealii,lethe}/{build,inst}
+
+The deal.II and Lethe projects can then be cloned in their corresponding folders, as indicated later in this tutorial.
+
+After installation is complete, the folder structure will be, for deal.II (and likewise for Lethe):
+
+* ``$HOME/dealii/dealii`` for deal.ii git,
+* ``$HOME/dealii/build`` for compilation (``cmake`` command),
+* ``$HOME/dealii/inst`` for installation (``make install`` command)
+
+Folders can be open with the ``cd`` command (``cd $folder_path``).
+
+For the sake of clarity, this is the folder structure considered for the rest of this tutorial.
+
+================================
+Installing deal.II
+================================
+
+On Niagara, Beluga, Graham or Cedar
+-----------------------------------
+
+All operations can be performed on login nodes.
+
+.. warning:: 
+ If on **Niagara**, this additional module is needed beforehand: ``module load CCENv``.
+
+For any cluster except Narval (that is: Niagara, Beluga, Graham, Cedar), load ``Trilinos``, ``Parmetis`` and ``P4est``, and their prerequisite modules:
+
+.. code-block:: text
+	
+ module load nixpkgs/16.09
+ module load gcc/7.3.0
+ module load openmpi/3.1.2
+ module load trilinos/12.12.1
+ module load parmetis/4.0.3
+ module load p4est/2.0
+
+Then, we can clone and compile ``dealii``. Although Lethe always supports the master branch of deal.II, we maintain an identical deal.II fork on the lethe repository. This fork is always tested to make sure it works with lethe. To clone the deal.II fork github repository, execute in ``$HOME/dealii`` directory:
+
+.. code-block:: text
+
+ git clone https://github.com/lethe-cfd/dealii.git
+
+We can compile ``dealii`` in the ``$HOME/dealii/build folder``, by defining path to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``:
+
+.. code-block:: text
+
+ cmake ../dealii -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=$EBROOTTRILINOS -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=$EBROOTP4EST -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=$EBROOTPARMETIS -DCMAKE_INSTALL_PREFIX=../inst
+
+and:
+
+.. code-block:: text
+
+ make -j8 install
+
+The argument ``-jX`` specifies the number of processors used for the compilation. On login nodes, a maximum of 8 cores should be used in order to ensure that other users can continue using the cluster without slowdowns. In addition, the ``nice`` command can be used at the beginning of the call to give a lower priority to this task. 
+
+.. note:: 
+ If ``make install`` triggers an error, run the command ``which trilinos``. If it returns ``/usr/bin/which: no trilinos in``, try removing the deal.II build folder, recreating it and explicitly specify libraries' paths on the ``cmake``.
+
+
+On Narval
+---------
+
+Load ``Trilinos``, ``Parmetis`` and ``P4est``, and their prerequisite modules:
+
+.. code-block:: text
+
+ module load gcc/9.3.0
+ module load openmpi/4.0.3
+ module load trilinos/13.0.1
+ module load parmetis/4.0.3
+ module load p4est/2.2
+
+Then, we can clone and compile ``dealii``. Although Lethe always supports the master branch of deal.II, we maintain an identical deal.II fork on the lethe repository. This fork is always tested to make sure it works with lethe. To clone the deal.II fork github repository, execute in ``$HOME/dealii`` directory:
+
+.. code-block:: text
+
+ git clone https://github.com/lethe-cfd/dealii.git
+
+We can compile ``dealii`` in the ``$HOME/dealii/build`` folder, by defining path to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``:
+
+.. code-block:: text
+
+ cmake ../dealii -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=$EBROOTTRILINOS -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=$EBROOTP4EST -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=$EBROOTPARMETIS -DCMAKE_INSTALL_PREFIX=../inst -DTrilinos_FIND_COMPONENTS="Pike;PikeImplicit;PikeBlackBox;TrilinosCouplings;Panzer;PanzerMiniEM;PanzerAdaptersSTK;PanzerDiscFE;PanzerDofMgr;PanzerCore;Piro;ROL;Stokhos;Tempus;Rythmos;ShyLU;ShyLU_DD;ShyLU_DDCommon;ShyLU_DDFROSch;ShyLU_DDBDDC;Zoltan2;Zoltan2Sphynx;MueLu;Moertel;NOX;Phalanx;Percept;STK;STKExprEval;STKDoc_tests;STKUnit_tests;STKBalance;STKTools;STKTransfer;STKSearchUtil;STKSearch;STKUnit_test_utils;STKNGP_TEST;STKIO;STKMesh;STKTopology;STKSimd;STKUtil;STKMath;Compadre;Intrepid2;Intrepid;Teko;FEI;Stratimikos;Ifpack2;Anasazi;Komplex;SEACAS;SEACASEx2ex1v2;SEACASTxtexo;SEACASNumbers;SEACASNemspread;SEACASNemslice;SEACASMat2exo;SEACASMapvar-kd;SEACASMapvar;SEACASMapvarlib;SEACASExplore;SEACASGrepos;SEACASGenshell;SEACASGen3D;SEACASGjoin;SEACASFastq;SEACASEx1ex2v2;SEACASExo_format;SEACASExotxt;SEACASExomatlab;SEACASExodiff;SEACASExo2mat;SEACASEpu;SEACASEjoin;SEACASConjoin;SEACASBlot;SEACASAprepro;SEACASAlgebra;SEACASPLT;SEACASSVDI;SEACASSuplibCpp;SEACASSuplibC;SEACASSuplib;SEACASSupes;SEACASAprepro_lib;SEACASChaco;SEACASIoss;SEACASNemesis;SEACASExoIIv2for32;SEACASExodus_for;SEACASExodus;Amesos2;ShyLU_Node;ShyLU_NodeTacho;ShyLU_NodeHTS;Belos;ML;Ifpack;Zoltan2Core;Pamgen;Amesos;Galeri;AztecOO;Pliris;Isorropia;Xpetra;Thyra;ThyraTpetraAdapters;ThyraEpetraExtAdapters;ThyraEpetraAdapters;ThyraCore;Domi;TrilinosSS;Tpetra;TpetraCore;TpetraTSQR;TpetraClassic;EpetraExt;Triutils;Shards;Zoltan;Epetra;MiniTensor;Sacado;RTOp;KokkosKernels;Teuchos;TeuchosKokkosComm;TeuchosKokkosCompat;TeuchosRemainder;TeuchosNumerics;TeuchosComm;TeuchosParameterList;TeuchosParser;TeuchosCore;Kokkos;KokkosAlgorithms;KokkosContainers;KokkosCore;Gtest;TrilinosATDMConfigTests;TrilinosFrameworkTests"
+
+This command is absolutely barbaric, but it is required to prevent the usage of the Zadelus library within Trilinos 13.0.1.
+
+and:
+
+.. code-block:: text
+ 
+ make -j8 install
+
+The argument ``-jX`` specifies the number of processors used for the compilation. On login nodes, a maximum of 8 cores should be used in order to ensure that other users can continue using the cluster without slowdowns. In addition, the ``nice`` command can be used at the beginning of the call to give a lower priority to this task. 
+
+.. note:: 
+ If ``make install`` triggers an error, run the command ``which trilinos``. If it returns ``/usr/bin/which: no trilinos in``, try removing the deal.II build folder, recreating it and explicitly specify libraries' paths on the ``cmake``.
+
+================================
+Installing Lethe
+================================
+
+After installing deal.II, compiling Lethe on Beluga, Niagara, Graham or Cedar is relatively straightforward, especially since all of these clusters share a very similar environment. To compile Lethe, the ``Trilinos``, ``Parmetis`` and ``P4est`` modules should be loaded.
+
+In the ``$HOME/lethe`` directory, download Lethe:
+
+.. code-block:: text
+
+ git clone https://github.com/lethe-cfd/lethe.git
+
+To install Lethe in the ``$HOME/lethe/inst`` directory (applications will be in ``inst/bin``), run in the ``$HOME/lethe/build`` directory:
+
+.. code-block:: text
+
+ cmake ../lethe  -DDEAL_II_DIR=../../dealii/inst -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst
+ make install -j8
+
+
+Installing numdiff if required
+------------------------------
+
+If numdiff is not installed, you will have an error at the cmake step of Lethe's installation, stating that this module is missing. To install the package manually use the following steps:
+
+1. Download the `compressed folder <https://mirror.csclub.uwaterloo.ca/nongnu/numdiff/>`_ (ex/ numdiff-5.9.0.tar.gz)
+2. Unzip it
+3. Copy it with ``scp -r`` to your Compute Canada account on the chosen cluster (see :ref:`copying-local-files` section)
+4. In the numdiff folder on the cluster, execute:
+   
+   .. code-block:: text
+   
+    ./configure
+    make
+
+5. Add it to your path environment:
+
+   .. code-block:: text
+   
+     PATH=$PATH:$HOME/path/to/numdiff/folder
+
+
+.. _copying-local-files:
+
+================================
+Copying local files
+================================
+
+On Linux, use ``scp`` (for secure copy) to copy needed files for the simulation (``prm``, ``msh``):
+
+.. code-block:: text
+
+	scp /home/path/in/your/computer/*.prm username@clustername.calculcanada.ca:/scratch/path/in/cluster
+
+If you need to copy a folder, use ``scp -r``.
+
+Simulation files must be in scratch. To get the address of your scratch folder, in your cluster account run:
+
+.. code-block:: text
+
+ cd $SCRATCH
+ pwd
+
+On Windows, use third-party, such as ``PuTTY`` (see the `wiki page on Transferring data <https://docs.computecanada.ca/wiki/Transferring_data>`_))
+
+
+================================
+Creating a .dealii
+================================
+
+In order to call your deal.II local installation, it is convenient to create a ``.dealii`` file in your ``$HOME`` directory:
+
+.. code-block:: text
+
+ nano .dealii
+
+In the nano terminal, copy-paste (with ``Ctrl+Shift+V``):
+
+.. code-block:: text
+
+ module load CCEnv #if on Niagara
+ module load nixpkgs/16.09
+ module load gcc/7.3.0
+ module load openmpi/3.1.2
+ module load p4est/2.0
+ module load trilinos/12.12.1
+ module load parmetis/4.0.3
+
+ export DEAL_II_DIR=$HOME/dealii/inst/
+ export PATH=$PATH:$HOME/lethe/inst/bin/
+
+Exit the nano mode with ``Ctrl+x`` and save the document by hitting ``y`` on the prompt "Save modify buffer?" (in the bottom). The prompt "File Name to Write: .dealii" should then appear, hit ``Enter``.
+
+You can then source it on the terminal with:
+
+.. code-block:: text
+
+ source $HOME/.dealii
+
+and use it in your ``.sh`` script (see Launching simulations below).
+
+================================
+Launching simulations
+================================
+
+Simulations are sent to the scheduler via batch scripts, visit Compute Canada wiki page more information about the `scheduler <https://docs.computecanada.ca/wiki/What_is_a_scheduler%3F>`_ and `running jobs <https://docs.computecanada.ca/wiki/Running_jobs>`_. For your convenience, an example of ``job.sh`` used on Beluga is given below:
+
+.. code-block:: text
+
+ #!/bin/bash
+ #SBATCH --account=$yourgroupaccount
+ #SBATCH --ntasks-per-node=$X #number of parallel tasks (as in mpirun -np X)
+ #SBATCH --nodes=1 #number of whole nodes used (each with up to 40 tasks-per-node)
+ #SBATCH --time=1:00:00 #maximum time for the simulation (hh:mm:ss)
+ #SBATCH --mem=120G #memory usage per node. See cluster specification for maximal amount.
+ #SBATCH --job-name=$yourjobname
+ #SBATCH --mail-type=END #email preferences
+ #SBATCH --mail-type=FAIL
+ #SBATCH --mail-user=$your.email.adress@email.provider
+
+ source $HOME/.dealii
+ srun $HOME/lethe/inst/bin/$lethe_application_name_wanted $parameter_file_name.prm
+
+The job is sent using:
+
+.. code-block:: text
+
+ sbatch job.sh
+
+Status can be followed with the ``sq`` command: under ``ST``, ``PD`` indicates a pending job, and ``R`` a running job.
+
+Console outputs are written in ``slurm-$jobID.out``. For instance, to display the 20 last lines from this file, use:
+
+.. code-block:: text
+
+ tail -n 20 slurm-$jobID.out
+
+.. note:: 
+ If you need to launch multiple simulations, such as with varying parameter, feel free to adapt one of the scripts provided on `lethe-utils <https://github.com/lethe-cfd/lethe-utils/tree/master/python/cluster>`_.
+
+
+================================
+Saving a SSH key (linux)
+================================
+
+To save your key on the cluster, so that it is not asked for each log or ``scp``, generate your ssh-key with:
+
+.. code-block:: text
+
+ ssh-keygen
+
+and copy it on the cluster:
+
+.. code-block:: text
+
+ ssh-copy-id username@clustername.computecanada.ca
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -46,6 +46,7 @@ Contents
    installation/installation
    structure
    first_simulation
+   compute_canada
    parameters/parameters
    examples/examples
    contributing


### PR DESCRIPTION
# Description of the problem

The instructions to run Lethe on Compute Canada clusters was only available on the wiki.

# Description of the solution

This PR migrates the instructions to the new sphinx documentation.

# How Has This Been Tested?

This does not require any test. 

# Future changes

None

# Comments

None
