### PR TITLE
Migration of the source term and analytical solution parameter sections

### DIFF
--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -13,7 +13,7 @@ If the problem being simulated has a known analytical solution, or an exact solu
     subsection uvwp
       set Function expression = 0; 0; 0  # In 2D : u;v;p
         or
-      set Function expression = 0; 0; 0; 0  #in 3D u;v;w;p
+      set Function expression = 0; 0; 0; 0  #In 3D u;v;w;p
     end
     subsection temperature
       set Function expression = 0
@@ -94,4 +94,7 @@ Ex.
       set Function expression = if(sin(x) > pi, 1, 0)
     end
    end
+
+.. note:: 
+   The first parameter in the ``if()`` function is the statement. If this statement is *true*, then the function expression takes the second parameter as value. If this statement is *false*, the function expression takes the third parameter as value. In this example, the analytical phase will vary within the calculation domain.
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -26,7 +26,7 @@ If the problem being simulated has a known analytical solution, or an exact solu
     end
    end
 
-* The ``enable`` parameter sets if the problem has an analytical solution and enables the calculation of the analytical solution and the :math:`L^2` norm of the error.
+* The ``enable`` parameter is set to true if the problem has an analytical solution. This enables the calculation of the analytical solution and the :math:`L^2` norm of the error.
 
 The :math:`L^2` norm of the error is calculated as
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -62,7 +62,6 @@ If there is an analytical solution for the fluid's phase, enter the ``phase`` su
 
 In all four last subsections, you can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``.
 
-You can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``. 
 
 Ex.
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -37,7 +37,7 @@ where :math:`u` is the numerical solution and  :math:`u_a` is the analytical sol
 
 
 
-* The ``verbosity`` parameter enables printing the L2 error after each mesh refinement if set to ``verbose``, if ``enable`` is ``true``.
+* The ``verbosity`` parameter enables printing the L2 error after each mesh refinement if it is set to ``verbose`` and if ``enable`` is ``true``.
 
 * The ``filename`` parameter sets the file name to output the L2 error norm if ``enable`` is ``true``.
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -26,7 +26,7 @@ If the problem being simulated has a known analytical solution, or an exact solu
     end
    end
 
-* The ``enable`` parameters sets if the problem has an analytical solution and enables the calculation of the analytical solution and the norm of the L2 error.
+* The ``enable`` parameter sets if the problem has an analytical solution and enables the calculation of the analytical solution and the norm of the L2 error.
 
 * The ``verbosity`` parameter enables printing the L2 error after each mesh refinement if set to ``verbose``, if ``enable`` is ``true``.
 
@@ -34,24 +34,24 @@ If the problem being simulated has a known analytical solution, or an exact solu
 
 If there is an analytical solution for velocity and pressure, enter the ``uvwp`` subsection.
 
-* The ``Function expression`` parameters sets the expression for the analytical solution in regards to u, v and p for a 2D simulation and to u, v, w and p for a 3D simulation.
+* The ``Function expression`` parameter sets the expression for the analytical solution in regards to *u*, *v* and *p* for a 2D simulation and to *u*, *v*, *w* and *p* for a 3D simulation.
 
 If there is an analytical solution for the fluid's temperature, enter the ``temperature`` subsection.
 
-* The ``Function expression`` parameters sets the expression of the temperature.
+* The ``Function expression`` parameter sets the expression of the temperature.
 
 If there is an analytical solution for a tracer, enter the ``tracer`` subsection.
 
-* The ``Function expression`` parameters sets the expression of the tracer.
+* The ``Function expression`` parameter sets the expression of the tracer.
 
-If there is an analytical solution for the fluid's phasee, enter the ``phase`` subsection.
+If there is an analytical solution for the fluid's phase, enter the ``phase`` subsection.
 
-* The ``Function expression`` parameters sets the expression of the phase.
+* The ``Function expression`` parameter sets the expression of the phase.
 
 .. note:: 
     The variables *x*, *y*, *z* (3D) and *t* (time-dependant) can be used in the function expressions.
 
-In all four last subsections, you can add a ``Function constant`` parameter that will act as a constant in the ``Function expression``.
+In all four last subsections, you can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``.
 
 You can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``. 
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -43,7 +43,7 @@ where :math:`u` is the numerical solution and  :math:`u_a` is the analytical sol
 
 If there is an analytical solution for velocity and pressure, enter the ``uvwp`` subsection.
 
-* The ``Function expression`` parameter sets the expression for the analytical solution in regards to *u*, *v* and *p* for a 2D simulation and to *u*, *v*, *w* and *p* for a 3D simulation.
+* The ``Function expression`` parameter sets the expression for the analytical solution in regards to :math:`u`, :math:`v` and :math:`p` for a 2D simulation and to :math:`u`, :math:`v`, :math:`w` and :math:`p` for a 3D simulation.
 
 If there is an analytical solution for the fluid's temperature, enter the ``temperature`` subsection.
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -48,4 +48,42 @@ If there is an analytical solution for the fluid's phasee, enter the ``phase`` s
 
 * The ``Function expression`` parameters sets the expression of the phase.
 
+.. note:: 
+    The variables *x*, *y*, *z* (3D) and *t* (time-dependant) can be used in the function expressions.
+
 In all four last subsections, you can add a ``Function constant`` parameter that will act as a constant in the ``Function expression``.
+
+You can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``. 
+
+Ex.
+
+.. code-block:: text
+
+   subsection analytical solution
+    set enable                = true
+    set verbosity             = true
+    set filename              = L2Error
+    subsection uvwp
+      set Function constants = A=2.0
+      set Function expression = A*y; -A*x; 0
+    end
+   end
+   
+.. note:: 
+    A :math:`\pi` variable is already defined as both ``pi`` and ``Pi``
+
+Your function expression can also contain common functions such as :math:`\sin`, :math:`\cos` as well as ``if`` statements.
+
+Ex.
+
+.. code-block:: text
+
+   subsection analytical solution
+    set enable                = true
+    set verbosity             = true
+    set filename              = L2Error
+    subsection phase
+      set Function expression = if(sin(x) > pi, 1, 0)
+    end
+   end
+

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -1,0 +1,51 @@
+
+Analytical solution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the problem being simulated has a known analytical solution, or an exact solution is imposed (manufactured solutions) it can be added in this section. The default parameters are:
+
+.. code-block:: text
+
+   subsection analytical solution
+    set enable                = false
+    set verbosity             = quiet
+    set filename              = L2Error
+    subsection uvwp
+      set Function expression = 0; 0; 0
+        or
+      set Function expression = 0; 0; 0; 0
+    end
+    subsection temperature
+      set Function expression = 0
+    end
+    subsection tracer
+      set Function expression = 0
+    end
+    subsection phase
+      set Function expression = 0
+    end
+   end
+
+* The ``enable`` parameters sets if the problem as an analytical solution and enables the calculation of the analytical solution and the norm of the L2 error.
+
+* The ``verbosity`` parameter enables printing the L2 error after each mesh refinement if set to ``verbose``, if ``enable`` is ``true``.
+
+* The ``filename`` parameter sets the file name to output the L2 error norm if ``enable`` is ``true``.
+
+If there is an analytical solution for velocity and pressure, enter the ``uvwp`` subsection.
+
+* The ``Function expression`` parameters sets the expression for the analytical solution in regards to u, v and p for a 2D simulation and to u, v, w and p for a 3D simulation.
+
+If there is an analytical solution for the fluid's temperature, enter the ``temperature`` subsection.
+
+* The ``Function expression`` parameters sets the expression of the temperature.
+
+If there is an analytical solution for a tracer, enter the ``tracer`` subsection.
+
+* The ``Function expression`` parameters sets the expression of the tracer.
+
+If there is an analytical solution for the fluid's phasee, enter the ``phase`` subsection.
+
+* The ``Function expression`` parameters sets the expression of the phase.
+
+In all four last subsections, you can add a ``Function constant`` parameter that will act as a constant in the ``Function expression``.

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -11,7 +11,7 @@ If the problem being simulated has a known analytical solution, or an exact solu
     set verbosity             = quiet
     set filename              = L2Error
     subsection uvwp
-      set Function expression = 0; 0; 0
+      set Function expression = 0; 0; 0  # In 2D : u;v;p
         or
       set Function expression = 0; 0; 0; 0
     end

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -26,7 +26,16 @@ If the problem being simulated has a known analytical solution, or an exact solu
     end
    end
 
-* The ``enable`` parameter sets if the problem has an analytical solution and enables the calculation of the analytical solution and the norm of the L2 error.
+* The ``enable`` parameter sets if the problem has an analytical solution and enables the calculation of the analytical solution and the :math:`L^2` norm of the error.
+
+The :math:`L^2` norm of the error is calculated as
+
+.. math::
+L^2 = \int_\Omega (u-u_a)^2 \mathrm{d} \Omega
+
+where :math:`u` is the numerical solution and  :math:`u_a` is the analytical solution.
+
+
 
 * The ``verbosity`` parameter enables printing the L2 error after each mesh refinement if set to ``verbose``, if ``enable`` is ``true``.
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -13,7 +13,7 @@ If the problem being simulated has a known analytical solution, or an exact solu
     subsection uvwp
       set Function expression = 0; 0; 0  # In 2D : u;v;p
         or
-      set Function expression = 0; 0; 0; 0
+      set Function expression = 0; 0; 0; 0  #in 3D u;v;w;p
     end
     subsection temperature
       set Function expression = 0

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -63,7 +63,7 @@ If there is an analytical solution for the fluid's phase, enter the ``phase`` su
 In all four last subsections, you can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``.
 
 
-Ex.
+Ex:
 
 .. code-block:: text
 

--- a/doc/source/parameters/cfd/analytical_solution.rst
+++ b/doc/source/parameters/cfd/analytical_solution.rst
@@ -26,7 +26,7 @@ If the problem being simulated has a known analytical solution, or an exact solu
     end
    end
 
-* The ``enable`` parameters sets if the problem as an analytical solution and enables the calculation of the analytical solution and the norm of the L2 error.
+* The ``enable`` parameters sets if the problem has an analytical solution and enables the calculation of the analytical solution and the norm of the L2 error.
 
 * The ``verbosity`` parameter enables printing the L2 error after each mesh refinement if set to ``verbose``, if ``enable`` is ``true``.
 

--- a/doc/source/parameters/cfd/cfd.rst
+++ b/doc/source/parameters/cfd/cfd.rst
@@ -12,7 +12,10 @@ General, CFD and Multiphysics
    mesh
    fem
    boundary_conditions_cfd
+   source_term
+   analytical_solution
    force_and_torque
+   post_processing
    timer
    multiphysics
    nitsche

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -24,7 +24,7 @@ If the problem being simulated has a source, it can be added in this section. Th
 
 If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
 
-* The ``Function expression`` parameters sets the expression for the source term in regards to *x*, *y* and *p* for a 2D simulation and to *x*, *y*, *z* and *p* for a 3D simulation.
+* The ``Function expression`` parameters sets the expression for the source term. In 2D, the first two terms are the source term for  the *x*, *y* component of the momentum equation. The third term is the mass source term. In 3D, the first three terms are for the *x*, *y* and *z* component of the momentum equation and the fourth term is for the mass source term.
 
 If there is a heat source term, enter the ``heat transfer`` subsection.
 

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -67,3 +67,5 @@ Ex.
     end
    end
 
+.. note:: 
+   The first parameter in the ``if()`` function is the statement. If this statement is *true*, then the function expression takes the second parameter as value. If this statement is *false*, the function expression takes the third parameter as value. In this example, the heat source term will vary within the calculation domain.

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -22,7 +22,7 @@ If the problem being simulated has a source, it can be added in this section. Th
 
 * The ``enable`` parameter is set to true if the problem has a source term and enables it's calculation.
 
-If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
+If there is a Navier-Stokes source term, enter the ``xyz`` subsection.
 
 * The ``Function expression`` parameters sets the expression for the source term. In 2D, the first two terms are the source terms for  the *x*, *y* component of the momentum equation. The third term is the mass source term. In 3D, the first three terms are for the *x*, *y* and *z* component of the momentum equation and the fourth term is for the mass source term.
 

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -20,7 +20,7 @@ If the problem being simulated has a source, it can be added in this section. Th
     end
    end
 
-* The ``enable`` parameter sets if the problem has a source term and enables it's calculation.
+* The ``enable`` parameter is set to true if the problem has a source term and enables it's calculation.
 
 If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
 

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -24,7 +24,7 @@ If the problem being simulated has a source, it can be added in this section. Th
 
 If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
 
-* The ``Function expression`` parameters sets the expression for the source term. In 2D, the first two terms are the source term for  the *x*, *y* component of the momentum equation. The third term is the mass source term. In 3D, the first three terms are for the *x*, *y* and *z* component of the momentum equation and the fourth term is for the mass source term.
+* The ``Function expression`` parameters sets the expression for the source term. In 2D, the first two terms are the source terms for  the *x*, *y* component of the momentum equation. The third term is the mass source term. In 3D, the first three terms are for the *x*, *y* and *z* component of the momentum equation and the fourth term is for the mass source term.
 
 If there is a heat source term, enter the ``heat transfer`` subsection.
 

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -20,7 +20,7 @@ If the problem being simulated has a source, it can be added in this section. Th
     end
    end
 
-* The ``enable`` parameters sets if the problem has a source term and enables it's calculation.
+* The ``enable`` parameter sets if the problem has a source term and enables it's calculation.
 
 If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
 
@@ -28,11 +28,11 @@ If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
 
 If there is a heat source term, enter the ``heat transfer`` subsection.
 
-* The ``Function expression`` parameters sets the expression for the heat transfer.
+* The ``Function expression`` parameter sets the expression for the heat transfer.
 
 If there is an source term for a tracer, enter the ``tracer`` subsection.
 
-* The ``Function expression`` parameters sets the expression for the tracer term.
+* The ``Function expression`` parameter sets the expression for the tracer term.
 
 .. note:: 
     The variables *x*, *y*, *z* (3D) and *t* (time-dependant) can be used in the function expressions.

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -1,0 +1,69 @@
+Source term
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the problem being simulated has a source, it can be added in this section. The default parameters are:
+
+.. code-block:: text
+
+   subsection source term
+    set enable                = true
+    subsection xyz
+      set Function expression = 0; 0; 0
+        or
+      set Function expression = 0; 0; 0; 0
+    end
+    subsection heat transfer
+      set Function expression = 0
+    end
+    subsection tracer
+      set Function expression = 0
+    end
+   end
+
+* The ``enable`` parameters sets if the problem has a source term and enables it's calculation.
+
+If there is an Navier-Stokes source term, enter the ``xyz`` subsection.
+
+* The ``Function expression`` parameters sets the expression for the source term in regards to *x*, *y* and *p* for a 2D simulation and to *x*, *y*, *z* and *p* for a 3D simulation.
+
+If there is a heat source term, enter the ``heat transfer`` subsection.
+
+* The ``Function expression`` parameters sets the expression for the heat transfer.
+
+If there is an source term for a tracer, enter the ``tracer`` subsection.
+
+* The ``Function expression`` parameters sets the expression for the tracer term.
+
+.. note:: 
+    The variables *x*, *y*, *z* (3D) and *t* (time-dependant) can be used in the function expressions.
+
+You can add a ``Function constants`` parameter that will act as a constant in the ``Function expression``. 
+
+Ex.
+
+.. code-block:: text
+
+   subsection source term
+    set enable                = true
+    subsection xyz
+      set Function constants = A=2.0
+      set Function expression = A*y; -A*x; 0
+    end
+   end
+   
+.. note:: 
+    A :math:`\pi` variable is already defined as both ``pi`` and ``Pi``
+
+Your function expression can also contain common functions such as :math:`\sin`, :math:`\cos` as well as ``if`` statements.
+
+Ex.
+
+.. code-block:: text
+
+   subsection source term
+    set enable                = true
+    subsection heat transfer
+      set Function expression = if(sin(x) > pi, 1, 0)
+    end
+   end
+


### PR DESCRIPTION
# Description of the problem

The source term and analytical solution sections were still to be merged. 

# Description of the solution

I added both files in this PR.

# Future changes

As I was checking the defaults parameters for the source term section, I noticed the default value for enable is true which should be changed to false. I also noticed it's definition is to "Enable calculation for analytical solution and L2 error" which should also be fixed.

# Comments

I added the post_processing name to the cfd.rst file since I hadn't done it previously.
