### PR TITLE
Add half-step angular velocity calculation

### DIFF
--- a/include/dem/explicit_euler_integrator.h
+++ b/include/dem/explicit_euler_integrator.h
@@ -54,15 +54,19 @@ public:
    * @param particle_handler The particle handler whose particle motion we wish
    * to integrate
    * @param body_force A constant volumetric body force applied to all particles
-   * @param force Force acting on particles
    * @param time_step The value of the time step used for the integration
+   * @param momentum Momentum of particles
+   * @param force Force acting on particles
+   * @param MOI A container of moment of inertia of particles
    */
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
     Tensor<1, dim> &                 body_force,
+    double                           time_step,
+    std::vector<Tensor<1, dim>> &    momentum,
     std::vector<Tensor<1, dim>> &    force,
-    double                           time_step) override;
+    std::vector<double> &            MOI) override;
 
   /**
    * Carries out integration of the motion of all

--- a/include/dem/explicit_euler_integrator.h
+++ b/include/dem/explicit_euler_integrator.h
@@ -61,12 +61,12 @@ public:
    */
   virtual void
   integrate_half_step_location(
-    Particles::ParticleHandler<dim> &particle_handler,
-    Tensor<1, dim> &                 body_force,
-    double                           time_step,
-    std::vector<Tensor<1, dim>> &    momentum,
-    std::vector<Tensor<1, dim>> &    force,
-    std::vector<double> &            MOI) override;
+    Particles::ParticleHandler<dim> &  particle_handler,
+    const Tensor<1, dim> &             body_force,
+    const double                       time_step,
+    const std::vector<Tensor<1, dim>> &momentum,
+    const std::vector<Tensor<1, dim>> &force,
+    const std::vector<double> &        MOI) override;
 
   /**
    * Carries out integration of the motion of all
@@ -82,11 +82,11 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            Tensor<1, dim> &                 body_force,
-            double                           time_step,
+            const Tensor<1, dim> &           body_force,
+            const double                     time_step,
             std::vector<Tensor<1, dim>> &    momentum,
             std::vector<Tensor<1, dim>> &    force,
-            std::vector<double> &            MOI) override;
+            const std::vector<double> &      MOI) override;
 
 private:
   Tensor<1, dim> acceleration;

--- a/include/dem/gear3_integrator.h
+++ b/include/dem/gear3_integrator.h
@@ -79,12 +79,12 @@ public:
    */
   virtual void
   integrate_half_step_location(
-    Particles::ParticleHandler<dim> &particle_handler,
-    Tensor<1, dim> &                 body_force,
-    double                           time_step,
-    std::vector<Tensor<1, dim>> &    momentum,
-    std::vector<Tensor<1, dim>> &    force,
-    std::vector<double> &            MOI) override;
+    Particles::ParticleHandler<dim> &  particle_handler,
+    const Tensor<1, dim> &             body_force,
+    const double                       time_step,
+    const std::vector<Tensor<1, dim>> &momentum,
+    const std::vector<Tensor<1, dim>> &force,
+    const std::vector<double> &        MOI) override;
 
   /**
    * Carries out the integration of the motion of all
@@ -100,11 +100,11 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            Tensor<1, dim> &                 body_force,
-            double                           time_step,
+            const Tensor<1, dim> &           body_force,
+            const double                     time_step,
             std::vector<Tensor<1, dim>> &    momentum,
             std::vector<Tensor<1, dim>> &    force,
-            std::vector<double> &            MOI) override;
+            const std::vector<double> &      MOI) override;
 
 private:
   Point<dim>     predicted_location;

--- a/include/dem/gear3_integrator.h
+++ b/include/dem/gear3_integrator.h
@@ -72,16 +72,19 @@ public:
    * @param particle_handler The particle handler whose particle motion we wish
    * to integrate
    * @param body_force A constant volumetric body force applied to all particles
-   * @param fluid_particle_force The fluid-particle force in CFD-DEM simulations
-   * @param force Force acting on particles
    * @param time_step The value of the time step used for the integration
+   * @param momentum Momentum of particles
+   * @param force Force acting on particles
+   * @param MOI A container of moment of inertia of particles
    */
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
     Tensor<1, dim> &                 body_force,
+    double                           time_step,
+    std::vector<Tensor<1, dim>> &    momentum,
     std::vector<Tensor<1, dim>> &    force,
-    double                           time_step) override;
+    std::vector<double> &            MOI) override;
 
   /**
    * Carries out the integration of the motion of all
@@ -90,7 +93,6 @@ public:
    * @param particle_handler The particle handler whose particle motion we wish
    * to integrate
    * @param body_force A constant volumetric body force applied to all particles
-   * @param fluid_particle_force The fluid-particle force in CFD-DEM simulations
    * @param time_step The value of the time step used for the integration
    * @param momentum Momentum of particles
    * @param force Force acting on particles

--- a/include/dem/integrator.h
+++ b/include/dem/integrator.h
@@ -60,12 +60,12 @@ public:
    */
   virtual void
   integrate_half_step_location(
-    Particles::ParticleHandler<dim> &particle_handler,
-    Tensor<1, dim> &                 body_force,
-    double                           time_step,
-    std::vector<Tensor<1, dim>> &    momentum,
-    std::vector<Tensor<1, dim>> &    force,
-    std::vector<double> &            MOI) = 0;
+    Particles::ParticleHandler<dim> &  particle_handler,
+    const Tensor<1, dim> &             body_force,
+    const double                       time_step,
+    const std::vector<Tensor<1, dim>> &momentum,
+    const std::vector<Tensor<1, dim>> &force,
+    const std::vector<double> &        MOI) = 0;
 
   /**
    * Carries out integrating of particles' velocity and position.
@@ -80,11 +80,11 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            Tensor<1, dim> &                 body_force,
-            double                           time_step,
+            const Tensor<1, dim> &           body_force,
+            const double                     time_step,
             std::vector<Tensor<1, dim>> &    momentum,
             std::vector<Tensor<1, dim>> &    force,
-            std::vector<double> &            MOI) = 0;
+            const std::vector<double> &      MOI) = 0;
 };
 
 #endif /* integration_h */

--- a/include/dem/integrator.h
+++ b/include/dem/integrator.h
@@ -53,15 +53,19 @@ public:
    * @param particle_handler The particle handler whose particle motion we wish
    * to integrate
    * @param body_force A constant volumetric body force applied to all particles
-   * @param force Force acting on particles
    * @param time_step The value of the time step used for the integration
+   * @param momentum Momentum of particles
+   * @param force Force acting on particles
+   * @param MOI A container of moment of inertia of particles
    */
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
     Tensor<1, dim> &                 body_force,
+    double                           time_step,
+    std::vector<Tensor<1, dim>> &    momentum,
     std::vector<Tensor<1, dim>> &    force,
-    double                           time_step) = 0;
+    std::vector<double> &            MOI) = 0;
 
   /**
    * Carries out integrating of particles' velocity and position.

--- a/include/dem/velocity_verlet_integrator.h
+++ b/include/dem/velocity_verlet_integrator.h
@@ -60,15 +60,19 @@ public:
    * @param particle_handler The particle handler whose particle motion we wish
    * to integrate
    * @param body_force A constant volumetric body force applied to all particles
-   * @param force Force acting on particles
    * @param time_step The value of the time step used for the integration
+   * @param momentum Momentum of particles
+   * @param force Force acting on particles
+   * @param MOI A container of moment of inertia of particles
    */
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
     Tensor<1, dim> &                 body_force,
+    double                           time_step,
+    std::vector<Tensor<1, dim>> &    momentum,
     std::vector<Tensor<1, dim>> &    force,
-    double                           time_step) override;
+    std::vector<double> &            MOI) override;
 
   /**
    * Carries out the correction integration of the motion of all

--- a/include/dem/velocity_verlet_integrator.h
+++ b/include/dem/velocity_verlet_integrator.h
@@ -67,12 +67,12 @@ public:
    */
   virtual void
   integrate_half_step_location(
-    Particles::ParticleHandler<dim> &particle_handler,
-    Tensor<1, dim> &                 body_force,
-    double                           time_step,
-    std::vector<Tensor<1, dim>> &    momentum,
-    std::vector<Tensor<1, dim>> &    force,
-    std::vector<double> &            MOI) override;
+    Particles::ParticleHandler<dim> &  particle_handler,
+    const Tensor<1, dim> &             body_force,
+    const double                       time_step,
+    const std::vector<Tensor<1, dim>> &momentum,
+    const std::vector<Tensor<1, dim>> &force,
+    const std::vector<double> &        MOI) override;
 
   /**
    * Carries out the correction integration of the motion of all
@@ -88,11 +88,11 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            Tensor<1, dim> &                 body_force,
-            double                           time_step,
+            const Tensor<1, dim> &           body_force,
+            const double                     time_step,
             std::vector<Tensor<1, dim>> &    momentum,
             std::vector<Tensor<1, dim>> &    force,
-            std::vector<double> &            MOI) override;
+            const std::vector<double> &      MOI) override;
 };
 
 #endif

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -1028,8 +1028,10 @@ DEMSolver<dim>::solve()
           integrator_object->integrate_half_step_location(
             particle_handler,
             parameters.lagrangian_physical_properties.g,
+            simulation_control->get_time_step(),
+            momentum,
             force,
-            simulation_control->get_time_step());
+            MOI);
         }
       else
         {

--- a/source/dem/explicit_euler_integrator.cc
+++ b/source/dem/explicit_euler_integrator.cc
@@ -8,9 +8,11 @@ template <int dim>
 void
 ExplicitEulerIntegrator<dim>::integrate_half_step_location(
   Particles::ParticleHandler<dim> & /*particle_handler*/,
-  Tensor<1, dim> & /*g*/,
+  Tensor<1, dim> & /*body_force*/,
+  double /*time_step*/,
+  std::vector<Tensor<1, dim>> & /*momentum*/,
   std::vector<Tensor<1, dim>> & /*force*/,
-  double /*dt*/)
+  std::vector<double> & /*MOI*/)
 {}
 
 template <int dim>

--- a/source/dem/explicit_euler_integrator.cc
+++ b/source/dem/explicit_euler_integrator.cc
@@ -8,22 +8,22 @@ template <int dim>
 void
 ExplicitEulerIntegrator<dim>::integrate_half_step_location(
   Particles::ParticleHandler<dim> & /*particle_handler*/,
-  Tensor<1, dim> & /*body_force*/,
-  double /*time_step*/,
-  std::vector<Tensor<1, dim>> & /*momentum*/,
-  std::vector<Tensor<1, dim>> & /*force*/,
-  std::vector<double> & /*MOI*/)
+  const Tensor<1, dim> & /*body_force*/,
+  const double /*time_step*/,
+  const std::vector<Tensor<1, dim>> & /*momentum*/,
+  const std::vector<Tensor<1, dim>> & /*force*/,
+  const std::vector<double> & /*MOI*/)
 {}
 
 template <int dim>
 void
 ExplicitEulerIntegrator<dim>::integrate(
   Particles::ParticleHandler<dim> &particle_handler,
-  Tensor<1, dim> &                 g,
-  double                           dt,
+  const Tensor<1, dim> &           g,
+  const double                     dt,
   std::vector<Tensor<1, dim>> &    momentum,
   std::vector<Tensor<1, dim>> &    force,
-  std::vector<double> &            MOI)
+  const std::vector<double> &      MOI)
 {
   for (auto particle = particle_handler.begin();
        particle != particle_handler.end();

--- a/source/dem/gear3_integrator.cc
+++ b/source/dem/gear3_integrator.cc
@@ -7,9 +7,11 @@ template <int dim>
 void
 Gear3Integrator<dim>::integrate_half_step_location(
   Particles::ParticleHandler<dim> & /*particle_handler*/,
-  Tensor<1, dim> & /*g*/,
+  Tensor<1, dim> & /*body_force*/,
+  double /*time_step*/,
+  std::vector<Tensor<1, dim>> & /*momentum*/,
   std::vector<Tensor<1, dim>> & /*force*/,
-  double /*dt*/)
+  std::vector<double> & /*MOI*/)
 {}
 
 template <int dim>

--- a/source/dem/gear3_integrator.cc
+++ b/source/dem/gear3_integrator.cc
@@ -7,22 +7,22 @@ template <int dim>
 void
 Gear3Integrator<dim>::integrate_half_step_location(
   Particles::ParticleHandler<dim> & /*particle_handler*/,
-  Tensor<1, dim> & /*body_force*/,
-  double /*time_step*/,
-  std::vector<Tensor<1, dim>> & /*momentum*/,
-  std::vector<Tensor<1, dim>> & /*force*/,
-  std::vector<double> & /*MOI*/)
+  const Tensor<1, dim> & /*body_force*/,
+  const double /*time_step*/,
+  const std::vector<Tensor<1, dim>> & /*momentum*/,
+  const std::vector<Tensor<1, dim>> & /*force*/,
+  const std::vector<double> & /*MOI*/)
 {}
 
 template <int dim>
 void
 Gear3Integrator<dim>::integrate(
   Particles::ParticleHandler<dim> & /*particle_handler*/,
-  Tensor<1, dim> & /*g*/,
-  double /*dt*/,
+  const Tensor<1, dim> & /*g*/,
+  const double /*dt*/,
   std::vector<Tensor<1, dim>> & /*momentum*/,
   std::vector<Tensor<1, dim>> & /*force*/,
-  std::vector<double> & /*MOI*/)
+  const std::vector<double> & /*MOI*/)
 {
   /*
 for (auto particle = particle_handler.begin();

--- a/source/dem/velocity_verlet_integrator.cc
+++ b/source/dem/velocity_verlet_integrator.cc
@@ -55,11 +55,11 @@ template <int dim>
 void
 VelocityVerletIntegrator<dim>::integrate(
   Particles::ParticleHandler<dim> &particle_handler,
-  Tensor<1, dim> &                 g,
-  double                           dt,
+  const Tensor<1, dim> &           g,
+  const double                     dt,
   std::vector<Tensor<1, dim>> &    momentum,
   std::vector<Tensor<1, dim>> &    force,
-  std::vector<double> &            MOI)
+  const std::vector<double> &      MOI)
 {
   for (auto &particle : particle_handler)
     {

--- a/source/dem/velocity_verlet_integrator.cc
+++ b/source/dem/velocity_verlet_integrator.cc
@@ -6,12 +6,12 @@ using namespace DEM;
 template <int dim>
 void
 VelocityVerletIntegrator<dim>::integrate_half_step_location(
-  Particles::ParticleHandler<dim> &particle_handler,
-  Tensor<1, dim> &                 g,
-  double                           dt,
-  std::vector<Tensor<1, dim>> &    momentum,
-  std::vector<Tensor<1, dim>> &    force,
-  std::vector<double> &            MOI)
+  Particles::ParticleHandler<dim> &  particle_handler,
+  const Tensor<1, dim> &             g,
+  const double                       dt,
+  const std::vector<Tensor<1, dim>> &momentum,
+  const std::vector<Tensor<1, dim>> &force,
+  const std::vector<double> &        MOI)
 {
   for (auto particle = particle_handler.begin();
        particle != particle_handler.end();
@@ -26,16 +26,14 @@ VelocityVerletIntegrator<dim>::integrate_half_step_location(
 #else
       types::particle_index particle_id = particle->get_id();
 #endif
-      Tensor<1, dim>  particle_acceleration;
-      Tensor<1, dim> &particle_force    = force[particle_id];
-      Tensor<1, dim> &particle_momentum = momentum[particle_id];
+      Tensor<1, dim> particle_acceleration;
 
       for (int d = 0; d < dim; ++d)
         {
           // Update acceleration
           particle_acceleration[d] =
-            g[d] +
-            (particle_force[d]) / particle_properties[PropertiesIndex::mass];
+            g[d] + (force[particle_id][d]) /
+                     particle_properties[PropertiesIndex::mass];
 
           // Half-step velocity
           particle_properties[PropertiesIndex::v_x + d] +=
@@ -43,7 +41,7 @@ VelocityVerletIntegrator<dim>::integrate_half_step_location(
 
           // Half-step angular velocity
           particle_properties[PropertiesIndex::omega_x + d] +=
-            0.5 * (particle_momentum[d] / MOI[particle_id]) * dt;
+            0.5 * (momentum[particle_id][d] / MOI[particle_id]) * dt;
 
           // Update particle position using half-step velocity
           particle_position[d] +=

--- a/source/dem/velocity_verlet_integrator.cc
+++ b/source/dem/velocity_verlet_integrator.cc
@@ -8,8 +8,10 @@ void
 VelocityVerletIntegrator<dim>::integrate_half_step_location(
   Particles::ParticleHandler<dim> &particle_handler,
   Tensor<1, dim> &                 g,
+  double                           dt,
+  std::vector<Tensor<1, dim>> &    momentum,
   std::vector<Tensor<1, dim>> &    force,
-  double                           dt)
+  std::vector<double> &            MOI)
 {
   for (auto particle = particle_handler.begin();
        particle != particle_handler.end();
@@ -25,7 +27,8 @@ VelocityVerletIntegrator<dim>::integrate_half_step_location(
       types::particle_index particle_id = particle->get_id();
 #endif
       Tensor<1, dim>  particle_acceleration;
-      Tensor<1, dim> &particle_force = force[particle_id];
+      Tensor<1, dim> &particle_force    = force[particle_id];
+      Tensor<1, dim> &particle_momentum = momentum[particle_id];
 
       for (int d = 0; d < dim; ++d)
         {
@@ -37,6 +40,10 @@ VelocityVerletIntegrator<dim>::integrate_half_step_location(
           // Half-step velocity
           particle_properties[PropertiesIndex::v_x + d] +=
             0.5 * particle_acceleration[d] * dt;
+
+          // Half-step angular velocity
+          particle_properties[PropertiesIndex::omega_x + d] +=
+            0.5 * (particle_momentum[d] / MOI[particle_id]) * dt;
 
           // Update particle position using half-step velocity
           particle_position[d] +=

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -997,8 +997,10 @@ CFDDEMSolver<dim>::dem_iterator(unsigned int counter)
       integrator_object->integrate_half_step_location(
         this->particle_handler,
         dem_parameters.lagrangian_physical_properties.g,
+        dem_time_step,
+        momentum,
         force,
-        dem_time_step);
+        MOI);
     }
   else
     {

--- a/tests/dem/integration_schemes_accuracy.cc
+++ b/tests/dem/integration_schemes_accuracy.cc
@@ -255,10 +255,8 @@ test()
       force[particle_iterator->get_id()][dim - 1] = -x0;
 #endif
 
-      velocity_verlet_object.integrate_half_step_location(particle_handler,
-                                                          g,
-                                                          force,
-                                                          dt1);
+      velocity_verlet_object.integrate_half_step_location(
+        particle_handler, g, dt1, momentum, force, MOI);
       t += dt1;
 
       while (t < t_final)
@@ -321,10 +319,8 @@ test()
 #else
       force[particle_iterator->get_id()][dim - 1] = -x0;
 #endif
-      velocity_verlet_object.integrate_half_step_location(particle_handler,
-                                                          g,
-                                                          force,
-                                                          dt2);
+      velocity_verlet_object.integrate_half_step_location(
+        particle_handler, g, dt2, momentum, force, MOI);
       t += dt2;
 
       while (t < t_final)


### PR DESCRIPTION
# Description of the problem

- Previously, in the half-step calculations of the velocity-verlet integration method, the half-step angular velocity wasn't calculated. In this PR we add the calculation of the half-step angular velocity to velocity-verlet integration method.
