### PR TITLE
Fix missing example rst file

### DIFF
--- a/doc/source/examples/examples.rst
+++ b/doc/source/examples/examples.rst
@@ -9,3 +9,4 @@ Examples
 
     incompressible-flow/incompressible-flow
     multiphysics/multiphysics
+    dem/dem


### PR DESCRIPTION
# Description of the problem

- DEM examples were not being inserted in the documentation

# Description of the solution

- Add inclusion of dem file


