### PR TITLE
Lethe Docker Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,69 @@
+# Projects
+*.cbp
+*.user
+*.cproject
+*.cproject
+*CMakeCache.txt*
+*.cmake
+.vscode/*
+*.vscode/
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Images / post-processing
+*.vtk
+*.pvd
+*.vtu
+*.pvtu
+*.eps
+
+# data
+*.dat
+
+# meshes
+*.msh
+
+# Ignore all build file
+build/*
+cmake-build*/*
+
+# Ignore clion recommandation file
+.idea/*
+
+# Doc
+doc/build/*
+
+# Docker
+Dockerfile
+.dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Docker Image Build & Push
+
+on:
+  # Runs on every push on master branch.
+  push:
+#    branches:
+#      - master
+  # Runs when a release is published
+  release:
+    types:
+      - published
+
+env:
+  IMAGE_TAG: lethe-cfg/lethe
+  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2.7.0
+        with:
+#          push: true
+          # Either the name of the branch or the tag used by the release
+          tags: ${{ env.IMAGE_TAG }}:latest,${{ env.IMAGE_TAG }}:${{ github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   IMAGE_TAG: lethe-cfg/lethe
-  MULTI_CORE_TESTS_REGEX: "mpirun=2"
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Docker Image Build & Push
 on:
   # Runs on every push on master branch.
   push:
-#    branches:
-#      - master
+    branches:
+      - master
   # Runs when a release is published
   release:
     types:
@@ -32,6 +32,6 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v2.7.0
         with:
-#          push: true
+          push: true
           # Either the name of the branch or the tag used by the release
           tags: ${{ env.IMAGE_TAG }}:latest,${{ env.IMAGE_TAG }}:${{ github.ref_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   docker:
-    name: Build and push Docker image
+    name: Build & Push Docker image
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +29,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker images
+      - name: Build & Push Docker Image
         uses: docker/build-push-action@v2.7.0
         with:
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
       - published
 
 env:
-  IMAGE_TAG: lethe-cfg/lethe
+  IMAGE_TAG: lethe-cfd/lethe
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,9 @@ on:
       - published
 
 env:
-  IMAGE_TAG: lethe-cfd/lethe
+  REGISTRY: ghcr.io
+  IMAGE_NAME: lethe-cfd/lethe
+  CACHE_IMAGE_TAG: master
 
 jobs:
   docker:
@@ -25,13 +27,22 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker Image Tags and Labels
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build & Push Docker Image
         uses: docker/build-push-action@v2.7.0
         with:
           push: true
-          # Either the name of the branch or the tag used by the release
-          tags: ${{ env.IMAGE_TAG }}:latest,${{ env.IMAGE_TAG }}:${{ github.ref_name }}
+          # Cache from the registry's most recent image
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.CACHE_IMAGE_TAG }}
+          # Use generated tags and labels from the meta step
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN mkdir lethe/build && cd lethe/build && \
 
 FROM dealii/dealii:${DEALII_IMAGE_VERSION}-focal as runner
 
+LABEL org.opencontainers.image.title="lethe" \
+      org.opencontainers.image.authors="lethe-cfd" \
+      org.opencontainers.image.source="https://github.com/lethe-cfd/lethe"
+
 ARG LETHE_INSTALL_DIR=/opt/lethe
 
 # Set env vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+ARG DEALII_IMAGE_VERSION="v9.3.0"
+
+FROM dealii/dealii:${DEALII_IMAGE_VERSION}-focal as builder
+
+# Don't run as dealii user to avoid permission problems
+USER root
+
+COPY . lethe
+
+RUN mkdir lethe/build && cd lethe/build && \
+    cmake .. \
+      -DCMAKE_BUILD_TYPE=Release  \
+      -DCMAKE_INSTALL_PREFIX=/tmp/lethe  \
+      -DBUILD_SHARED_LIBS=ON && \
+    make -j $(nproc) && \
+    make install
+
+FROM dealii/dealii:${DEALII_IMAGE_VERSION}-focal as runner
+
+COPY --from=builder /tmp/lethe/bin/ /usr/bin/
+COPY --from=builder /tmp/lethe/lib/ /usr/lib/
+
+ENTRYPOINT ["gls_navier_stokes_2d"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,42 @@ ARG DEALII_IMAGE_VERSION="v9.3.0"
 
 FROM dealii/dealii:${DEALII_IMAGE_VERSION}-focal as builder
 
+ARG LETHE_INSTALL_DIR=/opt/lethe
+
 # Don't run as dealii user to avoid permission problems
 USER root
 
-COPY . lethe
+# Copy required files and directories for compilation
+COPY CMakeLists.txt lethe/
+COPY source lethe/source
+COPY include lethe/include
+COPY applications lethe/applications
+COPY applications_tests lethe/applications_tests
+COPY tests lethe/tests
 
+# Build
 RUN mkdir lethe/build && cd lethe/build && \
     cmake .. \
       -DCMAKE_BUILD_TYPE=Release  \
-      -DCMAKE_INSTALL_PREFIX=/tmp/lethe  \
+      -DCMAKE_INSTALL_PREFIX=${LETHE_INSTALL_DIR} \
       -DBUILD_SHARED_LIBS=ON && \
     make -j $(nproc) && \
     make install
 
 FROM dealii/dealii:${DEALII_IMAGE_VERSION}-focal as runner
 
-COPY --from=builder /tmp/lethe/bin/ /usr/bin/
-COPY --from=builder /tmp/lethe/lib/ /usr/lib/
+ARG LETHE_INSTALL_DIR=/opt/lethe
 
-ENTRYPOINT ["gls_navier_stokes_2d"]
+# Set env vars
+ENV LETHE_INSTALL_DIR=${LETHE_INSTALL_DIR} \
+    PATH=${LETHE_INSTALL_DIR}/bin:${PATH} \
+    LD_LIBRARY_PATH=${LETHE_INSTALL_DIRECTORY}/lib
+
+# Copy entrypoint script and make it executable
+COPY container/docker_entrypoint.py /usr/local/bin/lethe
+RUN sudo chmod +x /usr/local/bin/lethe
+
+# Copy built executables from builder stage
+COPY --from=builder ${LETHE_INSTALL_DIR} ${LETHE_INSTALL_DIR}
+
+ENTRYPOINT ["/usr/local/bin/lethe"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ USER root
 
 # Copy required files and directories for compilation
 COPY CMakeLists.txt lethe/
-COPY source lethe/source
-COPY include lethe/include
-COPY applications lethe/applications
 COPY applications_tests lethe/applications_tests
 COPY tests lethe/tests
+COPY applications lethe/applications
+COPY include lethe/include
+COPY source lethe/source
 
 # Build
 RUN mkdir lethe/build && cd lethe/build && \

--- a/container/docker_entrypoint.py
+++ b/container/docker_entrypoint.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+from typing import List
+
+LETHE_TITLE = f"""
+██╗     ███████╗████████╗██╗  ██╗███████╗
+██║     ██╔════╝╚══██╔══╝██║  ██║██╔════╝
+██║     █████╗     ██║   ███████║█████╗
+██║     ██╔══╝     ██║   ██╔══██║██╔══╝
+███████╗███████╗   ██║   ██║  ██║███████╗
+╚══════╝╚══════╝   ╚═╝   ╚═╝  ╚═╝╚══════╝
+"""
+
+HELP_MESSAGE = f"""
+{LETHE_TITLE}
+
+Usage: <program name> [<program arg>, ...]
+
+Available programs:
+===================
+"""
+
+LETHE_INSTALL_DIR = os.getenv("LETHE_INSTALL_DIR", "/opt/lethe/")
+LETHE_EXECUTABLES = sorted(os.listdir(f"{LETHE_INSTALL_DIR}/bin/"))
+
+
+def print_help() -> None:
+    print(HELP_MESSAGE)
+
+    for program in LETHE_EXECUTABLES:
+        print(f"▸ {program}")
+
+
+def main(args: List[str]) -> None:
+    # Print help if program not specified
+    if len(args) < 2:
+        print_help()
+        sys.exit(-1)
+
+    # Check if program is valid
+    program = args[1]
+    if program not in LETHE_EXECUTABLES:
+        print(f"[Error] Unknown executable: {program}", file=sys.stderr)
+        print_help()
+        sys.exit(-1)
+
+    # Call selected program and forward args
+    subprocess.call(args[1:])
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/doc/source/installation/docker.rst
+++ b/doc/source/installation/docker.rst
@@ -1,5 +1,13 @@
+Docker
+======
+
+.. note::
+
+    You will need to install `Docker <https://www.docker.com/get-started>`_ and have 5 GB of free disk space.
+
+#################################
 Using a deal.II  Docker container
-=================================
+#################################
 
 The deal.II library is a mature project containing `O(1,000,000)` lines of C++ code, itself depending on other similar libraries (e.g. Trilinos). Compiling deal.II with its exact dependencies can be a daunting task even for moderate C++ programmers - one with many knobs and dials, normally taking 4-6 hours.
 
@@ -19,7 +27,7 @@ Sometimes it's easier to effectively set up a completely new OS than compile mil
 0. TL;DR
 --------
 
-Get `Docker <https://docs.docker.com/get-docker/>`_, then in some directory run:
+In some directory run:
 
 .. code-block:: bash
 
@@ -161,3 +169,57 @@ Final Notes
 You can now download, run and manage Docker containers pre-configured with deal.II; it is a powerful tool that you can use for any other projects as well, without polluting your main programming environment or spending hours figuring out the specific libraries needed (`dependency hell <https://en.wikipedia.org/wiki/Dependency_hell>`_ is real).
 
 You can now clone ``lethe``, compile it, and run large-scale, efficient multi-physics simulations!
+
+##############################################################
+No compilation required: Using the Provided Lethe Docker Image
+##############################################################
+
+If you don't want to build Lethe and its dependencies, you can use the provided `Docker image <https://github.com/lethe-cfd/lethe/pkgs/container/lethe>`_.
+
+For example, to launch the 2D Lid-Driven Cavity Flow simulation, run the following lines inside the root Lethe folder:
+
+.. code-block:: shell
+
+    docker run --rm \
+        -v $(pwd):/home/dealii \
+        ghcr.io/lethe-cfd/lethe:master \
+        gls_navier_stokes_2d examples/incompressible_flow/2d_lid_driven_cavity/cavity.prm
+
+Usage
+-----
+
+.. code-block:: text
+
+    ██╗     ███████╗████████╗██╗  ██╗███████╗
+    ██║     ██╔════╝╚══██╔══╝██║  ██║██╔════╝
+    ██║     █████╗     ██║   ███████║█████╗
+    ██║     ██╔══╝     ██║   ██╔══██║██╔══╝
+    ███████╗███████╗   ██║   ██║  ██║███████╗
+    ╚══════╝╚══════╝   ╚═╝   ╚═╝  ╚═╝╚══════╝
+
+
+    Usage: <program name> [<program arg>, ...]
+
+    Available programs:
+    ===================
+
+    ▸ cfd_dem_coupling_2d
+    ▸ cfd_dem_coupling_3d
+    ▸ dem_2d
+    ▸ dem_3d
+    ▸ dem_parameter_template
+    ▸ gd_navier_stokes_2d
+    ▸ gd_navier_stokes_3d
+    ▸ gls_navier_stokes_2d
+    ▸ gls_navier_stokes_3d
+    ▸ gls_nitsche_navier_stokes_22
+    ▸ gls_nitsche_navier_stokes_23
+    ▸ gls_nitsche_navier_stokes_33
+    ▸ gls_sharp_navier_stokes_2d
+    ▸ gls_sharp_navier_stokes_3d
+    ▸ gls_vans_2d
+    ▸ gls_vans_3d
+    ▸ initial_conditions
+    ▸ navier_stokes_parameter_template
+    ▸ rpt_3d
+    ▸ rpt_cell_reconstruction_3d


### PR DESCRIPTION
# Description of the problem

Compiling Lethe along with its dependencies can be a tall order for newcomers who simply wants to experiment with the project.

# Description of the solution

This PR introduces Docker support for Lethe. It includes:

- A Dockerfile to build Lethe in a containerized environment
- A Docker workflow to automate Docker image build and push of master commits
- A custom entrypoint script to bridge the multiple executables/applications to a single `lethe` command
- Usage documentation

# How Has This Been Tested?

The workflow was tested with my personal fork of Lethe to avoid polluting the master branch. You can see the outcome here: https://github.com/technophil98/lethe/runs/4830391609. Don't look at the commit names; bad practices disappear when debugging automated processes...

I also tested the resulting image with the 2D Lid-Driven Cavity Flow example. Additional tests are welcomed since I don't understand how Lethe (or CFD in general) works; I need a _real_ engineer's help. 😅 

# Future changes

- Remove dependency for test in Dockerfile and root CMakeLists.txt
- Tune Docker cache parameters to avoid a 15 minutes build time

# Comments

The docker workflow **will** fail with the current configuration of the repo. GitHub somehow requires us to manually build and push the image before anyway Action workflow. We can be proactive and run these commands before merging:
```shell
docker build -t ghcr.io/lethe-cfd/lethe:lethe_docker_image .
docker push ghcr.io/lethe-cfd/lethe:lethe_docker_image
```
We can delete this temporary image tag after a proper execution of the docker workflow.

By default, Lethe weighs about 2 GB. It is caused by duplicated compiled library object data copied over every executable. I was able to slim down the Lethe part of the image down to 300 MB by compiling with shared-library CMake flags. The image still weighs about 3 GB because it is based on the 2.7 GB dealii image.
