### PR TITLE
Fix vof conservation

### DIFF
--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -17,7 +17,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
     set VOF 			= false
     set interface sharpening 	= false
     set conservation monitoring = false
-    set fluid index 		= 0
+    set fluid monitored		= 1
   end
 
 
@@ -43,12 +43,17 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 
   When ``set VOF = true``, these optional parameters can be used:
     * ``interface sharpening``: controls if the interface sharpening method is used. Additional parameters can be found at :doc:`interface_sharpening`.
-    * ``conservation monitoring``: controls if conservation is monitored at each iteration, through the volume computation of the fluid with the given ``fluid index``. Results are outputted in a data table (`free_surface_monitoring.dat`).
+    * ``conservation monitoring``: controls if conservation is monitored at each iteration, through the volume computation of the ``fluid monitored``. Results are outputted in a data table (`VOF_monitoring_fluid_0.dat` or `VOF_monitoring_fluid_1.dat`).
+    * ``fluid monitored``: index of the monitored fluid, if ``set conservation monitoring = true``. 
+
+      .. important::
+
+        Must match with the index set in `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#two-phase-simulations>`_. For instance, if the physical properties for the fluid of interest is defined in ``subsection fluid 0``, use ``set fluid monitored = 0``.
 
 
 .. warning::
 
-  At the moment, a maximum of two fluids is supported, with respective ``fluid index`` of ``0`` and ``1``.
+  At the moment, a maximum of two fluids is supported, with respective index of ``0`` and ``1``. By convention, air is usually the ``fluid 0`` and the other fluid of interest is the ``fluid 1``.
 
 .. seealso::
 

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -46,7 +46,7 @@ namespace Parameters
 
     // subparameter for free_surface
     bool conservation_monitoring;
-    int  fluid_index;
+    int  monitor_fluid_id;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -150,11 +150,11 @@ public:
   calculate_L2_error();
 
   /**
-   * @brief Calculates the volume for the fluid phase with given fluid_index.
+   * @brief Calculates the volume for the fluid phase with given monitor_fluid_id.
    * Used for conservation monitoring.
    */
   double
-  calculate_volume(int fluid_index);
+  calculate_volume(int monitor_fluid_id);
 
   /**
    * @brief Carry out the operations required to finish a simulation correctly.

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -54,7 +54,7 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
       "Conservation monitoring in free surface calculation <true|false>");
 
     prm.declare_entry(
-      "fluid index",
+      "fluid monitored",
       "0",
       Patterns::Integer(),
       "Index of the fluid which conservation is monitored <0|1>");
@@ -79,7 +79,7 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
 
     // subparameter for free_surface
     conservation_monitoring = prm.get_bool("conservation monitoring");
-    fluid_index             = prm.get_integer("fluid index");
+    monitor_fluid_id        = prm.get_integer("fluid monitored");
   }
   prm.leave_subsection();
 }

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -1,7 +1,7 @@
 
-#include <deal.II/base/parameter_handler.h>
-
 #include <core/parameters_multiphysics.h>
+
+#include <deal.II/base/parameter_handler.h>
 
 
 

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -1,7 +1,7 @@
 
-#include <core/parameters_multiphysics.h>
-
 #include <deal.II/base/parameter_handler.h>
+
+#include <core/parameters_multiphysics.h>
 
 
 
@@ -55,7 +55,7 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
 
     prm.declare_entry(
       "fluid monitored",
-      "0",
+      "1",
       Patterns::Integer(),
       "Index of the fluid which conservation is monitored <0|1>");
   }


### PR DESCRIPTION
# Description of the problem

- Equation for VOF conservation monitoring was wrong for phase 0
- Parameter name was unclear

# Description of the solution

- Fix equation
- Change parameter to `fluid monitored`

# How Has This Been Tested?

No test added, I tested it on a local example (water droplet), with theoretical fluid surface known. 

I am unsure if it should become a test, do not hesitate to tell me if it should, I can add it to this PR!

# Documentation

- [x] Parameters/Multiphysics, to update the parameter name and to make the text clearer (considering @shahabgol questions).

# Comments

- It took me a while to see what was under my nose, but at least it is fixed now!
