### PR TITLE
Fix typo on Niagara cluster commands

### DIFF
--- a/doc/source/installation/compute_canada.rst
+++ b/doc/source/installation/compute_canada.rst
@@ -36,7 +36,7 @@ On Niagara, Beluga, Graham or Cedar
 All operations can be performed on login nodes.
 
 .. warning:: 
- If on **Niagara**, this additional module is needed beforehand: ``module load CCENv``.
+ If on **Niagara**, this additional module is needed beforehand: ``module load CCEnv``.
 
 For any cluster except Narval (that is: Niagara, Beluga, Graham, Cedar), load ``Trilinos``, ``Parmetis`` and ``P4est``, and their prerequisite modules:
 


### PR DESCRIPTION
# Description of the problem

- Typo on Niagara cluster commands to load prerequisite modules (case sensitive)

# Description of the solution

- Fix that

