### PR TITLE
correct the bug

### DIFF
--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -2680,6 +2680,7 @@ GLSSharpNavierStokesSolver<dim>::solve()
         }
       else
         {
+          ib_done.clear();
           refine_ib();
           NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
             refine_mesh();


### PR DESCRIPTION
# Description of the problem
The map of Ib_done was not clear at the beginning of a time step. This can lead to segfault when the force must be evaluated at the beginning of a time step. 

# Description of the solution

- Clear the map at the beginning of any time step

# How Has This Been Tested?

- no need to add a test
