### PR TITLE
Add shear post-process and remove dim from rheo

### DIFF
--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -27,7 +27,6 @@ using namespace dealii;
  * non-newtonian viscosity on each quadrature point and the shear rate
  * magnitude.
  */
-template <int dim>
 class RheologicalModel : public PhysicalPropertyModel
 {
 public:
@@ -45,21 +44,11 @@ public:
    * either the model rheological model being used or say it is a
    * Newtonian flow
    */
-  static std::shared_ptr<RheologicalModel<dim>>
+  static std::shared_ptr<RheologicalModel>
   model_cast(const Parameters::PhysicalProperties &physical_properties);
-
-  /**
-   * @brief Returns the magnitude of the shear rate tensor given in parameter.
-   *
-   * @param shear_rate The shear rate tensor at the position of the
-   * considered quadrature point
-   */
-  double
-  get_shear_rate_magnitude(const Tensor<2, dim> shear_rate);
 };
 
-template <int dim>
-class Newtonian : public RheologicalModel<dim>
+class Newtonian : public RheologicalModel
 {
 public:
   /**
@@ -127,8 +116,7 @@ private:
   double viscosity;
 };
 
-template <int dim>
-class PowerLaw : public RheologicalModel<dim>
+class PowerLaw : public RheologicalModel
 {
 public:
   /**
@@ -213,8 +201,7 @@ private:
   const double shear_rate_min;
 };
 
-template <int dim>
-class Carreau : public RheologicalModel<dim>
+class Carreau : public RheologicalModel
 {
 public:
   /**
@@ -297,6 +284,27 @@ private:
   double a;
   double n;
 };
+
+/**
+ * @brief Calculates the magnitude of the shear rate tensor given as input
+ *
+ * @param shear_rate A shear rate tensor
+ */
+template <int dim>
+inline double
+calculate_shear_rate_magnitude(const Tensor<2, dim> shear_rate)
+{
+  double shear_rate_magnitude = 0;
+  for (unsigned int i = 0; i < dim; ++i)
+    {
+      for (unsigned int j = 0; j < dim; ++j)
+        {
+          shear_rate_magnitude += (shear_rate[i][j] * shear_rate[j][i]);
+        }
+    }
+  shear_rate_magnitude = sqrt(0.5 * shear_rate_magnitude);
+  return shear_rate_magnitude;
+}
 
 
 #endif

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -184,7 +184,7 @@ public:
     : simulation_control(simulation_control)
     , physical_properties(physical_properties)
   {
-    rheological_model = RheologicalModel<dim>::model_cast(physical_properties);
+    rheological_model = RheologicalModel::model_cast(physical_properties);
   }
 
   /**
@@ -276,9 +276,9 @@ public:
    */
   const bool SUPG = true;
 
-  std::shared_ptr<SimulationControl>     simulation_control;
-  Parameters::PhysicalProperties         physical_properties;
-  std::shared_ptr<RheologicalModel<dim>> rheological_model;
+  std::shared_ptr<SimulationControl> simulation_control;
+  Parameters::PhysicalProperties     physical_properties;
+  std::shared_ptr<RheologicalModel>  rheological_model;
 };
 
 
@@ -426,7 +426,7 @@ public:
     , physical_properties(physical_properties)
     , gamma(gamma)
   {
-    rheological_model = RheologicalModel<dim>::model_cast(physical_properties);
+    rheological_model = RheologicalModel::model_cast(physical_properties);
   }
 
   /**
@@ -449,10 +449,10 @@ public:
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
-  std::shared_ptr<SimulationControl>     simulation_control;
-  Parameters::PhysicalProperties         physical_properties;
-  double                                 gamma;
-  std::shared_ptr<RheologicalModel<dim>> rheological_model;
+  std::shared_ptr<SimulationControl> simulation_control;
+  Parameters::PhysicalProperties     physical_properties;
+  double                             gamma;
+  std::shared_ptr<RheologicalModel>  rheological_model;
 };
 
 

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -1,23 +1,21 @@
 #include <core/rheological_model.h>
 
-template <int dim>
-std::shared_ptr<RheologicalModel<dim>>
-RheologicalModel<dim>::model_cast(
+std::shared_ptr<RheologicalModel>
+RheologicalModel::model_cast(
   const Parameters::PhysicalProperties &physical_properties)
 {
   if (!physical_properties.non_newtonian_flow)
-    return std::make_shared<Newtonian<dim>>(
-      physical_properties.fluids[0].viscosity);
+    return std::make_shared<Newtonian>(physical_properties.fluids[0].viscosity);
   else if (physical_properties.non_newtonian_parameters.model ==
            Parameters::NonNewtonian::Model::powerlaw)
-    return std::make_shared<PowerLaw<dim>>(
+    return std::make_shared<PowerLaw>(
       physical_properties.non_newtonian_parameters.powerlaw_parameters.K,
       physical_properties.non_newtonian_parameters.powerlaw_parameters.n,
       physical_properties.non_newtonian_parameters.powerlaw_parameters
         .shear_rate_min);
   else // if (physical_properties.non_newtonian_parameters.model ==
        //  Parameters::NonNewtonian::Model::carreau)
-    return std::make_shared<Carreau<dim>>(
+    return std::make_shared<Carreau>(
       physical_properties.non_newtonian_parameters.carreau_parameters
         .viscosity_0,
       physical_properties.non_newtonian_parameters.carreau_parameters
@@ -27,43 +25,22 @@ RheologicalModel<dim>::model_cast(
       physical_properties.non_newtonian_parameters.carreau_parameters.n);
 }
 
-template <int dim>
 double
-RheologicalModel<dim>::get_shear_rate_magnitude(const Tensor<2, dim> shear_rate)
-{
-  double shear_rate_magnitude = 0;
-  for (unsigned int i = 0; i < dim; ++i)
-    {
-      for (unsigned int j = 0; j < dim; ++j)
-        {
-          shear_rate_magnitude += (shear_rate[i][j] * shear_rate[j][i]);
-        }
-    }
-  shear_rate_magnitude = sqrt(0.5 * shear_rate_magnitude);
-  return shear_rate_magnitude;
-}
-
-template <int dim>
-double
-Newtonian<dim>::value(const std::map<field, double> & /*field_values*/)
+Newtonian::value(const std::map<field, double> & /*field_values*/)
 {
   return viscosity;
 }
 
-template <int dim>
 double
-PowerLaw<dim>::value(const std::map<field, double> &field_values)
+PowerLaw::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
   return calculate_viscosity(shear_rate_magnitude);
 }
 
-
-
-template <int dim>
 void
-PowerLaw<dim>::vector_value(
+PowerLaw::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
   std::vector<double> &                       property_vector)
 {
@@ -73,10 +50,8 @@ PowerLaw<dim>::vector_value(
     property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]);
 }
 
-template <int dim>
 double
-PowerLaw<dim>::jacobian(const std::map<field, double> &field_values,
-                        const field                    id)
+PowerLaw::jacobian(const std::map<field, double> &field_values, const field id)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
   if (id == field::shear_rate)
@@ -85,10 +60,8 @@ PowerLaw<dim>::jacobian(const std::map<field, double> &field_values,
     return 0;
 }
 
-
-template <int dim>
 void
-PowerLaw<dim>::vector_jacobian(
+PowerLaw::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
   std::vector<double> &                       jacobian_vector)
@@ -102,21 +75,17 @@ PowerLaw<dim>::vector_jacobian(
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
 }
 
-
-template <int dim>
 double
-Carreau<dim>::value(const std::map<field, double> &field_values)
+Carreau::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
   return calculate_viscosity(shear_rate_magnitude);
 }
 
-template <int dim>
 void
-Carreau<dim>::vector_value(
-  const std::map<field, std::vector<double>> &field_vectors,
-  std::vector<double> &                       property_vector)
+Carreau::vector_value(const std::map<field, std::vector<double>> &field_vectors,
+                      std::vector<double> &property_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -126,10 +95,8 @@ Carreau<dim>::vector_value(
     }
 }
 
-template <int dim>
 double
-Carreau<dim>::jacobian(const std::map<field, double> &field_values,
-                       const field                    id)
+Carreau::jacobian(const std::map<field, double> &field_values, const field id)
 {
   if (id == field::shear_rate)
     return this->numerical_jacobian(field_values, field::shear_rate);
@@ -137,10 +104,8 @@ Carreau<dim>::jacobian(const std::map<field, double> &field_values,
     return 0;
 }
 
-
-template <int dim>
 void
-Carreau<dim>::vector_jacobian(
+Carreau::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
   std::vector<double> &                       jacobian_vector)
@@ -152,13 +117,3 @@ Carreau<dim>::vector_jacobian(
   else
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
 }
-
-
-template class RheologicalModel<2>;
-template class RheologicalModel<3>;
-template class Newtonian<2>;
-template class Newtonian<3>;
-template class PowerLaw<2>;
-template class PowerLaw<3>;
-template class Carreau<2>;
-template class Carreau<3>;

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -233,8 +233,8 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
   double viscosity;
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel<dim>> rheological_model =
-    RheologicalModel<dim>::model_cast(
+  std::shared_ptr<RheologicalModel> rheological_model =
+    RheologicalModel::model_cast(
       this->simulation_parameters.physical_properties);
 
   const unsigned int vertices_per_face = GeometryInfo<dim>::vertices_per_face;
@@ -481,9 +481,8 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
 
 
                                       const double shear_rate_magnitude =
-                                        rheological_model
-                                          ->get_shear_rate_magnitude(
-                                            shear_rate);
+                                        calculate_shear_rate_magnitude(
+                                          shear_rate);
 
                                       std::map<field, double> field_values;
                                       field_values[field::shear_rate] =

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -304,8 +304,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
         velocity_gradient + transpose(velocity_gradient);
 
       // Calculate the shear rate magnitude
-      double shear_rate_magnitude =
-        rheological_model->get_shear_rate_magnitude(shear_rate);
+      double shear_rate_magnitude = calculate_shear_rate_magnitude(shear_rate);
       // Set the shear rate magnitude to 1e-12 if it is too close to zero,
       // since the viscosity gradient is undefined for shear_rate_magnitude = 0
       shear_rate_magnitude =
@@ -482,8 +481,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
         velocity_gradient + transpose(velocity_gradient);
 
       // Calculate the shear rate magnitude
-      double shear_rate_magnitude =
-        rheological_model->get_shear_rate_magnitude(shear_rate);
+      double shear_rate_magnitude = calculate_shear_rate_magnitude(shear_rate);
 
       shear_rate_magnitude =
         shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12;
@@ -1030,7 +1028,7 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 
       // Calculate the shear rate magnitude
       const double shear_rate_magnitude =
-        rheological_model->get_shear_rate_magnitude(shear_rate);
+        calculate_shear_rate_magnitude(shear_rate);
 
       // Calculate de current non newtonian viscosity on each quadrature point
       std::map<field, double> field_values;
@@ -1124,7 +1122,7 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
 
       // Calculate the shear rate magnitude
       const double shear_rate_magnitude =
-        rheological_model->get_shear_rate_magnitude(shear_rate);
+        calculate_shear_rate_magnitude(shear_rate);
 
       // Calculate de current non newtonian viscosity on each quadrature point
       std::map<field, double> field_values;

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1524,8 +1524,13 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
 
   NonNewtonianViscosityPostprocessor<dim> non_newtonian_viscosity(
     simulation_parameters.physical_properties);
+  ShearRatePostprocessor<dim> shear_rate_processor;
+
   if (simulation_parameters.physical_properties.non_newtonian_flow)
-    data_out.add_data_vector(solution, non_newtonian_viscosity);
+    {
+      data_out.add_data_vector(solution, non_newtonian_viscosity);
+      data_out.add_data_vector(solution, shear_rate_processor);
+    }
 
 
   output_field_hook(data_out);

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -438,8 +438,8 @@ calculate_apparent_viscosity(
   double viscosity;
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel<dim>> rheological_model =
-    RheologicalModel<dim>::model_cast(physical_properties);
+  std::shared_ptr<RheologicalModel> rheological_model =
+    RheologicalModel::model_cast(physical_properties);
 
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -465,10 +465,9 @@ calculate_apparent_viscosity(
 
           for (unsigned int q = 0; q < n_q_points; q++)
             {
-              shear_rate_magnitude =
-                rheological_model->get_shear_rate_magnitude(
-                  present_velocity_gradients[q] +
-                  transpose(present_velocity_gradients[q]));
+              shear_rate_magnitude = calculate_shear_rate_magnitude(
+                present_velocity_gradients[q] +
+                transpose(present_velocity_gradients[q]));
 
               std::map<field, double> field_values;
               field_values[field::shear_rate] = shear_rate_magnitude;
@@ -537,8 +536,8 @@ calculate_forces(
   double viscosity;
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel<dim>> rheological_model =
-    RheologicalModel<dim>::model_cast(physical_properties);
+  std::shared_ptr<RheologicalModel> rheological_model =
+    RheologicalModel::model_cast(physical_properties);
 
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
@@ -596,8 +595,7 @@ calculate_forces(
                                                transpose(velocity_gradients[q]);
 
                                   const double shear_rate_magnitude =
-                                    rheological_model->get_shear_rate_magnitude(
-                                      shear_rate);
+                                    calculate_shear_rate_magnitude(shear_rate);
 
                                   std::map<field, double> field_values;
                                   field_values[field::shear_rate] =
@@ -673,8 +671,8 @@ calculate_torques(
   double viscosity;
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel<dim>> rheological_model =
-    RheologicalModel<dim>::model_cast(physical_properties);
+  std::shared_ptr<RheologicalModel> rheological_model =
+    RheologicalModel::model_cast(physical_properties);
 
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
@@ -731,8 +729,7 @@ calculate_torques(
                               shear_rate = velocity_gradients[q] +
                                            transpose(velocity_gradients[q]);
                               const double shear_rate_magnitude =
-                                rheological_model->get_shear_rate_magnitude(
-                                  shear_rate);
+                                calculate_shear_rate_magnitude(shear_rate);
 
                               std::map<field, double> field_values;
                               field_values[field::shear_rate] =

--- a/tests/core/carreau_rheology.cc
+++ b/tests/core/carreau_rheology.cc
@@ -13,7 +13,7 @@ test()
 {
   deallog << "Beggining" << std::endl;
 
-  Carreau<2> rheology_model(5, 0, 1, 2, 0.5);
+  Carreau rheology_model(5, 0, 1, 2, 0.5);
 
 
   // field values can remain empty since the constant thermal conductivity does

--- a/tests/core/newtonian_rheology.cc
+++ b/tests/core/newtonian_rheology.cc
@@ -13,7 +13,7 @@ test()
 {
   deallog << "Beggining" << std::endl;
 
-  Newtonian<2> rheology_model(5);
+  Newtonian rheology_model(5);
 
   deallog << "Testing constant viscosity - nu" << std::endl;
 

--- a/tests/core/power_law_rheology.cc
+++ b/tests/core/power_law_rheology.cc
@@ -13,7 +13,7 @@ test()
 {
   deallog << "Beggining" << std::endl;
 
-  PowerLaw<2> rheology_model(5, 0.5, 1e-3);
+  PowerLaw rheology_model(5, 0.5, 1e-3);
 
 
   // field values can remain empty since the constant thermal conductivity does


### PR DESCRIPTION
# Description of the problem
- It is interesting to be able to visualize the shear rate in Paraview
- The Rheology classes were templated, which was not exactly necessary

# Description of the solution

- I moved the calculation of the shear rate outside of the rheology model class
- I added a shear rate post-processor
- I added a function outside to calculate the shear rate from a Tensor<2,dim>. With this, we don't need to template the rheology model.

# How Has This Been Tested?

- Existing test cover this :)


# Future changes

- None! The rheology models are robust and mature now it is getting cool.
- 