### PR TITLE
Add missing parameters in Multiphysics

### DIFF
--- a/doc/source/parameters/cfd/interface_sharpening.rst
+++ b/doc/source/parameters/cfd/interface_sharpening.rst
@@ -1,8 +1,9 @@
 Interface sharpening
 --------------------
 
-When running a simulation containing multiple fluids using the volume of fluid method (VOF), the interface between two fluids becomes more blurry after each time step due to diffusion. 
-To avoid that, this subsection includes parameters related to the interface sharpening. The default parameters are:
+When running a multiphase flow simulation using the volume of fluid method (VOF), the interface between two fluids becomes more and more blurry after each time step due to diffusion. 
+
+To avoid that, this subsection includes parameters related to the interface sharpening.
 
 .. code-block:: text
 
@@ -13,20 +14,18 @@ To avoid that, this subsection includes parameters related to the interface shar
   end
 
 .. warning::
-   Do not forget to ``set interface sharpening = true`` in the :doc:multiphysics subsection of the ``.prm``.   
+   Do not forget to ``set interface sharpening = true`` in the :doc:`multiphysics` subsection of the ``.prm``.   
+  
    
-.. warning::
-   Do not forget to ``set interface sharpening = true`` in the :doc:multiphysics subsection of the ``.prm``.   
-   
-* The ``sharpening threshold`` is the phase fraction threshold, and therefore takes a value between 0 and 1. It defines the interface sharpening threshold that represents the mass conservation level.
+* ``sharpening threshold``: phase fraction threshold, between 0 and 1. It defines the interface sharpening threshold that represents the mass conservation level.
 
-* The ``interface sharpness`` parameter defines the sharpness of the moving interface (parameter :math:`a` in the `interface sharpening model <https://www.researchgate.net/publication/287118331_Development_of_efficient_interface_sharpening_procedure_for_viscous_incompressible_flows>`_).
+* ``interface sharpness``: sharpness of the moving interface (parameter :math:`a` in the `interface sharpening model <https://www.researchgate.net/publication/287118331_Development_of_efficient_interface_sharpening_procedure_for_viscous_incompressible_flows>`_).
 
-.. warning::
+.. tip::
 
   This parameter must be larger than 1 for interface sharpening. Choosing values less than 1 leads to interface smoothing instead of sharpening. A good value would be between 1 and 2.
 
-* The ``sharpening frequency`` parameter defines the VOF interface sharpening frequency. It sets at what frequency the interface sharpening calculations should be carried out.
+* ``sharpening frequency``: sets the frequency (in number of iteration) for the interface sharpening computation.
 
 .. seealso::
 

--- a/doc/source/parameters/cfd/interface_sharpening.rst
+++ b/doc/source/parameters/cfd/interface_sharpening.rst
@@ -1,7 +1,7 @@
 Interface sharpening
 --------------------
 
-When running a multiphase flow simulation using the volume of fluid method (VOF), the interface between two fluids becomes more and more blurry after each time step due to diffusion. 
+When running a multiphase flow simulation using the volume of fluid method (VOF), the interface between two fluids becomes more and more blurry after each time step due to numerical diffusion. 
 
 To avoid that, this subsection includes parameters related to the interface sharpening.
 
@@ -25,7 +25,7 @@ To avoid that, this subsection includes parameters related to the interface shar
 
   This parameter must be larger than 1 for interface sharpening. Choosing values less than 1 leads to interface smoothing instead of sharpening. A good value would be between 1 and 2.
 
-* ``sharpening frequency``: sets the frequency (in number of iteration) for the interface sharpening computation.
+* ``sharpening frequency``: sets the frequency (in number of iterations) for the interface sharpening computation.
 
 .. seealso::
 

--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -5,21 +5,53 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 .. code-block:: text
 
   subsection multiphysics
-    set heat transfer = false
-    set buoyancy force = false
-    set tracer = false
-    set VOF = false
-    set interface sharpening = false
-    set viscous dissipation = false
+    # Thermal physics
+    set heat transfer 		= false
+    set viscous dissipation 	= false
+    set buoyancy force 		= false
+
+    # Tracer
+    set tracer 			= false
+
+    # Multiphase flow
+    set VOF 			= false
+    set interface sharpening 	= false
+    set conservation monitoring = false
+    set fluid index 		= 0
   end
 
 
-* The ``heat transfer`` parameter adds the heat transfer auxiliary physics. This is an advection-diffusion equation. If  ``viscous dissipation`` is set to true, viscous dissipation is taken into account in the heat transfer equation.
+* ``heat transfer``: controls if the heat transfer auxiliary physics are solved. This is an advection-diffusion equation. 
 
-* The ``buoyancy force`` parameter adds the buoyancy force in the Navier-Stokes equations. The buoyancy force is calculated using the Boussinesq approximation. Note that ``heat transfer`` is a prerequisite for ``buoyancy force``, and it must be set to true when we set ``buoyancy force`` to true.
+  When ``set heat transfer = true``, these optional parameters can be used:
+   * ``viscous dissipation``: controls if the viscous dissipation is taken into account in the heat transfer equation.
+   * ``buoyancy force``: controls if the buoyancy force is taken into account in the Navier-Stokes equations. The buoyancy force is calculated using the Boussinesq approximation.
+
+.. seealso::
+
+  The heat transfer solver is used in the example :doc:`../../examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid`.
 
 * The ``tracer`` parameter adds a passive tracer auxiliary physics. This is an advection-diffusion equation.
 
-* The ``VOF`` parameter enables defining a multiphasic simulation, with 2 fluids separated by a free surface. Volume-of-Fluid method is used, with the phase parameter following an advection equation. See :doc:`initial_conditions` for the definition of the VOF conditions and :doc:`physical_properties` for the definition of the physical properties of both fluids. At the moment, a maximum of two fluids is supported.
+.. seealso::
 
-* The ``interface sharpening`` parameter activates the interface sharpening method in VOF simulations.
+  The tracer solver is used in the example :doc:`../../examples/multiphysics/tracer-through-cad-junction/tracer-through-cad-junction`.
+
+* ``VOF``: enables multiphase flow simulations, with two fluids separated by a free surface. Volume-of-Fluid method is used, with the phase parameter following an advection equation. 
+
+  See :doc:`initial_conditions` for the definition of the VOF conditions and `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#two-phase-simulations>`_ for the definition of the physical properties of both fluids.
+
+  When ``set VOF = true``, these optional parameters can be used:
+    * ``interface sharpening``: controls if the interface sharpening method is used. Additional parameters can be found at :doc:`interface_sharpening`.
+    * ``conservation monitoring``: controls if conservation is monitored at each iteration, through the volume computation of the fluid with the given ``fluid index``. Results are outputed in a data table (`free_surface_monitoring.dat`).
+
+
+.. warning::
+
+  At the moment, a maximum of two fluids is supported, with respective ``fluid index`` of ``0`` and ``1``.
+
+.. seealso::
+
+  The VOF solver is used in the example :doc:`../../examples/multiphysics/dam-break-VOF/dam-break-VOF`.
+
+

--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -43,7 +43,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 
   When ``set VOF = true``, these optional parameters can be used:
     * ``interface sharpening``: controls if the interface sharpening method is used. Additional parameters can be found at :doc:`interface_sharpening`.
-    * ``conservation monitoring``: controls if conservation is monitored at each iteration, through the volume computation of the fluid with the given ``fluid index``. Results are outputed in a data table (`free_surface_monitoring.dat`).
+    * ``conservation monitoring``: controls if conservation is monitored at each iteration, through the volume computation of the fluid with the given ``fluid index``. Results are outputted in a data table (`free_surface_monitoring.dat`).
 
 
 .. warning::


### PR DESCRIPTION
Add missing parameters in Multiphysics + Review Multiphysics and Interface_sharpening pages.

# Description of the problem

- Missing parameters for VOF in Multiphysics
- Multiphysics and Interface_sharpening pages were not yet homogenized (see last doc PR on Simulation_control doc page)

# Description of the solution

- Add missing parameter
- Review those pages

# Future changes

Continue to review the other pages in the same fashion.

# Comments

Compile with `make html` and open in a web browser to see more clearly the changes!