### PR TITLE
Add dam break VOF example and fix warnings

### DIFF
--- a/doc/source/examples/multiphysics/multiphysics.rst
+++ b/doc/source/examples/multiphysics/multiphysics.rst
@@ -9,3 +9,4 @@ Multiphysics Examples
 
     warming-up-a-viscous-fluid/warming-up-a-viscous-fluid
     tracer-through-cad-junction/tracer-through-cad-junction
+    dam-break-VOF/dam-break-VOF

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -119,10 +119,12 @@ In this subsection, the control options of linear solvers are specified. These c
 * The ``minimum residual`` for the linear solver.
 
 * The ``relative residual`` for the linear solver.
+
 .. tip::
 	A good rule of thumb is to set the linear solver ``minimum residual`` at least :math:`10` times (preferably :math:`100` times) smaller than the `Non-linear solver :doc:non-linear_solver_control` ``tolerance`` parameter, and keep the relative residual reasonable, for instance ``set relative residual = 1e-3``. To lower the computational cost for more complex simulations, it can be lowered to ``set relative residual = 1e-4``.
 
 * The ``max iters`` puts a hard stop on the number of solver iterations (number of steps printed when ``set verbosity = verbose``).
+
 .. tip::
 	If ``max iters`` is reached, the code will throw this type of message: 
 	
@@ -133,10 +135,12 @@ In this subsection, the control options of linear solvers are specified. These c
 	meaning that the code increases the preconditioner fill (see definition below) in order to converge within the number of solver iterations. If you encounter this, consider increasing the ``max iters`` or adjusting other parameters, for example increasing ``max krylov vectors``.
 
 * ``force linear solver continuation`` enables, when set to ``true``, to force the linear solver to continue, even if the ``minimum residual`` is not reached. Only available for ``GMRES`` solver within the ``gls_navier_stokes`` application.
+
 .. warning::
 	With this mode on, errors on the linear solver convergence are not thrown. Forcing the solver to continue can be useful for debugging purposes if a given iteration is hard to pass, but use with caution!
 
 * ``max krylov vectors`` sets the maximum number of krylov vectors for ``GMRES`` and ``AMG`` solvers.
+
 .. tip::
 	Consider using ``set max krylov vectors = 200`` for complex simulations with convergence issues. 
 


### PR DESCRIPTION
# Description of the problem

The dam-break-VOF example was not being added to any toctree and there were some indentation warnings when compiling the documentation. 

# Description of the solution

- The example was added in the appropriate multiphysics file
- The indentation was fixed to avoid warnings

# How Has This Been Tested?

No test is needed. The documentation compiles without any warnings. 

# Documentation

- [doc/source/examples/multiphysics/multiphysics.rst]
- [doc/source/parameters/cfd/linear_solver_control.rst] 

