### PR TITLE
Migrate rheological models to Fluid class

### DIFF
--- a/applications_tests/gd_navier_stokes_2d/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/apparent_viscosity_carreau_gd.prm
@@ -25,6 +25,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
     set non newtonian flow	= true
     subsection non newtonian
     	set model 		= carreau
@@ -36,6 +38,7 @@ subsection physical properties
 	    	set n	      		= 0.5
 	end
     end
+  end
 end
 
 #--------------------------------------------------

--- a/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
@@ -57,6 +57,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+set number of fluids = 1
+  subsection fluid 0
     set non newtonian flow	= true
     subsection non newtonian
     	set model 		= carreau
@@ -68,6 +70,7 @@ subsection physical properties
 	    	set n			= 0.25
 	end
     end
+end
 end
 #---------------------------------------------------
 # Mesh

--- a/applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd.prm
@@ -13,6 +13,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+set number of fluids = 1
+  subsection fluid 0
     set non newtonian flow	= true
     subsection non newtonian
     	set model 		= power-law
@@ -22,6 +24,7 @@ subsection physical properties
 	    	set shear rate min = 1e-8
 	end
     end
+end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
@@ -13,6 +13,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+set number of fluids = 1
+  subsection fluid 0
     set non newtonian flow	= true
   subsection non newtonian
     	set model 		= carreau
@@ -24,6 +26,7 @@ subsection physical properties
 	    	set n	      		= 0.5
 	end
   end
+end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
@@ -13,6 +13,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+set number of fluids = 1
+  subsection fluid 0
     set non newtonian flow	= true
     subsection non newtonian
     	set model 		= carreau
@@ -24,6 +26,7 @@ subsection physical properties
 	    	set n	      		= 0.5
 	end
     end
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls.prm
@@ -13,6 +13,8 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
+set number of fluids = 1
+  subsection fluid 0
     set non newtonian flow	= true
     subsection non newtonian
     	set model 		= carreau
@@ -24,6 +26,7 @@ subsection physical properties
 	    	set n			= 0.5
 	end
     end
+  end
 end
 
 #---------------------------------------------------

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -69,10 +69,13 @@ Default values for a non Newtonian fluid are
 .. code-block:: text
 
     subsection physical properties
-    set non newtonian flow	= false
+      set number of fluids		= 1
+      subsection fluid 0
+        set non newtonian flow	= false
         subsection non newtonian
-        set model 		= carreau
+          set model 		= carreau
         end
+      end
     end
     
 * The ``non newtonian flow`` parameter has to be set to ``true`` to use a rheological model.
@@ -94,7 +97,9 @@ The parameters for the Carreau model are defined by the ``carreau`` subsection. 
 .. code-block:: text
 
   subsection physical properties
-    set non newtonian flow	= true
+    set number of fluids		= 1
+    subsection fluid 0
+      set non newtonian flow	= true
       subsection non newtonian
         set model 		= carreau
         subsection carreau
@@ -104,6 +109,7 @@ The parameters for the Carreau model are defined by the ``carreau`` subsection. 
           set lambda = 1.0
           set n = 0.5
         end
+      end
     end
   end
 
@@ -130,17 +136,20 @@ When using the Power-Law model, the default values are:
 
 .. code-block:: text
 
-    subsection physical properties
-    set non newtonian flow	= true
-        subsection non newtonian
+  subsection physical properties
+    set number of fluids		= 1
+    subsection fluid 0
+      set non newtonian flow	= true
+      subsection non newtonian
         set model 		= power-law
-            subsection power-law
-              set K = 1.0
-              set n = 0.5
-              set shear rate min = 1e-3
-            end
+        subsection power-law
+          set K = 1.0
+          set n = 0.5
+          set shear rate min = 1e-3
         end
+      end
     end
+  end
 
 * The ``K`` parameter is a fluid consistency index. It represents the fluid viscosity is it were Newtonian.
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -234,17 +234,17 @@ namespace Parameters
     void
     parse_parameters(ParameterHandler &prm, unsigned int id);
 
-    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
+    // Kinematic viscosity (nu = mu/rho) in units of m^2/s
     double viscosity;
     // volumetric mass density (rho) in units of kg/m^3
     double density;
-    // specific heat capacity (cp) in J/K/kg
+    // specific heat capacity (cp) in J/(kg.K)
     double specific_heat;
-    // thermal conductivity (k) in W/m/K
+    // thermal conductivity (k) in W/(m.K)
     double thermal_conductivity;
     // thermal expansion coefficient (alpha) in 1/K
     double thermal_expansion;
-    // tracer diffusivity) in L^2/s
+    // tracer diffusivity) in m^2/s
     double tracer_diffusivity;
 
     // Non Newtonian parameters

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -220,7 +220,7 @@ namespace Parameters
     parse_parameters(ParameterHandler &prm);
   };
 
-   /**
+  /**
    * @brief Fluid - Class for fluid definition
    */
   class Fluid

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -154,34 +154,6 @@ namespace Parameters
   };
 
   /**
-   * @brief Fluid - Class for fluid definition
-   */
-  class Fluid
-  {
-  public:
-    Fluid()
-    {}
-
-    void
-    declare_parameters(ParameterHandler &prm, unsigned int id);
-    void
-    parse_parameters(ParameterHandler &prm, unsigned int id);
-
-    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
-    double viscosity;
-    // volumetric mass density (rho) in units of kg/m^3
-    double density;
-    // specific heat capacity (cp) in J/K/kg
-    double specific_heat;
-    // thermal conductivity (k) in W/m/K
-    double thermal_conductivity;
-    // thermal expansion coefficient (alpha) in 1/K
-    double thermal_expansion;
-    // tracer diffusivity) in L^2/s
-    double tracer_diffusivity;
-  };
-
-  /**
    * @brief Power-law rheological model to solve for non Newtonian
    * flows.
    */
@@ -246,6 +218,38 @@ namespace Parameters
     declare_parameters(ParameterHandler &prm);
     void
     parse_parameters(ParameterHandler &prm);
+  };
+
+   /**
+   * @brief Fluid - Class for fluid definition
+   */
+  class Fluid
+  {
+  public:
+    Fluid()
+    {}
+
+    void
+    declare_parameters(ParameterHandler &prm, unsigned int id);
+    void
+    parse_parameters(ParameterHandler &prm, unsigned int id);
+
+    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
+    double viscosity;
+    // volumetric mass density (rho) in units of kg/m^3
+    double density;
+    // specific heat capacity (cp) in J/K/kg
+    double specific_heat;
+    // thermal conductivity (k) in W/m/K
+    double thermal_conductivity;
+    // thermal expansion coefficient (alpha) in 1/K
+    double thermal_expansion;
+    // tracer diffusivity) in L^2/s
+    double tracer_diffusivity;
+
+    // Non Newtonian parameters
+    bool         non_newtonian_flow;
+    NonNewtonian non_newtonian_parameters;
   };
 
 
@@ -321,11 +325,6 @@ namespace Parameters
   public:
     PhysicalProperties()
     {}
-
-    // Non Newtonian parameters
-    bool         non_newtonian_flow;
-    NonNewtonian non_newtonian_parameters;
-
     // Phase change parameters
     bool        enable_phase_change;
     PhaseChange phase_change_parameters;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -537,7 +537,7 @@ namespace Parameters
         Patterns::Double(),
         "Tracer diffusivity for the fluid corresponding to Phase = " +
           Utilities::int_to_string(id, 1));
-      
+
       prm.declare_entry("non newtonian flow",
                         "false",
                         Patterns::Bool(),

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -454,13 +454,6 @@ namespace Parameters
 
     prm.enter_subsection("physical properties");
     {
-      prm.declare_entry("non newtonian flow",
-                        "false",
-                        Patterns::Bool(),
-                        "Non Newtonian flow");
-      non_newtonian_parameters.declare_parameters(prm);
-
-
       prm.declare_entry("number of fluids",
                         "1",
                         Patterns::Integer(),
@@ -487,10 +480,6 @@ namespace Parameters
   {
     prm.enter_subsection("physical properties");
     {
-      // Management of non_newtonian_flows
-      non_newtonian_flow = prm.get_bool("non newtonian flow");
-      non_newtonian_parameters.parse_parameters(prm);
-
       // Management of phase_change
       enable_phase_change = prm.get_bool("enable phase change");
       phase_change_parameters.parse_parameters(prm);
@@ -548,6 +537,12 @@ namespace Parameters
         Patterns::Double(),
         "Tracer diffusivity for the fluid corresponding to Phase = " +
           Utilities::int_to_string(id, 1));
+      
+      prm.declare_entry("non newtonian flow",
+                        "false",
+                        Patterns::Bool(),
+                        "Non Newtonian flow");
+      non_newtonian_parameters.declare_parameters(prm);
     }
     prm.leave_subsection();
   }
@@ -563,6 +558,8 @@ namespace Parameters
       thermal_conductivity = prm.get_double("thermal conductivity");
       thermal_expansion    = prm.get_double("thermal expansion");
       tracer_diffusivity   = prm.get_double("tracer diffusivity");
+      non_newtonian_flow   = prm.get_bool("non newtonian flow");
+      non_newtonian_parameters.parse_parameters(prm);
     }
     prm.leave_subsection();
   }

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -4,25 +4,25 @@ std::shared_ptr<RheologicalModel>
 RheologicalModel::model_cast(
   const Parameters::PhysicalProperties &physical_properties)
 {
-  if (!physical_properties.non_newtonian_flow)
+  if (!physical_properties.fluids[0].non_newtonian_flow)
     return std::make_shared<Newtonian>(physical_properties.fluids[0].viscosity);
-  else if (physical_properties.non_newtonian_parameters.model ==
+  else if (physical_properties.fluids[0].non_newtonian_parameters.model ==
            Parameters::NonNewtonian::Model::powerlaw)
     return std::make_shared<PowerLaw>(
-      physical_properties.non_newtonian_parameters.powerlaw_parameters.K,
-      physical_properties.non_newtonian_parameters.powerlaw_parameters.n,
-      physical_properties.non_newtonian_parameters.powerlaw_parameters
+      physical_properties.fluids[0].non_newtonian_parameters.powerlaw_parameters.K,
+      physical_properties.fluids[0].non_newtonian_parameters.powerlaw_parameters.n,
+      physical_properties.fluids[0].non_newtonian_parameters.powerlaw_parameters
         .shear_rate_min);
-  else // if (physical_properties.non_newtonian_parameters.model ==
+  else // if (physical_properties.fluid[0].non_newtonian_parameters.model ==
        //  Parameters::NonNewtonian::Model::carreau)
     return std::make_shared<Carreau>(
-      physical_properties.non_newtonian_parameters.carreau_parameters
+      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters
         .viscosity_0,
-      physical_properties.non_newtonian_parameters.carreau_parameters
+      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters
         .viscosity_inf,
-      physical_properties.non_newtonian_parameters.carreau_parameters.lambda,
-      physical_properties.non_newtonian_parameters.carreau_parameters.a,
-      physical_properties.non_newtonian_parameters.carreau_parameters.n);
+      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters.lambda,
+      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters.a,
+      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters.n);
 }
 
 double

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -9,20 +9,25 @@ RheologicalModel::model_cast(
   else if (physical_properties.fluids[0].non_newtonian_parameters.model ==
            Parameters::NonNewtonian::Model::powerlaw)
     return std::make_shared<PowerLaw>(
-      physical_properties.fluids[0].non_newtonian_parameters.powerlaw_parameters.K,
-      physical_properties.fluids[0].non_newtonian_parameters.powerlaw_parameters.n,
-      physical_properties.fluids[0].non_newtonian_parameters.powerlaw_parameters
-        .shear_rate_min);
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.powerlaw_parameters.K,
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.powerlaw_parameters.n,
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.powerlaw_parameters.shear_rate_min);
   else // if (physical_properties.fluid[0].non_newtonian_parameters.model ==
        //  Parameters::NonNewtonian::Model::carreau)
     return std::make_shared<Carreau>(
-      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters
-        .viscosity_0,
-      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters
-        .viscosity_inf,
-      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters.lambda,
-      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters.a,
-      physical_properties.fluids[0].non_newtonian_parameters.carreau_parameters.n);
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.carreau_parameters.viscosity_0,
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.carreau_parameters.viscosity_inf,
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.carreau_parameters.lambda,
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.carreau_parameters.a,
+      physical_properties.fluids[0]
+        .non_newtonian_parameters.carreau_parameters.n);
 }
 
 double

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -110,7 +110,8 @@ GDNavierStokesSolver<dim>::setup_assemblers()
             this->simulation_parameters.physical_properties));
         }
 
-      if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties.fluids[0]
+            .non_newtonian_flow)
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -110,7 +110,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
             this->simulation_parameters.physical_properties));
         }
 
-      if (this->simulation_parameters.physical_properties.non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -425,7 +425,8 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
             this->simulation_parameters.physical_properties));
         }
 
-      if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties.fluids[0]
+            .non_newtonian_flow)
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(
@@ -479,7 +480,8 @@ GLSNavierStokesSolver<dim>::assemble_system_matrix_without_preconditioner()
                               *this->cell_quadrature,
                               *this->mapping);
     }
-  if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
+  if (this->simulation_parameters.physical_properties.fluids[0]
+        .non_newtonian_flow)
     scratch_data.enable_hessian();
 
   WorkStream::run(
@@ -590,7 +592,8 @@ GLSNavierStokesSolver<dim>::assemble_system_rhs()
                                         *this->mapping);
     }
 
-  if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
+  if (this->simulation_parameters.physical_properties.fluids[0]
+        .non_newtonian_flow)
     scratch_data.enable_hessian();
 
 

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -425,7 +425,7 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
             this->simulation_parameters.physical_properties));
         }
 
-      if (this->simulation_parameters.physical_properties.non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(
@@ -479,7 +479,7 @@ GLSNavierStokesSolver<dim>::assemble_system_matrix_without_preconditioner()
                               *this->cell_quadrature,
                               *this->mapping);
     }
-  if (this->simulation_parameters.physical_properties.non_newtonian_flow)
+  if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
     scratch_data.enable_hessian();
 
   WorkStream::run(
@@ -590,7 +590,7 @@ GLSNavierStokesSolver<dim>::assemble_system_rhs()
                                         *this->mapping);
     }
 
-  if (this->simulation_parameters.physical_properties.non_newtonian_flow)
+  if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
     scratch_data.enable_hessian();
 
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -2234,7 +2234,7 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
         }
 
       // Core assemblers
-      if (this->simulation_parameters.physical_properties.non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -2234,7 +2234,8 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
         }
 
       // Core assemblers
-      if (this->simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties.fluids[0]
+            .non_newtonian_flow)
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1526,7 +1526,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
     simulation_parameters.physical_properties);
   ShearRatePostprocessor<dim> shear_rate_processor;
 
-  if (simulation_parameters.physical_properties.non_newtonian_flow)
+  if (simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
     {
       data_out.add_data_vector(solution, non_newtonian_viscosity);
       data_out.add_data_vector(solution, shear_rate_processor);


### PR DESCRIPTION
# Description of the problem

When using rheological models, the non-Newtonian properties parser was still located in the PhysicalProperties class, rather than in the Fluid class. The migration of non-Newtonian properties is to standardize with the rest of the code.

# Description of the solution

This still does not allow for multiple fluids where one of them is non-Newtonian. The VOF method still has to be updated to allow one or more non-Newtonian rheologies.

# How Has This Been Tested?

These tests were modified so that the .prm file accesses the non-Newtonian properties throught fluid 0

- [x] applications_tests/gd_navier_stokes_2d/apparent_viscosity_careau_gd
- [x] applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd
- [x] applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd
- [x] applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls
- [x] applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls
- [x] applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls

# Documentation

The Physical properties documentation was updated.
- [x] doc/source/parameters/cfd/physical_properties.rst

# Future changes

- Allow for one or more non-Newtonian fluids when using VOF
- Allow for an initial viscous condition using a rheological model
