### PR TITLE
Sphinx warnings return error

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/doc/source/examples/resolved-cfd-dem/cylinder-with-sharp-interface/cylinder-with-sharp-interface.rst
+++ b/doc/source/examples/resolved-cfd-dem/cylinder-with-sharp-interface/cylinder-with-sharp-interface.rst
@@ -158,7 +158,7 @@ Pressure:
     :alt: Simulation schematic
     :align: center
 
-We get the following force applied on the particle for each of the mesh refinements, which is similar to the one obtained with a conformal mesh in :doc:`..incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder`. With the conformal mesh drag force applied to the particle is 7.123. The difference between the 2 can mostly be attributed to the discretization error.
+We get the following force applied on the particle for each of the mesh refinements, which is similar to the one obtained with a conformal mesh in :doc:`../../incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder`. With the conformal mesh drag force applied to the particle is 7.123. The difference between the 2 can mostly be attributed to the discretization error.
 
 .. code-block:: text
 


### PR DESCRIPTION
# Description of the problem

Sphinx build warnings don't return an error. This may jeopardize the doc's quality since the lack of failure of the CI may be interpreted as an "approval" of the changes.

# Description of the solution

Update the `doc` directory's `Makefile` to pass `-W` and `--keep-going` flags to `sphinx-build`. Not only will this will give feedback to contributors, but will mark the CI as failed if any warnings are generated.

# How Has This Been Tested?

Tried it on my local computer and found an error in `cylinder-with-sharp-interface.rst` along the way.

# Documentation

`cylinder-with-sharp-interface.rst` : Fixed an invalid relative path to the 2d flow around cylinder example.\

# Comments

A nice quick win!
