### PR TITLE
Add documentation section in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 - Explain the previous issue (description of the issue or the reference number of an open issue)
 - Explain the need for a new feature or component
 - Describe the added code
+
 # Description of the solution
 
 - Explain the solution to the existing issue
@@ -14,6 +15,12 @@
 
 - [ ] Test A
 - [ ] Test B
+
+# Documentation
+
+- If applicable, list the documentation files changed and their changes
+
+- [ ] File A
 
 # Future changes
 


### PR DESCRIPTION
# Description of the problem

Now that the documentation is becoming pretty handy and awesome, it would be nice to add a section in the pull request to ensure that this beautiful documentation stays consistant with future development.

# Description of the solution

I just added a section in the template.

# Comments

Sorry for the branch name, I made a mistake.
