### PR TITLE
Introduce PhysicalPropertiesManager

### DIFF
--- a/applications_tests/gd_navier_stokes_2d/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/apparent_viscosity_carreau_gd.prm
@@ -28,8 +28,8 @@ subsection physical properties
   set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
+   	set rheological model 	= carreau
     subsection non newtonian
-    	set model 		= carreau
     	subsection carreau
 	    	set viscosity_0		= 1.0
 	    	set viscosity_inf 	= 0

--- a/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
@@ -60,8 +60,8 @@ subsection physical properties
 set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
+  	set rheological model	= carreau
     subsection non newtonian
-    	set model 		= carreau
     	subsection carreau
 	    	set viscosity_0		= 2.0
 	    	set viscosity_inf 	= 1.0

--- a/applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd.prm
@@ -16,8 +16,9 @@ subsection physical properties
 set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
+   	set rheological model	= power-law
+
     subsection non newtonian
-    	set model 		= power-law
     	subsection power-law
 	    	set K 		   = 1.0
 	    	set n 		   = 0.7

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
@@ -13,18 +13,17 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
-    set rheological model 		= carreau
-  subsection non newtonian
+    set rheological model 	= carreau
+    subsection non newtonian
     	subsection carreau
 	    	set viscosity_0		= 1.0
 	    	set viscosity_inf 	= 0
 	    	set lambda	      	= 1
 	    	set a	      		= 2.0
 	    	set n	      		= 0.5
-	end
+	  end
   end
 end
 end

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
@@ -16,8 +16,8 @@ subsection physical properties
 set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
+    set rheological model 		= carreau
   subsection non newtonian
-    	set model 		= carreau
     	subsection carreau
 	    	set viscosity_0		= 1.0
 	    	set viscosity_inf 	= 0

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
@@ -16,8 +16,8 @@ subsection physical properties
 set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
+    set rheological model 		= carreau
     subsection non newtonian
-    	set model 		= carreau
     	subsection carreau
 	    	set viscosity_0		= 1.0
 	    	set viscosity_inf 	= 0

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
@@ -13,7 +13,6 @@ end
 # Physical Properties
 #---------------------------------------------------
 subsection physical properties
-set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
     set rheological model 		= carreau

--- a/applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls.prm
@@ -16,8 +16,8 @@ subsection physical properties
 set number of fluids = 1
   subsection fluid 0
     set non newtonian flow	= true
+   	set rheological model 		= carreau
     subsection non newtonian
-    	set model 		= carreau
     	subsection carreau
 	    	set viscosity_0		= 1.2
 	    	set viscosity_inf 	= 0.8

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -24,7 +24,17 @@
  * density.
  */
 class DensityModel : public PhysicalPropertyModel
-{};
+{
+public:
+  /**
+   * @brief Instantiates and returns a pointer to a DensityModel object by casting it to
+   * the proper child class
+   *
+   * @param physical_properties Parameters for a single fluid
+   */
+  static std::shared_ptr<DensityModel>
+  model_cast(const Parameters::Fluid &fluid_properties);
+};
 
 
 /**

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -187,59 +187,6 @@ namespace Parameters
   };
 
   /**
-   * @brief Fluid - Class for fluid definition
-   */
-  class Fluid
-  {
-  public:
-    Fluid()
-    {}
-
-    void
-    declare_parameters(ParameterHandler &prm, unsigned int id);
-    void
-    parse_parameters(ParameterHandler &prm, unsigned int id);
-
-    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
-    double viscosity;
-    // volumetric mass density (rho) in units of kg/m^3
-    double density;
-    // specific heat capacity (cp) in J/K/kg
-    double specific_heat;
-    // thermal conductivity (k) in W/m/K
-    double thermal_conductivity;
-    // thermal expansion coefficient (alpha) in 1/K
-    double thermal_expansion;
-    // tracer diffusivity) in L^2/s
-    double tracer_diffusivity;
-
-    // Phase change parameters
-    PhaseChange phase_change_parameters;
-
-
-    enum class DensityModel
-    {
-      constant
-    } density_model;
-
-    enum class SpecificHeatModel
-    {
-      constant,
-      phase_change
-    } specific_heat_model;
-
-    enum class ThermalConductivityModel
-    {
-      constant,
-      linear
-    } thermal_conductivity_model;
-
-    // Linear thermal conductivity parameters : k = k_A0 + k_A1 * T
-    double k_A0;
-    double k_A1;
-  };
-
-  /**
    * @brief Power-law rheological model to solve for non Newtonian
    * flows.
    */
@@ -290,13 +237,6 @@ namespace Parameters
 
   struct NonNewtonian
   {
-    // Non Newtonian model
-    enum class Model
-    {
-      powerlaw,
-      carreau
-    } model;
-
     CarreauParameters  carreau_parameters;
     PowerLawParameters powerlaw_parameters;
 
@@ -320,22 +260,52 @@ namespace Parameters
     void
     parse_parameters(ParameterHandler &prm, unsigned int id);
 
-    // Kinematic viscosity (nu = mu/rho) in units of m^2/s
+    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
     double viscosity;
     // volumetric mass density (rho) in units of kg/m^3
     double density;
-    // specific heat capacity (cp) in J/(kg.K)
+    // specific heat capacity (cp) in J/K/kg
     double specific_heat;
-    // thermal conductivity (k) in W/(m.K)
+    // thermal conductivity (k) in W/m/K
     double thermal_conductivity;
     // thermal expansion coefficient (alpha) in 1/K
     double thermal_expansion;
-    // tracer diffusivity) in m^2/s
+    // tracer diffusivity) in L^2/s
     double tracer_diffusivity;
 
-    // Non Newtonian parameters
-    bool         non_newtonian_flow;
+    // Phase change parameters
+    PhaseChange phase_change_parameters;
+
+    // Non Newtonian model parameters
+    bool non_newtonian_flow;
+    enum class RheologyModel
+    {
+      powerlaw,
+      carreau,
+      newtonian
+    } rheology_model;
     NonNewtonian non_newtonian_parameters;
+
+    enum class DensityModel
+    {
+      constant
+    } density_model;
+
+    enum class SpecificHeatModel
+    {
+      constant,
+      phase_change
+    } specific_heat_model;
+
+    enum class ThermalConductivityModel
+    {
+      constant,
+      linear
+    } thermal_conductivity_model;
+
+    // Linear thermal conductivity parameters : k = k_A0 + k_A1 * T
+    double k_A0;
+    double k_A1;
   };
 
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -233,6 +233,10 @@ namespace Parameters
       constant,
       linear
     } thermal_conductivity_model;
+
+    // Linear thermal conductivity parameters : k = k_A0 + k_A1 * T
+    double k_A0;
+    double k_A1;
   };
 
   /**

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -153,6 +153,88 @@ namespace Parameters
     parse_parameters(ParameterHandler &prm);
   };
 
+
+
+  /**
+   * @brief Phase change model for melting/freezing liquids
+   * The model assumes that the phase change occurs between
+   * a solidus and liquidus temperature. This defines a solidification
+   * interval which is used to smooth the non-linearity of the melting problem
+   * or to fit the real thermodynamics of the melting process.
+   *
+   */
+  struct PhaseChange
+  {
+    // Solidus temperature - Units in K
+    double T_solidus;
+
+    // Liquidus temperature - Units in K
+    double T_liquidus;
+
+    // Latent enthalpy for the phase change - Units in J/kg
+    double latent_enthalpy;
+
+    // Specific heat liquid - Units in J/(kg*K)
+    double cp_l;
+
+    // Specific heat solid - Units in J/(kg*K)
+    double cp_s;
+
+    static void
+    declare_parameters(ParameterHandler &prm);
+    void
+    parse_parameters(ParameterHandler &prm);
+  };
+
+  /**
+   * @brief Fluid - Class for fluid definition
+   */
+  class Fluid
+  {
+  public:
+    Fluid()
+    {}
+
+    void
+    declare_parameters(ParameterHandler &prm, unsigned int id);
+    void
+    parse_parameters(ParameterHandler &prm, unsigned int id);
+
+    // Kinematic viscosity (nu = mu/rho) in units of L^2/s
+    double viscosity;
+    // volumetric mass density (rho) in units of kg/m^3
+    double density;
+    // specific heat capacity (cp) in J/K/kg
+    double specific_heat;
+    // thermal conductivity (k) in W/m/K
+    double thermal_conductivity;
+    // thermal expansion coefficient (alpha) in 1/K
+    double thermal_expansion;
+    // tracer diffusivity) in L^2/s
+    double tracer_diffusivity;
+
+    // Phase change parameters
+    PhaseChange phase_change_parameters;
+
+
+    enum class DensityModel
+    {
+      constant
+    } density_model;
+
+    enum class SpecificHeatModel
+    {
+      constant,
+      phase_change
+    } specific_heat_model;
+
+    enum class ThermalConductivityModel
+    {
+      constant,
+      linear
+    } thermal_conductivity_model;
+  };
+
   /**
    * @brief Power-law rheological model to solve for non Newtonian
    * flows.
@@ -253,36 +335,6 @@ namespace Parameters
   };
 
 
-  /**
-   * @brief Phase change model for melting/freezing liquids
-   * The model assumes that the phase change occurs between
-   * a solidus and liquidus temperature. This defines a solidification
-   * interval which is used to smooth the non-linearity of the melting problem
-   * or to fit the real thermodynamics of the melting process.
-   *
-   */
-  struct PhaseChange
-  {
-    // Solidus temperature - Units in K
-    double T_solidus;
-
-    // Liquidus temperature - Units in K
-    double T_liquidus;
-
-    // Latent enthalpy for the phase change - Units in J/kg
-    double latent_enthalpy;
-
-    // Specific heat liquid - Units in J/(kg*K)
-    double cp_l;
-
-    // Specific heat solid - Units in J/(kg*K)
-    double cp_s;
-
-    static void
-    declare_parameters(ParameterHandler &prm);
-    void
-    parse_parameters(ParameterHandler &prm);
-  };
 
   /**
    * @brief InterfaceSharpening - Defines the parameters for
@@ -325,9 +377,6 @@ namespace Parameters
   public:
     PhysicalProperties()
     {}
-    // Phase change parameters
-    bool        enable_phase_change;
-    PhaseChange phase_change_parameters;
 
     // Fluid objects for multiphasic simulations
     std::vector<Fluid>        fluids;

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -45,7 +45,7 @@ public:
    * Newtonian flow
    */
   static std::shared_ptr<RheologicalModel>
-  model_cast(const Parameters::PhysicalProperties &physical_properties);
+  model_cast(const Parameters::Fluid &fluid_properties);
 };
 
 class Newtonian : public RheologicalModel

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -32,6 +32,14 @@ using namespace dealii;
 class SpecificHeatModel : public PhysicalPropertyModel
 {
 public:
+  /**
+   * @brief Instantiates and returns a pointer to a SpecificHeatModel object by casting it to
+   * the proper child class
+   *
+   * @param physical_properties Parameters for a single fluid
+   */
+  static std::shared_ptr<SpecificHeatModel>
+  model_cast(const Parameters::Fluid &fluid_properties);
 };
 
 

--- a/include/core/thermal_conductivity_model.h
+++ b/include/core/thermal_conductivity_model.h
@@ -28,6 +28,14 @@
 class ThermalConductivityModel : public PhysicalPropertyModel
 {
 public:
+  /**
+   * @brief Instantiates and returns a pointer to a ThermalConductivityModel object by casting it to
+   * the proper child class
+   *
+   * @param physical_properties Parameters for a single fluid
+   */
+  static std::shared_ptr<ThermalConductivityModel>
+  model_cast(const Parameters::Fluid &fluid_properties);
 };
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -91,7 +91,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -101,7 +101,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -148,7 +148,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -157,7 +157,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -184,7 +184,8 @@ public:
     : simulation_control(simulation_control)
     , physical_properties(physical_properties)
   {
-    rheological_model = RheologicalModel::model_cast(physical_properties);
+    rheological_model =
+      RheologicalModel::model_cast(physical_properties.fluids[0]);
   }
 
   /**
@@ -198,9 +199,9 @@ public:
   Tensor<1, dim>
   get_viscosity_gradient(const Tensor<2, dim> &velocity_gradient,
                          const Tensor<3, dim> &velocity_hessians,
-                         const double &        shear_rate_magnitude,
-                         const double &        non_newtonian_viscosity,
-                         const double &        d_gamma_dot) const
+                         const double         &shear_rate_magnitude,
+                         const double         &non_newtonian_viscosity,
+                         const double         &d_gamma_dot) const
   {
     std::map<field, double> field_values_plus;
 
@@ -256,7 +257,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -266,7 +267,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -308,7 +309,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -317,7 +318,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -347,7 +348,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -356,7 +357,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -394,7 +395,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -404,7 +405,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -426,7 +427,8 @@ public:
     , physical_properties(physical_properties)
     , gamma(gamma)
   {
-    rheological_model = RheologicalModel::model_cast(physical_properties);
+    rheological_model =
+      RheologicalModel::model_cast(physical_properties.fluids[0]);
   }
 
   /**
@@ -435,7 +437,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -445,7 +447,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -481,7 +483,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -491,7 +493,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -528,7 +530,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -538,7 +540,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -577,7 +579,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -587,7 +589,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -624,7 +626,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -634,7 +636,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -91,7 +91,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -101,7 +101,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -148,7 +148,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -157,7 +157,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -199,9 +199,9 @@ public:
   Tensor<1, dim>
   get_viscosity_gradient(const Tensor<2, dim> &velocity_gradient,
                          const Tensor<3, dim> &velocity_hessians,
-                         const double         &shear_rate_magnitude,
-                         const double         &non_newtonian_viscosity,
-                         const double         &d_gamma_dot) const
+                         const double &        shear_rate_magnitude,
+                         const double &        non_newtonian_viscosity,
+                         const double &        d_gamma_dot) const
   {
     std::map<field, double> field_values_plus;
 
@@ -257,7 +257,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -267,7 +267,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -309,7 +309,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -318,7 +318,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -348,7 +348,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -357,7 +357,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -395,7 +395,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -405,7 +405,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -437,7 +437,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -447,7 +447,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -483,7 +483,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -493,7 +493,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -530,7 +530,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -540,7 +540,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -579,7 +579,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -589,7 +589,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -626,7 +626,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -636,7 +636,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -29,15 +29,26 @@ using namespace dealii;
 
 class PhysicalPropertiesManager
 {
+public:
+  /**
+   * @brief Default constructor that initialized none of the physical properties
+   */
+  PhysicalPropertiesManager()
+  {}
+
   PhysicalPropertiesManager(Parameters::PhysicalProperties physical_properties);
 
+  void
+  initialize(Parameters::PhysicalProperties physical_properties);
 
-
-private:
   std::vector<std::shared_ptr<DensityModel>>             density;
   std::vector<std::shared_ptr<SpecificHeatModel>>        specific_heat;
   std::vector<std::shared_ptr<ThermalConductivityModel>> thermal_conductivity;
+  std::vector<std::shared_ptr<RheologicalModel>>         rheology;
 
+  bool non_newtonian_flow;
+
+private:
   unsigned int number_of_fluids;
 };
 

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -27,6 +27,14 @@
 using namespace dealii;
 
 
+/** @class The PhysicalPropertiesManager class manages the physical properties
+ * model which are required to calculate the various physical properties
+ * This centralizes the place where the models are created.
+ * The class can be constructed empty and initialized from parameters
+ * or it can be constructed directly with a Parameters section.
+ *
+ */
+
 class PhysicalPropertiesManager
 {
 public:
@@ -34,13 +42,57 @@ public:
    * @brief Default constructor that initialized none of the physical properties
    */
   PhysicalPropertiesManager()
+    : is_initialized(false)
   {}
 
+  /**
+   * @brief PhysicalPropertiesManager Constructor that initializes the class
+   * @param physical_properties Parameters for the physical properties
+   */
+
   PhysicalPropertiesManager(Parameters::PhysicalProperties physical_properties);
+
+  /**
+   * @brief initialize Initializes the physical properties using the parameters
+   * @param physical_properties Parameters for the physical properties
+   */
 
   void
   initialize(Parameters::PhysicalProperties physical_properties);
 
+  std::shared_ptr<DensityModel>
+  get_density(unsigned int fluid_id = 0)
+  {
+    return density[fluid_id];
+  }
+
+  std::shared_ptr<SpecificHeatModel>
+  get_specific_heat(unsigned int fluid_id = 0)
+  {
+    return specific_heat[fluid_id];
+  }
+
+  std::shared_ptr<ThermalConductivityModel>
+  get_thermal_conductivity(unsigned int fluid_id = 0)
+  {
+    return thermal_conductivity[fluid_id];
+  }
+
+  std::shared_ptr<RheologicalModel>
+  get_rheology(unsigned int fluid_id = 0)
+  {
+    return rheology[fluid_id];
+  }
+
+  bool
+  is_non_newtonian()
+  {
+    return non_newtonian_flow;
+  }
+
+
+private:
+  bool                                                   is_initialized;
   std::vector<std::shared_ptr<DensityModel>>             density;
   std::vector<std::shared_ptr<SpecificHeatModel>>        specific_heat;
   std::vector<std::shared_ptr<ThermalConductivityModel>> thermal_conductivity;
@@ -48,7 +100,6 @@ public:
 
   bool non_newtonian_flow;
 
-private:
   unsigned int number_of_fluids;
 };
 

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 - 2019 by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * This class manages the physical property models for a simulation
+ */
+
+#ifndef lethe_physical_properties_manager_h
+#define lethe_physical_properties_manager_h
+
+#include <core/density_model.h>
+#include <core/rheological_model.h>
+#include <core/specific_heat_model.h>
+#include <core/thermal_conductivity_model.h>
+
+using namespace dealii;
+
+
+class PhysicalPropertiesManager
+{
+  PhysicalPropertiesManager(Parameters::PhysicalProperties physical_properties);
+
+
+
+private:
+  std::vector<std::shared_ptr<DensityModel>>             density;
+  std::vector<std::shared_ptr<SpecificHeatModel>>        specific_heat;
+  std::vector<std::shared_ptr<ThermalConductivityModel>> thermal_conductivity;
+
+  unsigned int number_of_fluids;
+};
+
+#endif

--- a/include/solvers/post_processors.h
+++ b/include/solvers/post_processors.h
@@ -182,7 +182,8 @@ public:
     Parameters::PhysicalProperties p_physical_properties)
     : DataPostprocessorScalar<dim>("viscosity", update_gradients)
   {
-    rheological_model = RheologicalModel::model_cast(p_physical_properties);
+    rheological_model =
+      RheologicalModel::model_cast(p_physical_properties.fluids[0]);
   }
   virtual void
   evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &inputs,

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -55,13 +55,12 @@ public:
   BoundaryConditions::NSBoundaryConditions<dim>     boundary_conditions;
   BoundaryConditions::HTBoundaryConditions<dim>     boundary_conditions_ht;
   BoundaryConditions::TracerBoundaryConditions<dim> boundary_conditions_tracer;
-  Parameters::InitialConditions<dim> *              initial_condition;
-  AnalyticalSolutions::AnalyticalSolution<dim> *    analytical_solution;
-  SourceTerms::SourceTerm<dim> *                    source_term;
+  Parameters::InitialConditions<dim>               *initial_condition;
+  AnalyticalSolutions::AnalyticalSolution<dim>     *analytical_solution;
+  SourceTerms::SourceTerm<dim>                     *source_term;
   Parameters::VelocitySource                        velocity_sources;
   std::shared_ptr<Parameters::IBParticles<dim>>     particlesParameters;
   Parameters::DynamicFlowControl                    flow_control;
-  Parameters::NonNewtonian                          non_newtonian;
   Parameters::InterfaceSharpening                   interface_sharpening;
   Parameters::Multiphysics                          multiphysics;
 
@@ -97,7 +96,6 @@ public:
     particlesParameters = std::make_shared<Parameters::IBParticles<dim>>();
     particlesParameters->declare_parameters(prm);
     manifolds_parameters.declare_parameters(prm);
-    non_newtonian.declare_parameters(prm);
     interface_sharpening.declare_parameters(prm);
 
     analytical_solution = new AnalyticalSolutions::AnalyticalSolution<dim>;
@@ -128,7 +126,6 @@ public:
     forces_parameters.parse_parameters(prm);
     post_processing.parse_parameters(prm);
     flow_control.parse_parameters(prm);
-    non_newtonian.parse_parameters(prm);
     interface_sharpening.parse_parameters(prm);
     restart_parameters.parse_parameters(prm);
     boundary_conditions.parse_parameters(prm);

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -55,9 +55,9 @@ public:
   BoundaryConditions::NSBoundaryConditions<dim>     boundary_conditions;
   BoundaryConditions::HTBoundaryConditions<dim>     boundary_conditions_ht;
   BoundaryConditions::TracerBoundaryConditions<dim> boundary_conditions_tracer;
-  Parameters::InitialConditions<dim>               *initial_condition;
-  AnalyticalSolutions::AnalyticalSolution<dim>     *analytical_solution;
-  SourceTerms::SourceTerm<dim>                     *source_term;
+  Parameters::InitialConditions<dim> *              initial_condition;
+  AnalyticalSolutions::AnalyticalSolution<dim> *    analytical_solution;
+  SourceTerms::SourceTerm<dim> *                    source_term;
   Parameters::VelocitySource                        velocity_sources;
   std::shared_ptr<Parameters::IBParticles<dim>>     particlesParameters;
   Parameters::DynamicFlowControl                    flow_control;

--- a/source/core/density_model.cc
+++ b/source/core/density_model.cc
@@ -1,0 +1,23 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/density_model.h>
+
+std::shared_ptr<DensityModel>
+DensityModel::model_cast(const Parameters::Fluid &fluid_properties)
+{
+  return std::make_shared<DensityConstant>(fluid_properties.density);
+}

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -459,11 +459,7 @@ namespace Parameters
                         Patterns::Integer(),
                         "Number of fluids");
 
-      prm.declare_entry("enable phase change",
-                        "false",
-                        Patterns::Bool(),
-                        "Enable melting/freezing of fluids");
-      phase_change_parameters.declare_parameters(prm);
+
 
       // Multiphasic simulations parameters definition
       for (unsigned int i_fluid = 0; i_fluid < max_fluids; ++i_fluid)
@@ -480,9 +476,15 @@ namespace Parameters
   {
     prm.enter_subsection("physical properties");
     {
+<<<<<<< HEAD
       // Management of phase_change
       enable_phase_change = prm.get_bool("enable phase change");
       phase_change_parameters.parse_parameters(prm);
+=======
+      // Management of non_newtonian_flows
+      non_newtonian_flow = prm.get_bool("non newtonian flow");
+      non_newtonian_parameters.parse_parameters(prm);
+>>>>>>> 4a9cb28 (WIP physical properties)
 
       // Multiphasic simulations parameters definition
       number_of_fluids = prm.get_integer("number of fluids");
@@ -538,11 +540,37 @@ namespace Parameters
         "Tracer diffusivity for the fluid corresponding to Phase = " +
           Utilities::int_to_string(id, 1));
 
+<<<<<<< HEAD
       prm.declare_entry("non newtonian flow",
                         "false",
                         Patterns::Bool(),
                         "Non Newtonian flow");
       non_newtonian_parameters.declare_parameters(prm);
+=======
+
+
+      prm.declare_entry("density model",
+                        "constant",
+                        Patterns::Selection("constant"),
+                        "Model used for the calculation of the density"
+                        "Choices are <constant>.");
+
+      prm.declare_entry("specific heat model",
+                        "constant",
+                        Patterns::Selection("constant|phase_change"),
+                        "Model used for the calculation of the specific heat"
+                        "Choices are <constant|phase_change>.");
+
+      prm.declare_entry(
+        "thermal conductivity model",
+        "constant",
+        Patterns::Selection("constant|linear"),
+        "Model used for the calculation of the thermal conductivity"
+        "Choices are <constant|linear>.");
+
+
+      phase_change_parameters.declare_parameters(prm);
+>>>>>>> 4a9cb28 (WIP physical properties)
     }
     prm.leave_subsection();
   }
@@ -558,8 +586,37 @@ namespace Parameters
       thermal_conductivity = prm.get_double("thermal conductivity");
       thermal_expansion    = prm.get_double("thermal expansion");
       tracer_diffusivity   = prm.get_double("tracer diffusivity");
+<<<<<<< HEAD
       non_newtonian_flow   = prm.get_bool("non newtonian flow");
       non_newtonian_parameters.parse_parameters(prm);
+=======
+
+      // Parse models for the physical properties
+      std::string op;
+
+      // Density
+      op = prm.get("density model");
+      if (op == "constant")
+        density_model = DensityModel::constant;
+
+      // Thermal conductivity
+      op = prm.get("thermal conductivity model");
+      if (op == "constant")
+        thermal_conductivity_model = ThermalConductivityModel::constant;
+      else if (op == "linear")
+        thermal_conductivity_model = ThermalConductivityModel::linear;
+
+      // Specific heat
+      op = prm.get("specific heat model");
+      if (op == "constant")
+        specific_heat_model = SpecificHeatModel::constant;
+      else if (op == "phase_change")
+        specific_heat_model = SpecificHeatModel::phase_change;
+
+
+
+      phase_change_parameters.parse_parameters(prm);
+>>>>>>> 4a9cb28 (WIP physical properties)
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -308,11 +308,6 @@ namespace Parameters
   {
     prm.enter_subsection("non newtonian");
     {
-      prm.declare_entry("model",
-                        "carreau",
-                        Patterns::Selection("power-law|carreau"),
-                        "Non newtonian model "
-                        "Choices are <power-law|carreau>.");
       powerlaw_parameters.declare_parameters(prm);
       carreau_parameters.declare_parameters(prm);
     }
@@ -324,17 +319,8 @@ namespace Parameters
   {
     prm.enter_subsection("non newtonian");
     {
-      const std::string op = prm.get("model");
-      if (op == "power-law")
-        {
-          model = Model::powerlaw;
-          powerlaw_parameters.parse_parameters(prm);
-        }
-      else if (op == "carreau")
-        {
-          model = Model::carreau;
-          carreau_parameters.parse_parameters(prm);
-        }
+      powerlaw_parameters.parse_parameters(prm);
+      carreau_parameters.parse_parameters(prm);
     }
     prm.leave_subsection();
   }
@@ -529,13 +515,18 @@ namespace Parameters
         "Tracer diffusivity for the fluid corresponding to Phase = " +
           Utilities::int_to_string(id, 1));
 
-<<<<<<< HEAD
       prm.declare_entry("non newtonian flow",
                         "false",
                         Patterns::Bool(),
                         "Non Newtonian flow");
+
+      prm.declare_entry("rheological model",
+                        "newtonian",
+                        Patterns::Selection("newtonian|power-law|carreau"),
+                        "Rheological model "
+                        "Choices are <newtonian|power-law|carreau>.");
+
       non_newtonian_parameters.declare_parameters(prm);
-=======
 
 
       prm.declare_entry("density model",
@@ -564,15 +555,10 @@ namespace Parameters
                         Patterns::Double(),
                         "k_A0 parameter for linear conductivity model");
 
-<<<<<<< HEAD
-      phase_change_parameters.declare_parameters(prm);
->>>>>>> 4a9cb28 (WIP physical properties)
-=======
       prm.declare_entry("k_A1",
                         "0",
                         Patterns::Double(),
                         "k_A1 parameter for linear conductivity model");
->>>>>>> c6b6e35 (First working version of manager without rheology)
     }
     prm.leave_subsection();
   }
@@ -588,10 +574,7 @@ namespace Parameters
       thermal_conductivity = prm.get_double("thermal conductivity");
       thermal_expansion    = prm.get_double("thermal expansion");
       tracer_diffusivity   = prm.get_double("tracer diffusivity");
-<<<<<<< HEAD
-      non_newtonian_flow   = prm.get_bool("non newtonian flow");
-      non_newtonian_parameters.parse_parameters(prm);
-=======
+
 
       // Parse models for the physical properties
       std::string op;
@@ -620,7 +603,23 @@ namespace Parameters
         specific_heat_model = SpecificHeatModel::phase_change;
 
       phase_change_parameters.parse_parameters(prm);
->>>>>>> 4a9cb28 (WIP physical properties)
+
+      // Rheology
+      non_newtonian_flow = prm.get_bool("non newtonian flow");
+      op                 = prm.get("rheology model");
+      if (op == "power-law")
+        {
+          rheology_model = RheologyModel::powerlaw;
+        }
+      else if (op == "carreau")
+        {
+          rheology_model = RheologyModel::carreau;
+        }
+      else if (op == "newtonian")
+        {
+          rheology_model = RheologyModel::newtonian;
+        }
+      non_newtonian_parameters.parse_parameters(prm);
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -464,7 +464,6 @@ namespace Parameters
       // Multiphasic simulations parameters definition
       for (unsigned int i_fluid = 0; i_fluid < max_fluids; ++i_fluid)
         {
-          fluids[i_fluid] = Fluid();
           fluids[i_fluid].declare_parameters(prm, i_fluid);
         }
     }
@@ -476,16 +475,6 @@ namespace Parameters
   {
     prm.enter_subsection("physical properties");
     {
-<<<<<<< HEAD
-      // Management of phase_change
-      enable_phase_change = prm.get_bool("enable phase change");
-      phase_change_parameters.parse_parameters(prm);
-=======
-      // Management of non_newtonian_flows
-      non_newtonian_flow = prm.get_bool("non newtonian flow");
-      non_newtonian_parameters.parse_parameters(prm);
->>>>>>> 4a9cb28 (WIP physical properties)
-
       // Multiphasic simulations parameters definition
       number_of_fluids = prm.get_integer("number of fluids");
       Assert(number_of_fluids == 1 || number_of_fluids == 2,
@@ -561,6 +550,8 @@ namespace Parameters
                         "Model used for the calculation of the specific heat"
                         "Choices are <constant|phase_change>.");
 
+      phase_change_parameters.declare_parameters(prm);
+
       prm.declare_entry(
         "thermal conductivity model",
         "constant",
@@ -568,9 +559,20 @@ namespace Parameters
         "Model used for the calculation of the thermal conductivity"
         "Choices are <constant|linear>.");
 
+      prm.declare_entry("k_A0",
+                        "0",
+                        Patterns::Double(),
+                        "k_A0 parameter for linear conductivity model");
 
+<<<<<<< HEAD
       phase_change_parameters.declare_parameters(prm);
 >>>>>>> 4a9cb28 (WIP physical properties)
+=======
+      prm.declare_entry("k_A1",
+                        "0",
+                        Patterns::Double(),
+                        "k_A1 parameter for linear conductivity model");
+>>>>>>> c6b6e35 (First working version of manager without rheology)
     }
     prm.leave_subsection();
   }
@@ -606,14 +608,16 @@ namespace Parameters
       else if (op == "linear")
         thermal_conductivity_model = ThermalConductivityModel::linear;
 
+      // Linear conductivity model parameters
+      k_A0 = prm.get_double("k_A0");
+      k_A1 = prm.get_double("k_A1");
+
       // Specific heat
       op = prm.get("specific heat model");
       if (op == "constant")
         specific_heat_model = SpecificHeatModel::constant;
       else if (op == "phase_change")
         specific_heat_model = SpecificHeatModel::phase_change;
-
-
 
       phase_change_parameters.parse_parameters(prm);
 >>>>>>> 4a9cb28 (WIP physical properties)

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -606,7 +606,7 @@ namespace Parameters
 
       // Rheology
       non_newtonian_flow = prm.get_bool("non newtonian flow");
-      op                 = prm.get("rheology model");
+      op                 = prm.get("rheological model");
       if (op == "power-law")
         {
           rheology_model = RheologyModel::powerlaw;

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -1,33 +1,26 @@
 #include <core/rheological_model.h>
 
 std::shared_ptr<RheologicalModel>
-RheologicalModel::model_cast(
-  const Parameters::PhysicalProperties &physical_properties)
+RheologicalModel::model_cast(const Parameters::Fluid &fluid_properties)
 {
-  if (!physical_properties.fluids[0].non_newtonian_flow)
-    return std::make_shared<Newtonian>(physical_properties.fluids[0].viscosity);
-  else if (physical_properties.fluids[0].non_newtonian_parameters.model ==
-           Parameters::NonNewtonian::Model::powerlaw)
+  if (!fluid_properties.non_newtonian_flow)
+    return std::make_shared<Newtonian>(fluid_properties.viscosity);
+  else if (fluid_properties.rheology_model ==
+           Parameters::Fluid::RheologyModel::powerlaw)
     return std::make_shared<PowerLaw>(
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.powerlaw_parameters.K,
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.powerlaw_parameters.n,
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.powerlaw_parameters.shear_rate_min);
+      fluid_properties.non_newtonian_parameters.powerlaw_parameters.K,
+      fluid_properties.non_newtonian_parameters.powerlaw_parameters.n,
+      fluid_properties.non_newtonian_parameters.powerlaw_parameters
+        .shear_rate_min);
   else // if (physical_properties.fluid[0].non_newtonian_parameters.model ==
        //  Parameters::NonNewtonian::Model::carreau)
     return std::make_shared<Carreau>(
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.carreau_parameters.viscosity_0,
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.carreau_parameters.viscosity_inf,
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.carreau_parameters.lambda,
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.carreau_parameters.a,
-      physical_properties.fluids[0]
-        .non_newtonian_parameters.carreau_parameters.n);
+      fluid_properties.non_newtonian_parameters.carreau_parameters.viscosity_0,
+      fluid_properties.non_newtonian_parameters.carreau_parameters
+        .viscosity_inf,
+      fluid_properties.non_newtonian_parameters.carreau_parameters.lambda,
+      fluid_properties.non_newtonian_parameters.carreau_parameters.a,
+      fluid_properties.non_newtonian_parameters.carreau_parameters.n);
 }
 
 double
@@ -47,7 +40,7 @@ PowerLaw::value(const std::map<field, double> &field_values)
 void
 PowerLaw::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
-  std::vector<double> &                       property_vector)
+  std::vector<double>                        &property_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -69,7 +62,7 @@ void
 PowerLaw::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double> &                       jacobian_vector)
+  std::vector<double>                        &jacobian_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -113,7 +106,7 @@ void
 Carreau::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double> &                       jacobian_vector)
+  std::vector<double>                        &jacobian_vector)
 {
   if (id == field::shear_rate)
     this->vector_numerical_jacobian(field_vectors,

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -40,7 +40,7 @@ PowerLaw::value(const std::map<field, double> &field_values)
 void
 PowerLaw::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
-  std::vector<double>                        &property_vector)
+  std::vector<double> &                       property_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -62,7 +62,7 @@ void
 PowerLaw::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double>                        &jacobian_vector)
+  std::vector<double> &                       jacobian_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -106,7 +106,7 @@ void
 Carreau::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double>                        &jacobian_vector)
+  std::vector<double> &                       jacobian_vector)
 {
   if (id == field::shear_rate)
     this->vector_numerical_jacobian(field_vectors,

--- a/source/core/specific_heat_model.cc
+++ b/source/core/specific_heat_model.cc
@@ -1,0 +1,30 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/specific_heat_model.h>
+
+std::shared_ptr<SpecificHeatModel>
+SpecificHeatModel::model_cast(const Parameters::Fluid &fluid_properties)
+{
+  if (fluid_properties.specific_heat_model ==
+      Parameters::Fluid::SpecificHeatModel::phase_change)
+    return std::make_shared<PhaseChangeSpecificHeat>(
+      fluid_properties.phase_change_parameters);
+
+  else
+    return std::make_shared<SpecificHeatConstant>(
+      fluid_properties.specific_heat);
+}

--- a/source/core/thermal_conductivity_model.cc
+++ b/source/core/thermal_conductivity_model.cc
@@ -1,0 +1,24 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/thermal_conductivity_model.h>
+
+std::shared_ptr<ThermalConductivityModel>
+ThermalConductivityModel::model_cast(const Parameters::Fluid &fluid_properties)
+{
+  return std::make_shared<ThermalConductivityConstant>(
+    fluid_properties.thermal_conductivity);
+}

--- a/source/core/thermal_conductivity_model.cc
+++ b/source/core/thermal_conductivity_model.cc
@@ -19,6 +19,12 @@
 std::shared_ptr<ThermalConductivityModel>
 ThermalConductivityModel::model_cast(const Parameters::Fluid &fluid_properties)
 {
-  return std::make_shared<ThermalConductivityConstant>(
-    fluid_properties.thermal_conductivity);
+  if (fluid_properties.thermal_conductivity_model ==
+      Parameters::Fluid::ThermalConductivityModel::linear)
+    return std::make_shared<ThermalConductivityLinear>(fluid_properties.k_A0,
+                                                       fluid_properties.k_A1);
+  else
+
+    return std::make_shared<ThermalConductivityConstant>(
+      fluid_properties.thermal_conductivity);
 }

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -235,7 +235,7 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
   // non Newtonian models according to the physical properties
   std::shared_ptr<RheologicalModel> rheological_model =
     RheologicalModel::model_cast(
-      this->simulation_parameters.physical_properties);
+      this->simulation_parameters.physical_properties.fluids[0]);
 
   const unsigned int vertices_per_face = GeometryInfo<dim>::vertices_per_face;
   const unsigned int n_q_points_face   = this->face_quadrature->size();
@@ -1583,7 +1583,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index> &         local_dof_indices,
+  std::vector<types::global_dof_index>          &local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1617,8 +1617,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1640,8 +1640,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2263,8 +2263,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2355,8 +2355,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1583,7 +1583,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index>          &local_dof_indices,
+  std::vector<types::global_dof_index> &         local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1617,8 +1617,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1640,8 +1640,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2263,8 +2263,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2355,8 +2355,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------
+ *
+ * Copyright (C) 2021 - by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <solvers/physical_properties_manager.h>
+
+
+PhysicalPropertiesManager::PhysicalPropertiesManager(
+  Parameters::PhysicalProperties physical_properties)
+  : number_of_fluids(physical_properties.number_of_fluids)
+{
+  // For each fluid, declare the physical properties
+  for (unsigned int f = 0; f < number_of_fluids; ++f)
+    {
+    }
+  // For
+}

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -24,6 +24,14 @@ PhysicalPropertiesManager::PhysicalPropertiesManager(
   // For each fluid, declare the physical properties
   for (unsigned int f = 0; f < number_of_fluids; ++f)
     {
+      density.push_back(
+        DensityModel::model_cast(physical_properties.fluids[f]));
+
+      specific_heat.push_back(
+        SpecificHeatModel::model_cast(physical_properties.fluids[f]));
+
+      thermal_conductivity.push_back(
+        ThermalConductivityModel::model_cast(physical_properties.fluids[f]));
     }
   // For
 }

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -19,6 +19,7 @@
 
 PhysicalPropertiesManager::PhysicalPropertiesManager(
   Parameters::PhysicalProperties physical_properties)
+  : is_initialized(true)
 {
   initialize(physical_properties);
 }
@@ -44,6 +45,8 @@ PhysicalPropertiesManager::initialize(
 
       rheology.push_back(
         RheologicalModel::model_cast(physical_properties.fluids[f]));
+      if (physical_properties.fluids[f].rheology_model !=
+          Parameters::Fluid::RheologyModel::newtonian)
+        non_newtonian_flow = true;
     }
-  // For
 }

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -19,8 +19,17 @@
 
 PhysicalPropertiesManager::PhysicalPropertiesManager(
   Parameters::PhysicalProperties physical_properties)
-  : number_of_fluids(physical_properties.number_of_fluids)
 {
+  initialize(physical_properties);
+}
+
+void
+PhysicalPropertiesManager::initialize(
+  Parameters::PhysicalProperties physical_properties)
+{
+  number_of_fluids = physical_properties.number_of_fluids;
+
+  non_newtonian_flow = false;
   // For each fluid, declare the physical properties
   for (unsigned int f = 0; f < number_of_fluids; ++f)
     {
@@ -32,6 +41,9 @@ PhysicalPropertiesManager::PhysicalPropertiesManager(
 
       thermal_conductivity.push_back(
         ThermalConductivityModel::model_cast(physical_properties.fluids[f]));
+
+      rheology.push_back(
+        RheologicalModel::model_cast(physical_properties.fluids[f]));
     }
   // For
 }

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -34,11 +34,11 @@ using namespace dealii;
 
 template <int dim, typename VectorType>
 double
-calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
+calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType             &evaluation_point,
-                        const Quadrature<dim>        &cell_quadrature_formula,
-                        const Quadrature<dim - 1>    &face_quadrature_formula,
+                        const VectorType &            evaluation_point,
+                        const Quadrature<dim> &       cell_quadrature_formula,
+                        const Quadrature<dim - 1> &   face_quadrature_formula,
                         const unsigned int            inlet_boundary_id,
                         const unsigned int            outlet_boundary_id)
 {
@@ -121,51 +121,51 @@ calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
 
 template double
 calculate_pressure_drop<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                 &dof_handler,
+  const DoFHandler<2> &                dof_handler,
   std::shared_ptr<Mapping<2>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2>                 &cell_quadrature_formula,
-  const Quadrature<1>                 &face_quadrature_formula,
+  const Quadrature<2> &                cell_quadrature_formula,
+  const Quadrature<1> &                face_quadrature_formula,
   const unsigned int                   inlet_boundary_id,
   const unsigned int                   outlet_boundary_id);
 
 template double
 calculate_pressure_drop<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                 &dof_handler,
+  const DoFHandler<3> &                dof_handler,
   std::shared_ptr<Mapping<3>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3>                 &cell_quadrature_formula,
-  const Quadrature<2>                 &face_quadrature_formula,
+  const Quadrature<3> &                cell_quadrature_formula,
+  const Quadrature<2> &                face_quadrature_formula,
   const unsigned int                   inlet_boundary_id,
   const unsigned int                   outlet_boundary_id);
 
 template double
 calculate_pressure_drop<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                      &dof_handler,
+  const DoFHandler<2> &                     dof_handler,
   std::shared_ptr<Mapping<2>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2>                      &cell_quadrature_formula,
-  const Quadrature<1>                      &face_quadrature_formula,
+  const Quadrature<2> &                     cell_quadrature_formula,
+  const Quadrature<1> &                     face_quadrature_formula,
   const unsigned int                        inlet_boundary_id,
   const unsigned int                        outlet_boundary_id);
 
 template double
 calculate_pressure_drop<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                      &dof_handler,
+  const DoFHandler<3> &                     dof_handler,
   std::shared_ptr<Mapping<3>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3>                      &cell_quadrature_formula,
-  const Quadrature<2>                      &face_quadrature_formula,
+  const Quadrature<3> &                     cell_quadrature_formula,
+  const Quadrature<2> &                     face_quadrature_formula,
   const unsigned int                        inlet_boundary_id,
   const unsigned int                        outlet_boundary_id);
 
 template <int dim, typename VectorType>
 double
 calculate_CFL(const DoFHandler<dim> &dof_handler,
-              const VectorType      &evaluation_point,
+              const VectorType &     evaluation_point,
               const double           time_step,
               const Quadrature<dim> &quadrature_formula,
-              const Mapping<dim>    &mapping)
+              const Mapping<dim> &   mapping)
 {
   FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>      fe_values(mapping,
@@ -215,44 +215,44 @@ calculate_CFL(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_CFL<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                 &dof_handler,
+  const DoFHandler<2> &                dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
   const double                         time_step,
-  const Quadrature<2>                 &quadrature_formula,
-  const Mapping<2>                    &mapping);
+  const Quadrature<2> &                quadrature_formula,
+  const Mapping<2> &                   mapping);
 
 template double
 calculate_CFL<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                 &dof_handler,
+  const DoFHandler<3> &                dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
   const double                         time_step,
-  const Quadrature<3>                 &quadrature_formula,
-  const Mapping<3>                    &mapping);
+  const Quadrature<3> &                quadrature_formula,
+  const Mapping<3> &                   mapping);
 
 template double
 calculate_CFL<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                      &dof_handler,
+  const DoFHandler<2> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const double                              time_step,
-  const Quadrature<2>                      &quadrature_formula,
-  const Mapping<2>                         &mapping);
+  const Quadrature<2> &                     quadrature_formula,
+  const Mapping<2> &                        mapping);
 
 template double
 calculate_CFL<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                      &dof_handler,
+  const DoFHandler<3> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const double                              time_step,
-  const Quadrature<3>                      &quadrature_formula,
-  const Mapping<3>                         &mapping);
+  const Quadrature<3> &                     quadrature_formula,
+  const Mapping<3> &                        mapping);
 
 
 
 template <int dim, typename VectorType>
 double
 calculate_enstrophy(const DoFHandler<dim> &dof_handler,
-                    const VectorType      &evaluation_point,
+                    const VectorType &     evaluation_point,
                     const Quadrature<dim> &quadrature_formula,
-                    const Mapping<dim>    &mapping)
+                    const Mapping<dim> &   mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -314,39 +314,39 @@ calculate_enstrophy(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_enstrophy<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                 &dof_handler,
+  const DoFHandler<2> &                dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2>                 &quadrature_formula,
-  const Mapping<2>                    &mapping);
+  const Quadrature<2> &                quadrature_formula,
+  const Mapping<2> &                   mapping);
 
 template double
 calculate_enstrophy<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                 &dof_handler,
+  const DoFHandler<3> &                dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3>                 &quadrature_formula,
-  const Mapping<3>                    &mapping);
+  const Quadrature<3> &                quadrature_formula,
+  const Mapping<3> &                   mapping);
 
 template double
 calculate_enstrophy<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                      &dof_handler,
+  const DoFHandler<2> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2>                      &quadrature_formula,
-  const Mapping<2>                         &mapping);
+  const Quadrature<2> &                     quadrature_formula,
+  const Mapping<2> &                        mapping);
 
 template double
 calculate_enstrophy<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                      &dof_handler,
+  const DoFHandler<3> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3>                      &quadrature_formula,
-  const Mapping<3>                         &mapping);
+  const Quadrature<3> &                     quadrature_formula,
+  const Mapping<3> &                        mapping);
 
 
 template <int dim, typename VectorType>
 double
 calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
-                         const VectorType      &evaluation_point,
+                         const VectorType &     evaluation_point,
                          const Quadrature<dim> &quadrature_formula,
-                         const Mapping<dim>    &mapping)
+                         const Mapping<dim> &   mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -396,40 +396,40 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_kinetic_energy<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                 &dof_handler,
+  const DoFHandler<2> &                dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2>                 &quadrature_formula,
-  const Mapping<2>                    &mapping);
+  const Quadrature<2> &                quadrature_formula,
+  const Mapping<2> &                   mapping);
 
 template double
 calculate_kinetic_energy<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                 &dof_handler,
+  const DoFHandler<3> &                dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3>                 &quadrature_formula,
-  const Mapping<3>                    &mapping);
+  const Quadrature<3> &                quadrature_formula,
+  const Mapping<3> &                   mapping);
 
 template double
 calculate_kinetic_energy<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                      &dof_handler,
+  const DoFHandler<2> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2>                      &quadrature_formula,
-  const Mapping<2>                         &mapping);
+  const Quadrature<2> &                     quadrature_formula,
+  const Mapping<2> &                        mapping);
 
 template double
 calculate_kinetic_energy<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                      &dof_handler,
+  const DoFHandler<3> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3>                      &quadrature_formula,
-  const Mapping<3>                         &mapping);
+  const Quadrature<3> &                     quadrature_formula,
+  const Mapping<3> &                        mapping);
 
 
 template <int dim, typename VectorType>
 double
 calculate_apparent_viscosity(
-  const DoFHandler<dim>                &dof_handler,
-  const VectorType                     &evaluation_point,
-  const Quadrature<dim>                &quadrature_formula,
-  const Mapping<dim>                   &mapping,
+  const DoFHandler<dim> &               dof_handler,
+  const VectorType &                    evaluation_point,
+  const Quadrature<dim> &               quadrature_formula,
+  const Mapping<dim> &                  mapping,
   const Parameters::PhysicalProperties &physical_properties)
 {
   double integral_viscosity_x_shear_rate = 0;
@@ -490,45 +490,45 @@ calculate_apparent_viscosity(
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                  &dof_handler,
-  const TrilinosWrappers::MPI::Vector  &evaluation_point,
-  const Quadrature<2>                  &quadrature_formula,
-  const Mapping<2>                     &mapping,
+  const DoFHandler<2> &                 dof_handler,
+  const TrilinosWrappers::MPI::Vector & evaluation_point,
+  const Quadrature<2> &                 quadrature_formula,
+  const Mapping<2> &                    mapping,
   const Parameters::PhysicalProperties &physical_properties);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                  &dof_handler,
-  const TrilinosWrappers::MPI::Vector  &evaluation_point,
-  const Quadrature<3>                  &quadrature_formula,
-  const Mapping<3>                     &mapping,
+  const DoFHandler<3> &                 dof_handler,
+  const TrilinosWrappers::MPI::Vector & evaluation_point,
+  const Quadrature<3> &                 quadrature_formula,
+  const Mapping<3> &                    mapping,
   const Parameters::PhysicalProperties &physical_properties);
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                      &dof_handler,
+  const DoFHandler<2> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2>                      &quadrature_formula,
-  const Mapping<2>                         &mapping,
-  const Parameters::PhysicalProperties     &physical_properties);
+  const Quadrature<2> &                     quadrature_formula,
+  const Mapping<2> &                        mapping,
+  const Parameters::PhysicalProperties &    physical_properties);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                      &dof_handler,
+  const DoFHandler<3> &                     dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3>                      &quadrature_formula,
-  const Mapping<3>                         &mapping,
-  const Parameters::PhysicalProperties     &physical_properties);
+  const Quadrature<3> &                     quadrature_formula,
+  const Mapping<3> &                        mapping,
+  const Parameters::PhysicalProperties &    physical_properties);
 
 template <int dim, typename VectorType>
 std::vector<Tensor<1, dim>>
 calculate_forces(
-  const DoFHandler<dim>                               &dof_handler,
-  const VectorType                                    &evaluation_point,
-  const Parameters::PhysicalProperties                &physical_properties,
+  const DoFHandler<dim> &                              dof_handler,
+  const VectorType &                                   evaluation_point,
+  const Parameters::PhysicalProperties &               physical_properties,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1>                           &face_quadrature_formula,
-  const Mapping<dim>                                  &mapping)
+  const Quadrature<dim - 1> &                          face_quadrature_formula,
+  const Mapping<dim> &                                 mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -621,49 +621,49 @@ calculate_forces(
 
 template std::vector<Tensor<1, 2>>
 calculate_forces<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                               &dof_handler,
-  const TrilinosWrappers::MPI::Vector               &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<2> &                              dof_handler,
+  const TrilinosWrappers::MPI::Vector &              evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1>                               &face_quadrature_formula,
-  const Mapping<2>                                  &mapping);
+  const Quadrature<1> &                              face_quadrature_formula,
+  const Mapping<2> &                                 mapping);
 template std::vector<Tensor<1, 3>>
 calculate_forces<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                               &dof_handler,
-  const TrilinosWrappers::MPI::Vector               &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<3> &                              dof_handler,
+  const TrilinosWrappers::MPI::Vector &              evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2>                               &face_quadrature_formula,
-  const Mapping<3>                                  &mapping);
+  const Quadrature<2> &                              face_quadrature_formula,
+  const Mapping<3> &                                 mapping);
 
 template std::vector<Tensor<1, 2>>
 calculate_forces<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                               &dof_handler,
-  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<2> &                              dof_handler,
+  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1>                               &face_quadrature_formula,
-  const Mapping<2>                                  &mapping);
+  const Quadrature<1> &                              face_quadrature_formula,
+  const Mapping<2> &                                 mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_forces<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                               &dof_handler,
-  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<3> &                              dof_handler,
+  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2>                               &face_quadrature_formula,
-  const Mapping<3>                                  &mapping);
+  const Quadrature<2> &                              face_quadrature_formula,
+  const Mapping<3> &                                 mapping);
 
 
 template <int dim, typename VectorType>
 std::vector<Tensor<1, 3>>
 calculate_torques(
-  const DoFHandler<dim>                               &dof_handler,
-  const VectorType                                    &evaluation_point,
-  const Parameters::PhysicalProperties                &physical_properties,
+  const DoFHandler<dim> &                              dof_handler,
+  const VectorType &                                   evaluation_point,
+  const Parameters::PhysicalProperties &               physical_properties,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1>                           &face_quadrature_formula,
-  const Mapping<dim>                                  &mapping)
+  const Quadrature<dim - 1> &                          face_quadrature_formula,
+  const Mapping<dim> &                                 mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -773,38 +773,38 @@ calculate_torques(
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2>                               &dof_handler,
-  const TrilinosWrappers::MPI::Vector               &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<2> &                              dof_handler,
+  const TrilinosWrappers::MPI::Vector &              evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1>                               &face_quadrature_formula,
-  const Mapping<2>                                  &mapping);
+  const Quadrature<1> &                              face_quadrature_formula,
+  const Mapping<2> &                                 mapping);
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3>                               &dof_handler,
-  const TrilinosWrappers::MPI::Vector               &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<3> &                              dof_handler,
+  const TrilinosWrappers::MPI::Vector &              evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2>                               &face_quadrature_formula,
-  const Mapping<3>                                  &mapping);
+  const Quadrature<2> &                              face_quadrature_formula,
+  const Mapping<3> &                                 mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2>                               &dof_handler,
-  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<2> &                              dof_handler,
+  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1>                               &face_quadrature_formula,
-  const Mapping<2>                                  &mapping);
+  const Quadrature<1> &                              face_quadrature_formula,
+  const Mapping<2> &                                 mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3>                               &dof_handler,
-  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
-  const Parameters::PhysicalProperties              &physical_properties,
+  const DoFHandler<3> &                              dof_handler,
+  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
+  const Parameters::PhysicalProperties &             physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2>                               &face_quadrature_formula,
-  const Mapping<3>                                  &mapping);
+  const Quadrature<2> &                              face_quadrature_formula,
+  const Mapping<3> &                                 mapping);
 
 
 // Find the l2 norm of the error between the finite element sol'n and the exact
@@ -813,10 +813,10 @@ calculate_torques<3, TrilinosWrappers::MPI::BlockVector>(
 template <int dim, typename VectorType>
 std::pair<double, double>
 calculate_L2_error(const DoFHandler<dim> &dof_handler,
-                   const VectorType      &evaluation_point,
-                   const Function<dim>   *exact_solution,
+                   const VectorType &     evaluation_point,
+                   const Function<dim> *  exact_solution,
                    const Quadrature<dim> &quadrature_formula,
-                   const Mapping<dim>    &mapping)
+                   const Mapping<dim> &   mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -937,40 +937,40 @@ calculate_L2_error(const DoFHandler<dim> &dof_handler,
 }
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<2>                 &dof_handler,
+calculate_L2_error(const DoFHandler<2> &                dof_handler,
                    const TrilinosWrappers::MPI::Vector &present_solution,
-                   const Function<2>                   *l_exact_solution,
-                   const Quadrature<2>                 &quadrature_formula,
-                   const Mapping<2>                    &mapping);
+                   const Function<2> *                  l_exact_solution,
+                   const Quadrature<2> &                quadrature_formula,
+                   const Mapping<2> &                   mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<3>                 &dof_handler,
+calculate_L2_error(const DoFHandler<3> &                dof_handler,
                    const TrilinosWrappers::MPI::Vector &present_solution,
-                   const Function<3>                   *l_exact_solution,
-                   const Quadrature<3>                 &quadrature_formula,
-                   const Mapping<3>                    &mapping);
+                   const Function<3> *                  l_exact_solution,
+                   const Quadrature<3> &                quadrature_formula,
+                   const Mapping<3> &                   mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<2>                      &dof_handler,
+calculate_L2_error(const DoFHandler<2> &                     dof_handler,
                    const TrilinosWrappers::MPI::BlockVector &present_solution,
-                   const Function<2>                        *l_exact_solution,
-                   const Quadrature<2>                      &quadrature_formula,
-                   const Mapping<2>                         &mapping);
+                   const Function<2> *                       l_exact_solution,
+                   const Quadrature<2> &                     quadrature_formula,
+                   const Mapping<2> &                        mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<3>                      &dof_handler,
+calculate_L2_error(const DoFHandler<3> &                     dof_handler,
                    const TrilinosWrappers::MPI::BlockVector &present_solution,
-                   const Function<3>                        *l_exact_solution,
-                   const Quadrature<3>                      &quadrature_formula,
-                   const Mapping<3>                         &mapping);
+                   const Function<3> *                       l_exact_solution,
+                   const Quadrature<3> &                     quadrature_formula,
+                   const Mapping<3> &                        mapping);
 
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_flow_rate(const DoFHandler<dim>     &dof_handler,
-                    const VectorType          &present_solution,
-                    const unsigned int        &boundary_id,
+calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
+                    const VectorType &         present_solution,
+                    const unsigned int &       boundary_id,
                     const Quadrature<dim - 1> &face_quadrature_formula,
-                    const Mapping<dim>        &mapping)
+                    const Mapping<dim> &       mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -1024,29 +1024,29 @@ calculate_flow_rate(const DoFHandler<dim>     &dof_handler,
 }
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<2>                 &dof_handler,
+calculate_flow_rate(const DoFHandler<2> &                dof_handler,
                     const TrilinosWrappers::MPI::Vector &present_solution,
-                    const unsigned int                  &boundary_id,
+                    const unsigned int &                 boundary_id,
                     const Quadrature<1> &face_quadrature_formula,
-                    const Mapping<2>    &mapping);
+                    const Mapping<2> &   mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<3>                 &dof_handler,
+calculate_flow_rate(const DoFHandler<3> &                dof_handler,
                     const TrilinosWrappers::MPI::Vector &present_solution,
-                    const unsigned int                  &boundary_id,
+                    const unsigned int &                 boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
-                    const Mapping<3>    &mapping);
+                    const Mapping<3> &   mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<2>                      &dof_handler,
+calculate_flow_rate(const DoFHandler<2> &                     dof_handler,
                     const TrilinosWrappers::MPI::BlockVector &present_solution,
-                    const unsigned int                       &boundary_id,
+                    const unsigned int &                      boundary_id,
                     const Quadrature<1> &face_quadrature_formula,
-                    const Mapping<2>    &mapping);
+                    const Mapping<2> &   mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<3>                      &dof_handler,
+calculate_flow_rate(const DoFHandler<3> &                     dof_handler,
                     const TrilinosWrappers::MPI::BlockVector &present_solution,
-                    const unsigned int                       &boundary_id,
+                    const unsigned int &                      boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
-                    const Mapping<3>    &mapping);
+                    const Mapping<3> &   mapping);

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -34,11 +34,11 @@ using namespace dealii;
 
 template <int dim, typename VectorType>
 double
-calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
+calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
                         std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType &            evaluation_point,
-                        const Quadrature<dim> &       cell_quadrature_formula,
-                        const Quadrature<dim - 1> &   face_quadrature_formula,
+                        const VectorType             &evaluation_point,
+                        const Quadrature<dim>        &cell_quadrature_formula,
+                        const Quadrature<dim - 1>    &face_quadrature_formula,
                         const unsigned int            inlet_boundary_id,
                         const unsigned int            outlet_boundary_id)
 {
@@ -121,51 +121,51 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
 
 template double
 calculate_pressure_drop<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   std::shared_ptr<Mapping<2>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                cell_quadrature_formula,
-  const Quadrature<1> &                face_quadrature_formula,
+  const Quadrature<2>                 &cell_quadrature_formula,
+  const Quadrature<1>                 &face_quadrature_formula,
   const unsigned int                   inlet_boundary_id,
   const unsigned int                   outlet_boundary_id);
 
 template double
 calculate_pressure_drop<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   std::shared_ptr<Mapping<3>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                cell_quadrature_formula,
-  const Quadrature<2> &                face_quadrature_formula,
+  const Quadrature<3>                 &cell_quadrature_formula,
+  const Quadrature<2>                 &face_quadrature_formula,
   const unsigned int                   inlet_boundary_id,
   const unsigned int                   outlet_boundary_id);
 
 template double
 calculate_pressure_drop<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   std::shared_ptr<Mapping<2>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     cell_quadrature_formula,
-  const Quadrature<1> &                     face_quadrature_formula,
+  const Quadrature<2>                      &cell_quadrature_formula,
+  const Quadrature<1>                      &face_quadrature_formula,
   const unsigned int                        inlet_boundary_id,
   const unsigned int                        outlet_boundary_id);
 
 template double
 calculate_pressure_drop<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   std::shared_ptr<Mapping<3>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     cell_quadrature_formula,
-  const Quadrature<2> &                     face_quadrature_formula,
+  const Quadrature<3>                      &cell_quadrature_formula,
+  const Quadrature<2>                      &face_quadrature_formula,
   const unsigned int                        inlet_boundary_id,
   const unsigned int                        outlet_boundary_id);
 
 template <int dim, typename VectorType>
 double
 calculate_CFL(const DoFHandler<dim> &dof_handler,
-              const VectorType &     evaluation_point,
+              const VectorType      &evaluation_point,
               const double           time_step,
               const Quadrature<dim> &quadrature_formula,
-              const Mapping<dim> &   mapping)
+              const Mapping<dim>    &mapping)
 {
   FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>      fe_values(mapping,
@@ -215,44 +215,44 @@ calculate_CFL(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_CFL<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
   const double                         time_step,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_CFL<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
   const double                         time_step,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_CFL<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const double                              time_step,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_CFL<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const double                              time_step,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 
 
 template <int dim, typename VectorType>
 double
 calculate_enstrophy(const DoFHandler<dim> &dof_handler,
-                    const VectorType &     evaluation_point,
+                    const VectorType      &evaluation_point,
                     const Quadrature<dim> &quadrature_formula,
-                    const Mapping<dim> &   mapping)
+                    const Mapping<dim>    &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -314,39 +314,39 @@ calculate_enstrophy(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_enstrophy<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_enstrophy<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_enstrophy<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_enstrophy<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 
 template <int dim, typename VectorType>
 double
 calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
-                         const VectorType &     evaluation_point,
+                         const VectorType      &evaluation_point,
                          const Quadrature<dim> &quadrature_formula,
-                         const Mapping<dim> &   mapping)
+                         const Mapping<dim>    &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -396,40 +396,40 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_kinetic_energy<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_kinetic_energy<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_kinetic_energy<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_kinetic_energy<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 
 template <int dim, typename VectorType>
 double
 calculate_apparent_viscosity(
-  const DoFHandler<dim> &               dof_handler,
-  const VectorType &                    evaluation_point,
-  const Quadrature<dim> &               quadrature_formula,
-  const Mapping<dim> &                  mapping,
+  const DoFHandler<dim>                &dof_handler,
+  const VectorType                     &evaluation_point,
+  const Quadrature<dim>                &quadrature_formula,
+  const Mapping<dim>                   &mapping,
   const Parameters::PhysicalProperties &physical_properties)
 {
   double integral_viscosity_x_shear_rate = 0;
@@ -439,7 +439,7 @@ calculate_apparent_viscosity(
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
   std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(physical_properties);
+    RheologicalModel::model_cast(physical_properties.fluids[0]);
 
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -490,45 +490,45 @@ calculate_apparent_viscosity(
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                 dof_handler,
-  const TrilinosWrappers::MPI::Vector & evaluation_point,
-  const Quadrature<2> &                 quadrature_formula,
-  const Mapping<2> &                    mapping,
+  const DoFHandler<2>                  &dof_handler,
+  const TrilinosWrappers::MPI::Vector  &evaluation_point,
+  const Quadrature<2>                  &quadrature_formula,
+  const Mapping<2>                     &mapping,
   const Parameters::PhysicalProperties &physical_properties);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                 dof_handler,
-  const TrilinosWrappers::MPI::Vector & evaluation_point,
-  const Quadrature<3> &                 quadrature_formula,
-  const Mapping<3> &                    mapping,
+  const DoFHandler<3>                  &dof_handler,
+  const TrilinosWrappers::MPI::Vector  &evaluation_point,
+  const Quadrature<3>                  &quadrature_formula,
+  const Mapping<3>                     &mapping,
   const Parameters::PhysicalProperties &physical_properties);
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping,
-  const Parameters::PhysicalProperties &    physical_properties);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping,
+  const Parameters::PhysicalProperties     &physical_properties);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping,
-  const Parameters::PhysicalProperties &    physical_properties);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping,
+  const Parameters::PhysicalProperties     &physical_properties);
 
 template <int dim, typename VectorType>
 std::vector<Tensor<1, dim>>
 calculate_forces(
-  const DoFHandler<dim> &                              dof_handler,
-  const VectorType &                                   evaluation_point,
-  const Parameters::PhysicalProperties &               physical_properties,
+  const DoFHandler<dim>                               &dof_handler,
+  const VectorType                                    &evaluation_point,
+  const Parameters::PhysicalProperties                &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1> &                          face_quadrature_formula,
-  const Mapping<dim> &                                 mapping)
+  const Quadrature<dim - 1>                           &face_quadrature_formula,
+  const Mapping<dim>                                  &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -537,7 +537,7 @@ calculate_forces(
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
   std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(physical_properties);
+    RheologicalModel::model_cast(physical_properties.fluids[0]);
 
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
@@ -621,49 +621,49 @@ calculate_forces(
 
 template std::vector<Tensor<1, 2>>
 calculate_forces<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 template std::vector<Tensor<1, 3>>
 calculate_forces<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template std::vector<Tensor<1, 2>>
 calculate_forces<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_forces<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 
 template <int dim, typename VectorType>
 std::vector<Tensor<1, 3>>
 calculate_torques(
-  const DoFHandler<dim> &                              dof_handler,
-  const VectorType &                                   evaluation_point,
-  const Parameters::PhysicalProperties &               physical_properties,
+  const DoFHandler<dim>                               &dof_handler,
+  const VectorType                                    &evaluation_point,
+  const Parameters::PhysicalProperties                &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1> &                          face_quadrature_formula,
-  const Mapping<dim> &                                 mapping)
+  const Quadrature<dim - 1>                           &face_quadrature_formula,
+  const Mapping<dim>                                  &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -672,7 +672,7 @@ calculate_torques(
   // Cast rheological model to either a Newtonian model or one of the
   // non Newtonian models according to the physical properties
   std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(physical_properties);
+    RheologicalModel::model_cast(physical_properties.fluids[0]);
 
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
@@ -773,38 +773,38 @@ calculate_torques(
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  const Parameters::PhysicalProperties              &physical_properties,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 
 // Find the l2 norm of the error between the finite element sol'n and the exact
@@ -813,10 +813,10 @@ calculate_torques<3, TrilinosWrappers::MPI::BlockVector>(
 template <int dim, typename VectorType>
 std::pair<double, double>
 calculate_L2_error(const DoFHandler<dim> &dof_handler,
-                   const VectorType &     evaluation_point,
-                   const Function<dim> *  exact_solution,
+                   const VectorType      &evaluation_point,
+                   const Function<dim>   *exact_solution,
                    const Quadrature<dim> &quadrature_formula,
-                   const Mapping<dim> &   mapping)
+                   const Mapping<dim>    &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -937,40 +937,40 @@ calculate_L2_error(const DoFHandler<dim> &dof_handler,
 }
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<2> &                dof_handler,
+calculate_L2_error(const DoFHandler<2>                 &dof_handler,
                    const TrilinosWrappers::MPI::Vector &present_solution,
-                   const Function<2> *                  l_exact_solution,
-                   const Quadrature<2> &                quadrature_formula,
-                   const Mapping<2> &                   mapping);
+                   const Function<2>                   *l_exact_solution,
+                   const Quadrature<2>                 &quadrature_formula,
+                   const Mapping<2>                    &mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<3> &                dof_handler,
+calculate_L2_error(const DoFHandler<3>                 &dof_handler,
                    const TrilinosWrappers::MPI::Vector &present_solution,
-                   const Function<3> *                  l_exact_solution,
-                   const Quadrature<3> &                quadrature_formula,
-                   const Mapping<3> &                   mapping);
+                   const Function<3>                   *l_exact_solution,
+                   const Quadrature<3>                 &quadrature_formula,
+                   const Mapping<3>                    &mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<2> &                     dof_handler,
+calculate_L2_error(const DoFHandler<2>                      &dof_handler,
                    const TrilinosWrappers::MPI::BlockVector &present_solution,
-                   const Function<2> *                       l_exact_solution,
-                   const Quadrature<2> &                     quadrature_formula,
-                   const Mapping<2> &                        mapping);
+                   const Function<2>                        *l_exact_solution,
+                   const Quadrature<2>                      &quadrature_formula,
+                   const Mapping<2>                         &mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<3> &                     dof_handler,
+calculate_L2_error(const DoFHandler<3>                      &dof_handler,
                    const TrilinosWrappers::MPI::BlockVector &present_solution,
-                   const Function<3> *                       l_exact_solution,
-                   const Quadrature<3> &                     quadrature_formula,
-                   const Mapping<3> &                        mapping);
+                   const Function<3>                        *l_exact_solution,
+                   const Quadrature<3>                      &quadrature_formula,
+                   const Mapping<3>                         &mapping);
 
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
-                    const VectorType &         present_solution,
-                    const unsigned int &       boundary_id,
+calculate_flow_rate(const DoFHandler<dim>     &dof_handler,
+                    const VectorType          &present_solution,
+                    const unsigned int        &boundary_id,
                     const Quadrature<dim - 1> &face_quadrature_formula,
-                    const Mapping<dim> &       mapping)
+                    const Mapping<dim>        &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -1024,29 +1024,29 @@ calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
 }
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<2> &                dof_handler,
+calculate_flow_rate(const DoFHandler<2>                 &dof_handler,
                     const TrilinosWrappers::MPI::Vector &present_solution,
-                    const unsigned int &                 boundary_id,
+                    const unsigned int                  &boundary_id,
                     const Quadrature<1> &face_quadrature_formula,
-                    const Mapping<2> &   mapping);
+                    const Mapping<2>    &mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<3> &                dof_handler,
+calculate_flow_rate(const DoFHandler<3>                 &dof_handler,
                     const TrilinosWrappers::MPI::Vector &present_solution,
-                    const unsigned int &                 boundary_id,
+                    const unsigned int                  &boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
-                    const Mapping<3> &   mapping);
+                    const Mapping<3>    &mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<2> &                     dof_handler,
+calculate_flow_rate(const DoFHandler<2>                      &dof_handler,
                     const TrilinosWrappers::MPI::BlockVector &present_solution,
-                    const unsigned int &                      boundary_id,
+                    const unsigned int                       &boundary_id,
                     const Quadrature<1> &face_quadrature_formula,
-                    const Mapping<2> &   mapping);
+                    const Mapping<2>    &mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<3> &                     dof_handler,
+calculate_flow_rate(const DoFHandler<3>                      &dof_handler,
                     const TrilinosWrappers::MPI::BlockVector &present_solution,
-                    const unsigned int &                      boundary_id,
+                    const unsigned int                       &boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
-                    const Mapping<3> &   mapping);
+                    const Mapping<3>    &mapping);

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -21,6 +21,7 @@
 
 // Lethe
 #include <core/parameters.h>
+#include <core/physical_property_model.h>
 
 #include <solvers/physical_properties_manager.h>
 
@@ -29,7 +30,39 @@
 
 void
 test()
-{}
+{
+  // Create a physical property manager
+
+  Parameters::PhysicalProperties physical_properties;
+  physical_properties.number_of_fluids = 1;
+  physical_properties.fluids.resize(1);
+  physical_properties.fluids[0].density_model =
+    Parameters::Fluid::DensityModel::constant;
+  physical_properties.fluids[0].specific_heat_model =
+    Parameters::Fluid::SpecificHeatModel::constant;
+  physical_properties.fluids[0].thermal_conductivity_model =
+    Parameters::Fluid::ThermalConductivityModel::constant;
+
+  physical_properties.fluids[0].density              = 1;
+  physical_properties.fluids[0].thermal_conductivity = 3;
+  physical_properties.fluids[0].specific_heat        = 2;
+
+  PhysicalPropertiesManager physical_properties_manager(physical_properties);
+
+  std::map<field, double> dummy_fields;
+
+  deallog << "Testing PhysicalPropertiesManager" << std::endl;
+  deallog << "Density              : "
+          << physical_properties_manager.density[0]->value(dummy_fields)
+          << std::endl;
+  deallog << "Specific heat        : "
+          << physical_properties_manager.specific_heat[0]->value(dummy_fields)
+          << std::endl;
+  deallog << "Thermal conductivity : "
+          << physical_properties_manager.thermal_conductivity[0]->value(
+               dummy_fields)
+          << std::endl;
+}
 
 int
 main()

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -1,0 +1,69 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 - by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 3.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+
+*/
+
+/**
+ * @brief This code tests the PhysicalPropertiesManager class and its capacity to instantiate the various models for physical properties
+ */
+
+// Lethe
+#include <core/parameters.h>
+
+#include <solvers/physical_properties_manager.h>
+
+// Tests
+#include <../tests/tests.h>
+
+void
+test()
+{}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -53,13 +53,14 @@ test()
 
   deallog << "Testing PhysicalPropertiesManager" << std::endl;
   deallog << "Density              : "
-          << physical_properties_manager.density[0]->value(dummy_fields)
+          << physical_properties_manager.get_density()->value(dummy_fields)
           << std::endl;
   deallog << "Specific heat        : "
-          << physical_properties_manager.specific_heat[0]->value(dummy_fields)
+          << physical_properties_manager.get_specific_heat()->value(
+               dummy_fields)
           << std::endl;
   deallog << "Thermal conductivity : "
-          << physical_properties_manager.thermal_conductivity[0]->value(
+          << physical_properties_manager.get_thermal_conductivity()->value(
                dummy_fields)
           << std::endl;
 }

--- a/tests/solvers/physical_properties_manager_01.output
+++ b/tests/solvers/physical_properties_manager_01.output
@@ -1,0 +1,5 @@
+
+DEAL::Testing PhysicalPropertiesManager
+DEAL::Density              : 1.00000
+DEAL::Specific heat        : 2.00000
+DEAL::Thermal conductivity : 3.00000


### PR DESCRIPTION
# Description of the problem

- Physical properties model (such as rheology) are always re-created whenever we need them. This is very problematic  since we always need to carry the physical property structure everywhere (assemblers, for calculation, etc.) and we always need to "recreate" the properties everywhere we need them. It's confusing and error prone.

# Description of the solution

- Create a new class, PhysicalPropertyManager that houses all the physical properties for all the model. This class is created from the physical properties parameter. It also natively supports having different physical properties model for different fluids.
- 

# How Has This Been Tested?


- [X] physical_property_manager_01.cc


# Future changes

- The next step will be to remove the physical properties from the NavierStokesParameter and to replace them with the physical properties manager. This will give us the flexibility we finally need. Right now, the present feature is not complete, but I would rather merge it now, because the follow-up PR will be significantly larger.
The following goal will be to replace the calculation of the physical properties in each and every assembler with a calculation of the physical properties in the scratch. This will be significantly more generic and will enable  a better connection between the physics



