### PR TITLE
Nitsche table restart

### DIFF
--- a/include/core/nitsche.h
+++ b/include/core/nitsche.h
@@ -161,7 +161,7 @@ namespace Parameters
     // Nitsche solid objects
     std::vector<std::shared_ptr<NitscheSolid<dim>>> nitsche_solids;
     unsigned int                                    number_solids;
-    static const unsigned int                       max_nitsche_solids = 2;
+    static const unsigned int                       max_nitsche_solids = 10;
   };
 
   template <int dim>

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -956,17 +956,22 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::read_checkpoint()
         Utilities::int_to_string(i_solid, 2));
 
       // Refill force and torque table from checkpoint
-      std::string filename_force =
-        this->simulation_parameters.simulation_control.output_folder +
-        this->simulation_parameters.nitsche->force_output_name + "_" +
-        Utilities::int_to_string(i_solid, 2) + ".dat";
-      fill_table_from_file(solid_forces_table[i_solid], filename_force);
-
-      std::string filename_torque =
-        this->simulation_parameters.simulation_control.output_folder +
-        this->simulation_parameters.nitsche->torque_output_name + "_" +
-        Utilities::int_to_string(i_solid, 2) + ".dat";
-      fill_table_from_file(solid_torques_table[i_solid], filename_torque);
+      if (this->simulation_parameters.nitsche->calculate_force_on_solid)
+        {
+          std::string filename_force =
+            this->simulation_parameters.simulation_control.output_folder +
+            this->simulation_parameters.nitsche->force_output_name + "_" +
+            Utilities::int_to_string(i_solid, 2) + ".dat";
+          fill_table_from_file(solid_forces_table[i_solid], filename_force);
+        }
+      if (this->simulation_parameters.nitsche->calculate_torque_on_solid)
+        {
+          std::string filename_torque =
+            this->simulation_parameters.simulation_control.output_folder +
+            this->simulation_parameters.nitsche->torque_output_name + "_" +
+            Utilities::int_to_string(i_solid, 2) + ".dat";
+          fill_table_from_file(solid_torques_table[i_solid], filename_torque);
+        }
     }
 }
 

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -18,13 +18,6 @@
  Montreal, 2020-
  */
 
-#include <deal.II/numerics/fe_field_function.h>
-
-#include <deal.II/particles/data_out.h>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-
 #include <core/bdf.h>
 #include <core/grids.h>
 #include <core/manifolds.h>
@@ -32,7 +25,15 @@
 #include <core/solutions_output.h>
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
+
 #include <solvers/gls_nitsche_navier_stokes.h>
+
+#include <deal.II/numerics/fe_field_function.h>
+
+#include <deal.II/particles/data_out.h>
+
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
 
 // Constructor for class GLSNitscheNavierStokesSolver
 template <int dim, int spacedim>
@@ -953,6 +954,19 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::read_checkpoint()
       pvdhandler_solid_triangulation[i_solid].read(
         prefix + "_solid_triangulation_" +
         Utilities::int_to_string(i_solid, 2));
+
+      // Refill force and torque table from checkpoint
+      std::string filename_force =
+        this->simulation_parameters.simulation_control.output_folder +
+        this->simulation_parameters.nitsche->force_output_name + "_" +
+        Utilities::int_to_string(i_solid, 2) + ".dat";
+      fill_table_from_file(solid_forces_table[i_solid], filename_force);
+
+      std::string filename_torque =
+        this->simulation_parameters.simulation_control.output_folder +
+        this->simulation_parameters.nitsche->torque_output_name + "_" +
+        Utilities::int_to_string(i_solid, 2) + ".dat";
+      fill_table_from_file(solid_torques_table[i_solid], filename_torque);
     }
 }
 

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -18,6 +18,13 @@
  Montreal, 2020-
  */
 
+#include <deal.II/numerics/fe_field_function.h>
+
+#include <deal.II/particles/data_out.h>
+
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
 #include <core/bdf.h>
 #include <core/grids.h>
 #include <core/manifolds.h>
@@ -25,15 +32,7 @@
 #include <core/solutions_output.h>
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
-
 #include <solvers/gls_nitsche_navier_stokes.h>
-
-#include <deal.II/numerics/fe_field_function.h>
-
-#include <deal.II/particles/data_out.h>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 // Constructor for class GLSNitscheNavierStokesSolver
 template <int dim, int spacedim>
@@ -594,13 +593,14 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_torques()
   TimerOutput::Scope t(this->computing_timer, "calculate_torque_on_solid");
 
   std::vector<Tensor<1, 3>> torque;
+
   std::vector<unsigned int> solid_indices;
 
   for (unsigned int i_solid = 0;
        i_solid < this->simulation_parameters.nitsche->number_solids;
        ++i_solid)
     {
-      torque.push_back(calculate_torque_on_solid(i_solid));
+      torque.push_back(this->calculate_torque_on_solid(i_solid));
       solid_indices.push_back(i_solid);
     }
 
@@ -661,7 +661,8 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_torques()
 
       std::string filename_torque =
         this->simulation_parameters.simulation_control.output_folder +
-        this->simulation_parameters.nitsche->torque_output_name + ".dat";
+        this->simulation_parameters.nitsche->torque_output_name + "_" +
+        Utilities::int_to_string(i_solid, 2) + ".dat";
       std::ofstream output_torque(filename_torque.c_str());
 
       solid_torques_table[i_solid].write_text(output_torque);


### PR DESCRIPTION
# Description of the problem
Fixing various problems in gls_nitsche:
1. torque tables had the same filename for multiple solids
2. when restarting a Nitsche simulation, force and torque tables were rewritten (previous values were lost)
3. maximum number of Nitsche solid was 2

# Description of the solution
1. torque filename is incremented with the number of solids
2. previous force and torque tables are loaded and used to refill the restarting simulation (see `read_checkpoint` function)
3. maximum number of Nistche solid set to 10

# How Has This Been Tested?

Tested locally on a case almost similar to the `two-bar-mixer-restart` test (adding calculations of forces and torques). Tell me if you want me to turn it into a test.