### PR TITLE
Adjust docker workflow triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,16 @@
 name: Docker Image Build & Push
 
 on:
-  # Runs on every push on master branch.
   push:
+    # Runs on every push on master branch
     branches:
       - master
-  # Runs when a release is published
-  release:
-    types:
-      - published
+    # Except when its just doc changes
+    paths-ignore:
+      - 'doc/**'
+    # Runs when a tag following semantic versioning is pushed
+    tags:
+      - v*
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Run Docker workflow on master pushes and semantic versioning tags. Won't run if changes are made exclusively to documentation.