### PR TITLE
Fix warnings when compiling documentation

### DIFF
--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
@@ -279,7 +279,7 @@ Results
 ---------------------------
 
 Uniform mesh refinement
-^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~
 For the uniform mesh refinement problem, the evolution of the L2 error is as follows:
 
 .. code-block:: text
@@ -322,7 +322,7 @@ Running the simulation with finer meshes lead to this results.
 
 
 Adaptative mesh refinement
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using Paraview, the steady-state velocity profile can be visualized for the adaptative mesh refinement case:
 

--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -25,8 +25,10 @@ For heat transfer boundary conditions, the defaults parameters are:
     end
 
 * ``number``: This is the number of boundary conditions of the problem. 
+
 .. warning::
     The number of boundary conditions must be specified explicitly as the ParameterHandler is not able to deduce the number of boundary conditions from the number of ``bc`` subsections. This is often a source of error.
+
 * ``type``: This is the type of boundary condition been imposed. At the moment, choices are
     * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary 
     * ``convection`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` following Newton's law of cooling (and heating)

--- a/doc/source/parameters/cfd/mesh_adaptation_control.rst
+++ b/doc/source/parameters/cfd/mesh_adaptation_control.rst
@@ -47,21 +47,27 @@ This subsection controls the mesh adaptation method, with default values given b
 * The minimal and maximal refinement level reachable for a cell are controlled respectively with the ``min refinement`` and ``max refinement`` parameters.
    * for ``deal.ii`` meshes, if the ``min refinement level`` is equal to the ``initial refinement`` (see `Mesh paramater <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh.html>`_), no cell will be coarser than the initial mesh.
    * for ``gmsh`` imported meshes, if ``set min refinement level = 0``, no cell will be coarser than the initial mesh.
+
 .. tip:: 
 	For a ``gmsh`` mesh, a cell cannot be coarsened more than it's initial level. Consequently, adaptively refined simulations should start with a mesh as coarse as possible. 
+
 .. tip:: 
 	For a good compromise between speed and precision, ``max refinement level`` should be set to ``2`` or ``3`` more than the ``min refinement level``
+
 * The fraction of cell that are refined and coarsened are controlled with the ``fraction refinement`` and ``fraction coarsening`` parameters. 
+
 .. tip:: 
 	For ``set type = kelly``, and ``set variable = velocity`` or ``pressure``, a good first start is achieve with ``set fraction refinement = 0.2`` and ``set fraction coarsening = 0.1``.
 
 	For ``set type = kelly``, and ``set variable = phase``, use ``fraction type = fraction`` (explained below) and ``set fraction refinement = 0.8`` for a good tracking of the entire free surface (see `Multiphysics <file:///home/jeannej/Softwares/lethe/lethe/doc/build/html/parameters/cfd/multiphysics.html>`_).
+
 * The fraction of refinement/coarsening can be interpreted in ``number`` or ``fraction``  depending on the parameter ``fraction type``. At first sight, this is a relatively difficult concept to understand that is inherited from deal.II. 
 	* When ``fraction type = number``  the  `refine_and_coarsen_fixed_number <https://www.dealii.org/current/doxygen/deal.II/namespaceGridRefinement.html#a48e5395381ed87155942a61a1edd134d>`_ strategy of deal.II is used. This function provides a strategy to mark cells for refinement and coarsening with the goal of providing predictable growth in the size of the mesh by refining  and coarsening a given fraction of all cells.  
 	* When ``fraction type = fraction``,  the `refine_and_coarsen_fixed_fraction <https://www.dealii.org/current/doxygen/deal.II/namespaceGridRefinement.html#ae90dc87c4db158b8d01f6d564ac614e5>`_ strategy is used. This function provides a strategy to mark cells for refinement and coarsening with the goal of controlling the reduction of the error estimate. Also known as the bulk criterion or Dörfler marking, this function computes the thresholds for refinement and coarsening such that the criteria of cells getting flagged for refinement make up for a certain fraction of the total error.
 
 
 * The maximum number of elements in the entire domain can be controlled with the ``max number elements`` parameter.
+
 .. warning::
 	The ``max number elements`` parameter puts a hard limit on the number of cells in the domain, even if the ``fraction refinement`` is increased.
 

--- a/doc/source/parameters/cfd/non-linear_solver_control.rst
+++ b/doc/source/parameters/cfd/non-linear_solver_control.rst
@@ -41,11 +41,14 @@ The Navier-Stokes equations (and other) are non-linear equations. The parameters
 	* ``inexact_newton`` solver, a Newton-Raphson solver where the Jacobian matrix is reused between iterations. 
 		*  ``matrix tolerance`` parameter sets the tolerance to re-assemble the Jacobian matrix. If the residual after a newton step :math:`<` ``matrix tolerance`` :math:`\times` the previous residual, that iteration is considered sufficient and the Newton iteration will keep using the same jacobian matrix. 
 		* Setting ``reuse matrix = true`` enables the usage of the same Jacobian matrix for the following non-linear problem. 
+
 	.. tip::
 		The ``inexact_newton`` solver, along with ``reuse matrix = true`` can be worthwhile in transient simulations with a small time-step. The goal is to seek a compromise between the cost of assembling the matrix and the preconditioner versus the cost of solving the linear system of equations.
+	
 	* ``kinsol_newton`` solver, that uses the Newton-Raphson solver through deal.II, as implemented in the `Sundials library <https://computing.llnl.gov/projects/sundials/kinsol>`_. This solver has an internal algorithm that decides whether to reassemble the Jacobian matrix or not. This non-linear solver is still being tested.
 		* ``kinsol strategy`` parameter enables to choose the strategy that will be used by the kinsol newton solver, and can be ``line_search`` (default value), ``normal_newton``, ``fixed_point`` or ``picard``.
 * The ``verbosity`` option enables the display of the residual at each non-linear iteration, to monitor the progress of the non-linear iterations.
+
 .. note::
 	The residual should decrease rapidly between Newton iterations.
 	Example of a ``set verbosity = verbose`` output:
@@ -63,14 +66,17 @@ The Navier-Stokes equations (and other) are non-linear equations. The parameters
 
 * The ``step tolerance`` parameter controls how much the L2 norm of the residual must decrease to proceed to the next non-linear step. If the ``new_residual``:math:`<` ``old_residual``:math:`\times` ``step tolerance``, then a Newton iteration is accepted. If this condition is not reached, then a relaxation of the step is applied (increasing the ``alpha`` parameter, as printed on the terminal if ``set verbosity = verbose``) until this condition is reached.
 * The ``tolerance`` parameter controls the value under which the residual must be to proceed to the next iteration.
+
 .. hint::
 	The ``tolerance`` parameter is directly linked to the numerical convergence of the simulation, but also to the computational cost (number of Newton iteration).
 
 	For simple simulations, the tolerance can be set quite low, for instance ``set tolerance = 1e-12``. However, such a tolerance can be impossible to attain for more complex simulations : the step tolerance of the non-linear solver can be increased, for instance ``set tolerance = 1e-4``
+
 * The ``max iterations`` parameter sets a hard limit to the number of Newton iterations, even if the ``tolerance`` is not reached.
 
 .. warning::
 	Be careful to always set an absolute tolerance for the linear solver that is below the tolerance of the non-linear solver. Otherwise, you might find that it is impossible to converge because the linear system of equation is solved with insufficient accuracy.
+
 * The ``residual precision`` parameter enables to change the number of digits displayed when showing residuals (with ``set verbosity = verbose``).
 * The ``force_rhs_calculation``: Force RHS recalculation at the beginning of every non-linear steps, This is required if there is a fixed point component to the non-linear solver that is changed at the beginning of every newton iteration. This is notably the case of the sharp edge method. The default value of this parameter is false.
 


### PR DESCRIPTION
# Description of the problem

- There were several warnings due to some required lines before and after some directives when compiling the documentation.  

- Two titles of one example were not being recognized.

# Description of the solution

The required empty lines before and after some directives were added and the titles were fixed.

# How Has This Been Tested?

The documentation compiles without any warning. 
