### PR TITLE
Add the capacity for transient BC Vans & CFD-DEM

### DIFF
--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -19,8 +19,8 @@ template <int dim>
 bool
 check_contact_detection_method(
   unsigned int                          counter,
-  CFDDEMSimulationParameters<dim>      &param,
-  std::vector<double>                  &displacement,
+  CFDDEMSimulationParameters<dim> &     param,
+  std::vector<double> &                 displacement,
   Particles::ParticleHandler<dim, dim> &particle_handler,
   MPI_Comm                              mpi_communicator,
   std::shared_ptr<SimulationControl>    simulation_control,
@@ -80,9 +80,9 @@ check_contact_detection_method(
 template <int dim>
 bool
 check_load_balance_method(
-  CFDDEMSimulationParameters<dim>      &param,
+  CFDDEMSimulationParameters<dim> &     param,
   Particles::ParticleHandler<dim, dim> &particle_handler,
-  const MPI_Comm                       &mpi_communicator,
+  const MPI_Comm &                      mpi_communicator,
   const unsigned int                    n_mpi_processes,
   std::shared_ptr<SimulationControl>    simulation_control)
 { // Setting load-balance method (single-step, frequent or dynamic)
@@ -809,7 +809,7 @@ template <int dim>
 void
 CFDDEMSolver<dim>::update_moment_of_inertia(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  std::vector<double>                     &MOI)
+  std::vector<double> &                    MOI)
 {
   MOI.resize(momentum.size());
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -19,8 +19,8 @@ template <int dim>
 bool
 check_contact_detection_method(
   unsigned int                          counter,
-  CFDDEMSimulationParameters<dim> &     param,
-  std::vector<double> &                 displacement,
+  CFDDEMSimulationParameters<dim>      &param,
+  std::vector<double>                  &displacement,
   Particles::ParticleHandler<dim, dim> &particle_handler,
   MPI_Comm                              mpi_communicator,
   std::shared_ptr<SimulationControl>    simulation_control,
@@ -80,9 +80,9 @@ check_contact_detection_method(
 template <int dim>
 bool
 check_load_balance_method(
-  CFDDEMSimulationParameters<dim> &     param,
+  CFDDEMSimulationParameters<dim>      &param,
   Particles::ParticleHandler<dim, dim> &particle_handler,
-  const MPI_Comm &                      mpi_communicator,
+  const MPI_Comm                       &mpi_communicator,
   const unsigned int                    n_mpi_processes,
   std::shared_ptr<SimulationControl>    simulation_control)
 { // Setting load-balance method (single-step, frequent or dynamic)
@@ -809,7 +809,7 @@ template <int dim>
 void
 CFDDEMSolver<dim>::update_moment_of_inertia(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  std::vector<double> &                    MOI)
+  std::vector<double>                     &MOI)
 {
   MOI.resize(momentum.size());
 
@@ -1335,6 +1335,17 @@ CFDDEMSolver<dim>::solve()
   while (this->simulation_control->integrate())
     {
       this->simulation_control->print_progression(this->pcout);
+      if ((this->simulation_control->get_step_number() %
+               this->simulation_parameters.mesh_adaptation.frequency !=
+             0 ||
+           this->simulation_parameters.mesh_adaptation.type ==
+             Parameters::MeshAdaptation::Type::none ||
+           this->simulation_control->is_at_start()) &&
+          this->simulation_parameters.boundary_conditions.time_dependent)
+        {
+          this->update_boundary_conditions();
+        }
+
       if (this->simulation_control->is_at_start())
         {
           this->initialize_void_fraction();

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -633,8 +633,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -741,8 +741,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -633,8 +633,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -741,8 +741,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -1021,6 +1021,18 @@ GLSVANSSolver<dim>::solve()
   while (this->simulation_control->integrate())
     {
       this->simulation_control->print_progression(this->pcout);
+      if ((this->simulation_control->get_step_number() %
+               this->simulation_parameters.mesh_adaptation.frequency !=
+             0 ||
+           this->simulation_parameters.mesh_adaptation.type ==
+             Parameters::MeshAdaptation::Type::none ||
+           this->simulation_control->is_at_start()) &&
+          this->simulation_parameters.boundary_conditions.time_dependent)
+        {
+          this->update_boundary_conditions();
+        }
+
+
       if (this->simulation_control->is_at_start())
         {
           initialize_void_fraction();


### PR DESCRIPTION
# Description of the problem

- Lethe supports transient boundary conditions,  but the VANS and the CFD-DEM solvers don't integrate this capability

# Description of the solution

- The feature for transient Boundary conditions are added to these solvers


# How Has This Been Tested?

- This was quickly tested on a few cases to work, since this is already tested in the basic CFD solver and it uses the same functon, I don't think it is necessary to add a test.


# Comments

- Doable because of the good work of @Luckabarbeau  in the past.
