### PR TITLE
Nitsche parameters fix

### DIFF
--- a/doc/source/parameters/cfd/nitsche.rst
+++ b/doc/source/parameters/cfd/nitsche.rst
@@ -28,7 +28,9 @@ Lethe can also run simulations using the Nitsche immersed boundary method.
 	  end
           set particles sub iterations = 5
           set stop if particles lost = true
+          set enable particles motion = false
     end
+  end
 
 * ``beta`` is a parameter needed to apply the immersed boundary conditions on the fluid domain, its value is normally between 1 and 1000. ``beta = 0`` (the solid has no influence on the flow) can be used for debugging purposes. A classical value is ``beta = 10``.
 * ``verbosity`` enables printing Nitsche intermediate results to the terminal.
@@ -45,4 +47,9 @@ Lethe can also run simulations using the Nitsche immersed boundary method.
 * ``enable particles motion`` must be set to ``true`` if the immersed boundary moves. If the boundary is static, for example a rotating cylinder, the shape does not have to move within the fluid and this option can be set to ``false``. This saves significant computational time.
 * ``particles sub iterations`` splits the particle time-stepping into ``n`` sub time steps. This enables the particles to move less per iteration and makes the ``sort_particles_into_cells_and_subdomain()`` routine, which is used to locate the cells in which the particles reside, significantly faster. 
 * ``stop if particles lost`` enables stopping the simulation if Nitsche particles have been lost. If ``false``, the simulation will continue. To prevent particle loss, try increasing the ``particles sub iterations``.
+* ``enable particles motion`` makes the particles move physically in the fluid domain.
+
+.. note::
+  The particles motion should remain ``false`` (the default parameter) if steady-state solutions are to be obtain.
+
 * ``subsection test`` prints the positions of the particles in the terminal at the end of the simulation. This is mostly used for testing purposes.

--- a/doc/source/parameters/cfd/nitsche.rst
+++ b/doc/source/parameters/cfd/nitsche.rst
@@ -16,19 +16,23 @@ Lethe can also run simulations using the Nitsche immersed boundary method.
     set number of solids = 1
 
     subsection nitsche solid 0
-	  subsection mesh
-	  	set type = dealii
-	  	set grid type = hyper_ball
-	  	set grid arguments = 0, 0 : 0.25 : true
-	  	set initial refinement = 5
-	  	set simplex = false
-	  end
-	  subsection solid velocity
-	  	set Function expression = -y ; x
-	  end
-          set particles sub iterations = 5
-          set stop if particles lost = true
-          set enable particles motion = false
+      subsection mesh
+        set type = dealii
+        set grid type = hyper_ball
+        set grid arguments = 0, 0 : 0.25 : true
+        set initial refinement = 5
+        set simplex = false
+      end
+      subsection solid velocity
+        set Function expression = -y ; x
+      end
+      subsection center of rotation
+        set x = 0
+        set y = 0
+      end
+      set particles sub iterations = 5
+      set stop if particles lost = true
+      set enable particles motion = false
     end
   end
 
@@ -43,13 +47,9 @@ Lethe can also run simulations using the Nitsche immersed boundary method.
 .. note::
   If ``set type = gmsh`` and a simplex mesh is given, do not forget to ``set simplex = true`` (it is ``false`` by default)
 
-* ``subsection solid velocity`` defines the velocity of the solid mesh. This velocity is defined by a ``Function  expression`` and can depend on both space and time.
-* ``enable particles motion`` must be set to ``true`` if the immersed boundary moves. If the boundary is static, for example a rotating cylinder, the shape does not have to move within the fluid and this option can be set to ``false``. This saves significant computational time.
+* ``subsection solid velocity`` defines the velocity of the solid mesh. This velocity is defined by a ``Function expression`` and can depend on both space and time.
+* ``subsection center of rotation`` sets coordinates (x, y) of the center of the rotation for torque calculation. Default center of rotation is (0, 0). Add coordinate z for 3D simulations.
 * ``particles sub iterations`` splits the particle time-stepping into ``n`` sub time steps. This enables the particles to move less per iteration and makes the ``sort_particles_into_cells_and_subdomain()`` routine, which is used to locate the cells in which the particles reside, significantly faster. 
 * ``stop if particles lost`` enables stopping the simulation if Nitsche particles have been lost. If ``false``, the simulation will continue. To prevent particle loss, try increasing the ``particles sub iterations``.
-* ``enable particles motion`` makes the particles move physically in the fluid domain.
-
-.. note::
-  The particles motion should remain ``false`` (the default parameter) if steady-state solutions are to be obtain.
-
+* ``enable particles motion`` must be set to ``true`` if the immersed boundary moves. If the boundary is static, for example a rotating cylinder, the shape does not have to move within the fluid and this option can be set to ``false``. This saves significant computational time.
 * ``subsection test`` prints the positions of the particles in the terminal at the end of the simulation. This is mostly used for testing purposes.

--- a/doc/source/parameters/cfd/nitsche.rst
+++ b/doc/source/parameters/cfd/nitsche.rst
@@ -30,6 +30,7 @@ Lethe can also run simulations using the Nitsche immersed boundary method.
         set x = 0
         set y = 0
       end
+      set number of quadrature points = 2
       set particles sub iterations = 5
       set stop if particles lost = true
       set enable particles motion = false
@@ -49,6 +50,7 @@ Lethe can also run simulations using the Nitsche immersed boundary method.
 
 * ``subsection solid velocity`` defines the velocity of the solid mesh. This velocity is defined by a ``Function expression`` and can depend on both space and time.
 * ``subsection center of rotation`` sets coordinates (x, y) of the center of the rotation for torque calculation. Default center of rotation is (0, 0). Add coordinate z for 3D simulations.
+* ``number of quadrature points`` sets the number of Nitsche (quadrature) points to insert in a 1D cell. The number of inserted points will be higher for higher dimensions. Increasing this number will lead to a higher points density inside the solid.
 * ``particles sub iterations`` splits the particle time-stepping into ``n`` sub time steps. This enables the particles to move less per iteration and makes the ``sort_particles_into_cells_and_subdomain()`` routine, which is used to locate the cells in which the particles reside, significantly faster. 
 * ``stop if particles lost`` enables stopping the simulation if Nitsche particles have been lost. If ``false``, the simulation will continue. To prevent particle loss, try increasing the ``particles sub iterations``.
 * ``enable particles motion`` must be set to ``true`` if the immersed boundary moves. If the boundary is static, for example a rotating cylinder, the shape does not have to move within the fluid and this option can be set to ``false``. This saves significant computational time.


### PR DESCRIPTION
# Description of the problem

- Previous issue:
Mistake in the code-block text for the parameter file. An "end" was missing.
- Need for a new feature or component:
Some parameters (features) for Nitsche specifically were missing.
- Added code:
Missing parameters -> center of rotation, number of quadrature points and enable particles motion.

# Description of the solution

- Solution to the existing issue:
Add an "end" at the end of the parameter file to close the Nitsche subsection.

# How Has This Been Tested?

No test needed.

# Comments

I am not sure about the center of rotation in regards of Nitsche simulations. My understanding is that it allows to calculate the torque.
