### PR TITLE
Use physical properties manager

### DIFF
--- a/applications_tests/gd_navier_stokes_2d/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/apparent_viscosity_carreau_gd.prm
@@ -27,7 +27,6 @@ end
 subsection physical properties
   set number of fluids = 1
   subsection fluid 0
-    set non newtonian flow	= true
    	set rheological model 	= carreau
     subsection non newtonian
     	subsection carreau

--- a/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
@@ -59,7 +59,6 @@ end
 subsection physical properties
 set number of fluids = 1
   subsection fluid 0
-    set non newtonian flow	= true
   	set rheological model	= carreau
     subsection non newtonian
     	subsection carreau

--- a/applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/mms2d_powerlaw_gd.prm
@@ -15,7 +15,6 @@ end
 subsection physical properties
 set number of fluids = 1
   subsection fluid 0
-    set non newtonian flow	= true
    	set rheological model	= power-law
 
     subsection non newtonian

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_linear_thermal_conductivity.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_linear_thermal_conductivity.output
@@ -1,0 +1,51 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       16
+   Number of degrees of freedom: 75
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 25
+
+*****************************************************************
+Steady iteration :        1/4
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 9.14469e-05
+
+*****************************************************************
+Steady iteration :        2/4
+*****************************************************************
+   Number of active cells:       64
+   Number of degrees of freedom: 243
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 81
+L2 error velocity : 0
+L2 error temperature : 7.10039e-06
+
+*****************************************************************
+Steady iteration :        3/4
+*****************************************************************
+   Number of active cells:       256
+   Number of degrees of freedom: 867
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 289
+L2 error velocity : 0
+L2 error temperature : 4.84016e-07
+
+*****************************************************************
+Steady iteration :        4/4
+*****************************************************************
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 1089
+L2 error velocity : 0
+L2 error temperature : 3.10866e-08
+cells  error_velocity   error_pressure  
+   16 0.000000e+00   - 0.000000e+00   - 
+   64 0.000000e+00 nan 0.000000e+00 nan 
+  256 0.000000e+00 nan 0.000000e+00 nan 
+ 1024 0.000000e+00 nan 0.000000e+00 nan 
+cells error_temperature 
+   16 9.144688e-05    - 
+   64 7.100392e-06 3.69 
+  256 4.840160e-07 3.87 
+ 1024 3.108665e-08 3.96 

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_linear_thermal_conductivity.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_linear_thermal_conductivity.prm
@@ -1,0 +1,141 @@
+# Listing of Parameters
+# ---------------------
+
+
+# --------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  = steady
+  set number mesh adapt       = 3
+  set output frequency        = 1
+  set output name             = mms_conv_22
+end
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+subsection FEM
+    set velocity order        = 1
+    set pressure order        = 1
+    set temperature order     = 1
+end
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+subsection timer
+    set type    = none                                  # <none|iteration|end>
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection uvwp
+            set Function expression = 0; 0; 0
+    end
+end
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set thermal conductivity model = linear
+    # k_A0 parameter for linear conductivity model
+    set k_A0                       = 1
+
+    # k_A1 parameter for linear conductivity model
+    set k_A1                       = 2
+
+    set kinematic viscosity = 1
+  end
+end
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+        set type = dealii
+        set grid type = hyper_rectangle
+        set grid arguments = 0, 0 : 1, 1 : true
+        set initial refinement = 2
+end
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+    set heat transfer = true
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable                 = true
+  set verbosity = verbose
+    subsection uvwp
+            set Function expression =  0 ; 0 ; 0
+    end
+    subsection temperature
+            
+            set Function expression =  (-1+sqrt(1+8*x))/2
+    end
+end
+
+# --------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+subsection mesh adaptation
+  set type                    = uniform
+end
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions
+  set number                  = 4
+end
+
+subsection boundary conditions heat transfer
+  set number                  = 2
+    subsection bc 0
+    set id = 0
+	set type	      = temperature
+        set value	      = 0
+    end
+    subsection bc 1
+    set id = 1
+	  set type	      = temperature
+        set value = 1
+    end
+end
+# --------------------------------------------------
+# Source term
+#---------------------------------------------------
+subsection source term
+  set enable                 = true
+    subsection heat transfer
+	    set Function expression =0	
+    end
+end
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set verbosity               = quiet
+  set tolerance               = 1e-12
+  set max iterations          = 15
+end
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               = quiet
+  set method                  = gmres
+  set max iters               = 5000
+  set relative residual       = 1e-13
+  set minimum residual        = 1e-13
+  set ilu preconditioner fill = 0
+  set ilu preconditioner absolute tolerance = 1e-14
+  set ilu preconditioner relative tolerance = 1.00
+end
+

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.prm
@@ -14,7 +14,6 @@ end
 #---------------------------------------------------
 subsection physical properties
   subsection fluid 0
-    set non newtonian flow	= true
     set rheological model 	= carreau
     subsection non newtonian
     	subsection carreau

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.prm
@@ -14,7 +14,6 @@ end
 #---------------------------------------------------
 subsection physical properties
   subsection fluid 0
-    set non newtonian flow	= true
     set rheological model 		= carreau
     subsection non newtonian
     	subsection carreau

--- a/applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/taylorcouette2d_carreau_gls.prm
@@ -15,7 +15,6 @@ end
 subsection physical properties
 set number of fluids = 1
   subsection fluid 0
-    set non newtonian flow	= true
    	set rheological model 		= carreau
     subsection non newtonian
     	subsection carreau

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -277,13 +277,12 @@ namespace Parameters
     PhaseChange phase_change_parameters;
 
     // Non Newtonian model parameters
-    bool non_newtonian_flow;
-    enum class RheologyModel
+    enum class RheologicalModel
     {
       powerlaw,
       carreau,
       newtonian
-    } rheology_model;
+    } rheological_model;
     NonNewtonian non_newtonian_parameters;
 
     enum class DensityModel

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -37,8 +37,8 @@ enum field : int
 };
 
 inline void
-set_field_vector(const field                          id,
-                 const std::vector<double> &          data,
+set_field_vector(const field                           id,
+                 const std::vector<double> &           data,
                  std::map<field, std::vector<double>> &fields)
 {
   std::vector<double> &target = fields.at(id);

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -36,15 +36,29 @@ enum field : int
   previous_temperature
 };
 
+inline void
+set_field_vector(const field                          id,
+                 const std::vector<double> &          data,
+                 std::map<field, std::vector<double>> fields)
+{
+  std::vector<double> &target = fields.at(id);
+  size_t               sz     = target.size();
+  for (size_t i = 0; i < sz; ++i)
+    {
+      target[i] = data[i];
+    }
+}
+
 /**
  * @brief PhysicalPropertyModel. Abstract class that defines the interface for a physical property model
- * Physical property model provides an abstract interface to calculate the value
- * of a physical property or a vector of physical property value for given field
- * value. By default, the interface does not require that all (or any) fields be
- * specified. This is why a map is used to pass the dependent variable. To allow
- * for the calculation of the appropriate jacobian matrix (when that is
- * necessary) the interface also provides a jacobian function, which must
- * provide the derivative with respect to the field specified as an argument.
+ * Physical property model provides an abstract interface to calculate the
+ * value of a physical property or a vector of physical property value for
+ * given field value. By default, the interface does not require that all (or
+ * any) fields be specified. This is why a map is used to pass the dependent
+ * variable. To allow for the calculation of the appropriate jacobian matrix
+ * (when that is necessary) the interface also provides a jacobian function,
+ * which must provide the derivative with respect to the field specified as an
+ * argument.
  */
 class PhysicalPropertyModel
 {

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -73,6 +73,16 @@ public:
     model_depends_on[previous_temperature] = false;
   }
 
+  /**
+   * @brief Returns true if the PhysicalPropertyModel depends on a field, false if not.
+   */
+
+  inline bool
+  depends_on(field id)
+  {
+    return model_depends_on[id];
+  }
+
 
   /**
    * @brief value Calculates the value of a physical property.

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -37,7 +37,7 @@ enum field : int
 };
 
 inline void
-set_field_vector(const field                           id,
+set_field_vector(const field                        &   id,
                  const std::vector<double> &           data,
                  std::map<field, std::vector<double>> &fields)
 {
@@ -78,7 +78,7 @@ public:
    */
 
   inline bool
-  depends_on(field id)
+  depends_on(const field &id)
   {
     return model_depends_on[id];
   }

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -39,7 +39,7 @@ enum field : int
 inline void
 set_field_vector(const field                          id,
                  const std::vector<double> &          data,
-                 std::map<field, std::vector<double>> fields)
+                 std::map<field, std::vector<double>> &fields)
 {
   std::vector<double> &target = fields.at(id);
   size_t               sz     = target.size();

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -37,7 +37,7 @@ enum field : int
 };
 
 inline void
-set_field_vector(const field                        &   id,
+set_field_vector(const field &                         id,
                  const std::vector<double> &           data,
                  std::map<field, std::vector<double>> &fields)
 {

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -129,7 +129,7 @@ public:
     , n(n)
     , shear_rate_min(shear_rate_min)
   {
-    this->model_depends_on[shear_rate] = false;
+    this->model_depends_on[shear_rate] = true;
   }
 
   /**
@@ -220,7 +220,7 @@ public:
     , a(a)
     , n(n)
   {
-    this->model_depends_on[shear_rate] = false;
+    this->model_depends_on[shear_rate] = true;
   }
 
   /**

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -47,13 +47,13 @@ public:
  * @brief Constant specific heat. Returns a constant specific
  * heat for a fluid
  */
-class SpecificHeatConstant : public SpecificHeatModel
+class ConstantSpecificHeat : public SpecificHeatModel
 {
 public:
   /**
    * @brief Default constructor
    */
-  SpecificHeatConstant(const double p_specific_heat)
+  ConstantSpecificHeat(const double p_specific_heat)
     : specific_heat(p_specific_heat)
   {}
 

--- a/include/core/thermal_conductivity_model.h
+++ b/include/core/thermal_conductivity_model.h
@@ -42,13 +42,13 @@ public:
 /**
  * @brief Constant thermal conductivity.
  */
-class ThermalConductivityConstant : public ThermalConductivityModel
+class ConstantThermalConductivity : public ThermalConductivityModel
 {
 public:
   /**
    * @brief Default constructor
    */
-  ThermalConductivityConstant(const double p_thermal_conductivity)
+  ConstantThermalConductivity(const double p_thermal_conductivity)
     : thermal_conductivity(p_thermal_conductivity)
   {}
 

--- a/include/core/thermal_expansion_model.h
+++ b/include/core/thermal_expansion_model.h
@@ -40,13 +40,13 @@ public:
 /**
  * @brief Constant thermal expansion coefficient.
  */
-class ThermalExpansionConstant : public ThermalExpansionModel
+class ConstantThermalExpansion : public ThermalExpansionModel
 {
 public:
   /**
    * @brief Default constructor
    */
-  ThermalExpansionConstant(const double p_thermal_expansion)
+  ConstantThermalExpansion(const double p_thermal_expansion)
     : thermal_expansion(p_thermal_expansion)
   {}
 

--- a/include/core/thermal_expansion_model.h
+++ b/include/core/thermal_expansion_model.h
@@ -1,0 +1,113 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef lethe_thermal_expansion_model_h
+#define lethe_thermal_expansion_model_h
+
+#include <core/physical_property_model.h>
+
+/**
+ * @brief ThermalExpansionModel. Abstract class that allows to calculate the
+ * thermal expansion coefficient (with unit of inverse temperature)
+ */
+class ThermalExpansionModel : public PhysicalPropertyModel
+{
+public:
+  /**
+   * @brief Instantiates and returns a pointer to a ThermalExpansionModel object by casting it to
+   * the proper child class
+   *
+   * @param physical_properties Parameters for a single fluid
+   */
+  static std::shared_ptr<ThermalExpansionModel>
+  model_cast(const Parameters::Fluid &fluid_properties);
+};
+
+
+/**
+ * @brief Constant thermal expansion coefficient.
+ */
+class ThermalExpansionConstant : public ThermalExpansionModel
+{
+public:
+  /**
+   * @brief Default constructor
+   */
+  ThermalExpansionConstant(const double p_thermal_expansion)
+    : thermal_expansion(p_thermal_expansion)
+  {}
+
+  /**
+   * @brief value Calculates the thermale expansion
+   * @param fields_value Value of the various field on which the property may depend.
+   * @return value of the physical property calculated with the fields_value
+   */
+  double
+  value(const std::map<field, double> & /*fields_value*/) override
+  {
+    return thermal_expansion;
+  };
+
+  /**
+   * @brief vector_value Calculates the vector of thermal expansion.
+   * @param field_vectors Vectors of the fields on which the thermal expansion may depend.
+   * @param property_vector Vectors of the thermal expansion values
+   */
+  void
+  vector_value(const std::map<field, std::vector<double>> & /*field_vectors*/,
+               std::vector<double> &property_vector) override
+  {
+    std::fill(property_vector.begin(),
+              property_vector.end(),
+              thermal_expansion);
+  }
+
+  /**
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the thermal expansion with respect to a field
+   * @param field_values Value of the various fields on which the property may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated.
+   * @return value of the partial derivative of the thermal expansion with respect to the field.
+   */
+
+  double
+  jacobian(const std::map<field, double> & /*field_values*/,
+           field /*id*/) override
+  {
+    return 0;
+  };
+
+  /**
+   * @brief vector_jacobian Calculates the derivative of the thermal expansion with respect to a field.
+   * @param field_vectors Vector for the values of the fields used to evaluate the property.
+   * @param id Identifier of the field with respect to which a derivative should be calculated.
+   * @param jacobian vector of the value of the derivative of the thermal expansion with respect to the field id.
+   */
+
+  void
+  vector_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field /*id*/,
+    std::vector<double> &jacobian_vector) override
+  {
+    std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+  };
+
+private:
+  const double thermal_expansion;
+};
+
+#endif

--- a/include/core/tracer_diffusivity_model.h
+++ b/include/core/tracer_diffusivity_model.h
@@ -40,13 +40,13 @@ public:
 /**
  * @brief Constant tracer diffusivity.
  */
-class TracerDiffusivityConstant : public TracerDiffusivityModel
+class ConstantTracerDiffusivity : public TracerDiffusivityModel
 {
 public:
   /**
    * @brief Default constructor
    */
-  TracerDiffusivityConstant(const double p_tracer_diffusivity)
+  ConstantTracerDiffusivity(const double p_tracer_diffusivity)
     : tracer_diffusivity(p_tracer_diffusivity)
   {}
 

--- a/include/core/tracer_diffusivity_model.h
+++ b/include/core/tracer_diffusivity_model.h
@@ -52,7 +52,7 @@ public:
 
   /**
    * @brief value Calculates the tracer diffusivity
-   * @param fields_value Value of the various field on which the property may depend.
+   * @param fields_value Value of the various fields on which the property may depend.
    * @return value of the physical property calculated with the fields_value
    */
   double

--- a/include/core/tracer_diffusivity_model.h
+++ b/include/core/tracer_diffusivity_model.h
@@ -1,0 +1,113 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef lethe_tracer_diffusivity_model_h
+#define lethe_tracer_diffusivity_model_h
+
+#include <core/physical_property_model.h>
+
+/**
+ * @brief DensityModel. Abstract class that allows to calculate the
+ * density.
+ */
+class TracerDiffusivityModel : public PhysicalPropertyModel
+{
+public:
+  /**
+   * @brief Instantiates and returns a pointer to a TracerDiffusivityModel object by casting it to
+   * the proper child class
+   *
+   * @param physical_properties Parameters for a single fluid
+   */
+  static std::shared_ptr<TracerDiffusivityModel>
+  model_cast(const Parameters::Fluid &fluid_properties);
+};
+
+
+/**
+ * @brief Constant tracer diffusivity.
+ */
+class TracerDiffusivityConstant : public TracerDiffusivityModel
+{
+public:
+  /**
+   * @brief Default constructor
+   */
+  TracerDiffusivityConstant(const double p_tracer_diffusivity)
+    : tracer_diffusivity(p_tracer_diffusivity)
+  {}
+
+  /**
+   * @brief value Calculates the tracer diffusivity
+   * @param fields_value Value of the various field on which the property may depend.
+   * @return value of the physical property calculated with the fields_value
+   */
+  double
+  value(const std::map<field, double> & /*fields_value*/) override
+  {
+    return tracer_diffusivity;
+  };
+
+  /**
+   * @brief vector_value Calculates the vector of tracer diffusivity.
+   * @param field_vectors Vectors of the fields on which the diffusivity may depend.
+   * @param property_vector Vectors of the tracer diffusivity values
+   */
+  void
+  vector_value(const std::map<field, std::vector<double>> & /*field_vectors*/,
+               std::vector<double> &property_vector) override
+  {
+    std::fill(property_vector.begin(),
+              property_vector.end(),
+              tracer_diffusivity);
+  }
+
+  /**
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the diffusivity with respect to a field
+   * @param field_values Value of the various fields on which the property may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated.
+   * @return value of the partial derivative of the diffusivity with respect to the field.
+   */
+
+  double
+  jacobian(const std::map<field, double> & /*field_values*/,
+           field /*id*/) override
+  {
+    return 0;
+  };
+
+  /**
+   * @brief vector_jacobian Calculates the derivative of the tracer diffusivity with respect to a field.
+   * @param field_vectors Vector for the values of the fields used to evaluate the property.
+   * @param id Identifier of the field with respect to which a derivative should be calculated.
+   * @param jacobian vector of the value of the derivative of the tracer diffusivity with respect to the field id.
+   */
+
+  void
+  vector_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field /*id*/,
+    std::vector<double> &jacobian_vector) override
+  {
+    std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+  };
+
+private:
+  const double tracer_diffusivity;
+};
+
+#endif

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -67,10 +67,8 @@ class GLSVansAssemblerCoreModelB : public NavierStokesAssemblerBase<dim>
 public:
   GLSVansAssemblerCoreModelB(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
     Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , cfd_dem(cfd_dem)
   {}
 
@@ -95,7 +93,6 @@ public:
   const bool SUPG = true;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
   Parameters::CFDDEM                 cfd_dem;
 };
 
@@ -112,10 +109,8 @@ class GLSVansAssemblerCoreModelA : public NavierStokesAssemblerBase<dim>
 public:
   GLSVansAssemblerCoreModelA(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
     Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , cfd_dem(cfd_dem)
   {}
 
@@ -140,7 +135,6 @@ public:
   const bool SUPG = true;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
   Parameters::CFDDEM                 cfd_dem;
 };
 
@@ -161,10 +155,8 @@ class GLSVansAssemblerBDF : public NavierStokesAssemblerBase<dim>
 {
 public:
   GLSVansAssemblerBDF(std::shared_ptr<SimulationControl> simulation_control,
-                      Parameters::PhysicalProperties     physical_properties,
                       Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , cfd_dem(cfd_dem)
   {}
 
@@ -187,7 +179,6 @@ public:
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 
   Parameters::CFDDEM cfd_dem;
 };
@@ -211,9 +202,7 @@ template <int dim>
 class GLSVansAssemblerDiFelice : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerDiFelice(Parameters::PhysicalProperties physical_properties)
-    : physical_properties(physical_properties)
-
+  GLSVansAssemblerDiFelice()
   {}
 
   /**
@@ -224,8 +213,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::PhysicalProperties physical_properties;
 };
 
 /**
@@ -249,9 +236,7 @@ template <int dim>
 class GLSVansAssemblerRong : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerRong(Parameters::PhysicalProperties physical_properties)
-    : physical_properties(physical_properties)
-
+  GLSVansAssemblerRong()
   {}
 
   /**
@@ -262,8 +247,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::PhysicalProperties physical_properties;
 };
 
 /**
@@ -283,9 +266,7 @@ template <int dim>
 class GLSVansAssemblerDallavalle : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerDallavalle(Parameters::PhysicalProperties physical_properties)
-    : physical_properties(physical_properties)
-
+  GLSVansAssemblerDallavalle()
   {}
 
   /**
@@ -296,8 +277,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::PhysicalProperties physical_properties;
 };
 
 
@@ -351,11 +330,8 @@ template <int dim>
 class GLSVansAssemblerPressureForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerPressureForce(
-    Parameters::PhysicalProperties physical_properties,
-    Parameters::CFDDEM             cfd_dem)
-    : physical_properties(physical_properties)
-    , cfd_dem(cfd_dem)
+  GLSVansAssemblerPressureForce(Parameters::CFDDEM cfd_dem)
+    : cfd_dem(cfd_dem)
   {}
 
   /**
@@ -367,8 +343,7 @@ public:
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
 
-  Parameters::PhysicalProperties physical_properties;
-  Parameters::CFDDEM             cfd_dem;
+  Parameters::CFDDEM cfd_dem;
 };
 
 /**
@@ -384,8 +359,8 @@ template <int dim>
 class GLSVansAssemblerShearForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerShearForce(Parameters::PhysicalProperties physical_properties)
-    : physical_properties(physical_properties)
+  GLSVansAssemblerShearForce()
+
   {}
 
   /**
@@ -396,8 +371,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::PhysicalProperties physical_properties;
 };
 
 /**

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -295,11 +295,9 @@ template <int dim>
 class GLSVansAssemblerBuoyancy : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerBuoyancy(Parameters::PhysicalProperties physical_properties,
-                           Parameters::Lagrangian::LagrangianPhysicalProperties
+  GLSVansAssemblerBuoyancy(Parameters::Lagrangian::LagrangianPhysicalProperties
                              lagrangian_physical_properties)
-    : physical_properties(physical_properties)
-    , lagrangian_physical_properties(lagrangian_physical_properties)
+    : lagrangian_physical_properties(lagrangian_physical_properties)
 
   {}
 
@@ -312,7 +310,6 @@ public:
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
 
-  Parameters::PhysicalProperties physical_properties;
   Parameters::Lagrangian::LagrangianPhysicalProperties
     lagrangian_physical_properties;
 };

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -44,12 +44,8 @@ class HeatTransferAssemblerBase
 {
 public:
   HeatTransferAssemblerBase(
-    std::shared_ptr<SimulationControl>   p_simulation_control,
-    const Parameters::PhysicalProperties p_physical_properties,
-    const Parameters::Multiphysics &     p_multiphysics_parameters)
+    std::shared_ptr<SimulationControl> p_simulation_control)
     : simulation_control(p_simulation_control)
-    , physical_properties(p_physical_properties)
-    , multiphysics_parameters(p_multiphysics_parameters)
   {}
 
 
@@ -78,9 +74,7 @@ public:
                StabilizedMethodsCopyData &   copy_data) = 0;
 
 protected:
-  std::shared_ptr<SimulationControl>   simulation_control;
-  const Parameters::PhysicalProperties physical_properties;
-  const Parameters::Multiphysics &     multiphysics_parameters;
+  std::shared_ptr<SimulationControl> simulation_control;
 };
 
 /**
@@ -100,12 +94,8 @@ class HeatTransferAssemblerCore : public HeatTransferAssemblerBase<dim>
 {
 public:
   HeatTransferAssemblerCore(
-    std::shared_ptr<SimulationControl>   simulation_control,
-    const Parameters::PhysicalProperties physical_properties,
-    const Parameters::Multiphysics &     multiphysics_parameters)
-    : HeatTransferAssemblerBase<dim>(simulation_control,
-                                     physical_properties,
-                                     multiphysics_parameters)
+    std::shared_ptr<SimulationControl> simulation_control)
+    : HeatTransferAssemblerBase<dim>(simulation_control)
   {}
 
   /**
@@ -141,12 +131,8 @@ class HeatTransferAssemblerBDF : public HeatTransferAssemblerBase<dim>
 {
 public:
   HeatTransferAssemblerBDF(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics &   multiphysics_parameters)
-    : HeatTransferAssemblerBase<dim>(simulation_control,
-                                     physical_properties,
-                                     multiphysics_parameters)
+    std::shared_ptr<SimulationControl> simulation_control)
+    : HeatTransferAssemblerBase<dim>(simulation_control)
   {}
 
   /**
@@ -184,13 +170,9 @@ class HeatTransferAssemblerRobinBC : public HeatTransferAssemblerBase<dim>
 public:
   HeatTransferAssemblerRobinBC(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics &   multiphysics_parameters,
     const BoundaryConditions::HTBoundaryConditions<dim>
       &p_boundary_conditions_ht)
-    : HeatTransferAssemblerBase<dim>(simulation_control,
-                                     physical_properties,
-                                     multiphysics_parameters)
+    : HeatTransferAssemblerBase<dim>(simulation_control)
     , boundary_conditions_ht(p_boundary_conditions_ht)
   {}
 
@@ -230,12 +212,8 @@ class HeatTransferAssemblerViscousDissipation
 {
 public:
   HeatTransferAssemblerViscousDissipation(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
-    const Parameters::Multiphysics &   multiphysics_parameters)
-    : HeatTransferAssemblerBase<dim>(simulation_control,
-                                     physical_properties,
-                                     multiphysics_parameters)
+    std::shared_ptr<SimulationControl> simulation_control)
+    : HeatTransferAssemblerBase<dim>(simulation_control)
   {}
 
   virtual void

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -86,16 +86,13 @@ public:
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    *
    */
-  HeatTransferScratchData(
-    const Parameters::PhysicalProperties physical_properties,
-    const PhysicalPropertiesManager      properties_manager,
-    const FiniteElement<dim> &           fe_ht,
-    const Quadrature<dim> &              quadrature,
-    const Mapping<dim> &                 mapping,
-    const FiniteElement<dim> &           fe_navier_stokes,
-    const Quadrature<dim - 1> &          face_quadrature)
-    : physical_properties(physical_properties)
-    , properties_manager(properties_manager)
+  HeatTransferScratchData(const PhysicalPropertiesManager properties_manager,
+                          const FiniteElement<dim> &      fe_ht,
+                          const Quadrature<dim> &         quadrature,
+                          const Mapping<dim> &            mapping,
+                          const FiniteElement<dim> &      fe_navier_stokes,
+                          const Quadrature<dim - 1> &     face_quadrature)
+    : properties_manager(properties_manager)
     , fe_values_T(mapping,
                   fe_ht,
                   quadrature,
@@ -129,8 +126,7 @@ public:
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    */
   HeatTransferScratchData(const HeatTransferScratchData<dim> &sd)
-    : physical_properties(sd.physical_properties)
-    , properties_manager(sd.properties_manager)
+    : properties_manager(sd.properties_manager)
     , fe_values_T(sd.fe_values_T.get_mapping(),
                   sd.fe_values_T.get_fe(),
                   sd.fe_values_T.get_quadrature(),
@@ -365,13 +361,23 @@ public:
 
 
   // Physical properties
-  const Parameters::PhysicalProperties physical_properties;
   PhysicalPropertiesManager            properties_manager;
   std::map<field, std::vector<double>> fields;
   std::vector<double>                  specific_heat;
   std::vector<double>                  thermal_conductivity;
   std::vector<double>                  density;
   std::vector<double>                  viscosity;
+
+  // Auxiliary property vector for VOF simulations
+  std::vector<double> specific_heat_0;
+  std::vector<double> thermal_conductivity_0;
+  std::vector<double> density_0;
+  std::vector<double> viscosity_0;
+
+  std::vector<double> specific_heat_1;
+  std::vector<double> thermal_conductivity_1;
+  std::vector<double> density_1;
+  std::vector<double> viscosity_1;
 
 
   // FEValues for the HT problem
@@ -424,6 +430,7 @@ public:
   FEValues<dim>               fe_values_navier_stokes;
   std::vector<Tensor<1, dim>> velocity_values;
   std::vector<Tensor<2, dim>> velocity_gradient_values;
+  std::vector<double>         shear_rate_values;
 
   // Scratch for the face boundary condition
   FEFaceValues<dim>                fe_face_values_ht;

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -27,6 +27,7 @@
 
 #include <core/density_model.h>
 #include <core/multiphysics.h>
+#include <core/physical_property_model.h>
 #include <core/specific_heat_model.h>
 #include <core/thermal_conductivity_model.h>
 
@@ -87,6 +88,7 @@ public:
    */
   HeatTransferScratchData(
     const Parameters::PhysicalProperties physical_properties,
+    const PhysicalPropertiesManager      propertis_manager,
     const FiniteElement<dim> &           fe_ht,
     const Quadrature<dim> &              quadrature,
     const Mapping<dim> &                 mapping,
@@ -349,6 +351,18 @@ public:
       }
   }
 
+
+  /** @brief Calculates the physical properties. This function calculates the physical properties
+   * that may be required by the heat transfer problem. Namely the density,
+   * specific heat, thermal conductivity and viscosity (for viscous
+   * dissipation).
+   *
+   */
+  void
+  calculate_physical_properties();
+
+
+
   // FEValues for the HT problem
   const Parameters::PhysicalProperties physical_properties;
   FEValues<dim>                        fe_values_T;
@@ -369,9 +383,12 @@ public:
   std::vector<std::vector<Tensor<1, dim>>> previous_temperature_gradients;
   std::vector<std::vector<double>>         stages_temperature_values;
 
-  std::vector<double> specific_heat;
-  std::vector<double> thermal_conductivity;
-  std::vector<double> density;
+  // Physical properties
+  std::map<field, std::vector<double>> fields;
+  std::vector<double>                  specific_heat;
+  std::vector<double>                  thermal_conductivity;
+  std::vector<double>                  density;
+  std::vector<double>                  viscosity;
 
   // Shape functions and gradients
   std::vector<std::vector<double>>         phi_T;

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -88,13 +88,14 @@ public:
    */
   HeatTransferScratchData(
     const Parameters::PhysicalProperties physical_properties,
-    const PhysicalPropertiesManager      propertis_manager,
+    const PhysicalPropertiesManager      properties_manager,
     const FiniteElement<dim> &           fe_ht,
     const Quadrature<dim> &              quadrature,
     const Mapping<dim> &                 mapping,
     const FiniteElement<dim> &           fe_navier_stokes,
     const Quadrature<dim - 1> &          face_quadrature)
     : physical_properties(physical_properties)
+    , properties_manager(properties_manager)
     , fe_values_T(mapping,
                   fe_ht,
                   quadrature,
@@ -129,6 +130,7 @@ public:
    */
   HeatTransferScratchData(const HeatTransferScratchData<dim> &sd)
     : physical_properties(sd.physical_properties)
+    , properties_manager(sd.properties_manager)
     , fe_values_T(sd.fe_values_T.get_mapping(),
                   sd.fe_values_T.get_fe(),
                   sd.fe_values_T.get_quadrature(),
@@ -362,13 +364,23 @@ public:
   calculate_physical_properties();
 
 
+  // Physical properties
+  const Parameters::PhysicalProperties physical_properties;
+  PhysicalPropertiesManager            properties_manager;
+  std::map<field, std::vector<double>> fields;
+  std::vector<double>                  specific_heat;
+  std::vector<double>                  thermal_conductivity;
+  std::vector<double>                  density;
+  std::vector<double>                  viscosity;
+
 
   // FEValues for the HT problem
-  const Parameters::PhysicalProperties physical_properties;
-  FEValues<dim>                        fe_values_T;
-  unsigned int                         n_dofs;
-  unsigned int                         n_q_points;
-  double                               cell_size;
+  FEValues<dim> fe_values_T;
+  unsigned int  n_dofs;
+  unsigned int  n_q_points;
+  double        cell_size;
+
+
 
   // Quadrature
   std::vector<double>     JxW;
@@ -383,12 +395,6 @@ public:
   std::vector<std::vector<Tensor<1, dim>>> previous_temperature_gradients;
   std::vector<std::vector<double>>         stages_temperature_values;
 
-  // Physical properties
-  std::map<field, std::vector<double>> fields;
-  std::vector<double>                  specific_heat;
-  std::vector<double>                  thermal_conductivity;
-  std::vector<double>                  density;
-  std::vector<double>                  viscosity;
 
   // Shape functions and gradients
   std::vector<std::vector<double>>         phi_T;

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -57,7 +57,7 @@ public:
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,
-    ConditionalOStream                &p_pcout);
+    ConditionalOStream &               p_pcout);
 
   std::vector<PhysicsID>
   get_active_physics()

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -53,7 +53,7 @@ public:
    *
    */
   MultiphysicsInterface(
-    SimulationParameters<dim> &nsparam,
+    const SimulationParameters<dim> &nsparam,
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -53,11 +53,11 @@ public:
    *
    */
   MultiphysicsInterface(
-    const SimulationParameters<dim> &nsparam,
+    SimulationParameters<dim> &nsparam,
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,
-    ConditionalOStream &               p_pcout);
+    ConditionalOStream                &p_pcout);
 
   std::vector<PhysicsID>
   get_active_physics()

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -89,7 +89,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -145,7 +145,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -154,7 +154,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -196,9 +196,9 @@ public:
   Tensor<1, dim>
   get_viscosity_gradient(const Tensor<2, dim> &velocity_gradient,
                          const Tensor<3, dim> &velocity_hessians,
-                         const double         &shear_rate_magnitude,
-                         const double         &non_newtonian_viscosity,
-                         const double         &d_gamma_dot) const
+                         const double &        shear_rate_magnitude,
+                         const double &        non_newtonian_viscosity,
+                         const double &        d_gamma_dot) const
   {
     std::map<field, double> field_values_plus;
 
@@ -254,7 +254,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -264,7 +264,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -306,7 +306,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -315,7 +315,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -345,7 +345,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -354,7 +354,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -392,7 +392,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -402,7 +402,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -434,7 +434,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -444,7 +444,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -480,7 +480,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -490,7 +490,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -527,7 +527,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -537,7 +537,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -576,7 +576,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -586,7 +586,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -623,7 +623,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -633,7 +633,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -89,7 +89,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -145,7 +145,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -154,7 +154,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -236,7 +236,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -246,7 +246,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -286,7 +286,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -295,7 +295,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -325,7 +325,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -334,7 +334,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -359,10 +359,8 @@ class GDNavierStokesAssemblerCore : public NavierStokesAssemblerBase<dim>
 public:
   GDNavierStokesAssemblerCore(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
     const double                       gamma)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , gamma(gamma)
   {}
 
@@ -372,7 +370,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -382,12 +380,11 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
   double                             gamma;
 };
 
@@ -409,7 +406,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -419,7 +416,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -453,7 +450,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -463,7 +460,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -500,7 +497,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -510,7 +507,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -549,7 +546,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -559,7 +556,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -584,10 +581,8 @@ template <int dim>
 class BuoyancyAssembly : public NavierStokesAssemblerBase<dim>
 {
 public:
-  BuoyancyAssembly(std::shared_ptr<SimulationControl> simulation_control,
-                   Parameters::PhysicalProperties     physical_properties)
+  BuoyancyAssembly(std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
   {}
 
   /**
@@ -596,7 +591,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -606,12 +601,11 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 };
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -89,7 +89,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -145,7 +145,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -154,7 +154,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -236,7 +236,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -246,7 +246,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -286,7 +286,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -295,7 +295,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -325,7 +325,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -334,7 +334,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -370,7 +370,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -380,7 +380,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -406,7 +406,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -416,7 +416,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -438,10 +438,8 @@ template <int dim>
 class LaplaceAssembly : public NavierStokesAssemblerBase<dim>
 {
 public:
-  LaplaceAssembly(std::shared_ptr<SimulationControl> simulation_control,
-                  Parameters::PhysicalProperties     physical_properties)
+  LaplaceAssembly(std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
   {}
 
   /**
@@ -450,7 +448,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -460,12 +458,11 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 };
 
 /**
@@ -495,7 +492,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -505,7 +502,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -541,7 +538,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -551,7 +548,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -585,7 +582,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -595,7 +592,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -176,14 +176,9 @@ class GLSNavierStokesAssemblerNonNewtonianCore
 {
 public:
   GLSNavierStokesAssemblerNonNewtonianCore(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties)
+    std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
-  {
-    rheological_model =
-      RheologicalModel::model_cast(physical_properties.fluids[0]);
-  }
+  {}
 
   /**
    * @brief Calculates an approximation of the gradient of the viscosity
@@ -193,25 +188,12 @@ public:
      @param d_gamma_dot Th difference in the shear rate magnitude to approximate the
      viscosity variation with a slight change in the shear_rate magnitude
    */
-  Tensor<1, dim>
+  inline Tensor<1, dim>
   get_viscosity_gradient(const Tensor<2, dim> &velocity_gradient,
                          const Tensor<3, dim> &velocity_hessians,
-                         const double &        shear_rate_magnitude,
-                         const double &        non_newtonian_viscosity,
-                         const double &        d_gamma_dot) const
+                         const double          shear_rate_magnitude,
+                         const double          grad_viscosity_shear_rate) const
   {
-    std::map<field, double> field_values_plus;
-
-    // Calculates an approximation of the derivative of the viscosity with a
-    // slight change in the shear rate magnitude using finite difference
-    field_values_plus[field::shear_rate] = shear_rate_magnitude + d_gamma_dot;
-
-    const double non_newtonian_viscosity_plus =
-      rheological_model->value(field_values_plus);
-
-    double grad_viscosity_shear_rate =
-      (non_newtonian_viscosity_plus - non_newtonian_viscosity) / d_gamma_dot;
-
     // Calculates an approximation of the shear rate magnitude gradient using
     // the derived form, since it does not change with rheological models
     Tensor<1, dim> grad_shear_rate;
@@ -275,8 +257,6 @@ public:
   const bool SUPG = true;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
-  std::shared_ptr<RheologicalModel>  rheological_model;
 };
 
 
@@ -418,15 +398,10 @@ class GDNavierStokesAssemblerNonNewtonianCore
 public:
   GDNavierStokesAssemblerNonNewtonianCore(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
     const double                       gamma)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , gamma(gamma)
-  {
-    rheological_model =
-      RheologicalModel::model_cast(physical_properties.fluids[0]);
-  }
+  {}
 
   /**
    * @brief assemble_matrix Assembles the matrix
@@ -449,9 +424,7 @@ public:
 
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
   double                             gamma;
-  std::shared_ptr<RheologicalModel>  rheological_model;
 };
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -79,10 +79,8 @@ class GLSNavierStokesAssemblerCore : public NavierStokesAssemblerBase<dim>
 {
 public:
   GLSNavierStokesAssemblerCore(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties)
+    std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
   {}
 
   /**
@@ -91,7 +89,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -101,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -112,7 +110,6 @@ public:
   const bool SUPG = true;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 };
 
 
@@ -148,7 +145,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -157,7 +154,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -199,9 +196,9 @@ public:
   Tensor<1, dim>
   get_viscosity_gradient(const Tensor<2, dim> &velocity_gradient,
                          const Tensor<3, dim> &velocity_hessians,
-                         const double &        shear_rate_magnitude,
-                         const double &        non_newtonian_viscosity,
-                         const double &        d_gamma_dot) const
+                         const double         &shear_rate_magnitude,
+                         const double         &non_newtonian_viscosity,
+                         const double         &d_gamma_dot) const
   {
     std::map<field, double> field_values_plus;
 
@@ -257,7 +254,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -267,7 +264,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -309,7 +306,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -318,7 +315,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -348,7 +345,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -357,7 +354,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -395,7 +392,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -405,7 +402,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -437,7 +434,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -447,7 +444,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -483,7 +480,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -493,7 +490,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -530,7 +527,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -540,7 +537,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -579,7 +576,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -589,7 +586,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -626,7 +623,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -636,7 +633,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -89,7 +89,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -145,7 +145,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -154,7 +154,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -236,7 +236,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -246,7 +246,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -286,7 +286,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -295,7 +295,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -325,7 +325,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -334,7 +334,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -370,7 +370,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -380,7 +380,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -406,7 +406,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -416,7 +416,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -448,7 +448,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -458,7 +458,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -492,7 +492,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -502,7 +502,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -538,7 +538,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -548,7 +548,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -582,7 +582,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -592,7 +592,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -89,7 +89,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -145,7 +145,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -154,7 +154,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -236,7 +236,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -246,7 +246,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -286,7 +286,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -295,7 +295,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -325,7 +325,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -334,7 +334,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -370,7 +370,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -380,7 +380,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -406,7 +406,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -416,7 +416,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -450,7 +450,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -460,7 +460,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -483,11 +483,9 @@ class PressureBoundaryCondition : public NavierStokesAssemblerBase<dim>
 public:
   PressureBoundaryCondition(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
     const BoundaryConditions::NSBoundaryConditions<dim>
       &pressure_boundary_conditions_input)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , pressure_boundary_conditions(pressure_boundary_conditions_input)
   {}
 
@@ -497,7 +495,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -507,12 +505,11 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
   const BoundaryConditions::NSBoundaryConditions<dim>
     &pressure_boundary_conditions;
 };
@@ -532,11 +529,9 @@ class WeakDirichletBoundaryCondition : public NavierStokesAssemblerBase<dim>
 public:
   WeakDirichletBoundaryCondition(
     std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties,
     const BoundaryConditions::NSBoundaryConditions<dim>
       &boundary_conditions_input)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
     , boundary_conditions(boundary_conditions_input)
   {}
 
@@ -546,7 +541,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -556,12 +551,11 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
   std::shared_ptr<SimulationControl>                   simulation_control;
-  Parameters::PhysicalProperties                       physical_properties;
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions;
 };
 
@@ -591,7 +585,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -601,7 +595,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -86,9 +86,9 @@ public:
    *
    */
   NavierStokesScratchData(PhysicalPropertiesManager &properties_manager,
-                          const FESystem<dim> &      fe,
-                          const Quadrature<dim> &    quadrature,
-                          const Mapping<dim> &       mapping,
+                          const FESystem<dim>       &fe,
+                          const Quadrature<dim>     &quadrature,
+                          const Mapping<dim>        &mapping,
                           const Quadrature<dim - 1> &face_quadrature)
     : properties_manager(properties_manager)
     , fe_values(mapping,
@@ -193,10 +193,10 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
          const std::vector<VectorType> &solution_stages,
-         Function<dim> *                forcing_function,
+         Function<dim>                 *forcing_function,
          Tensor<1, dim>                 beta_force)
   {
     this->fe_values.reinit(cell);
@@ -439,8 +439,8 @@ public:
 
   void
   enable_VOF(const FiniteElement<dim> &fe,
-             const Quadrature<dim> &   quadrature,
-             const Mapping<dim> &      mapping);
+             const Quadrature<dim>    &quadrature,
+             const Mapping<dim>       &mapping);
 
   /** @brief Reinitialize the content of the scratch for the VOF
    *
@@ -459,7 +459,7 @@ public:
   template <typename VectorType>
   void
   reinit_VOF(const typename DoFHandler<dim>::active_cell_iterator &cell,
-             const VectorType &             current_solution,
+             const VectorType              &current_solution,
              const std::vector<VectorType> &previous_solutions,
              const std::vector<VectorType> & /*solution_stages*/)
   {
@@ -490,8 +490,8 @@ public:
 
   void
   enable_void_fraction(const FiniteElement<dim> &fe,
-                       const Quadrature<dim> &   quadrature,
-                       const Mapping<dim> &      mapping);
+                       const Quadrature<dim>    &quadrature,
+                       const Mapping<dim>       &mapping);
 
   /** @brief Reinitialize the content of the scratch for the void fraction
    *
@@ -511,8 +511,8 @@ public:
   void
   reinit_void_fraction(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType &                                    current_solution,
-    const std::vector<VectorType> &                       previous_solutions,
+    const VectorType                                     &current_solution,
+    const std::vector<VectorType>                        &previous_solutions,
     const std::vector<VectorType> & /*solution_stages*/)
   {
     this->fe_values_void_fraction->reinit(cell);
@@ -567,8 +567,8 @@ public:
     const VectorType                                      previous_solution,
     const VectorType                       void_fraction_solution,
     const Particles::ParticleHandler<dim> &particle_handler,
-    DoFHandler<dim> &                      dof_handler,
-    DoFHandler<dim> &                      void_fraction_dof_handler)
+    DoFHandler<dim>                       &dof_handler,
+    DoFHandler<dim>                       &void_fraction_dof_handler)
   {
     const FiniteElement<dim> &fe = this->fe_values.get_fe();
     const FiniteElement<dim> &fe_void_fraction =
@@ -700,8 +700,8 @@ public:
 
   void
   enable_heat_transfer(const FiniteElement<dim> &fe,
-                       const Quadrature<dim> &   quadrature,
-                       const Mapping<dim> &      mapping);
+                       const Quadrature<dim>    &quadrature,
+                       const Mapping<dim>       &mapping);
 
 
   /** @brief Reinitialize the content of the scratch for the heat transfer
@@ -720,7 +720,7 @@ public:
   void
   reinit_heat_transfer(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType &                                    current_solution)
+    const VectorType                                     &current_solution)
   {
     this->fe_values_temperature->reinit(cell);
 
@@ -742,9 +742,11 @@ public:
   std::map<field, std::vector<double>> fields;
   std::vector<double>                  density;
   std::vector<double>                  viscosity;
+  std::vector<double>                  thermal_expansion;
   std::vector<double>                  grad_viscosity_shear_rate;
+  std::vector<std::vector<double>>     previous_density;
 
-  // For VOF simulations
+  // For VOF simulations. Present properties for fluid 0 and 1.
   std::vector<double> density_0;
   std::vector<double> density_1;
   std::vector<double> viscosity_0;

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -141,6 +141,11 @@ public:
                        update_JxW_values | update_gradients | update_hessians |
                        update_normal_vectors)
   {
+    gather_VOF                   = false;
+    gather_void_fraction         = false;
+    gather_particles_information = false;
+    gather_temperature           = false;
+
     allocate();
     if (sd.gather_VOF)
       enable_VOF(sd.fe_values_VOF->get_fe(),

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -742,6 +742,7 @@ public:
   std::map<field, std::vector<double>> fields;
   std::vector<double>                  density;
   std::vector<double>                  viscosity;
+  std::vector<double>                  grad_viscosity_shear_rate;
 
   // For VOF simulations
   std::vector<double> density_0;

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -86,9 +86,9 @@ public:
    *
    */
   NavierStokesScratchData(PhysicalPropertiesManager &properties_manager,
-                          const FESystem<dim>       &fe,
-                          const Quadrature<dim>     &quadrature,
-                          const Mapping<dim>        &mapping,
+                          const FESystem<dim> &      fe,
+                          const Quadrature<dim> &    quadrature,
+                          const Mapping<dim> &       mapping,
                           const Quadrature<dim - 1> &face_quadrature)
     : properties_manager(properties_manager)
     , fe_values(mapping,
@@ -193,10 +193,10 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType                                     &current_solution,
+         const VectorType &                                    current_solution,
          const std::vector<VectorType> &previous_solutions,
          const std::vector<VectorType> &solution_stages,
-         Function<dim>                 *forcing_function,
+         Function<dim> *                forcing_function,
          Tensor<1, dim>                 beta_force)
   {
     this->fe_values.reinit(cell);
@@ -439,8 +439,8 @@ public:
 
   void
   enable_VOF(const FiniteElement<dim> &fe,
-             const Quadrature<dim>    &quadrature,
-             const Mapping<dim>       &mapping);
+             const Quadrature<dim> &   quadrature,
+             const Mapping<dim> &      mapping);
 
   /** @brief Reinitialize the content of the scratch for the VOF
    *
@@ -459,7 +459,7 @@ public:
   template <typename VectorType>
   void
   reinit_VOF(const typename DoFHandler<dim>::active_cell_iterator &cell,
-             const VectorType              &current_solution,
+             const VectorType &             current_solution,
              const std::vector<VectorType> &previous_solutions,
              const std::vector<VectorType> & /*solution_stages*/)
   {
@@ -490,8 +490,8 @@ public:
 
   void
   enable_void_fraction(const FiniteElement<dim> &fe,
-                       const Quadrature<dim>    &quadrature,
-                       const Mapping<dim>       &mapping);
+                       const Quadrature<dim> &   quadrature,
+                       const Mapping<dim> &      mapping);
 
   /** @brief Reinitialize the content of the scratch for the void fraction
    *
@@ -511,8 +511,8 @@ public:
   void
   reinit_void_fraction(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType                                     &current_solution,
-    const std::vector<VectorType>                        &previous_solutions,
+    const VectorType &                                    current_solution,
+    const std::vector<VectorType> &                       previous_solutions,
     const std::vector<VectorType> & /*solution_stages*/)
   {
     this->fe_values_void_fraction->reinit(cell);
@@ -567,8 +567,8 @@ public:
     const VectorType                                      previous_solution,
     const VectorType                       void_fraction_solution,
     const Particles::ParticleHandler<dim> &particle_handler,
-    DoFHandler<dim>                       &dof_handler,
-    DoFHandler<dim>                       &void_fraction_dof_handler)
+    DoFHandler<dim> &                      dof_handler,
+    DoFHandler<dim> &                      void_fraction_dof_handler)
   {
     const FiniteElement<dim> &fe = this->fe_values.get_fe();
     const FiniteElement<dim> &fe_void_fraction =
@@ -700,8 +700,8 @@ public:
 
   void
   enable_heat_transfer(const FiniteElement<dim> &fe,
-                       const Quadrature<dim>    &quadrature,
-                       const Mapping<dim>       &mapping);
+                       const Quadrature<dim> &   quadrature,
+                       const Mapping<dim> &      mapping);
 
 
   /** @brief Reinitialize the content of the scratch for the heat transfer
@@ -720,7 +720,7 @@ public:
   void
   reinit_heat_transfer(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType                                     &current_solution)
+    const VectorType &                                    current_solution)
   {
     this->fe_values_temperature->reinit(cell);
 

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -50,7 +50,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -59,7 +59,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   const bool SUPG = true;
@@ -94,7 +94,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -103,7 +103,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -40,10 +40,8 @@ class GLSNavierStokesVOFAssemblerCore : public NavierStokesAssemblerBase<dim>
 {
 public:
   GLSNavierStokesVOFAssemblerCore(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties)
+    std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
   {}
 
   /**
@@ -52,7 +50,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -61,13 +59,12 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   const bool SUPG = true;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 };
 
 /**
@@ -87,10 +84,8 @@ class GLSNavierStokesVOFAssemblerBDF : public NavierStokesAssemblerBase<dim>
 {
 public:
   GLSNavierStokesVOFAssemblerBDF(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::PhysicalProperties     physical_properties)
+    std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
   {}
 
   /**
@@ -99,7 +94,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -108,11 +103,10 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 };
 
 #endif

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -34,7 +34,8 @@ DeclException1(
   std::string,
   "The following assembler or post-processing utility "
     << arg1
-    << " that you are trying to use does not support the use of a non-constant density model. Modifications to Lethe are required to take this into account.");
+    << " that you are trying to use does not support the use of a non-constant density model."
+       " Modifications to Lethe are required to take this into account.");
 
 
 DeclException1(
@@ -42,7 +43,8 @@ DeclException1(
   std::string,
   "The following assembler or post-processing utility "
     << arg1
-    << " that you are trying to use does not support the use of a non-constant viscosity model. Modifications to Lethe are required to take this into account.");
+    << " that you are trying to use does not support the use of a non-constant viscosity model. "
+       "Modifications to Lethe are required to take this into account.");
 
 
 
@@ -83,51 +85,88 @@ public:
 
 
   inline unsigned int
-  get_number_of_fluids()
+  get_number_of_fluids() const
   {
     return number_of_fluids;
   }
 
   // Getters for the physical property models
   std::shared_ptr<DensityModel>
-  get_density(unsigned int fluid_id = 0)
+  get_density(const unsigned int fluid_id = 0) const
   {
     return density[fluid_id];
   }
 
   std::shared_ptr<SpecificHeatModel>
-  get_specific_heat(unsigned int fluid_id = 0)
+  get_specific_heat(const unsigned int fluid_id = 0) const
   {
     return specific_heat[fluid_id];
   }
 
   std::shared_ptr<ThermalConductivityModel>
-  get_thermal_conductivity(unsigned int fluid_id = 0)
+  get_thermal_conductivity(const unsigned int fluid_id = 0) const
   {
     return thermal_conductivity[fluid_id];
   }
 
   std::shared_ptr<RheologicalModel>
-  get_rheology(unsigned int fluid_id = 0)
+  get_rheology(const unsigned int fluid_id = 0) const
   {
     return rheology[fluid_id];
   }
 
   std::shared_ptr<ThermalExpansionModel>
-  get_thermal_expansion(unsigned int fluid_id = 0)
+  get_thermal_expansion(const unsigned int fluid_id = 0) const
   {
     return thermal_expansion[fluid_id];
   }
 
   std::shared_ptr<TracerDiffusivityModel>
-  get_tracer_diffusivity(unsigned int fluid_id = 0)
+  get_tracer_diffusivity(const unsigned int fluid_id = 0) const
   {
     return tracer_diffusivity[fluid_id];
   }
 
+  // Vector Getters for the physical property models
+  std::vector<std::shared_ptr<DensityModel>>
+  get_density_vector() const
+  {
+    return density;
+  }
+
+  std::vector<std::shared_ptr<SpecificHeatModel>>
+  get_specific_heat_vector() const
+  {
+    return specific_heat;
+  }
+
+  std::vector<std::shared_ptr<ThermalConductivityModel>>
+  get_thermal_conductivity_vector() const
+  {
+    return thermal_conductivity;
+  }
+
+  std::vector<std::shared_ptr<RheologicalModel>>
+  get_rheology_vector() const
+  {
+    return rheology;
+  }
+
+  std::vector<std::shared_ptr<ThermalExpansionModel>>
+  get_thermal_expansion_vector() const
+  {
+    return thermal_expansion;
+  }
+
+  std::vector<std::shared_ptr<TracerDiffusivityModel>>
+  get_tracer_diffusivity_vector() const
+  {
+    return tracer_diffusivity;
+  }
+
   void
   set_rheology(std::shared_ptr<RheologicalModel> p_rheology,
-               unsigned int                      fluid_id = 0)
+               const unsigned int                fluid_id = 0)
   {
     rheology[fluid_id] = p_rheology;
   }
@@ -139,18 +178,18 @@ public:
   }
 
   bool
-  field_is_required(field id)
+  field_is_required(const field id) const
   {
-    return required_fields[id];
+    return required_fields.at(id);
   }
 
   bool
-  density_is_constant()
+  density_is_constant() const
   {
     return constant_density;
   }
 
-
+private:
   void
   establish_fields_required_by_model(PhysicalPropertyModel &model);
 

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -60,6 +60,8 @@ public:
   void
   initialize(Parameters::PhysicalProperties physical_properties);
 
+
+  // Getters for the physical property models
   std::shared_ptr<DensityModel>
   get_density(unsigned int fluid_id = 0)
   {
@@ -90,6 +92,15 @@ public:
     return non_newtonian_flow;
   }
 
+  bool
+  field_is_required(field id)
+  {
+    return required_fields[id];
+  }
+
+  void
+  establish_fields_required_by_model(PhysicalPropertyModel &model);
+
 
 private:
   bool                                                   is_initialized;
@@ -97,6 +108,8 @@ private:
   std::vector<std::shared_ptr<SpecificHeatModel>>        specific_heat;
   std::vector<std::shared_ptr<ThermalConductivityModel>> thermal_conductivity;
   std::vector<std::shared_ptr<RheologicalModel>>         rheology;
+
+  std::map<field, bool> required_fields;
 
   bool non_newtonian_flow;
 

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -108,7 +108,7 @@ public:
   }
 
   bool
-  is_non_newtonian()
+  is_non_newtonian() const
   {
     return non_newtonian_flow;
   }

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -144,6 +144,9 @@ private:
   bool non_newtonian_flow;
 
   unsigned int number_of_fluids;
+
+  // Viscosity scaling, used for GD solver.
+  double viscosity_scale;
 };
 
 #endif

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -107,6 +107,13 @@ public:
     return tracer_diffusivity[fluid_id];
   }
 
+  void
+  set_rheology(std::shared_ptr<RheologicalModel> p_rheology,
+               unsigned int                      fluid_id = 0)
+  {
+    rheology[fluid_id] = p_rheology;
+  }
+
   bool
   is_non_newtonian() const
   {

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -130,6 +130,13 @@ public:
   establish_fields_required_by_model(PhysicalPropertyModel &model);
 
 
+  // Temporary scaling variables. This will be deprecated once the migration is
+  // well finished.
+public:
+  // Viscosity and density scaling used for some post-processing capabilities.
+  double viscosity_scale;
+  double density_scale;
+
 private:
   bool                                                   is_initialized;
   std::vector<std::shared_ptr<DensityModel>>             density;
@@ -144,9 +151,6 @@ private:
   bool non_newtonian_flow;
 
   unsigned int number_of_fluids;
-
-  // Viscosity scaling, used for GD solver.
-  double viscosity_scale;
 };
 
 #endif

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -61,6 +61,13 @@ public:
   initialize(Parameters::PhysicalProperties physical_properties);
 
 
+
+  inline unsigned int
+  get_number_of_fluids()
+  {
+    return number_of_fluids;
+  }
+
   // Getters for the physical property models
   std::shared_ptr<DensityModel>
   get_density(unsigned int fluid_id = 0)

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -162,8 +162,10 @@ public:
   double viscosity_scale;
   double density_scale;
 
+  bool is_initialized;
+
+
 private:
-  bool                                                   is_initialized;
   std::vector<std::shared_ptr<DensityModel>>             density;
   std::vector<std::shared_ptr<SpecificHeatModel>>        specific_heat;
   std::vector<std::shared_ptr<ThermalConductivityModel>> thermal_conductivity;

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -23,6 +23,8 @@
 #include <core/rheological_model.h>
 #include <core/specific_heat_model.h>
 #include <core/thermal_conductivity_model.h>
+#include <core/thermal_expansion_model.h>
+#include <core/tracer_diffusivity_model.h>
 
 using namespace dealii;
 
@@ -93,6 +95,18 @@ public:
     return rheology[fluid_id];
   }
 
+  std::shared_ptr<ThermalExpansionModel>
+  get_thermal_expansion(unsigned int fluid_id = 0)
+  {
+    return thermal_expansion[fluid_id];
+  }
+
+  std::shared_ptr<TracerDiffusivityModel>
+  get_tracer_diffusivity(unsigned int fluid_id = 0)
+  {
+    return tracer_diffusivity[fluid_id];
+  }
+
   bool
   is_non_newtonian()
   {
@@ -115,6 +129,8 @@ private:
   std::vector<std::shared_ptr<SpecificHeatModel>>        specific_heat;
   std::vector<std::shared_ptr<ThermalConductivityModel>> thermal_conductivity;
   std::vector<std::shared_ptr<RheologicalModel>>         rheology;
+  std::vector<std::shared_ptr<ThermalExpansionModel>>    thermal_expansion;
+  std::vector<std::shared_ptr<TracerDiffusivityModel>>   tracer_diffusivity;
 
   std::map<field, bool> required_fields;
 

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -29,6 +29,23 @@
 using namespace dealii;
 
 
+DeclException1(
+  RequiresConstantDensity,
+  std::string,
+  "The following assembler or post-processing utility "
+    << arg1
+    << " that you are trying to use does not support the use of a non-constant density model. Modifications to Lethe are required to take this into account.");
+
+
+DeclException1(
+  RequiresConstantViscosity,
+  std::string,
+  "The following assembler or post-processing utility "
+    << arg1
+    << " that you are trying to use does not support the use of a non-constant viscosity model. Modifications to Lethe are required to take this into account.");
+
+
+
 /** @class The PhysicalPropertiesManager class manages the physical properties
  * model which are required to calculate the various physical properties
  * This centralizes the place where the models are created.
@@ -45,6 +62,7 @@ public:
    */
   PhysicalPropertiesManager()
     : is_initialized(false)
+
   {}
 
   /**
@@ -126,6 +144,13 @@ public:
     return required_fields[id];
   }
 
+  bool
+  density_is_constant()
+  {
+    return constant_density;
+  }
+
+
   void
   establish_fields_required_by_model(PhysicalPropertyModel &model);
 
@@ -149,6 +174,7 @@ private:
   std::map<field, bool> required_fields;
 
   bool non_newtonian_flow;
+  bool constant_density;
 
   unsigned int number_of_fluids;
 };

--- a/include/solvers/post_processors.h
+++ b/include/solvers/post_processors.h
@@ -179,12 +179,11 @@ class NonNewtonianViscosityPostprocessor : public DataPostprocessorScalar<dim>
 {
 public:
   NonNewtonianViscosityPostprocessor(
-    Parameters::PhysicalProperties p_physical_properties)
+    std::shared_ptr<RheologicalModel> rheological_model)
     : DataPostprocessorScalar<dim>("viscosity", update_gradients)
-  {
-    rheological_model =
-      RheologicalModel::model_cast(p_physical_properties.fluids[0]);
-  }
+    , rheological_model(rheological_model)
+  {}
+
   virtual void
   evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &inputs,
                         std::vector<Vector<double>> &computed_quantities) const

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -40,6 +40,8 @@
 #  include <core/boundary_conditions.h>
 #  include <core/parameters.h>
 
+#  include <solvers/physical_properties_manager.h>
+
 /**
  * @brief Calculate the pressure drop between two boundaries. The pressure drop thus calculated has units of Length^2/Time^2.
  * @return Pressure drop of the flow between two boundaries of the domain
@@ -149,12 +151,11 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
  */
 template <int dim, typename VectorType>
 double
-calculate_apparent_viscosity(
-  const DoFHandler<dim> &               dof_handler,
-  const VectorType &                    evaluation_point,
-  const Quadrature<dim> &               quadrature_formula,
-  const Mapping<dim> &                  mapping,
-  const Parameters::PhysicalProperties &physical_properties);
+calculate_apparent_viscosity(const DoFHandler<dim> &    dof_handler,
+                             const VectorType &         evaluation_point,
+                             const Quadrature<dim> &    quadrature_formula,
+                             const Mapping<dim> &       mapping,
+                             PhysicalPropertiesManager &properties_manager);
 
 /**
  * @brief Calculates the force due to the fluid motion on every boundary conditions
@@ -181,7 +182,7 @@ std::vector<Tensor<1, dim>>
 calculate_forces(
   const DoFHandler<dim> &                              dof_handler,
   const VectorType &                                   evaluation_point,
-  const Parameters::PhysicalProperties &               physical_properties,
+  PhysicalPropertiesManager &                          properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
   const Quadrature<dim - 1> &                          face_quadrature_formula,
   const Mapping<dim> &                                 mapping);
@@ -212,7 +213,7 @@ std::vector<Tensor<1, 3>>
 calculate_torques(
   const DoFHandler<dim> &                              dof_handler,
   const VectorType &                                   evaluation_point,
-  const Parameters::PhysicalProperties &               physical_properties,
+  PhysicalPropertiesManager &                          properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
   const Quadrature<dim - 1> &                          face_quadrature_formula,
   const Mapping<dim> &                                 mapping);

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -28,6 +28,7 @@
 
 #include <solvers/analytical_solutions.h>
 #include <solvers/initial_conditions.h>
+#include <solvers/physical_properties_manager.h>
 #include <solvers/source_terms.h>
 
 #include <dem/dem_solver_parameters.h>
@@ -63,6 +64,8 @@ public:
   Parameters::DynamicFlowControl                    flow_control;
   Parameters::InterfaceSharpening                   interface_sharpening;
   Parameters::Multiphysics                          multiphysics;
+
+  PhysicalPropertiesManager physical_properties_manager;
 
   void
   declare(ParameterHandler &prm)
@@ -140,6 +143,8 @@ public:
     particlesParameters->parse_parameters(prm);
 
     multiphysics.parse_parameters(prm);
+
+    physical_properties_manager.initialize(physical_properties);
 
     // Check consistency of parameters parsed in different subsections
     if (multiphysics.VOF && physical_properties.number_of_fluids != 2)

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -55,9 +55,9 @@ public:
   BoundaryConditions::NSBoundaryConditions<dim>     boundary_conditions;
   BoundaryConditions::HTBoundaryConditions<dim>     boundary_conditions_ht;
   BoundaryConditions::TracerBoundaryConditions<dim> boundary_conditions_tracer;
-  Parameters::InitialConditions<dim>               *initial_condition;
-  AnalyticalSolutions::AnalyticalSolution<dim>     *analytical_solution;
-  SourceTerms::SourceTerm<dim>                     *source_term;
+  Parameters::InitialConditions<dim> *              initial_condition;
+  AnalyticalSolutions::AnalyticalSolution<dim> *    analytical_solution;
+  SourceTerms::SourceTerm<dim> *                    source_term;
   Parameters::VelocitySource                        velocity_sources;
   std::shared_ptr<Parameters::IBParticles<dim>>     particlesParameters;
   Parameters::DynamicFlowControl                    flow_control;

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -55,9 +55,9 @@ public:
   BoundaryConditions::NSBoundaryConditions<dim>     boundary_conditions;
   BoundaryConditions::HTBoundaryConditions<dim>     boundary_conditions_ht;
   BoundaryConditions::TracerBoundaryConditions<dim> boundary_conditions_tracer;
-  Parameters::InitialConditions<dim> *              initial_condition;
-  AnalyticalSolutions::AnalyticalSolution<dim> *    analytical_solution;
-  SourceTerms::SourceTerm<dim> *                    source_term;
+  Parameters::InitialConditions<dim>               *initial_condition;
+  AnalyticalSolutions::AnalyticalSolution<dim>     *analytical_solution;
+  SourceTerms::SourceTerm<dim>                     *source_term;
   Parameters::VelocitySource                        velocity_sources;
   std::shared_ptr<Parameters::IBParticles<dim>>     particlesParameters;
   Parameters::DynamicFlowControl                    flow_control;
@@ -153,7 +153,7 @@ public:
       }
   }
 
-public:
+private:
   Parameters::PhysicalProperties physical_properties;
 };
 

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -45,7 +45,6 @@ public:
   Parameters::Mesh                                  mesh;
   std::shared_ptr<Parameters::MeshBoxRefinement>    mesh_box_refinement;
   std::shared_ptr<Parameters::Nitsche<dim>>         nitsche;
-  Parameters::PhysicalProperties                    physical_properties;
   Parameters::SimulationControl                     simulation_control;
   Parameters::Timer                                 timer;
   Parameters::FEM                                   fem_parameters;
@@ -56,9 +55,9 @@ public:
   BoundaryConditions::NSBoundaryConditions<dim>     boundary_conditions;
   BoundaryConditions::HTBoundaryConditions<dim>     boundary_conditions_ht;
   BoundaryConditions::TracerBoundaryConditions<dim> boundary_conditions_tracer;
-  Parameters::InitialConditions<dim> *              initial_condition;
-  AnalyticalSolutions::AnalyticalSolution<dim> *    analytical_solution;
-  SourceTerms::SourceTerm<dim> *                    source_term;
+  Parameters::InitialConditions<dim>               *initial_condition;
+  AnalyticalSolutions::AnalyticalSolution<dim>     *analytical_solution;
+  SourceTerms::SourceTerm<dim>                     *source_term;
   Parameters::VelocitySource                        velocity_sources;
   std::shared_ptr<Parameters::IBParticles<dim>>     particlesParameters;
   Parameters::DynamicFlowControl                    flow_control;
@@ -153,6 +152,9 @@ public:
           "Inconsistency in .prm!\n with VOF = true\n use: number of fluids = 2");
       }
   }
+
+public:
+  Parameters::PhysicalProperties physical_properties;
 };
 
 #endif

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -53,7 +53,7 @@ class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
   Tracer<dim>(MultiphysicsInterface<dim> *multiphysics_interface,
-              SimulationParameters<dim>  &p_simulation_parameters,
+              SimulationParameters<dim> & p_simulation_parameters,
               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                  p_triangulation,
               std::shared_ptr<SimulationControl> p_simulation_control)
@@ -285,8 +285,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim>                               &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    TracerScratchData<dim> &                              scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -304,8 +304,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim>                               &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    TracerScratchData<dim> &                              scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -342,7 +342,7 @@ private:
   write_tracer_statistics();
 
   MultiphysicsInterface<dim> *multiphysics;
-  SimulationParameters<dim>  &simulation_parameters;
+  SimulationParameters<dim> & simulation_parameters;
 
 
   // Core elements for the tracer

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -52,8 +52,8 @@ template <int dim>
 class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  Tracer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
-              const SimulationParameters<dim> &p_simulation_parameters,
+  Tracer<dim>(MultiphysicsInterface<dim> *multiphysics_interface,
+              SimulationParameters<dim>  &p_simulation_parameters,
               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                  p_triangulation,
               std::shared_ptr<SimulationControl> p_simulation_control)
@@ -285,8 +285,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim> &                              scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    TracerScratchData<dim>                               &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -304,8 +304,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim> &                              scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    TracerScratchData<dim>                               &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -341,8 +341,8 @@ private:
   void
   write_tracer_statistics();
 
-  MultiphysicsInterface<dim> *     multiphysics;
-  const SimulationParameters<dim> &simulation_parameters;
+  MultiphysicsInterface<dim> *multiphysics;
+  SimulationParameters<dim>  &simulation_parameters;
 
 
   // Core elements for the tracer

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -52,8 +52,8 @@ template <int dim>
 class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  Tracer<dim>(MultiphysicsInterface<dim> *multiphysics_interface,
-              SimulationParameters<dim> & p_simulation_parameters,
+  Tracer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
+              const SimulationParameters<dim> &p_simulation_parameters,
               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                  p_triangulation,
               std::shared_ptr<SimulationControl> p_simulation_control)
@@ -341,8 +341,8 @@ private:
   void
   write_tracer_statistics();
 
-  MultiphysicsInterface<dim> *multiphysics;
-  SimulationParameters<dim> & simulation_parameters;
+  MultiphysicsInterface<dim> *     multiphysics;
+  const SimulationParameters<dim> &simulation_parameters;
 
 
   // Core elements for the tracer

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -44,7 +44,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(TracerScratchData<dim> &   scratch_data,
+  assemble_matrix(TracerScratchData<dim>    &scratch_data,
                   StabilizedMethodsCopyData &copy_data) = 0;
 
 
@@ -57,7 +57,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(TracerScratchData<dim> &   scratch_data,
+  assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) = 0;
 };
 
@@ -78,10 +78,8 @@ template <int dim>
 class TracerAssemblerCore : public TracerAssemblerBase<dim>
 {
 public:
-  TracerAssemblerCore(std::shared_ptr<SimulationControl> simulation_control,
-                      Parameters::PhysicalProperties     physical_properties)
+  TracerAssemblerCore(std::shared_ptr<SimulationControl> simulation_control)
     : simulation_control(simulation_control)
-    , physical_properties(physical_properties)
   {}
 
   /**
@@ -90,7 +88,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(TracerScratchData<dim> &   scratch_data,
+  assemble_matrix(TracerScratchData<dim>    &scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
 
@@ -100,13 +98,12 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(TracerScratchData<dim> &   scratch_data,
+  assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   const bool DCDD = true;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  Parameters::PhysicalProperties     physical_properties;
 };
 
 /**
@@ -134,7 +131,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(TracerScratchData<dim> &   scratch_data,
+  assemble_matrix(TracerScratchData<dim>    &scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
   /**
@@ -143,7 +140,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(TracerScratchData<dim> &   scratch_data,
+  assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -44,7 +44,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(TracerScratchData<dim>    &scratch_data,
+  assemble_matrix(TracerScratchData<dim> &   scratch_data,
                   StabilizedMethodsCopyData &copy_data) = 0;
 
 
@@ -57,7 +57,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(TracerScratchData<dim>    &scratch_data,
+  assemble_rhs(TracerScratchData<dim> &   scratch_data,
                StabilizedMethodsCopyData &copy_data) = 0;
 };
 
@@ -88,7 +88,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(TracerScratchData<dim>    &scratch_data,
+  assemble_matrix(TracerScratchData<dim> &   scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
 
@@ -98,7 +98,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(TracerScratchData<dim>    &scratch_data,
+  assemble_rhs(TracerScratchData<dim> &   scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   const bool DCDD = true;
@@ -131,7 +131,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(TracerScratchData<dim>    &scratch_data,
+  assemble_matrix(TracerScratchData<dim> &   scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
   /**
@@ -140,7 +140,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(TracerScratchData<dim>    &scratch_data,
+  assemble_rhs(TracerScratchData<dim> &   scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -77,11 +77,11 @@ public:
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    *
    */
-  TracerScratchData(PhysicalPropertiesManager &properties_manager,
-                    const FiniteElement<dim> & fe_tracer,
-                    const Quadrature<dim> &    quadrature,
-                    const Mapping<dim> &       mapping,
-                    const FiniteElement<dim> & fe_navier_stokes)
+  TracerScratchData(const PhysicalPropertiesManager &properties_manager,
+                    const FiniteElement<dim> &       fe_tracer,
+                    const Quadrature<dim> &          quadrature,
+                    const Mapping<dim> &             mapping,
+                    const FiniteElement<dim> &       fe_navier_stokes)
     : properties_manager(properties_manager)
     , fe_values_tracer(mapping,
                        fe_tracer,

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -18,6 +18,8 @@
 
 #include <core/multiphysics.h>
 
+#include <solvers/physical_properties_manager.h>
+
 #include <deal.II/base/quadrature.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -75,11 +77,13 @@ public:
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    *
    */
-  TracerScratchData(const FiniteElement<dim> &fe_tracer,
-                    const Quadrature<dim> &   quadrature,
-                    const Mapping<dim> &      mapping,
-                    const FiniteElement<dim> &fe_navier_stokes)
-    : fe_values_tracer(mapping,
+  TracerScratchData(PhysicalPropertiesManager &properties_manager,
+                    const FiniteElement<dim>  &fe_tracer,
+                    const Quadrature<dim>     &quadrature,
+                    const Mapping<dim>        &mapping,
+                    const FiniteElement<dim>  &fe_navier_stokes)
+    : properties_manager(properties_manager)
+    , fe_values_tracer(mapping,
                        fe_tracer,
                        quadrature,
                        update_values | update_quadrature_points |
@@ -106,7 +110,8 @@ public:
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    */
   TracerScratchData(const TracerScratchData<dim> &sd)
-    : fe_values_tracer(sd.fe_values_tracer.get_mapping(),
+    : properties_manager(sd.properties_manager)
+    , fe_values_tracer(sd.fe_values_tracer.get_mapping(),
                        sd.fe_values_tracer.get_fe(),
                        sd.fe_values_tracer.get_quadrature(),
                        update_values | update_quadrature_points |
@@ -149,10 +154,10 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
          const std::vector<VectorType> &solution_stages,
-         Function<dim> *                source_function)
+         Function<dim>                 *source_function)
   {
     this->fe_values_tracer.reinit(cell);
 
@@ -216,6 +221,21 @@ public:
     this->fe_values_navier_stokes[velocities].get_function_values(
       current_solution, velocity_values);
   }
+
+  /** @brief Calculates the physical properties. This function calculates the physical properties
+   * that may be required by the tracer. Namely the diffusivity.
+   *
+   */
+  void
+  calculate_physical_properties();
+
+  // Physical properties
+  PhysicalPropertiesManager            properties_manager;
+  std::map<field, std::vector<double>> fields;
+  std::vector<double>                  tracer_diffusivity;
+  std::vector<double>                  tracer_diffusivity_0;
+  std::vector<double>                  tracer_diffusivity_1;
+
 
 
   // FEValues for the Tracer problem

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -78,10 +78,10 @@ public:
    *
    */
   TracerScratchData(PhysicalPropertiesManager &properties_manager,
-                    const FiniteElement<dim>  &fe_tracer,
-                    const Quadrature<dim>     &quadrature,
-                    const Mapping<dim>        &mapping,
-                    const FiniteElement<dim>  &fe_navier_stokes)
+                    const FiniteElement<dim> & fe_tracer,
+                    const Quadrature<dim> &    quadrature,
+                    const Mapping<dim> &       mapping,
+                    const FiniteElement<dim> & fe_navier_stokes)
     : properties_manager(properties_manager)
     , fe_values_tracer(mapping,
                        fe_tracer,
@@ -154,10 +154,10 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType                                     &current_solution,
+         const VectorType &                                    current_solution,
          const std::vector<VectorType> &previous_solutions,
          const std::vector<VectorType> &solution_stages,
-         Function<dim>                 *source_function)
+         Function<dim> *                source_function)
   {
     this->fe_values_tracer.reinit(cell);
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -515,11 +515,6 @@ namespace Parameters
         "Tracer diffusivity for the fluid corresponding to Phase = " +
           Utilities::int_to_string(id, 1));
 
-      prm.declare_entry("non newtonian flow",
-                        "false",
-                        Patterns::Bool(),
-                        "Non Newtonian flow");
-
       prm.declare_entry("rheological model",
                         "newtonian",
                         Patterns::Selection("newtonian|power-law|carreau"),
@@ -605,19 +600,18 @@ namespace Parameters
       phase_change_parameters.parse_parameters(prm);
 
       // Rheology
-      non_newtonian_flow = prm.get_bool("non newtonian flow");
-      op                 = prm.get("rheological model");
+      op = prm.get("rheological model");
       if (op == "power-law")
         {
-          rheology_model = RheologyModel::powerlaw;
+          rheological_model = RheologicalModel::powerlaw;
         }
       else if (op == "carreau")
         {
-          rheology_model = RheologyModel::carreau;
+          rheological_model = RheologicalModel::carreau;
         }
       else if (op == "newtonian")
         {
-          rheology_model = RheologyModel::newtonian;
+          rheological_model = RheologicalModel::newtonian;
         }
       non_newtonian_parameters.parse_parameters(prm);
     }

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -34,7 +34,7 @@ PowerLaw::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
-  return calculate_viscosity(shear_rate_magnitude);
+  return calculate_viscosity(shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
 }
 
 void
@@ -45,7 +45,7 @@ PowerLaw::vector_value(
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
-    property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]);
+    property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]> 1e-12 ? shear_rate_magnitude[i] : 1e-12);
 }
 
 double
@@ -78,7 +78,7 @@ Carreau::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
-  return calculate_viscosity(shear_rate_magnitude);
+  return calculate_viscosity(shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
 }
 
 void
@@ -89,7 +89,7 @@ Carreau::vector_value(const std::map<field, std::vector<double>> &field_vectors,
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
     {
-      property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]);
+      property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]> 1e-12 ? shear_rate_magnitude[i] : 1e-12);
     }
 }
 

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -34,7 +34,8 @@ PowerLaw::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
-  return calculate_viscosity(shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
+  return calculate_viscosity(
+    shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
 }
 
 void
@@ -45,7 +46,8 @@ PowerLaw::vector_value(
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
-    property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]> 1e-12 ? shear_rate_magnitude[i] : 1e-12);
+    property_vector[i] = calculate_viscosity(
+      shear_rate_magnitude[i] > 1e-12 ? shear_rate_magnitude[i] : 1e-12);
 }
 
 double
@@ -78,7 +80,8 @@ Carreau::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
-  return calculate_viscosity(shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
+  return calculate_viscosity(
+    shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
 }
 
 void
@@ -89,7 +92,8 @@ Carreau::vector_value(const std::map<field, std::vector<double>> &field_vectors,
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
     {
-      property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]> 1e-12 ? shear_rate_magnitude[i] : 1e-12);
+      property_vector[i] = calculate_viscosity(
+        shear_rate_magnitude[i] > 1e-12 ? shear_rate_magnitude[i] : 1e-12);
     }
 }
 

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -3,10 +3,11 @@
 std::shared_ptr<RheologicalModel>
 RheologicalModel::model_cast(const Parameters::Fluid &fluid_properties)
 {
-  if (!fluid_properties.non_newtonian_flow)
+  if (fluid_properties.rheological_model ==
+      Parameters::Fluid::RheologicalModel::newtonian)
     return std::make_shared<Newtonian>(fluid_properties.viscosity);
-  else if (fluid_properties.rheology_model ==
-           Parameters::Fluid::RheologyModel::powerlaw)
+  else if (fluid_properties.rheological_model ==
+           Parameters::Fluid::RheologicalModel::powerlaw)
     return std::make_shared<PowerLaw>(
       fluid_properties.non_newtonian_parameters.powerlaw_parameters.K,
       fluid_properties.non_newtonian_parameters.powerlaw_parameters.n,

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -34,8 +34,7 @@ PowerLaw::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
-  return calculate_viscosity(
-    shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
+  return calculate_viscosity(shear_rate_magnitude);
 }
 
 void
@@ -46,8 +45,7 @@ PowerLaw::vector_value(
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
-    property_vector[i] = calculate_viscosity(
-      shear_rate_magnitude[i] > 1e-12 ? shear_rate_magnitude[i] : 1e-12);
+    property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]);
 }
 
 double
@@ -80,8 +78,7 @@ Carreau::value(const std::map<field, double> &field_values)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
-  return calculate_viscosity(
-    shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12);
+  return calculate_viscosity(shear_rate_magnitude);
 }
 
 void
@@ -92,8 +89,7 @@ Carreau::vector_value(const std::map<field, std::vector<double>> &field_vectors,
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
     {
-      property_vector[i] = calculate_viscosity(
-        shear_rate_magnitude[i] > 1e-12 ? shear_rate_magnitude[i] : 1e-12);
+      property_vector[i] = calculate_viscosity(shear_rate_magnitude[i]);
     }
 }
 

--- a/source/core/specific_heat_model.cc
+++ b/source/core/specific_heat_model.cc
@@ -25,6 +25,6 @@ SpecificHeatModel::model_cast(const Parameters::Fluid &fluid_properties)
       fluid_properties.phase_change_parameters);
 
   else
-    return std::make_shared<SpecificHeatConstant>(
+    return std::make_shared<ConstantSpecificHeat>(
       fluid_properties.specific_heat);
 }

--- a/source/core/thermal_conductivity_model.cc
+++ b/source/core/thermal_conductivity_model.cc
@@ -25,6 +25,6 @@ ThermalConductivityModel::model_cast(const Parameters::Fluid &fluid_properties)
                                                        fluid_properties.k_A1);
   else
 
-    return std::make_shared<ThermalConductivityConstant>(
+    return std::make_shared<ConstantThermalConductivity>(
       fluid_properties.thermal_conductivity);
 }

--- a/source/core/thermal_expansion_model.cc
+++ b/source/core/thermal_expansion_model.cc
@@ -19,6 +19,6 @@
 std::shared_ptr<ThermalExpansionModel>
 ThermalExpansionModel::model_cast(const Parameters::Fluid &fluid_properties)
 {
-  return std::make_shared<ThermalExpansionConstant>(
+  return std::make_shared<ConstantThermalExpansion>(
     fluid_properties.thermal_expansion);
 }

--- a/source/core/thermal_expansion_model.cc
+++ b/source/core/thermal_expansion_model.cc
@@ -1,0 +1,24 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/thermal_expansion_model.h>
+
+std::shared_ptr<ThermalExpansionModel>
+ThermalExpansionModel::model_cast(const Parameters::Fluid &fluid_properties)
+{
+  return std::make_shared<ThermalExpansionConstant>(
+    fluid_properties.thermal_expansion);
+}

--- a/source/core/tracer_diffusivity_model.cc
+++ b/source/core/tracer_diffusivity_model.cc
@@ -19,6 +19,6 @@
 std::shared_ptr<TracerDiffusivityModel>
 TracerDiffusivityModel::model_cast(const Parameters::Fluid &fluid_properties)
 {
-  return std::make_shared<TracerDiffusivityConstant>(
+  return std::make_shared<ConstantTracerDiffusivity>(
     fluid_properties.tracer_diffusivity);
 }

--- a/source/core/tracer_diffusivity_model.cc
+++ b/source/core/tracer_diffusivity_model.cc
@@ -1,0 +1,24 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/tracer_diffusivity_model.h>
+
+std::shared_ptr<TracerDiffusivityModel>
+TracerDiffusivityModel::model_cast(const Parameters::Fluid &fluid_properties)
+{
+  return std::make_shared<TracerDiffusivityConstant>(
+    fluid_properties.tracer_diffusivity);
+}

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -527,9 +527,7 @@ GLSVANSSolver<dim>::setup_assemblers()
         {
           // DiFelice Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerDiFelice<dim>>(
-              this->cfd_dem_simulation_parameters.cfd_parameters
-                .physical_properties));
+            std::make_shared<GLSVansAssemblerDiFelice<dim>>());
         }
 
       if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
@@ -537,9 +535,7 @@ GLSVANSSolver<dim>::setup_assemblers()
         {
           // Rong Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerRong<dim>>(
-              this->cfd_dem_simulation_parameters.cfd_parameters
-                .physical_properties));
+            std::make_shared<GLSVansAssemblerRong<dim>>());
         }
 
       if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
@@ -547,9 +543,7 @@ GLSVANSSolver<dim>::setup_assemblers()
         {
           // Dallavalle Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerDallavalle<dim>>(
-              this->cfd_dem_simulation_parameters.cfd_parameters
-                .physical_properties));
+            std::make_shared<GLSVansAssemblerDallavalle<dim>>());
         }
     }
 
@@ -557,7 +551,6 @@ GLSVANSSolver<dim>::setup_assemblers()
     // Buoyancy Force Assembler
     particle_fluid_assemblers.push_back(
       std::make_shared<GLSVansAssemblerBuoyancy<dim>>(
-        this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties,
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
@@ -565,23 +558,18 @@ GLSVANSSolver<dim>::setup_assemblers()
     // Pressure Force
     particle_fluid_assemblers.push_back(
       std::make_shared<GLSVansAssemblerPressureForce<dim>>(
-        this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties,
         this->cfd_dem_simulation_parameters.cfd_dem));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.shear_force == true)
     // Shear Force
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerShearForce<dim>>(
-        this->cfd_dem_simulation_parameters.cfd_parameters
-          .physical_properties));
+      std::make_shared<GLSVansAssemblerShearForce<dim>>());
 
   // Time-stepping schemes
   if (is_bdf(this->simulation_control->get_assembly_method()))
     {
       this->assemblers.push_back(std::make_shared<GLSVansAssemblerBDF<dim>>(
-        this->simulation_control,
-        this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties,
-        this->cfd_dem_simulation_parameters.cfd_dem));
+        this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
     }
 
   //  Fluid_Particle Interactions Assembler
@@ -595,17 +583,13 @@ GLSVANSSolver<dim>::setup_assemblers()
       Parameters::VANSModel::modelA)
     this->assemblers.push_back(
       std::make_shared<GLSVansAssemblerCoreModelA<dim>>(
-        this->simulation_control,
-        this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties,
-        this->cfd_dem_simulation_parameters.cfd_dem));
+        this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.vans_model ==
       Parameters::VANSModel::modelB)
     this->assemblers.push_back(
       std::make_shared<GLSVansAssemblerCoreModelB<dim>>(
-        this->simulation_control,
-        this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties,
-        this->cfd_dem_simulation_parameters.cfd_dem));
+        this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
 }
 
 template <int dim>
@@ -683,6 +667,7 @@ GLSVANSSolver<dim>::assemble_local_system_matrix(
                                                   particle_handler,
                                                   this->dof_handler,
                                                   void_fraction_dof_handler);
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
   for (auto &pf_assembler : particle_fluid_assemblers)
@@ -794,6 +779,7 @@ GLSVANSSolver<dim>::assemble_local_system_rhs(
                                                   this->dof_handler,
                                                   void_fraction_dof_handler);
 
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
   for (auto &pf_assembler : particle_fluid_assemblers)

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -649,8 +649,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -759,8 +759,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -988,6 +988,10 @@ GLSVANSSolver<dim>::post_processing()
 
   QGauss<dim>     cell_quadrature_formula(this->number_quadrature_points);
   QGauss<dim - 1> face_quadrature_formula(this->number_quadrature_points);
+
+  Assert(this->cfd_dem_simulation_parameters.cfd_parameters
+           .physical_properties_manager.density_is_constant(),
+         RequiresConstantDensity("Pressure drop calculation"));
   pressure_drop =
     calculate_pressure_drop(
       this->dof_handler,

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -617,10 +617,12 @@ GLSVANSSolver<dim>::assemble_system_matrix()
 
   setup_assemblers();
 
-  auto scratch_data = NavierStokesScratchData<dim>(*this->fe,
-                                                   *this->cell_quadrature,
-                                                   *this->mapping,
-                                                   *this->face_quadrature);
+  auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    *this->face_quadrature);
 
   scratch_data.enable_void_fraction(fe_void_fraction,
                                     *this->cell_quadrature,
@@ -647,8 +649,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -721,10 +723,12 @@ GLSVANSSolver<dim>::assemble_system_rhs()
 
   setup_assemblers();
 
-  auto scratch_data = NavierStokesScratchData<dim>(*this->fe,
-                                                   *this->cell_quadrature,
-                                                   *this->mapping,
-                                                   *this->face_quadrature);
+  auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    *this->face_quadrature);
 
 
   scratch_data.enable_void_fraction(fe_void_fraction,
@@ -755,8 +759,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -633,8 +633,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -744,8 +744,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -633,8 +633,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -744,8 +744,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -997,9 +997,8 @@ GLSVANSSolver<dim>::post_processing()
       face_quadrature_formula,
       this->cfd_dem_simulation_parameters.cfd_dem.inlet_boundary_id,
       this->cfd_dem_simulation_parameters.cfd_dem.outlet_boundary_id) *
-    this->cfd_dem_simulation_parameters.cfd_parameters.physical_properties
-      .fluids[0]
-      .density;
+    this->cfd_dem_simulation_parameters.cfd_parameters
+      .physical_properties_manager.density_scale;
 
   this->pcout << "Mass Source: " << mass_source << " s^-1" << std::endl;
   this->pcout << "Max Local Mass Source: " << max_local_mass_source << " s^-1"

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -12,7 +12,7 @@ GLSVansAssemblerCoreModelB<dim>::assemble_matrix(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Scheme and physical properties
+  // Viscosity at Gauss points
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
@@ -779,8 +779,19 @@ GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   Tensor<1, dim> relative_velocity;
   Tensor<1, dim> drag_force;
 
-  const double viscosity = scratch_data.viscosity[0];
-  const double density   = scratch_data.density[0];
+
+  // Physical Properties
+  Assert(
+    !scratch_data.properties_manager.is_non_newtonian(),
+    RequiresConstantViscosity(
+      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+  const double viscosity = scratch_data.properties_manager.viscosity_scale;
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+  const double density = scratch_data.properties_manager.density_scale;
 
   const auto pic  = scratch_data.pic;
   beta_drag       = 0;
@@ -845,8 +856,16 @@ GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   Tensor<1, dim> relative_velocity;
   Tensor<1, dim> drag_force;
 
-  const double viscosity = scratch_data.viscosity[0];
-  const double density   = scratch_data.density[0];
+  // Physical Properties
+  Assert(!scratch_data.properties_manager.is_non_newtonian(),
+         RequiresConstantViscosity(
+           "GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
+  const double viscosity = scratch_data.properties_manager.viscosity_scale;
+
+  Assert(scratch_data.properties_manager.density_is_constant(),
+         RequiresConstantDensity(
+           "GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
+  const double density = scratch_data.properties_manager.density_scale;
 
   const auto pic  = scratch_data.pic;
   beta_drag       = 0;
@@ -914,8 +933,18 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   Tensor<1, dim> relative_velocity;
   Tensor<1, dim> drag_force;
 
-  const double viscosity = scratch_data.viscosity[0];
-  const double density   = scratch_data.density[0];
+  // Physical Properties
+  Assert(
+    !scratch_data.properties_manager.is_non_newtonian(),
+    RequiresConstantViscosity(
+      "GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+  const double viscosity = scratch_data.properties_manager.viscosity_scale;
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+  const double density = scratch_data.properties_manager.density_scale;
 
   const auto pic  = scratch_data.pic;
   beta_drag       = 0;
@@ -971,8 +1000,12 @@ GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
   const auto   pic = scratch_data.pic;
   Tensor<1, 3> buoyancy_force;
 
-  const double density = scratch_data.density[0];
-
+  // Physical Properties
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions"));
+  const double density = scratch_data.properties_manager.density_scale;
 
   // Loop over particles in cell
   for (auto &particle : pic)
@@ -1010,10 +1043,14 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
 
   particle_number = 0;
 
-  // Viscosity and density are currently assumed constant from the particle
-  // point of view.
-  const double density = scratch_data.density[0];
+  // Physical Properties
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerPressureForc<dim>::calculate_particle_fluid_interactions"));
 
+
+  const double density = scratch_data.properties_manager.density_scale;
   // Loop over particles in cell
   for (auto &particle : pic)
     {
@@ -1063,8 +1100,18 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
 
   // Viscosity and density are currently assumed constant from the particle
   // point of view.
-  const double viscosity = scratch_data.viscosity[0];
-  const double density   = scratch_data.density[0];
+  // Physical Properties
+  Assert(
+    !scratch_data.properties_manager.is_non_newtonian(),
+    RequiresConstantViscosity(
+      "GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+  const double viscosity = scratch_data.properties_manager.viscosity_scale;
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+  const double density = scratch_data.properties_manager.density_scale;
 
   // Loop over particles in cell
   for (auto &particle : pic)

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1005,6 +1005,7 @@ GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
       "GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions"));
+
   const double density = scratch_data.properties_manager.density_scale;
 
   // Loop over particles in cell

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -768,6 +768,7 @@ GDNavierStokesSolver<dim>::set_initial_condition_fd(
       std::shared_ptr<RheologicalModel> original_viscosity_model =
         this->simulation_parameters.physical_properties_manager.get_rheology();
 
+      // Temporarily set the rheology to be newtonian with predefined viscosity
       std::shared_ptr<Newtonian> temporary_rheology =
         std::make_shared<Newtonian>(
           this->simulation_parameters.initial_condition->viscosity);

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -184,8 +184,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -302,8 +302,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -848,7 +848,7 @@ GDNavierStokesSolver<dim>::setup_ILU()
   system_ilu_preconditioner = std::make_shared<
     BlockSchurPreconditioner<TrilinosWrappers::PreconditionILU>>(
     gamma,
-    this->simulation_parameters.physical_properties.fluids[0].viscosity,
+    this->simulation_parameters.physical_properties_manager.viscosity_scale,
     system_matrix,
     pressure_mass_matrix,
     &(*velocity_ilu_preconditioner),
@@ -934,7 +934,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   if (this->pressure_fem_degree > 1)
     higher_order_elements = true;
   TrilinosWrappers::PreconditionAMG::AdditionalData
-                                      pressure_preconditioner_options(elliptic_pressure,
+                         pressure_preconditioner_options(elliptic_pressure,
                                     higher_order_elements,
                                     n_cycles,
                                     w_cycle,
@@ -945,7 +945,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
                                     output_details,
                                     smoother_type,
                                     coarse_type);
-  Teuchos::ParameterList              pressure_parameter_ml;
+  Teuchos::ParameterList pressure_parameter_ml;
   std::unique_ptr<Epetra_MultiVector> pressure_distributed_constant_modes;
   velocity_preconditioner_options.set_parameters(
     pressure_parameter_ml,
@@ -963,7 +963,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   system_amg_preconditioner = std::make_shared<
     BlockSchurPreconditioner<TrilinosWrappers::PreconditionAMG>>(
     gamma,
-    this->simulation_parameters.physical_properties.fluids[0].viscosity,
+    this->simulation_parameters.physical_properties_manager.viscosity_scale,
     system_matrix,
     pressure_mass_matrix,
     &(*velocity_amg_preconditioner),

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -191,8 +191,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -309,8 +309,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -933,7 +933,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   if (this->pressure_fem_degree > 1)
     higher_order_elements = true;
   TrilinosWrappers::PreconditionAMG::AdditionalData
-                         pressure_preconditioner_options(elliptic_pressure,
+                                      pressure_preconditioner_options(elliptic_pressure,
                                     higher_order_elements,
                                     n_cycles,
                                     w_cycle,
@@ -944,7 +944,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
                                     output_details,
                                     smoother_type,
                                     coarse_type);
-  Teuchos::ParameterList pressure_parameter_ml;
+  Teuchos::ParameterList              pressure_parameter_ml;
   std::unique_ptr<Epetra_MultiVector> pressure_distributed_constant_modes;
   velocity_preconditioner_options.set_parameters(
     pressure_parameter_ml,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -184,8 +184,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -302,8 +302,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -934,7 +934,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   if (this->pressure_fem_degree > 1)
     higher_order_elements = true;
   TrilinosWrappers::PreconditionAMG::AdditionalData
-                         pressure_preconditioner_options(elliptic_pressure,
+                                      pressure_preconditioner_options(elliptic_pressure,
                                     higher_order_elements,
                                     n_cycles,
                                     w_cycle,
@@ -945,7 +945,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
                                     output_details,
                                     smoother_type,
                                     coarse_type);
-  Teuchos::ParameterList pressure_parameter_ml;
+  Teuchos::ParameterList              pressure_parameter_ml;
   std::unique_ptr<Epetra_MultiVector> pressure_distributed_constant_modes;
   velocity_preconditioner_options.set_parameters(
     pressure_parameter_ml,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -110,15 +110,13 @@ GDNavierStokesSolver<dim>::setup_assemblers()
             this->simulation_parameters.physical_properties));
         }
 
-      if (this->simulation_parameters.physical_properties.fluids[0]
-            .non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties_manager
+            .is_non_newtonian())
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(
             std::make_shared<GDNavierStokesAssemblerNonNewtonianCore<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties,
-              gamma));
+              this->simulation_control, gamma));
         }
       else
         {
@@ -772,17 +770,25 @@ GDNavierStokesSolver<dim>::set_initial_condition_fd(
   else if (initial_condition_type == Parameters::InitialConditionType::viscous)
     {
       this->set_nodal_values();
-      double viscosity =
-        this->simulation_parameters.physical_properties.fluids[0].viscosity;
-      this->simulation_parameters.physical_properties.fluids[0].viscosity =
-        this->simulation_parameters.initial_condition->viscosity;
+      std::shared_ptr<RheologicalModel> original_viscosity_model =
+        this->simulation_parameters.physical_properties_manager.get_rheology();
+
+      std::shared_ptr<Newtonian> temporary_rheology =
+        std::make_shared<Newtonian>(
+          this->simulation_parameters.initial_condition->viscosity);
+
+      this->simulation_parameters.physical_properties_manager.set_rheology(
+        temporary_rheology);
+
+
       this->simulation_control->set_assembly_method(
         Parameters::SimulationControl::TimeSteppingMethod::steady);
       PhysicsSolver<
         TrilinosWrappers::MPI::BlockVector>::solve_non_linear_system(false);
       this->finish_time_step_fd();
-      this->simulation_parameters.physical_properties.fluids[0].viscosity =
-        viscosity;
+
+      this->simulation_parameters.physical_properties_manager.set_rheology(
+        original_viscosity_model);
     }
   else
     {

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -224,6 +224,7 @@ GDNavierStokesSolver<dim>::assemble_local_system_matrix(
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
 
@@ -359,6 +360,7 @@ GDNavierStokesSolver<dim>::assemble_local_system_rhs(
                                           PhysicsID::heat_transfer));
     }
 
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
   for (auto &assembler : this->assemblers)
     {

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -142,10 +142,12 @@ GDNavierStokesSolver<dim>::assemble_system_matrix()
   this->system_matrix = 0;
   setup_assemblers();
 
-  auto scratch_data = NavierStokesScratchData<dim>(*this->fe,
-                                                   *this->cell_quadrature,
-                                                   *this->mapping,
-                                                   *this->face_quadrature);
+  auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    *this->face_quadrature);
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
@@ -189,8 +191,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -259,10 +261,12 @@ GDNavierStokesSolver<dim>::assemble_system_rhs()
   this->system_rhs = 0;
   setup_assemblers();
 
-  auto scratch_data = NavierStokesScratchData<dim>(*this->fe,
-                                                   *this->cell_quadrature,
-                                                   *this->mapping,
-                                                   *this->face_quadrature);
+  auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    *this->face_quadrature);
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
@@ -304,8 +308,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -927,7 +931,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   if (this->pressure_fem_degree > 1)
     higher_order_elements = true;
   TrilinosWrappers::PreconditionAMG::AdditionalData
-                                      pressure_preconditioner_options(elliptic_pressure,
+                         pressure_preconditioner_options(elliptic_pressure,
                                     higher_order_elements,
                                     n_cycles,
                                     w_cycle,
@@ -938,7 +942,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
                                     output_details,
                                     smoother_type,
                                     coarse_type);
-  Teuchos::ParameterList              pressure_parameter_ml;
+  Teuchos::ParameterList pressure_parameter_ml;
   std::unique_ptr<Epetra_MultiVector> pressure_distributed_constant_modes;
   velocity_preconditioner_options.set_parameters(
     pressure_parameter_ml,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -67,15 +67,13 @@ GDNavierStokesSolver<dim>::setup_assemblers()
         {
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesVOFAssemblerBDF<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties));
+              this->simulation_control));
         }
 
       // Core assembler
       this->assemblers.push_back(
         std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
-          this->simulation_control,
-          this->simulation_parameters.physical_properties));
+          this->simulation_control));
     }
   else
     {
@@ -105,9 +103,8 @@ GDNavierStokesSolver<dim>::setup_assemblers()
       // Buoyant force
       if (this->simulation_parameters.multiphysics.buoyancy_force)
         {
-          this->assemblers.push_back(std::make_shared<BuoyancyAssembly<dim>>(
-            this->simulation_control,
-            this->simulation_parameters.physical_properties));
+          this->assemblers.push_back(
+            std::make_shared<BuoyancyAssembly<dim>>(this->simulation_control));
         }
 
       if (this->simulation_parameters.physical_properties_manager
@@ -123,9 +120,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
           // Core assembler
           this->assemblers.push_back(
             std::make_shared<GDNavierStokesAssemblerCore<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties,
-              gamma));
+              this->simulation_control, gamma));
         }
     }
 }
@@ -189,8 +184,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -307,8 +302,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -939,7 +934,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
   if (this->pressure_fem_degree > 1)
     higher_order_elements = true;
   TrilinosWrappers::PreconditionAMG::AdditionalData
-                                      pressure_preconditioner_options(elliptic_pressure,
+                         pressure_preconditioner_options(elliptic_pressure,
                                     higher_order_elements,
                                     n_cycles,
                                     w_cycle,
@@ -950,7 +945,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
                                     output_details,
                                     smoother_type,
                                     coarse_type);
-  Teuchos::ParameterList              pressure_parameter_ml;
+  Teuchos::ParameterList pressure_parameter_ml;
   std::unique_ptr<Epetra_MultiVector> pressure_distributed_constant_modes;
   velocity_preconditioner_options.set_parameters(
     pressure_parameter_ml,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -122,7 +122,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto &                 nonzero_constraints = this->get_nonzero_constraints();
+  auto                  &nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -467,10 +467,12 @@ GLSNavierStokesSolver<dim>::assemble_system_matrix_without_preconditioner()
   this->system_matrix = 0;
   setup_assemblers();
 
-  auto scratch_data = NavierStokesScratchData<dim>(*this->fe,
-                                                   *this->cell_quadrature,
-                                                   *this->mapping,
-                                                   *this->face_quadrature);
+  auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    *this->face_quadrature);
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
@@ -480,9 +482,6 @@ GLSNavierStokesSolver<dim>::assemble_system_matrix_without_preconditioner()
                               *this->cell_quadrature,
                               *this->mapping);
     }
-  if (this->simulation_parameters.physical_properties.fluids[0]
-        .non_newtonian_flow)
-    scratch_data.enable_hessian();
 
   WorkStream::run(
     this->dof_handler.begin_active(),
@@ -500,8 +499,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -569,10 +568,12 @@ GLSNavierStokesSolver<dim>::assemble_system_rhs()
   this->system_rhs = 0;
   setup_assemblers();
 
-  auto scratch_data = NavierStokesScratchData<dim>(*this->fe,
-                                                   *this->cell_quadrature,
-                                                   *this->mapping,
-                                                   *this->face_quadrature);
+  auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    *this->face_quadrature);
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
@@ -591,11 +592,6 @@ GLSNavierStokesSolver<dim>::assemble_system_rhs()
                                         *this->cell_quadrature,
                                         *this->mapping);
     }
-
-  if (this->simulation_parameters.physical_properties.fluids[0]
-        .non_newtonian_flow)
-    scratch_data.enable_hessian();
-
 
   WorkStream::run(
     this->dof_handler.begin_active(),
@@ -618,8 +614,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -921,8 +917,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
   const unsigned int smoother_overlap =
     this->simulation_parameters.linear_solver.amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char *                                      smoother_type  = "ILU";
-  const char *                                      coarse_type    = "ILU";
+  const char                                       *smoother_type  = "ILU";
+  const char                                       *coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -122,7 +122,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto                  &nonzero_constraints = this->get_nonzero_constraints();
+  auto &                 nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -364,7 +364,6 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
       this->assemblers.push_back(
         std::make_shared<WeakDirichletBoundaryCondition<dim>>(
           this->simulation_control,
-          this->simulation_parameters.physical_properties,
           this->simulation_parameters.boundary_conditions));
     }
   if (this->check_existance_of_bc(BoundaryConditions::BoundaryType::pressure))
@@ -372,7 +371,6 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
       this->assemblers.push_back(
         std::make_shared<PressureBoundaryCondition<dim>>(
           this->simulation_control,
-          this->simulation_parameters.physical_properties,
           this->simulation_parameters.boundary_conditions));
     }
   if (this->simulation_parameters.multiphysics.VOF)
@@ -494,8 +492,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -611,8 +609,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -924,8 +922,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
   const unsigned int smoother_overlap =
     this->simulation_parameters.linear_solver.amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char                                       *smoother_type  = "ILU";
-  const char                                       *coarse_type    = "ILU";
+  const char *                                      smoother_type  = "ILU";
+  const char *                                      coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -122,7 +122,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto &                 nonzero_constraints = this->get_nonzero_constraints();
+  auto                  &nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -382,15 +382,13 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
         {
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesVOFAssemblerBDF<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties));
+              this->simulation_control));
         }
 
       // Core assembler
       this->assemblers.push_back(
         std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
-          this->simulation_control,
-          this->simulation_parameters.physical_properties));
+          this->simulation_control));
     }
   else
     {
@@ -420,9 +418,8 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
       // Buoyant force
       if (this->simulation_parameters.multiphysics.buoyancy_force)
         {
-          this->assemblers.push_back(std::make_shared<BuoyancyAssembly<dim>>(
-            this->simulation_control,
-            this->simulation_parameters.physical_properties));
+          this->assemblers.push_back(
+            std::make_shared<BuoyancyAssembly<dim>>(this->simulation_control));
         }
 
       if (this->simulation_parameters.physical_properties_manager
@@ -497,8 +494,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -614,8 +611,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -927,8 +924,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
   const unsigned int smoother_overlap =
     this->simulation_parameters.linear_solver.amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char *                                      smoother_type  = "ILU";
-  const char *                                      coarse_type    = "ILU";
+  const char                                       *smoother_type  = "ILU";
+  const char                                       *coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -122,7 +122,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto                  &nonzero_constraints = this->get_nonzero_constraints();
+  auto &                 nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -498,8 +498,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -531,7 +531,7 @@ GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
-  scratch_data.calculate_physical_properties(); 
+  scratch_data.calculate_physical_properties();
 
   copy_data.reset();
 
@@ -615,8 +615,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -666,7 +666,7 @@ GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
                                           PhysicsID::heat_transfer));
     }
 
-  scratch_data.calculate_physical_properties(); 
+  scratch_data.calculate_physical_properties();
 
   copy_data.reset();
 
@@ -920,8 +920,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
   const unsigned int smoother_overlap =
     this->simulation_parameters.linear_solver.amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char                                       *smoother_type  = "ILU";
-  const char                                       *coarse_type    = "ILU";
+  const char *                                      smoother_type  = "ILU";
+  const char *                                      coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -532,6 +532,8 @@ GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
+  scratch_data.calculate_physical_properties(); 
+
   copy_data.reset();
 
 
@@ -664,6 +666,8 @@ GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
                                         *this->multiphysics->get_solution(
                                           PhysicsID::heat_transfer));
     }
+
+  scratch_data.calculate_physical_properties(); 
 
   copy_data.reset();
 

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -439,8 +439,7 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
           // Core assembler
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesAssemblerCore<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties));
+              this->simulation_control));
         }
     }
 }

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -726,6 +726,7 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
       std::shared_ptr<RheologicalModel> original_viscosity_model =
         this->simulation_parameters.physical_properties_manager.get_rheology();
 
+      // Temporarily set the rheology to be newtonian with predefined viscosity
       std::shared_ptr<Newtonian> temporary_rheology =
         std::make_shared<Newtonian>(
           this->simulation_parameters.initial_condition->viscosity);

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -69,7 +69,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_nitsche_restriction()
 
   // Viscosity for stabilization constant
   const double viscosity =
-    this->simulation_parameters.physical_properties.fluids[0].viscosity;
+    this->simulation_parameters.physical_properties_manager.viscosity_scale;
 
   // Time steps and inverse time steps which is used for stabilization constant
   std::vector<double> time_steps_vector =
@@ -251,7 +251,7 @@ GLSNitscheNavierStokesSolver<2, 3>::calculate_forces_on_solid(
   Tensor<1, 3> force; // to be changed for a vector of tensors when
   // allowing multiple solids
   const double viscosity =
-    this->simulation_parameters.physical_properties.fluids[0].viscosity;
+    this->simulation_parameters.physical_properties_manager.viscosity_scale;
 
   // Loop over all local particles
   auto particle = solid_ph->begin();

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -67,6 +67,10 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_nitsche_restriction()
 {
   TimerOutput::Scope t(this->computing_timer, "assemble Nitsche restriction");
 
+  Assert(
+    !this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
+    RequiresConstantViscosity("assemble_nitsche_restriction"));
+
   // Viscosity for stabilization constant
   const double viscosity =
     this->simulation_parameters.physical_properties_manager.viscosity_scale;
@@ -250,6 +254,12 @@ GLSNitscheNavierStokesSolver<2, 3>::calculate_forces_on_solid(
   Tensor<2, 3> fluid_pressure;
   Tensor<1, 3> force; // to be changed for a vector of tensors when
   // allowing multiple solids
+
+
+  Assert(
+    !this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
+    RequiresConstantViscosity("assemble_nitsche_restriction"));
+
   const double viscosity =
     this->simulation_parameters.physical_properties_manager.viscosity_scale;
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1583,7 +1583,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index> &         local_dof_indices,
+  std::vector<types::global_dof_index>          &local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1617,8 +1617,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1640,8 +1640,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2248,8 +2248,7 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
           // Core assembler
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesAssemblerCore<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties));
+              this->simulation_control));
         }
     }
 
@@ -2263,8 +2262,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2309,6 +2308,7 @@ GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
   // check if we assemble the NS eqaution inside the particle or the Laplacien
@@ -2355,8 +2355,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2402,6 +2402,7 @@ GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
   // check if we assemble the NS eqaution inside the particle or the Laplacien

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1580,7 +1580,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index> &         local_dof_indices,
+  std::vector<types::global_dof_index>          &local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1614,8 +1614,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1637,8 +1637,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2196,14 +2196,12 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
         {
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesVOFAssemblerBDF<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties));
+              this->simulation_control));
         }
       // Core assembler
       this->assemblers.push_back(
         std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
-          this->simulation_control,
-          this->simulation_parameters.physical_properties));
+          this->simulation_control));
     }
   else
     {
@@ -2258,8 +2256,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2351,8 +2349,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1583,7 +1583,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index>          &local_dof_indices,
+  std::vector<types::global_dof_index> &         local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1617,8 +1617,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1640,8 +1640,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2262,8 +2262,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2355,8 +2355,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1580,7 +1580,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index> &         local_dof_indices,
+  std::vector<types::global_dof_index>          &local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1614,8 +1614,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1637,8 +1637,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index> &                local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>> &       support_points)
+  std::vector<types::global_dof_index>                 &local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>>        &support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2244,8 +2244,8 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
         }
     }
 
-  assemblers_inside_ib.push_back(std::make_shared<LaplaceAssembly<dim>>(
-    this->simulation_control, this->simulation_parameters.physical_properties));
+  assemblers_inside_ib.push_back(
+    std::make_shared<LaplaceAssembly<dim>>(this->simulation_control));
 }
 
 
@@ -2254,8 +2254,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2347,8 +2347,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1580,7 +1580,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index>          &local_dof_indices,
+  std::vector<types::global_dof_index> &         local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1614,8 +1614,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1637,8 +1637,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2254,8 +2254,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2347,8 +2347,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -230,7 +230,7 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
   std::vector<double> ib_coef = stencil.coefficients(order, length_ratio);
 
   // Rheological model for viscosity properties
-  double viscosity;
+  double     viscosity;
   const auto rheological_model =
     this->simulation_parameters.physical_properties_manager.get_rheology();
 

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -2234,14 +2234,13 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
         }
 
       // Core assemblers
-      if (this->simulation_parameters.physical_properties.fluids[0]
-            .non_newtonian_flow)
+      if (this->simulation_parameters.physical_properties_manager
+            .is_non_newtonian())
         {
           // Core assembler with Non newtonian viscosity
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesAssemblerNonNewtonianCore<dim>>(
-              this->simulation_control,
-              this->simulation_parameters.physical_properties));
+              this->simulation_control));
         }
       else
         {

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -231,11 +231,8 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
 
   // Rheological model for viscosity properties
   double viscosity;
-  // Cast rheological model to either a Newtonian model or one of the
-  // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(
-      this->simulation_parameters.physical_properties.fluids[0]);
+  const auto rheological_model =
+    this->simulation_parameters.physical_properties_manager.get_rheology();
 
   const unsigned int vertices_per_face = GeometryInfo<dim>::vertices_per_face;
   const unsigned int n_q_points_face   = this->face_quadrature->size();

--- a/source/solvers/gls_sharp_navier_stokes.cc
+++ b/source/solvers/gls_sharp_navier_stokes.cc
@@ -72,7 +72,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                        this->dof_handler,
                                        support_points);
   cut_cells_map.clear();
-  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -1580,7 +1580,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p(
-  std::vector<types::global_dof_index>          &local_dof_indices,
+  std::vector<types::global_dof_index> &         local_dof_indices,
   std::map<types::global_dof_index, Point<dim>> &support_points,
   unsigned int                                   p)
 {
@@ -1614,8 +1614,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_cut(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -1637,8 +1637,8 @@ template <int dim>
 std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
 GLSSharpNavierStokesSolver<dim>::cell_inside(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::vector<types::global_dof_index>                 &local_dof_indices,
-  std::map<types::global_dof_index, Point<dim>>        &support_points)
+  std::vector<types::global_dof_index> &                local_dof_indices,
+  std::map<types::global_dof_index, Point<dim>> &       support_points)
 {
   // Check if a cell is cut and if it's rerun the particle by which it's cut and
   // the local DOFs index. The check is done by counting the number of DOFs that
@@ -2178,7 +2178,6 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
       this->assemblers.push_back(
         std::make_shared<WeakDirichletBoundaryCondition<dim>>(
           this->simulation_control,
-          this->simulation_parameters.physical_properties,
           this->simulation_parameters.boundary_conditions));
     }
   if (this->check_existance_of_bc(BoundaryConditions::BoundaryType::pressure))
@@ -2186,7 +2185,6 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
       this->assemblers.push_back(
         std::make_shared<PressureBoundaryCondition<dim>>(
           this->simulation_control,
-          this->simulation_parameters.physical_properties,
           this->simulation_parameters.boundary_conditions));
     }
   if (this->simulation_parameters.multiphysics.VOF)
@@ -2256,8 +2254,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -2349,8 +2347,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -91,7 +91,6 @@ HeatTransfer<dim>::assemble_system_matrix()
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   auto scratch_data = HeatTransferScratchData<dim>(
-    this->simulation_parameters.physical_properties,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
@@ -189,7 +188,6 @@ HeatTransfer<dim>::assemble_system_rhs()
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   auto scratch_data = HeatTransferScratchData<dim>(
-    this->simulation_parameters.physical_properties,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -49,18 +49,13 @@ HeatTransfer<dim>::setup_assemblers()
   // Robin boundary condition
   this->assemblers.push_back(
     std::make_shared<HeatTransferAssemblerRobinBC<dim>>(
-      this->simulation_control,
-      this->simulation_parameters.physical_properties,
-      this->simulation_parameters.multiphysics,
-      simulation_parameters.boundary_conditions_ht));
+      this->simulation_control, simulation_parameters.boundary_conditions_ht));
 
   if (this->simulation_parameters.multiphysics.viscous_dissipation)
     {
       this->assemblers.push_back(
         std::make_shared<HeatTransferAssemblerViscousDissipation<dim>>(
-          this->simulation_control,
-          this->simulation_parameters.physical_properties,
-          this->simulation_parameters.multiphysics));
+          this->simulation_control));
     }
 
   // Time-stepping schemes
@@ -68,16 +63,12 @@ HeatTransfer<dim>::setup_assemblers()
     {
       this->assemblers.push_back(
         std::make_shared<HeatTransferAssemblerBDF<dim>>(
-          this->simulation_control,
-          this->simulation_parameters.physical_properties,
-          this->simulation_parameters.multiphysics));
+          this->simulation_control));
     }
 
   // Core assembler
-  this->assemblers.push_back(std::make_shared<HeatTransferAssemblerCore<dim>>(
-    this->simulation_control,
-    this->simulation_parameters.physical_properties,
-    this->simulation_parameters.multiphysics));
+  this->assemblers.push_back(
+    std::make_shared<HeatTransferAssemblerCore<dim>>(this->simulation_control));
 }
 
 template <int dim>

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -92,6 +92,7 @@ HeatTransfer<dim>::assemble_system_matrix()
 
   auto scratch_data = HeatTransferScratchData<dim>(
     this->simulation_parameters.physical_properties,
+    this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
     *this->temperature_mapping,
@@ -186,6 +187,7 @@ HeatTransfer<dim>::assemble_system_rhs()
 
   auto scratch_data = HeatTransferScratchData<dim>(
     this->simulation_parameters.physical_properties,
+    this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
     *this->temperature_mapping,

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -148,6 +148,9 @@ HeatTransfer<dim>::assemble_local_system_matrix(
       scratch_data.reinit_velocity(
         velocity_cell, *multiphysics->get_solution(PhysicsID::fluid_dynamics));
     }
+
+  scratch_data.calculate_physical_properties();
+
   copy_data.reset();
 
   for (auto &assembler : this->assemblers)
@@ -249,6 +252,8 @@ HeatTransfer<dim>::assemble_local_system_rhs(
       scratch_data.reinit_velocity_gradient(
         *multiphysics->get_solution(PhysicsID::fluid_dynamics));
     }
+
+  scratch_data.calculate_physical_properties();
 
   copy_data.reset();
 

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -312,7 +312,7 @@ HeatTransferAssemblerBDF<dim>::assemble_rhs(
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      double rho_cp = density[q] * specific_heat[q];
+      const double rho_cp = density[q] * specific_heat[q];
 
       const double tau_ggls =
         std::pow(h, scratch_data.fe_values_T.get_fe().degree + 1) / 6. / rho_cp;

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -491,7 +491,7 @@ HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
     {
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double dynamic_viscosity = viscosity[q] * density[q];
+      const double dynamic_viscosity = viscosity[q] * density[q];
 
       // Store JxW in local variable for faster access
       const double JxW = scratch_data.fe_values_T.JxW(q);

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -14,12 +14,11 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = this->physical_properties.fluids[0].density;
-  double specific_heat = this->physical_properties.fluids[0].specific_heat;
-  double thermal_conductivity =
-    this->physical_properties.fluids[0].thermal_conductivity;
-  double rho_cp = density * specific_heat;
-  double alpha  = thermal_conductivity / rho_cp;
+  const std::vector<double> &density       = scratch_data.density;
+  const std::vector<double> &specific_heat = scratch_data.specific_heat;
+  const std::vector<double> &thermal_conductivity =
+    scratch_data.thermal_conductivity;
+
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;
@@ -47,29 +46,8 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
   // assembling local matrix and right hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      if (this->multiphysics_parameters.VOF)
-        {
-          // Calculation of the equivalent physical properties at the
-          // quadrature point
-          density = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].density,
-            this->physical_properties.fluids[1].density);
-
-          specific_heat = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].specific_heat,
-            this->physical_properties.fluids[1].specific_heat);
-
-          thermal_conductivity = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].thermal_conductivity,
-            this->physical_properties.fluids[1].thermal_conductivity);
-
-          // Useful definitions
-          rho_cp = density * specific_heat;
-          alpha  = thermal_conductivity / rho_cp;
-        }
+      const double rho_cp = density[q] * specific_heat[q];
+      const double alpha  = thermal_conductivity[q] / rho_cp;
 
       const auto method = this->simulation_control->get_assembly_method();
 
@@ -112,7 +90,7 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
               // so tau:grad(u) =
               // mu*(grad(u)+transpose(grad(u)).transpose(grad(u))
               local_matrix(i, j) +=
-                (thermal_conductivity * grad_phi_T_i * grad_phi_T_j +
+                (thermal_conductivity[q] * grad_phi_T_i * grad_phi_T_j +
                  rho_cp * phi_T_i * velocity * grad_phi_T_j) *
                 JxW;
 
@@ -135,6 +113,11 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
   const double       h          = scratch_data.cell_size;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
+  const std::vector<double> &density       = scratch_data.density;
+  const std::vector<double> &specific_heat = scratch_data.specific_heat;
+  const std::vector<double> &thermal_conductivity =
+    scratch_data.thermal_conductivity;
+
 
   // Time steps and inverse time steps which is used for stabilization constant
   std::vector<double> time_steps_vector =
@@ -156,37 +139,8 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
 
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double density       = this->physical_properties.fluids[0].density;
-      double specific_heat = this->physical_properties.fluids[0].specific_heat;
-      double thermal_conductivity =
-        this->physical_properties.fluids[0].thermal_conductivity;
-
-      double rho_cp = density * specific_heat;
-      double alpha  = thermal_conductivity / rho_cp;
-
-      if (this->multiphysics_parameters.VOF)
-        {
-          // Calculation of the equivalent physical properties at the
-          // quadrature point
-          density = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].density,
-            this->physical_properties.fluids[1].density);
-
-          specific_heat = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].specific_heat,
-            this->physical_properties.fluids[1].specific_heat);
-
-          thermal_conductivity = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].thermal_conductivity,
-            this->physical_properties.fluids[1].thermal_conductivity);
-
-          // Useful definitions
-          rho_cp = density * specific_heat;
-          alpha  = thermal_conductivity / rho_cp;
-        }
+      double rho_cp = density[q] * specific_heat[q];
+      double alpha  = thermal_conductivity[q] / rho_cp;
 
       // Store JxW in local variable for faster access
       const double JxW = scratch_data.fe_values_T.JxW(q);
@@ -211,7 +165,7 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
 
       // Calculate the strong residual for GLS stabilization
       strong_residual_vec[q] += rho_cp * velocity * temperature_gradient -
-                                thermal_conductivity * temperature_laplacian;
+                                thermal_conductivity[q] * temperature_laplacian;
 
 
       for (unsigned int i = 0; i < n_dofs; ++i)
@@ -222,7 +176,7 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
           // rhs for : - k * laplacian T + rho * cp * u * grad T - f
           // -grad(u)*grad(u) = 0
           local_rhs(i) -=
-            (thermal_conductivity * grad_phi_T_i * temperature_gradient +
+            (thermal_conductivity[q] * grad_phi_T_i * temperature_gradient +
              rho_cp * phi_T_i * velocity * temperature_gradient -
              scratch_data.source[q] * phi_T_i) *
             JxW;
@@ -248,6 +202,9 @@ HeatTransferAssemblerBDF<dim>::assemble_matrix(
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
+  const std::vector<double> &density       = scratch_data.density;
+  const std::vector<double> &specific_heat = scratch_data.specific_heat;
+
   // Copy data elements
   auto &strong_residual = copy_data.strong_residual;
   auto &strong_jacobian = copy_data.strong_jacobian;
@@ -260,9 +217,6 @@ HeatTransferAssemblerBDF<dim>::assemble_matrix(
 
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = this->physical_properties.fluids[0].density;
-  double specific_heat = this->physical_properties.fluids[0].specific_heat;
-  double rho_cp        = density * specific_heat;
 
   const double h = scratch_data.cell_size;
 
@@ -275,24 +229,7 @@ HeatTransferAssemblerBDF<dim>::assemble_matrix(
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      if (this->multiphysics_parameters.VOF)
-        {
-          // Calculation of the equivalent physical properties at the
-          // quadrature point
-          density = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].density,
-            this->physical_properties.fluids[1].density);
-
-          specific_heat = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].specific_heat,
-            this->physical_properties.fluids[1].specific_heat);
-
-          // Useful definitions
-          rho_cp = density * specific_heat;
-        }
-
+      const double rho_cp = density[q] * specific_heat[q];
 
       temperature[0] = scratch_data.present_temperature_values[q];
       for (unsigned int p = 0; p < number_of_previous_solutions(method); ++p)
@@ -347,9 +284,8 @@ HeatTransferAssemblerBDF<dim>::assemble_rhs(
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
-  double density       = this->physical_properties.fluids[0].density;
-  double specific_heat = this->physical_properties.fluids[0].specific_heat;
-  double rho_cp        = density * specific_heat;
+  const std::vector<double> &density       = scratch_data.density;
+  const std::vector<double> &specific_heat = scratch_data.specific_heat;
 
 
   // Loop and quadrature informations
@@ -373,30 +309,14 @@ HeatTransferAssemblerBDF<dim>::assemble_rhs(
   std::vector<Tensor<1, dim>> temperature_gradient(
     1 + number_of_previous_solutions(method));
 
-
-  const double tau_ggls =
-    std::pow(h, scratch_data.fe_values_T.get_fe().degree + 1) / 6. / rho_cp;
-
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      if (this->multiphysics_parameters.VOF)
-        {
-          // Calculation of the equivalent physical properties at the
-          // quadrature point
-          density = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].density,
-            this->physical_properties.fluids[1].density);
+      double rho_cp = density[q] * specific_heat[q];
 
-          specific_heat = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].specific_heat,
-            this->physical_properties.fluids[1].specific_heat);
+      const double tau_ggls =
+        std::pow(h, scratch_data.fe_values_T.get_fe().degree + 1) / 6. / rho_cp;
 
-          // Useful definitions
-          rho_cp = density * specific_heat;
-        }
 
       temperature[0]          = scratch_data.present_temperature_values[q];
       temperature_gradient[0] = scratch_data.temperature_gradients[q];
@@ -552,8 +472,10 @@ HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
   StabilizedMethodsCopyData &   copy_data)
 {
   const unsigned int n_q_points = scratch_data.n_q_points;
+  const unsigned int n_dofs     = scratch_data.n_dofs;
 
-  const unsigned int n_dofs = scratch_data.n_dofs;
+  const std::vector<double> &density   = scratch_data.density;
+  const std::vector<double> &viscosity = scratch_data.viscosity;
 
 
   // Time steps and inverse time steps which is used for stabilization
@@ -569,28 +491,7 @@ HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
     {
       // Gather physical properties in case of mono fluids simulations (to be
       // modified by cell in case of multiple fluids simulations)
-      double density   = this->physical_properties.fluids[0].density;
-      double viscosity = this->physical_properties.fluids[0].viscosity;
-
-      double dynamic_viscosity = viscosity * density;
-
-      if (this->multiphysics_parameters.VOF)
-        {
-          // Calculation of the equivalent physical properties at the
-          // quadrature point
-          density = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].density,
-            this->physical_properties.fluids[1].density);
-
-          viscosity = calculate_point_property(
-            scratch_data.phase_values[q],
-            this->physical_properties.fluids[0].viscosity,
-            this->physical_properties.fluids[1].viscosity);
-
-          // Useful definitions
-          dynamic_viscosity = viscosity * density;
-        }
+      double dynamic_viscosity = viscosity[q] * density[q];
 
       // Store JxW in local variable for faster access
       const double JxW = scratch_data.fe_values_T.JxW(q);

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -32,6 +32,7 @@ HeatTransferScratchData<dim>::allocate()
   this->specific_heat        = std::vector<double>(n_q_points);
   this->thermal_conductivity = std::vector<double>(n_q_points);
   this->density              = std::vector<double>(n_q_points);
+  this->viscosity            = std::vector<double>(n_q_points);
 
   // Velocity for BDF schemes
   this->previous_temperature_values =
@@ -59,6 +60,11 @@ HeatTransferScratchData<dim>::allocate()
     std::vector<std::vector<double>>(n_q_points, std::vector<double>(n_dofs));
 
   // Allocate memory for the physical properties
+  fields.insert(
+    std::pair<field, std::vector<double>>(field::temperature, n_q_points));
+  fields.insert(
+    std::pair<field, std::vector<double>>(field::previous_temperature,
+                                          n_q_points));
   specific_heat        = std::vector<double>(n_q_points);
   density              = std::vector<double>(n_q_points);
   thermal_conductivity = std::vector<double>(n_q_points);
@@ -79,6 +85,20 @@ HeatTransferScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
   previous_vof_values =
     std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
                                      std::vector<double>(this->n_q_points));
+}
+
+
+template <int dim>
+void
+HeatTransferScratchData<dim>::calculate_physical_properties()
+{
+  set_field_vector(field::temperature,
+                   this->present_temperature_values,
+                   this->fields);
+
+  set_field_vector(field::previous_temperature,
+                   this->previous_temperature_values[0],
+                   this->fields);
 }
 
 

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -96,9 +96,34 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
                    this->present_temperature_values,
                    this->fields);
 
-  set_field_vector(field::previous_temperature,
-                   this->previous_temperature_values[0],
-                   this->fields);
+  if (properties_manager.field_is_required(field::previous_temperature))
+    set_field_vector(field::previous_temperature,
+                     this->previous_temperature_values[0],
+                     this->fields);
+
+  if (properties_manager.field_is_required(field::shear_rate))
+    {
+      // TODO calculate shear rate
+    }
+
+
+  // Case where you have one fluid
+  if (properties_manager.get_number_of_fluids() == 1)
+    {
+      const auto density_model       = properties_manager.get_density();
+      const auto specific_heat_model = properties_manager.get_specific_heat();
+      const auto thermal_conductivity_model =
+        properties_manager.get_thermal_conductivity();
+
+      density_model->vector_value(fields, density);
+      specific_heat_model->vector_value(fields, specific_heat);
+      thermal_conductivity_model->vector_value(fields, thermal_conductivity);
+    }
+
+
+  // Case where you have two fluids
+
+  // const auto &density =
 }
 
 

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -80,8 +80,8 @@ HeatTransferScratchData<dim>::allocate()
 template <int dim>
 void
 HeatTransferScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
-                                         const Quadrature<dim>    &quadrature,
-                                         const Mapping<dim>       &mapping)
+                                         const Quadrature<dim> &   quadrature,
+                                         const Mapping<dim> &      mapping)
 {
   gather_vof    = true;
   fe_values_vof = std::make_shared<FEValues<dim>>(

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -69,6 +69,8 @@ HeatTransferScratchData<dim>::allocate()
   fields.insert(
     std::pair<field, std::vector<double>>(field::previous_temperature,
                                           n_q_points));
+  fields.insert(
+    std::pair<field, std::vector<double>>(field::shear_rate, n_q_points));
   specific_heat        = std::vector<double>(n_q_points);
   density              = std::vector<double>(n_q_points);
   thermal_conductivity = std::vector<double>(n_q_points);
@@ -78,8 +80,8 @@ HeatTransferScratchData<dim>::allocate()
 template <int dim>
 void
 HeatTransferScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
-                                         const Quadrature<dim> &   quadrature,
-                                         const Mapping<dim> &      mapping)
+                                         const Quadrature<dim>    &quadrature,
+                                         const Mapping<dim>       &mapping)
 {
   gather_vof    = true;
   fe_values_vof = std::make_shared<FEValues<dim>>(
@@ -147,7 +149,7 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
       density_model->vector_value(fields, density);
       specific_heat_model->vector_value(fields, specific_heat);
       thermal_conductivity_model->vector_value(fields, thermal_conductivity);
-      thermal_conductivity_model->vector_value(fields, viscosity);
+      rheology_model->vector_value(fields, viscosity);
     }
   else // properties_manager.get_number_of_fluids() == 2
     {

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -6,7 +6,7 @@
 
 template <int dim>
 MultiphysicsInterface<dim>::MultiphysicsInterface(
-  SimulationParameters<dim> &                                  nsparam,
+  const SimulationParameters<dim> &                            nsparam,
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> p_triangulation,
   std::shared_ptr<SimulationControl> p_simulation_control,
   ConditionalOStream &               p_pcout)

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -6,10 +6,10 @@
 
 template <int dim>
 MultiphysicsInterface<dim>::MultiphysicsInterface(
-  const SimulationParameters<dim> &                            nsparam,
+  SimulationParameters<dim>                                   &nsparam,
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> p_triangulation,
   std::shared_ptr<SimulationControl> p_simulation_control,
-  ConditionalOStream &               p_pcout)
+  ConditionalOStream                &p_pcout)
   : multiphysics_parameters(nsparam.multiphysics)
   , verbosity(nsparam.non_linear_solver.verbosity)
   , pcout(p_pcout)

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -6,10 +6,10 @@
 
 template <int dim>
 MultiphysicsInterface<dim>::MultiphysicsInterface(
-  SimulationParameters<dim>                                   &nsparam,
+  SimulationParameters<dim> &                                  nsparam,
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> p_triangulation,
   std::shared_ptr<SimulationControl> p_simulation_control,
-  ConditionalOStream                &p_pcout)
+  ConditionalOStream &               p_pcout)
   : multiphysics_parameters(nsparam.multiphysics)
   , verbosity(nsparam.non_linear_solver.verbosity)
   , pcout(p_pcout)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,14 +9,14 @@
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -155,14 +155,14 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -265,14 +265,14 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -438,14 +438,14 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -566,11 +566,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -654,12 +654,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW               = scratch_data.JxW;
-  const auto &       quadrature_points = scratch_data.quadrature_points;
+  const auto        &JxW               = scratch_data.JxW;
+  const auto        &quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -742,11 +742,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -800,11 +800,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -857,11 +857,11 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -925,11 +925,11 @@ GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -987,14 +987,14 @@ template class GLSNavierStokesAssemblerSDIRK<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1068,14 +1068,14 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1138,14 +1138,14 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1215,14 +1215,14 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1282,14 +1282,11 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Scheme and physical properties
-  const double viscosity = physical_properties.fluids[0].viscosity;
-
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1321,11 +1318,12 @@ LaplaceAssembly<dim>::assemble_matrix(
 
               // Laplacian on the velocity terms
               double local_matrix_ij =
-                viscosity * scalar_product(grad_phi_u_j, grad_phi_u_i);
+                scratch_data.viscosity[q] *
+                scalar_product(grad_phi_u_j, grad_phi_u_i);
 
               // Laplacian on the pressure terms
-              local_matrix_ij +=
-                1 / viscosity * h * scalar_product(grad_phi_p_j, grad_phi_p_i);
+              local_matrix_ij += 1 / scratch_data.viscosity[q] * h *
+                                 scalar_product(grad_phi_p_j, grad_phi_p_i);
 
               // The jacobian matrix for the SUPG formulation
               // currently does not include the jacobian of the stabilization
@@ -1343,14 +1341,11 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Scheme and physical properties
-  const double viscosity = physical_properties.fluids[0].viscosity;
-
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1388,12 +1383,12 @@ LaplaceAssembly<dim>::assemble_rhs(
           double local_rhs_i = 0;
 
           // Laplacian on the velocity terms
-          local_rhs_i +=
-            -viscosity * scalar_product(velocity_gradient, grad_phi_u_i) * JxW;
+          local_rhs_i += -scratch_data.viscosity[q] *
+                         scalar_product(velocity_gradient, grad_phi_u_i) * JxW;
 
 
           // Laplacian on the pressure terms
-          local_rhs_i += -1 / viscosity * h *
+          local_rhs_i += -1 / scratch_data.viscosity[q] * h *
                          scalar_product(pressure_gradient, grad_phi_p_i) * JxW;
 
           local_rhs(i) += local_rhs_i;
@@ -1415,11 +1410,11 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1462,7 +1457,7 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1547,7 +1542,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1632,7 +1627,7 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1656,7 +1651,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto & local_matrix = copy_data.local_matrix;
+  auto  &local_matrix = copy_data.local_matrix;
   double beta         = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)
@@ -1738,7 +1733,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1763,7 +1758,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto & local_rhs = copy_data.local_rhs;
+  auto  &local_rhs = copy_data.local_rhs;
   double beta      = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,14 +9,14 @@
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -155,14 +155,14 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -265,14 +265,14 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity      = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -446,14 +446,14 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity      = scratch_data.viscosity;
   
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -583,11 +583,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -671,12 +671,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW               = scratch_data.JxW;
-  const auto        &quadrature_points = scratch_data.quadrature_points;
+  const auto &       JxW               = scratch_data.JxW;
+  const auto &       quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -759,11 +759,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -817,11 +817,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -874,11 +874,11 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -942,11 +942,11 @@ GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1004,11 +1004,11 @@ template class GLSNavierStokesAssemblerSDIRK<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1097,11 +1097,11 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1176,14 +1176,14 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1253,14 +1253,14 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1320,14 +1320,14 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1381,14 +1381,14 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1453,7 +1453,7 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -1461,7 +1461,7 @@ BuoyancyAssembly<dim>::assemble_rhs(
     physical_properties.fluids[0].thermal_expansion;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1501,7 +1501,7 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1585,7 +1585,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1670,7 +1670,7 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1694,7 +1694,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto  &local_matrix = copy_data.local_matrix;
+  auto & local_matrix = copy_data.local_matrix;
   double beta         = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)
@@ -1776,7 +1776,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1801,7 +1801,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto  &local_rhs = copy_data.local_rhs;
+  auto & local_rhs = copy_data.local_rhs;
   double beta      = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,14 +9,14 @@
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -155,14 +155,14 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -265,14 +265,14 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -438,14 +438,14 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -566,11 +566,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -654,12 +654,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW               = scratch_data.JxW;
-  const auto        &quadrature_points = scratch_data.quadrature_points;
+  const auto &       JxW               = scratch_data.JxW;
+  const auto &       quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -742,11 +742,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -800,11 +800,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -857,11 +857,11 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -925,11 +925,11 @@ GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -987,14 +987,14 @@ template class GLSNavierStokesAssemblerSDIRK<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1068,14 +1068,14 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1138,14 +1138,14 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1215,14 +1215,14 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1282,11 +1282,11 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1341,11 +1341,11 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1410,11 +1410,11 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1457,7 +1457,7 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1542,7 +1542,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1627,7 +1627,7 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1651,7 +1651,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto  &local_matrix = copy_data.local_matrix;
+  auto & local_matrix = copy_data.local_matrix;
   double beta         = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)
@@ -1733,7 +1733,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1758,7 +1758,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto  &local_rhs = copy_data.local_rhs;
+  auto & local_rhs = copy_data.local_rhs;
   double beta      = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -313,10 +313,6 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
       shear_rate_magnitude =
         shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12;
 
-      // Calculate de current non newtonian viscosity on each quadrature point
-      std::map<field, double> field_values;
-      field_values[field::shear_rate] = shear_rate_magnitude;
-
       // Calculate viscosity gradient
       const Tensor<1, dim> viscosity_gradient =
         this->get_viscosity_gradient(velocity_gradient,
@@ -486,10 +482,6 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
 
       shear_rate_magnitude =
         shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12;
-
-      // Calculate de current non newtonian viscosity on each quadrature point
-      std::map<field, double> field_values;
-      field_values[field::shear_rate] = shear_rate_magnitude;
 
       // Calculate viscosity gradient
       const Tensor<1, dim> viscosity_gradient =
@@ -1019,18 +1011,6 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
       const Tensor<2, dim> velocity_gradient =
         scratch_data.velocity_gradients[q];
 
-      // Calculate shear rate (at each q)
-      const Tensor<2, dim> shear_rate =
-        velocity_gradient + transpose(velocity_gradient);
-
-      // Calculate the shear rate magnitude
-      const double shear_rate_magnitude =
-        calculate_shear_rate_magnitude(shear_rate);
-
-      // Calculate de current non newtonian viscosity on each quadrature point
-      std::map<field, double> field_values;
-      field_values[field::shear_rate] = shear_rate_magnitude;
-
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
 
@@ -1116,14 +1096,6 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
       // Calculate shear rate (at each q)
       const Tensor<2, dim> shear_rate =
         velocity_gradient + transpose(velocity_gradient);
-
-      // Calculate the shear rate magnitude
-      const double shear_rate_magnitude =
-        calculate_shear_rate_magnitude(shear_rate);
-
-      // Calculate de current non newtonian viscosity on each quadrature point
-      std::map<field, double> field_values;
-      field_values[field::shear_rate] = shear_rate_magnitude;
 
       // Pressure
       const double pressure = scratch_data.pressure_values[q];

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,14 +9,14 @@
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const std::vector<double> &viscosity      = scratch_data.viscosity;
+  const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -155,14 +155,14 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
-  const std::vector<double> &viscosity      = scratch_data.viscosity;
+  const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -265,14 +265,14 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity      = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -446,14 +446,14 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity      = scratch_data.viscosity;
   
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -583,11 +583,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -671,12 +671,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW               = scratch_data.JxW;
-  const auto &       quadrature_points = scratch_data.quadrature_points;
+  const auto        &JxW               = scratch_data.JxW;
+  const auto        &quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -759,11 +759,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -817,11 +817,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -874,11 +874,11 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -942,11 +942,11 @@ GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1004,11 +1004,11 @@ template class GLSNavierStokesAssemblerSDIRK<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1097,11 +1097,11 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1176,14 +1176,14 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1253,14 +1253,14 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1320,14 +1320,14 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1381,14 +1381,14 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1453,7 +1453,7 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -1461,7 +1461,7 @@ BuoyancyAssembly<dim>::assemble_rhs(
     physical_properties.fluids[0].thermal_expansion;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1501,7 +1501,7 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1585,7 +1585,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1670,7 +1670,7 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1694,7 +1694,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto & local_matrix = copy_data.local_matrix;
+  auto  &local_matrix = copy_data.local_matrix;
   double beta         = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)
@@ -1776,7 +1776,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1801,7 +1801,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto & local_rhs = copy_data.local_rhs;
+  auto  &local_rhs = copy_data.local_rhs;
   double beta      = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,14 +9,14 @@
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -155,14 +155,14 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -265,14 +265,14 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -438,14 +438,14 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -566,11 +566,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -654,12 +654,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW               = scratch_data.JxW;
-  const auto &       quadrature_points = scratch_data.quadrature_points;
+  const auto        &JxW               = scratch_data.JxW;
+  const auto        &quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -742,11 +742,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -800,11 +800,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -857,11 +857,11 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -925,11 +925,11 @@ GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -987,14 +987,14 @@ template class GLSNavierStokesAssemblerSDIRK<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1068,14 +1068,14 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1138,14 +1138,14 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1215,14 +1215,14 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1282,14 +1282,14 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1343,14 +1343,14 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1415,15 +1415,11 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Scheme and physical properties
-  const double thermal_expansion =
-    physical_properties.fluids[0].thermal_expansion;
-
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1436,6 +1432,9 @@ BuoyancyAssembly<dim>::assemble_rhs(
     {
       // Forcing term (gravity)
       const Tensor<1, dim> force = scratch_data.force[q];
+
+      const double thermal_expansion = scratch_data.thermal_expansion[q];
+
 
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
@@ -1463,7 +1462,7 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1547,7 +1546,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1632,7 +1631,7 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1656,7 +1655,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto & local_matrix = copy_data.local_matrix;
+  auto  &local_matrix = copy_data.local_matrix;
   double beta         = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)
@@ -1738,7 +1737,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1763,7 +1762,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto & local_rhs = copy_data.local_rhs;
+  auto  &local_rhs = copy_data.local_rhs;
   double beta      = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,14 +9,14 @@
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -155,14 +155,14 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -265,14 +265,14 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -438,14 +438,14 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -566,11 +566,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -654,12 +654,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW               = scratch_data.JxW;
-  const auto        &quadrature_points = scratch_data.quadrature_points;
+  const auto &       JxW               = scratch_data.JxW;
+  const auto &       quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -742,11 +742,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -800,11 +800,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -857,11 +857,11 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -925,11 +925,11 @@ GLSNavierStokesAssemblerSDIRK<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSDIRK<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -987,14 +987,14 @@ template class GLSNavierStokesAssemblerSDIRK<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1068,14 +1068,14 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1138,14 +1138,14 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1215,14 +1215,14 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const std::vector<double> &viscosity = scratch_data.viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1282,14 +1282,14 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1343,14 +1343,14 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
   const double viscosity = physical_properties.fluids[0].viscosity;
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -1415,11 +1415,11 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1462,14 +1462,15 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.fluids[0].viscosity;
+  // To generalize for dependent viscosity
+  const double viscosity = scratch_data.viscosity[0];
 
   // Loop and quadrature informationshessian
   Tensor<2, dim> identity;
@@ -1546,14 +1547,14 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.fluids[0].viscosity;
+  const double viscosity = scratch_data.viscosity[0];
 
   // Loop and quadrature informations
   Tensor<2, dim> identity;
@@ -1631,14 +1632,14 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.fluids[0].viscosity;
+  const double viscosity = scratch_data.viscosity[0];
 
   // Loop and quadrature informations
   Tensor<2, dim> identity;
@@ -1655,7 +1656,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto  &local_matrix = copy_data.local_matrix;
+  auto & local_matrix = copy_data.local_matrix;
   double beta         = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)
@@ -1737,14 +1738,14 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
 
   // Scheme and physical properties
-  const double viscosity = physical_properties.fluids[0].viscosity;
+  const double viscosity = scratch_data.viscosity[0];
 
   // Loop and quadrature informations
   Tensor<2, dim> identity;
@@ -1762,7 +1763,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_rhs(
 
   const double penalty_parameter =
     1. / std::pow(scratch_data.cell_size, fe.degree + 1);
-  auto  &local_rhs = copy_data.local_rhs;
+  auto & local_rhs = copy_data.local_rhs;
   double beta      = boundary_conditions.beta;
   // Loop over the BCs
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions.size; ++i_bc)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -318,8 +318,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
         this->get_viscosity_gradient(velocity_gradient,
                                      velocity_hessian,
                                      shear_rate_magnitude,
-                                     viscosity[q],
-                                     1e-6);
+                                     scratch_data.grad_viscosity_shear_rate[q]);
 
       // Forcing term
       const Tensor<1, dim> force       = scratch_data.force[q];
@@ -488,8 +487,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
         this->get_viscosity_gradient(velocity_gradient,
                                      velocity_hessian,
                                      shear_rate_magnitude,
-                                     viscosity[q],
-                                     1e-6);
+                                     scratch_data.grad_viscosity_shear_rate[q]);
 
       // Pressure
       const double         pressure = scratch_data.pressure_values[q];

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1527,7 +1527,8 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
     simulation_parameters.physical_properties);
   ShearRatePostprocessor<dim> shear_rate_processor;
 
-  if (simulation_parameters.physical_properties.fluids[0].non_newtonian_flow)
+  if (this->simulation_parameters.physical_properties_manager
+        .is_non_newtonian())
     {
       data_out.add_data_vector(solution, non_newtonian_viscosity);
       data_out.add_data_vector(solution, shear_rate_processor);

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -269,7 +269,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocessing_forces(
   this->forces_on_boundaries =
     calculate_forces(this->dof_handler,
                      evaluation_point,
-                     simulation_parameters.physical_properties,
+                     simulation_parameters.physical_properties_manager,
                      simulation_parameters.boundary_conditions,
                      *this->face_quadrature,
                      *this->mapping);
@@ -348,7 +348,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocessing_torques(
   this->torques_on_boundaries =
     calculate_torques(this->dof_handler,
                       evaluation_point,
-                      simulation_parameters.physical_properties,
+                      simulation_parameters.physical_properties_manager,
                       simulation_parameters.boundary_conditions,
                       *this->face_quadrature,
                       *this->mapping);
@@ -1081,7 +1081,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         this->present_solution,
         *this->cell_quadrature,
         *this->mapping,
-        this->simulation_parameters.physical_properties);
+        this->simulation_parameters.physical_properties_manager);
 
       this->apparent_viscosity_table.add_value(
         "time", simulation_control->get_current_time());

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -795,7 +795,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto &                           present_solution = this->present_solution;
+  auto                            &present_solution = this->present_solution;
 
   if (this->simulation_parameters.mesh_adaptation.variable ==
       Parameters::MeshAdaptation::Variable::pressure)
@@ -1131,9 +1131,8 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
           Parameters::Verbosity::verbose)
         {
           this->pcout << "Pressure drop: "
-                      << this->simulation_parameters.physical_properties
-                             .fluids[0]
-                             .density *
+                      << this->simulation_parameters.physical_properties_manager
+                             .density_scale *
                            pressure_drop
                       << " Pa" << std::endl;
         }
@@ -1524,7 +1523,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
     data_out.add_data_vector(solution, srf);
 
   NonNewtonianViscosityPostprocessor<dim> non_newtonian_viscosity(
-    simulation_parameters.physical_properties);
+    this->simulation_parameters.physical_properties_manager.get_rheology());
   ShearRatePostprocessor<dim> shear_rate_processor;
 
   if (this->simulation_parameters.physical_properties_manager

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -795,7 +795,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto                            &present_solution = this->present_solution;
+  auto &                           present_solution = this->present_solution;
 
   if (this->simulation_parameters.mesh_adaptation.variable ==
       Parameters::MeshAdaptation::Variable::pressure)

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -97,8 +97,8 @@ NavierStokesScratchData<dim>::allocate()
 template <int dim>
 void
 NavierStokesScratchData<dim>::enable_VOF(const FiniteElement<dim> &fe,
-                                         const Quadrature<dim>    &quadrature,
-                                         const Mapping<dim>       &mapping)
+                                         const Quadrature<dim> &   quadrature,
+                                         const Mapping<dim> &      mapping)
 {
   gather_VOF    = true;
   fe_values_VOF = std::make_shared<FEValues<dim>>(
@@ -117,8 +117,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_void_fraction(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim>    &quadrature,
-  const Mapping<dim>       &mapping)
+  const Quadrature<dim> &   quadrature,
+  const Mapping<dim> &      mapping)
 {
   gather_void_fraction    = true;
   fe_values_void_fraction = std::make_shared<FEValues<dim>>(
@@ -153,8 +153,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_heat_transfer(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim>    &quadrature,
-  const Mapping<dim>       &mapping)
+  const Quadrature<dim> &   quadrature,
+  const Mapping<dim> &      mapping)
 {
   gather_temperature = true;
   fe_values_temperature =

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -78,8 +78,10 @@ NavierStokesScratchData<dim>::allocate()
   fields.insert(
     std::pair<field, std::vector<double>>(field::shear_rate, n_q_points));
 
-  density   = std::vector<double>(n_q_points);
-  viscosity = std::vector<double>(n_q_points);
+  density                   = std::vector<double>(n_q_points);
+  viscosity                 = std::vector<double>(n_q_points);
+  grad_viscosity_shear_rate = std::vector<double>(n_q_points);
+
 
   density_0   = std::vector<double>(n_q_points);
   density_1   = std::vector<double>(n_q_points);
@@ -192,6 +194,15 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
 
       const auto density_model = properties_manager.get_density(0);
       density_model->vector_value(fields, density);
+
+
+      if (properties_manager.is_non_newtonian())
+        {
+          // Calculate derivative of viscosity with respect to shear rate
+          rheology_model->vector_jacobian(fields,
+                                          field::shear_rate,
+                                          grad_viscosity_shear_rate);
+        }
     }
   else // properties_manager.get_number_of_fluids() == 2
     {

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -211,8 +211,7 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
                                           grad_viscosity_shear_rate);
         }
 
-      if (properties_manager.field_is_required(field::temperature) &&
-          gather_temperature)
+      if (gather_temperature)
         {
           const auto thermal_expansion_model =
             properties_manager.get_thermal_expansion();

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -90,8 +90,8 @@ NavierStokesScratchData<dim>::allocate()
 template <int dim>
 void
 NavierStokesScratchData<dim>::enable_VOF(const FiniteElement<dim> &fe,
-                                         const Quadrature<dim>    &quadrature,
-                                         const Mapping<dim>       &mapping)
+                                         const Quadrature<dim> &   quadrature,
+                                         const Mapping<dim> &      mapping)
 {
   gather_VOF    = true;
   fe_values_VOF = std::make_shared<FEValues<dim>>(
@@ -110,8 +110,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_void_fraction(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim>    &quadrature,
-  const Mapping<dim>       &mapping)
+  const Quadrature<dim> &   quadrature,
+  const Mapping<dim> &      mapping)
 {
   gather_void_fraction    = true;
   fe_values_void_fraction = std::make_shared<FEValues<dim>>(
@@ -146,8 +146,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_heat_transfer(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim>    &quadrature,
-  const Mapping<dim>       &mapping)
+  const Quadrature<dim> &   quadrature,
+  const Mapping<dim> &      mapping)
 {
   gather_temperature = true;
   fe_values_temperature =

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -189,6 +189,9 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
       // In this case, only viscosity is the required property
       const auto rheology_model = properties_manager.get_rheology();
       rheology_model->vector_value(fields, viscosity);
+
+      const auto density_model = properties_manager.get_density(0);
+      density_model->vector_value(fields, density);
     }
   else // properties_manager.get_number_of_fluids() == 2
     {

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -41,6 +41,11 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
   const double density_ratio      = 2;
   double       phase_force_cutoff = 0;
 
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+
   if (scratch_data.density_0[0] < scratch_data.density_1[0] &&
       scratch_data.density_0[0] * density_ratio < scratch_data.density_1[0])
     {
@@ -223,6 +228,11 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
   const double density_ratio      = 2;
   double       phase_force_cutoff = 0;
 
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
 
   if (scratch_data.density_0[0] < scratch_data.density_1[0] &&
       scratch_data.density_0[0] * density_ratio < scratch_data.density_1[0])

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -9,11 +9,11 @@
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -41,18 +41,14 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
   const double density_ratio      = 2;
   double       phase_force_cutoff = 0;
 
-  if (physical_properties.fluids[0].density <
-        physical_properties.fluids[1].density &&
-      physical_properties.fluids[0].density * density_ratio <
-        physical_properties.fluids[1].density)
+  if (scratch_data.density_0[0] < scratch_data.density_1[0] &&
+      scratch_data.density_0[0] * density_ratio < scratch_data.density_1[0])
     {
       // gravity not will be applied for phase < phase_force_cutoff
       phase_force_cutoff = 1e-6;
     }
-  if (physical_properties.fluids[1].density <
-        physical_properties.fluids[0].density &&
-      physical_properties.fluids[1].density * density_ratio <
-        physical_properties.fluids[0].density)
+  if (scratch_data.density_1[0] < scratch_data.density_0[0] &&
+      scratch_data.density_1[0] * density_ratio < scratch_data.density_0[0])
     {
       // gravity not will be applied for phase > phase_force_cutoff
       phase_force_cutoff = 1 - 1e-6;
@@ -88,15 +84,9 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
       const double JxW = JxW_vec[q];
 
       // Calculation of the equivalent density at the quadrature point
-      double density_eq =
-        calculate_point_property(phase_values[q],
-                                 physical_properties.fluids[0].density,
-                                 physical_properties.fluids[1].density);
+      double density_eq = scratch_data.density[q];
 
-      double viscosity_eq =
-        calculate_point_property(phase_values[q],
-                                 physical_properties.fluids[0].viscosity,
-                                 physical_properties.fluids[1].viscosity);
+      double viscosity_eq = scratch_data.viscosity[q];
 
       const double dynamic_viscosity_eq = density_eq * viscosity_eq;
 
@@ -201,11 +191,11 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -233,22 +223,20 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
   const double density_ratio      = 2;
   double       phase_force_cutoff = 0;
 
-  if (physical_properties.fluids[0].density <
-        physical_properties.fluids[1].density &&
-      physical_properties.fluids[0].density * density_ratio <
-        physical_properties.fluids[1].density)
+
+  if (scratch_data.density_0[0] < scratch_data.density_1[0] &&
+      scratch_data.density_0[0] * density_ratio < scratch_data.density_1[0])
     {
       // gravity not will be applied for phase < phase_force_cutoff
       phase_force_cutoff = 1e-6;
     }
-  if (physical_properties.fluids[1].density <
-        physical_properties.fluids[0].density &&
-      physical_properties.fluids[1].density * density_ratio <
-        physical_properties.fluids[0].density)
+  if (scratch_data.density_1[0] < scratch_data.density_0[0] &&
+      scratch_data.density_1[0] * density_ratio < scratch_data.density_0[0])
     {
       // gravity not will be applied for phase > phase_force_cutoff
       phase_force_cutoff = 1 - 1e-6;
     }
+
 
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
@@ -283,16 +271,9 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
       const double JxW = JxW_vec[q];
 
       // Calculation of the equivalent density at the quadrature point
-      double density_eq =
-        calculate_point_property(phase_values[q],
-                                 physical_properties.fluids[0].density,
-                                 physical_properties.fluids[1].density);
+      double density_eq = scratch_data.density[q];
 
-      double viscosity_eq =
-        calculate_point_property(phase_values[q],
-                                 physical_properties.fluids[0].viscosity,
-                                 physical_properties.fluids[1].viscosity);
-
+      double       viscosity_eq         = scratch_data.viscosity[q];
       const double dynamic_viscosity_eq = density_eq * viscosity_eq;
 
       // Calculation of the GLS stabilization parameter. The
@@ -358,11 +339,11 @@ template class GLSNavierStokesVOFAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -382,7 +363,7 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
                                        number_of_previous_solutions(method));
 
   // Phase values and limiters
-  std::vector<double> &             phase_values = scratch_data.phase_values;
+  std::vector<double>              &phase_values = scratch_data.phase_values;
   std::vector<std::vector<double>> &previous_phase_values =
     scratch_data.previous_phase_values;
 
@@ -395,18 +376,12 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
 
       std::vector<double> densities(number_of_previous_solutions(method) + 1);
 
-      densities[0] =
-        calculate_point_property(phase_values[q],
-                                 physical_properties.fluids[0].density,
-                                 physical_properties.fluids[1].density);
+      densities[0] = scratch_data.density[q];
 
       for (unsigned int p = 1; p < number_of_previous_solutions(method) + 1;
            ++p)
         {
-          densities[p] =
-            calculate_point_property(previous_phase_values[p - 1][q],
-                                     physical_properties.fluids[0].density,
-                                     physical_properties.fluids[1].density);
+          densities[p] = scratch_data.previous_density[p - 1][q];
         }
 
       for (unsigned int p = 0; p < number_of_previous_solutions(method) + 1;
@@ -439,11 +414,11 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -462,7 +437,7 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
                                        number_of_previous_solutions(method));
 
   // Phase values and limiters
-  std::vector<double> &             phase_values = scratch_data.phase_values;
+  std::vector<double>              &phase_values = scratch_data.phase_values;
   std::vector<std::vector<double>> &previous_phase_values =
     scratch_data.previous_phase_values;
 
@@ -476,18 +451,12 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
 
       std::vector<double> densities(number_of_previous_solutions(method) + 1);
 
-      densities[0] =
-        calculate_point_property(phase_values[q],
-                                 physical_properties.fluids[0].density,
-                                 physical_properties.fluids[1].density);
+      densities[0] = scratch_data.density[q];
 
       for (unsigned int p = 1; p < number_of_previous_solutions(method) + 1;
            ++p)
         {
-          densities[p] =
-            calculate_point_property(previous_phase_values[p - 1][q],
-                                     physical_properties.fluids[0].density,
-                                     physical_properties.fluids[1].density);
+          densities[p] = scratch_data.previous_density[p - 1][q];
         }
 
       for (unsigned int p = 0; p < number_of_previous_solutions(method) + 1;

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -9,11 +9,11 @@
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -191,11 +191,11 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -339,11 +339,11 @@ template class GLSNavierStokesVOFAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -363,7 +363,7 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
                                        number_of_previous_solutions(method));
 
   // Phase values and limiters
-  std::vector<double>              &phase_values = scratch_data.phase_values;
+  std::vector<double> &             phase_values = scratch_data.phase_values;
   std::vector<std::vector<double>> &previous_phase_values =
     scratch_data.previous_phase_values;
 
@@ -414,11 +414,11 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim>         &scratch_data,
+  NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -437,7 +437,7 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
                                        number_of_previous_solutions(method));
 
   // Phase values and limiters
-  std::vector<double>              &phase_values = scratch_data.phase_values;
+  std::vector<double> &             phase_values = scratch_data.phase_values;
   std::vector<std::vector<double>> &previous_phase_values =
     scratch_data.previous_phase_values;
 

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -362,11 +362,6 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
   std::vector<Tensor<1, dim>> velocity(1 +
                                        number_of_previous_solutions(method));
 
-  // Phase values and limiters
-  std::vector<double> &             phase_values = scratch_data.phase_values;
-  std::vector<std::vector<double>> &previous_phase_values =
-    scratch_data.previous_phase_values;
-
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
@@ -435,11 +430,6 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
   Vector<double> bdf_coefs = bdf_coefficients(method, time_steps_vector);
   std::vector<Tensor<1, dim>> velocity(1 +
                                        number_of_previous_solutions(method));
-
-  // Phase values and limiters
-  std::vector<double> &             phase_values = scratch_data.phase_values;
-  std::vector<std::vector<double>> &previous_phase_values =
-    scratch_data.previous_phase_values;
 
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -16,17 +16,6 @@
 
 #include <solvers/physical_properties_manager.h>
 
-
-PhysicalPropertiesManager::PhysicalPropertiesManager(
-  Parameters::PhysicalProperties physical_properties)
-  : is_initialized(true)
-{
-  initialize(physical_properties);
-  required_fields[field::temperature]          = false;
-  required_fields[field::previous_temperature] = false;
-  required_fields[field::shear_rate]           = false;
-}
-
 void
 PhysicalPropertiesManager::establish_fields_required_by_model(
   PhysicalPropertyModel &model)
@@ -43,16 +32,19 @@ void
 PhysicalPropertiesManager::initialize(
   Parameters::PhysicalProperties physical_properties)
 {
+  is_initialized = true;
+
   number_of_fluids = physical_properties.number_of_fluids;
 
   non_newtonian_flow = false;
+
+  required_fields[field::temperature]          = false;
+  required_fields[field::previous_temperature] = false;
+  required_fields[field::shear_rate]           = false;
+
   // For each fluid, declare the physical properties
   for (unsigned int f = 0; f < number_of_fluids; ++f)
     {
-      required_fields[field::temperature]          = false;
-      required_fields[field::previous_temperature] = false;
-      required_fields[field::shear_rate]           = false;
-
       density.push_back(
         DensityModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model((*density[f]));

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -47,27 +47,27 @@ PhysicalPropertiesManager::initialize(
     {
       density.push_back(
         DensityModel::model_cast(physical_properties.fluids[f]));
-      establish_fields_required_by_model((*density[f]));
+      establish_fields_required_by_model(*density[f]);
 
       specific_heat.push_back(
         SpecificHeatModel::model_cast(physical_properties.fluids[f]));
-      establish_fields_required_by_model((*specific_heat[f]));
+      establish_fields_required_by_model(*specific_heat[f]);
 
       thermal_conductivity.push_back(
         ThermalConductivityModel::model_cast(physical_properties.fluids[f]));
-      establish_fields_required_by_model((*thermal_conductivity[f]));
+      establish_fields_required_by_model(*thermal_conductivity[f]);
 
       rheology.push_back(
         RheologicalModel::model_cast(physical_properties.fluids[f]));
-      this->establish_fields_required_by_model(*(rheology[f]));
+      this->establish_fields_required_by_model(*rheology[f]);
 
       tracer_diffusivity.push_back(
         TracerDiffusivityModel::model_cast(physical_properties.fluids[f]));
-      establish_fields_required_by_model((*tracer_diffusivity[f]));
+      establish_fields_required_by_model(*tracer_diffusivity[f]);
 
       thermal_expansion.push_back(
         ThermalExpansionModel::model_cast(physical_properties.fluids[f]));
-      establish_fields_required_by_model((*thermal_expansion[f]));
+      establish_fields_required_by_model(*thermal_expansion[f]);
 
       if (physical_properties.fluids[f].rheology_model !=
           Parameters::Fluid::RheologyModel::newtonian)

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -22,7 +22,15 @@ PhysicalPropertiesManager::PhysicalPropertiesManager(
   : is_initialized(true)
 {
   initialize(physical_properties);
+  required_fields[field::temperature]          = false;
+  required_fields[field::previous_temperature] = false;
+  required_fields[field::shear_rate]           = false;
 }
+
+void
+PhysicalPropertiesManager::establish_fields_required_by_model(
+  PhysicalPropertyModel &model)
+{}
 
 void
 PhysicalPropertiesManager::initialize(
@@ -36,15 +44,21 @@ PhysicalPropertiesManager::initialize(
     {
       density.push_back(
         DensityModel::model_cast(physical_properties.fluids[f]));
+      establish_fields_required_by_model((*density[f]));
 
       specific_heat.push_back(
         SpecificHeatModel::model_cast(physical_properties.fluids[f]));
+      establish_fields_required_by_model((*specific_heat[f]));
+
 
       thermal_conductivity.push_back(
         ThermalConductivityModel::model_cast(physical_properties.fluids[f]));
+      establish_fields_required_by_model((*thermal_conductivity[f]));
 
       rheology.push_back(
         RheologicalModel::model_cast(physical_properties.fluids[f]));
+      establish_fields_required_by_model((*rheology[f]));
+
       if (physical_properties.fluids[f].rheology_model !=
           Parameters::Fluid::RheologyModel::newtonian)
         non_newtonian_flow = true;

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -36,6 +36,8 @@ PhysicalPropertiesManager::initialize(
 
   number_of_fluids = physical_properties.number_of_fluids;
 
+  viscosity_scale = physical_properties.fluids[0].viscosity;
+
   non_newtonian_flow = false;
 
   required_fields[field::temperature]          = false;

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -49,6 +49,10 @@ PhysicalPropertiesManager::initialize(
   // For each fluid, declare the physical properties
   for (unsigned int f = 0; f < number_of_fluids; ++f)
     {
+      required_fields[field::temperature]          = false;
+      required_fields[field::previous_temperature] = false;
+      required_fields[field::shear_rate]           = false;
+
       density.push_back(
         DensityModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model((*density[f]));
@@ -63,7 +67,7 @@ PhysicalPropertiesManager::initialize(
 
       rheology.push_back(
         RheologicalModel::model_cast(physical_properties.fluids[f]));
-      establish_fields_required_by_model((*rheology[f]));
+      this->establish_fields_required_by_model(*(rheology[f]));
 
       tracer_diffusivity.push_back(
         TracerDiffusivityModel::model_cast(physical_properties.fluids[f]));

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -37,6 +37,7 @@ PhysicalPropertiesManager::initialize(
   number_of_fluids = physical_properties.number_of_fluids;
 
   viscosity_scale = physical_properties.fluids[0].viscosity;
+  density_scale   = physical_properties.fluids[0].density;
 
   non_newtonian_flow = false;
 

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -69,8 +69,8 @@ PhysicalPropertiesManager::initialize(
         ThermalExpansionModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model(*thermal_expansion[f]);
 
-      if (physical_properties.fluids[f].rheology_model !=
-          Parameters::Fluid::RheologyModel::newtonian)
+      if (physical_properties.fluids[f].rheological_model !=
+          Parameters::Fluid::RheologicalModel::newtonian)
         non_newtonian_flow = true;
     }
 }

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -65,6 +65,14 @@ PhysicalPropertiesManager::initialize(
         RheologicalModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model((*rheology[f]));
 
+      tracer_diffusivity.push_back(
+        TracerDiffusivityModel::model_cast(physical_properties.fluids[f]));
+      establish_fields_required_by_model((*tracer_diffusivity[f]));
+
+      thermal_expansion.push_back(
+        ThermalExpansionModel::model_cast(physical_properties.fluids[f]));
+      establish_fields_required_by_model((*thermal_expansion[f]));
+
       if (physical_properties.fluids[f].rheology_model !=
           Parameters::Fluid::RheologyModel::newtonian)
         non_newtonian_flow = true;

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -30,7 +30,14 @@ PhysicalPropertiesManager::PhysicalPropertiesManager(
 void
 PhysicalPropertiesManager::establish_fields_required_by_model(
   PhysicalPropertyModel &model)
-{}
+{
+  // Loop through the map. The use of or (||) is there to ensure
+  // that if a field is already required, it won't be erased.
+  for (auto &f : required_fields)
+    {
+      f.second = f.second || model.depends_on(f.first);
+    }
+}
 
 void
 PhysicalPropertiesManager::initialize(
@@ -49,7 +56,6 @@ PhysicalPropertiesManager::initialize(
       specific_heat.push_back(
         SpecificHeatModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model((*specific_heat[f]));
-
 
       thermal_conductivity.push_back(
         ThermalConductivityModel::model_cast(physical_properties.fluids[f]));

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -40,6 +40,7 @@ PhysicalPropertiesManager::initialize(
   density_scale   = physical_properties.fluids[0].density;
 
   non_newtonian_flow = false;
+  constant_density   = true;
 
   required_fields[field::temperature]          = false;
   required_fields[field::previous_temperature] = false;
@@ -51,6 +52,13 @@ PhysicalPropertiesManager::initialize(
       density.push_back(
         DensityModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model(*density[f]);
+
+      // Store an indicator for the density to indicate if it is not constant
+      // This indicator is used elsewhere in the code to throw assertions
+      // if non-constant density is not implemented in a post-processing utility
+      if (physical_properties.fluids[f].density_model !=
+          Parameters::Fluid::DensityModel::constant)
+        constant_density = false;
 
       specific_heat.push_back(
         SpecificHeatModel::model_cast(physical_properties.fluids[f]));

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -425,21 +425,17 @@ calculate_kinetic_energy<3, TrilinosWrappers::MPI::BlockVector>(
 
 template <int dim, typename VectorType>
 double
-calculate_apparent_viscosity(
-  const DoFHandler<dim> &               dof_handler,
-  const VectorType &                    evaluation_point,
-  const Quadrature<dim> &               quadrature_formula,
-  const Mapping<dim> &                  mapping,
-  const Parameters::PhysicalProperties &physical_properties)
+calculate_apparent_viscosity(const DoFHandler<dim> &    dof_handler,
+                             const VectorType &         evaluation_point,
+                             const Quadrature<dim> &    quadrature_formula,
+                             const Mapping<dim> &       mapping,
+                             PhysicalPropertiesManager &properties_manager)
 {
-  double integral_viscosity_x_shear_rate = 0;
-  double integral_shear_rate             = 0;
-  double shear_rate_magnitude;
-  double viscosity;
-  // Cast rheological model to either a Newtonian model or one of the
-  // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(physical_properties.fluids[0]);
+  double     integral_viscosity_x_shear_rate = 0;
+  double     integral_shear_rate             = 0;
+  double     shear_rate_magnitude;
+  double     viscosity;
+  const auto rheological_model = properties_manager.get_rheology();
 
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -490,19 +486,19 @@ calculate_apparent_viscosity(
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                 dof_handler,
-  const TrilinosWrappers::MPI::Vector & evaluation_point,
-  const Quadrature<2> &                 quadrature_formula,
-  const Mapping<2> &                    mapping,
-  const Parameters::PhysicalProperties &physical_properties);
+  const DoFHandler<2> &                dof_handler,
+  const TrilinosWrappers::MPI::Vector &evaluation_point,
+  const Quadrature<2> &                quadrature_formula,
+  const Mapping<2> &                   mapping,
+  PhysicalPropertiesManager &          properties_manager);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                 dof_handler,
-  const TrilinosWrappers::MPI::Vector & evaluation_point,
-  const Quadrature<3> &                 quadrature_formula,
-  const Mapping<3> &                    mapping,
-  const Parameters::PhysicalProperties &physical_properties);
+  const DoFHandler<3> &                dof_handler,
+  const TrilinosWrappers::MPI::Vector &evaluation_point,
+  const Quadrature<3> &                quadrature_formula,
+  const Mapping<3> &                   mapping,
+  PhysicalPropertiesManager &          properties_manager);
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::BlockVector>(
@@ -510,7 +506,7 @@ calculate_apparent_viscosity<2, TrilinosWrappers::MPI::BlockVector>(
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const Quadrature<2> &                     quadrature_formula,
   const Mapping<2> &                        mapping,
-  const Parameters::PhysicalProperties &    physical_properties);
+  PhysicalPropertiesManager &               properties_manager);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::BlockVector>(
@@ -518,14 +514,14 @@ calculate_apparent_viscosity<3, TrilinosWrappers::MPI::BlockVector>(
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const Quadrature<3> &                     quadrature_formula,
   const Mapping<3> &                        mapping,
-  const Parameters::PhysicalProperties &    physical_properties);
+  PhysicalPropertiesManager &               properties_manager);
 
 template <int dim, typename VectorType>
 std::vector<Tensor<1, dim>>
 calculate_forces(
   const DoFHandler<dim> &                              dof_handler,
   const VectorType &                                   evaluation_point,
-  const Parameters::PhysicalProperties &               physical_properties,
+  PhysicalPropertiesManager &                          properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
   const Quadrature<dim - 1> &                          face_quadrature_formula,
   const Mapping<dim> &                                 mapping)
@@ -533,11 +529,8 @@ calculate_forces(
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
   // Rheological model for viscosity properties
-  double viscosity;
-  // Cast rheological model to either a Newtonian model or one of the
-  // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(physical_properties.fluids[0]);
+  double     viscosity;
+  const auto rheological_model = properties_manager.get_rheology();
 
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
@@ -623,7 +616,7 @@ template std::vector<Tensor<1, 2>>
 calculate_forces<2, TrilinosWrappers::MPI::Vector>(
   const DoFHandler<2> &                              dof_handler,
   const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
   const Quadrature<1> &                              face_quadrature_formula,
   const Mapping<2> &                                 mapping);
@@ -631,7 +624,7 @@ template std::vector<Tensor<1, 3>>
 calculate_forces<3, TrilinosWrappers::MPI::Vector>(
   const DoFHandler<3> &                              dof_handler,
   const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
   const Quadrature<2> &                              face_quadrature_formula,
   const Mapping<3> &                                 mapping);
@@ -640,7 +633,7 @@ template std::vector<Tensor<1, 2>>
 calculate_forces<2, TrilinosWrappers::MPI::BlockVector>(
   const DoFHandler<2> &                              dof_handler,
   const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
   const Quadrature<1> &                              face_quadrature_formula,
   const Mapping<2> &                                 mapping);
@@ -649,7 +642,7 @@ template std::vector<Tensor<1, 3>>
 calculate_forces<3, TrilinosWrappers::MPI::BlockVector>(
   const DoFHandler<3> &                              dof_handler,
   const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
   const Quadrature<2> &                              face_quadrature_formula,
   const Mapping<3> &                                 mapping);
@@ -660,7 +653,7 @@ std::vector<Tensor<1, 3>>
 calculate_torques(
   const DoFHandler<dim> &                              dof_handler,
   const VectorType &                                   evaluation_point,
-  const Parameters::PhysicalProperties &               physical_properties,
+  PhysicalPropertiesManager &                          properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
   const Quadrature<dim - 1> &                          face_quadrature_formula,
   const Mapping<dim> &                                 mapping)
@@ -668,11 +661,8 @@ calculate_torques(
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
   // Rheological model for viscosity properties
-  double viscosity;
-  // Cast rheological model to either a Newtonian model or one of the
-  // non Newtonian models according to the physical properties
-  std::shared_ptr<RheologicalModel> rheological_model =
-    RheologicalModel::model_cast(physical_properties.fluids[0]);
+  double     viscosity;
+  const auto rheological_model = properties_manager.get_rheology();
 
 
   const unsigned int               n_q_points = face_quadrature_formula.size();
@@ -775,7 +765,7 @@ template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::Vector>(
   const DoFHandler<2> &                              dof_handler,
   const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
   const Quadrature<1> &                              face_quadrature_formula,
   const Mapping<2> &                                 mapping);
@@ -783,7 +773,7 @@ template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::Vector>(
   const DoFHandler<3> &                              dof_handler,
   const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
   const Quadrature<2> &                              face_quadrature_formula,
   const Mapping<3> &                                 mapping);
@@ -792,7 +782,7 @@ template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::BlockVector>(
   const DoFHandler<2> &                              dof_handler,
   const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
   const Quadrature<1> &                              face_quadrature_formula,
   const Mapping<2> &                                 mapping);
@@ -801,7 +791,7 @@ template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::BlockVector>(
   const DoFHandler<3> &                              dof_handler,
   const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  const Parameters::PhysicalProperties &             physical_properties,
+  PhysicalPropertiesManager &                        properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
   const Quadrature<2> &                              face_quadrature_formula,
   const Mapping<3> &                                 mapping);

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -76,8 +76,8 @@ template <int dim>
 void
 Tracer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  TracerScratchData<dim>                               &scratch_data,
-  StabilizedMethodsCopyData                            &copy_data)
+  TracerScratchData<dim> &                              scratch_data,
+  StabilizedMethodsCopyData &                           copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -171,8 +171,8 @@ template <int dim>
 void
 Tracer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  TracerScratchData<dim>                               &scratch_data,
-  StabilizedMethodsCopyData                            &copy_data)
+  TracerScratchData<dim> &                              scratch_data,
+  StabilizedMethodsCopyData &                           copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -39,8 +39,8 @@ Tracer<dim>::setup_assemblers()
         std::make_shared<TracerAssemblerBDF<dim>>(this->simulation_control));
     }
   // Core assembler
-  this->assemblers.push_back(std::make_shared<TracerAssemblerCore<dim>>(
-    this->simulation_control, this->simulation_parameters.physical_properties));
+  this->assemblers.push_back(
+    std::make_shared<TracerAssemblerCore<dim>>(this->simulation_control));
 }
 
 template <int dim>
@@ -53,10 +53,12 @@ Tracer<dim>::assemble_system_matrix()
   const DoFHandler<dim> *dof_handler_fluid =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
-  auto scratch_data = TracerScratchData<dim>(*this->fe,
-                                             *this->cell_quadrature,
-                                             *this->mapping,
-                                             dof_handler_fluid->get_fe());
+  auto scratch_data = TracerScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    dof_handler_fluid->get_fe());
 
   WorkStream::run(this->dof_handler.begin_active(),
                   this->dof_handler.end(),
@@ -74,8 +76,8 @@ template <int dim>
 void
 Tracer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  TracerScratchData<dim> &                              scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  TracerScratchData<dim>                               &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -107,6 +109,8 @@ Tracer<dim>::assemble_local_system_matrix(
       scratch_data.reinit_velocity(
         velocity_cell, *multiphysics->get_solution(PhysicsID::fluid_dynamics));
     }
+
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
   for (auto &assembler : this->assemblers)
@@ -144,10 +148,12 @@ Tracer<dim>::assemble_system_rhs()
   const DoFHandler<dim> *dof_handler_fluid =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
-  auto scratch_data = TracerScratchData<dim>(*this->fe,
-                                             *this->cell_quadrature,
-                                             *this->mapping,
-                                             dof_handler_fluid->get_fe());
+  auto scratch_data = TracerScratchData<dim>(
+    this->simulation_parameters.physical_properties_manager,
+    *this->fe,
+    *this->cell_quadrature,
+    *this->mapping,
+    dof_handler_fluid->get_fe());
 
   WorkStream::run(this->dof_handler.begin_active(),
                   this->dof_handler.end(),
@@ -165,8 +171,8 @@ template <int dim>
 void
 Tracer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  TracerScratchData<dim> &                              scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  TracerScratchData<dim>                               &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -199,6 +205,7 @@ Tracer<dim>::assemble_local_system_rhs(
         velocity_cell, *multiphysics->get_solution(PhysicsID::fluid_dynamics));
     }
 
+  scratch_data.calculate_physical_properties();
   copy_data.reset();
 
   for (auto &assembler : this->assemblers)

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -15,7 +15,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
   const auto method = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -126,7 +126,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
 
 template <int dim>
 void
-TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
+TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim> &   scratch_data,
                                        StabilizedMethodsCopyData &copy_data)
 {
   // Scheme and physical properties
@@ -134,7 +134,7 @@ TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
   const auto method = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature informations
-  const auto        &JxW_vec    = scratch_data.JxW;
+  const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -231,7 +231,7 @@ TracerAssemblerBDF<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
                                          StabilizedMethodsCopyData &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -283,11 +283,11 @@ TracerAssemblerBDF<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
 
 template <int dim>
 void
-TracerAssemblerBDF<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
+TracerAssemblerBDF<dim>::assemble_rhs(TracerScratchData<dim> &   scratch_data,
                                       StabilizedMethodsCopyData &copy_data)
 {
   // Loop and quadrature informations
-  const auto        &JxW        = scratch_data.JxW;
+  const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/solvers/tracer_scratch_data.cc
+++ b/source/solvers/tracer_scratch_data.cc
@@ -59,31 +59,38 @@ void
 TracerScratchData<dim>::calculate_physical_properties()
 {
   // Case where you have one fluid
-  if (properties_manager.get_number_of_fluids() == 1)
+  switch (properties_manager.get_number_of_fluids())
     {
-      // In this case, only viscosity is the required property
-      const auto diffusivity_model =
-        properties_manager.get_tracer_diffusivity();
-      diffusivity_model->vector_value(fields, tracer_diffusivity);
-    }
-  else // properties_manager.get_number_of_fluids() == 2
-    {
-      // In this case,  we need both density and viscosity
-      const auto diffusivity_model_0 = properties_manager.get_density(0);
-      const auto diffusivity_model_1 = properties_manager.get_density(1);
-
-      diffusivity_model_0->vector_value(fields, tracer_diffusivity_0);
-      diffusivity_model_1->vector_value(fields, tracer_diffusivity_1);
-
-      // Incomplete at the present time because the tracer VOF complete is not
-      // finished Blend the physical properties using the VOF field
-      for (unsigned int q = 0; q < this->n_q_points; ++q)
+      case 1:
         {
-          //          tracer_diffusivity[q] =
-          //            calculate_point_property(this->phase_values[q],
-          //                                     this->density_0[q],
-          //                                     this->density_1[q]);
+          // In this case, only viscosity is the required property
+          const auto diffusivity_model =
+            properties_manager.get_tracer_diffusivity();
+          diffusivity_model->vector_value(fields, tracer_diffusivity);
+          break;
         }
+      case 2:
+        {
+          // In this case,  we need both density and viscosity
+          const auto diffusivity_models =
+            properties_manager.get_tracer_diffusivity_vector();
+
+          diffusivity_models[0]->vector_value(fields, tracer_diffusivity_0);
+          diffusivity_models[1]->vector_value(fields, tracer_diffusivity_1);
+
+          // Incomplete at the present time because the tracer VOF complete is
+          // not finished Blend the physical properties using the VOF field
+          for (unsigned int q = 0; q < this->n_q_points; ++q)
+            {
+              //          tracer_diffusivity[q] =
+              //            calculate_point_property(this->phase_values[q],
+              //                                     this->density_0[q],
+              //                                     this->density_1[q]);
+            }
+          break;
+        }
+      default:
+        throw std::runtime_error("Unsupported number of fluids (>2)");
     }
 }
 

--- a/source/solvers/tracer_scratch_data.cc
+++ b/source/solvers/tracer_scratch_data.cc
@@ -22,9 +22,13 @@ TracerScratchData<dim>::allocate()
   // Velocity
   this->velocity_values = std::vector<Tensor<1, dim>>(n_q_points);
   // Tracer
-  this->tracer_values     = std::vector<double>(n_q_points);
-  this->tracer_gradients  = std::vector<Tensor<1, dim>>(n_q_points);
-  this->tracer_laplacians = std::vector<double>(n_q_points);
+  this->tracer_values        = std::vector<double>(n_q_points);
+  this->tracer_gradients     = std::vector<Tensor<1, dim>>(n_q_points);
+  this->tracer_laplacians    = std::vector<double>(n_q_points);
+  this->tracer_diffusivity   = std::vector<double>(n_q_points);
+  this->tracer_diffusivity_0 = std::vector<double>(n_q_points);
+  this->tracer_diffusivity_1 = std::vector<double>(n_q_points);
+
 
   // Velocity for BDF schemes
   this->previous_tracer_values =
@@ -47,6 +51,40 @@ TracerScratchData<dim>::allocate()
     n_q_points, std::vector<Tensor<2, dim>>(n_dofs));
   this->laplacian_phi =
     std::vector<std::vector<double>>(n_q_points, std::vector<double>(n_dofs));
+}
+
+
+template <int dim>
+void
+TracerScratchData<dim>::calculate_physical_properties()
+{
+  // Case where you have one fluid
+  if (properties_manager.get_number_of_fluids() == 1)
+    {
+      // In this case, only viscosity is the required property
+      const auto diffusivity_model =
+        properties_manager.get_tracer_diffusivity();
+      diffusivity_model->vector_value(fields, tracer_diffusivity);
+    }
+  else // properties_manager.get_number_of_fluids() == 2
+    {
+      // In this case,  we need both density and viscosity
+      const auto diffusivity_model_0 = properties_manager.get_density(0);
+      const auto diffusivity_model_1 = properties_manager.get_density(1);
+
+      diffusivity_model_0->vector_value(fields, tracer_diffusivity_0);
+      diffusivity_model_1->vector_value(fields, tracer_diffusivity_1);
+
+      // Incomplete at the present time because the tracer VOF complete is not
+      // finished Blend the physical properties using the VOF field
+      for (unsigned int q = 0; q < this->n_q_points; ++q)
+        {
+          //          tracer_diffusivity[q] =
+          //            calculate_point_property(this->phase_values[q],
+          //                                     this->density_0[q],
+          //                                     this->density_1[q]);
+        }
+    }
 }
 
 

--- a/tests/core/specific_heat_constant.cc
+++ b/tests/core/specific_heat_constant.cc
@@ -16,7 +16,7 @@ test()
   std::map<field, double> field_values;
 
 
-  SpecificHeatConstant specific_heat_model(5);
+  ConstantSpecificHeat specific_heat_model(5);
 
   deallog << "Testing specific heat" << std::endl;
 

--- a/tests/core/thermal_conductivity_constant.cc
+++ b/tests/core/thermal_conductivity_constant.cc
@@ -13,7 +13,7 @@ test()
 {
   deallog << "Beggining" << std::endl;
 
-  ThermalConductivityConstant thermal_conductivity_model(5);
+  ConstantThermalConductivity thermal_conductivity_model(5);
 
   deallog << "Testing thermal conductivity - k" << std::endl;
 

--- a/tests/core/thermal_expansion_constant.cc
+++ b/tests/core/thermal_expansion_constant.cc
@@ -1,5 +1,5 @@
 /**
- * @brief Tests the constant density model. This model should always return a constant.
+ * @brief Tests the constant thermal expansion model. This model should always return a constant.
  */
 
 // Lethe

--- a/tests/core/thermal_expansion_constant.cc
+++ b/tests/core/thermal_expansion_constant.cc
@@ -1,0 +1,66 @@
+/**
+ * @brief Tests the constant density model. This model should always return a constant.
+ */
+
+// Lethe
+#include <core/thermal_expansion_model.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beggining" << std::endl;
+
+
+  ThermalExpansionConstant model(5);
+
+  deallog << "Testing thermal expansion" << std::endl;
+
+  // field values can remain empty since the constant thermal expansion does
+  // not depend on any fields
+  std::map<field, double> field_values;
+
+  deallog << " T = 1    , thermal expansion = " << model.value(field_values)
+          << std::endl;
+  deallog << " T = 2    , thermal expansion = " << model.value(field_values)
+          << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/thermal_expansion_constant.cc
+++ b/tests/core/thermal_expansion_constant.cc
@@ -14,7 +14,7 @@ test()
   deallog << "Beggining" << std::endl;
 
 
-  ThermalExpansionConstant model(5);
+  ConstantThermalExpansion model(5);
 
   deallog << "Testing thermal expansion" << std::endl;
 

--- a/tests/core/thermal_expansion_constant.output
+++ b/tests/core/thermal_expansion_constant.output
@@ -1,0 +1,6 @@
+
+DEAL::Beggining
+DEAL::Testing thermal expansion
+DEAL:: T = 1    , thermal expansion = 5.00000
+DEAL:: T = 2    , thermal expansion = 5.00000
+DEAL::OK

--- a/tests/core/tracer_diffusivity_constant.cc
+++ b/tests/core/tracer_diffusivity_constant.cc
@@ -1,5 +1,5 @@
 /**
- * @brief Tests the constant density model. This model should always return a constant.
+ * @brief Tests the constant tracer diffusivity model. This model should always return a constant.
  */
 
 // Lethe

--- a/tests/core/tracer_diffusivity_constant.cc
+++ b/tests/core/tracer_diffusivity_constant.cc
@@ -1,0 +1,66 @@
+/**
+ * @brief Tests the constant density model. This model should always return a constant.
+ */
+
+// Lethe
+#include <core/tracer_diffusivity_model.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beggining" << std::endl;
+
+
+  TracerDiffusivityConstant model(5);
+
+  deallog << "Testing tracer diffusivity" << std::endl;
+
+  // field values can remain empty since the constant thermal expansion does
+  // not depend on any fields
+  std::map<field, double> field_values;
+
+  deallog << " T = 1    , tracer diffusivity = " << model.value(field_values)
+          << std::endl;
+  deallog << " T = 2    , tracer diffusivity = " << model.value(field_values)
+          << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/tracer_diffusivity_constant.cc
+++ b/tests/core/tracer_diffusivity_constant.cc
@@ -14,7 +14,7 @@ test()
   deallog << "Beggining" << std::endl;
 
 
-  TracerDiffusivityConstant model(5);
+  ConstantTracerDiffusivity model(5);
 
   deallog << "Testing tracer diffusivity" << std::endl;
 

--- a/tests/core/tracer_diffusivity_constant.output
+++ b/tests/core/tracer_diffusivity_constant.output
@@ -1,0 +1,6 @@
+
+DEAL::Beggining
+DEAL::Testing tracer diffusivity
+DEAL:: T = 1    , tracer diffusivity = 5.00000
+DEAL:: T = 2    , tracer diffusivity = 5.00000
+DEAL::OK

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -47,7 +47,8 @@ test()
   physical_properties.fluids[0].thermal_conductivity = 3;
   physical_properties.fluids[0].specific_heat        = 2;
 
-  PhysicalPropertiesManager physical_properties_manager(physical_properties);
+  PhysicalPropertiesManager physical_properties_manager;
+  physical_properties_manager.initialize(physical_properties);
 
   std::map<field, double> dummy_fields;
 

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -34,7 +34,7 @@ public:
 template <int dim>
 void
 ExactSolutionMMS<dim>::vector_value(const Point<dim> &p,
-                                    Vector<double>   &values) const
+                                    Vector<double> &  values) const
 {
   assert(dim == 2);
   const double a = M_PI;
@@ -58,7 +58,7 @@ public:
 template <int dim>
 void
 MMSSineForcingFunction<dim>::vector_value(const Point<dim> &p,
-                                          Vector<double>   &values) const
+                                          Vector<double> &  values) const
 {
   assert(dim == 2);
   const double a = M_PI;

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -34,7 +34,7 @@ public:
 template <int dim>
 void
 ExactSolutionMMS<dim>::vector_value(const Point<dim> &p,
-                                    Vector<double> &  values) const
+                                    Vector<double>   &values) const
 {
   assert(dim == 2);
   const double a = M_PI;
@@ -58,7 +58,7 @@ public:
 template <int dim>
 void
 MMSSineForcingFunction<dim>::vector_value(const Point<dim> &p,
-                                          Vector<double> &  values) const
+                                          Vector<double>   &values) const
 {
   assert(dim == 2);
   const double a = M_PI;
@@ -100,9 +100,15 @@ RestartNavierStokes<dim>::run()
   this->setup_dofs_fd();
   this->exact_solution   = new ExactSolutionMMS<dim>;
   this->forcing_function = new MMSSineForcingFunction<dim>;
-  this->simulation_parameters.physical_properties.fluids.push_back(
-    Parameters::Fluid());
-  this->simulation_parameters.physical_properties.fluids[0].viscosity = 1.;
+  Parameters::PhysicalProperties physical_properties;
+  physical_properties.fluids.push_back(Parameters::Fluid());
+  physical_properties.number_of_fluids = 1;
+  physical_properties.fluids[0].rheological_model =
+    Parameters::Fluid::RheologicalModel::newtonian;
+  physical_properties.fluids[0].viscosity = 1;
+
+  this->simulation_parameters.physical_properties_manager.initialize(
+    physical_properties);
 
   this->simulation_control->print_progression(this->pcout);
   this->iterate();


### PR DESCRIPTION
# Description of the problem

- The Physical Property Manager was developed and well implemented, but it was not used yet in the assemblers and scratch

# Description of the solution

- Add the usage of the physical Property manager in 

- [x] Heat Transfer
- [x] Tracer
- [x] Fluid Dynamics
- [x] VANS

- Add the physical properties model for tracer diffusivity and thermal expansion coefficient

# How Has This Been Tested?

- If all previous tests are working, I think everything is a go
- Added a new test for linear thermal conductivity (gls_navier_stokes_2d/heat_transfer_linear_thermal_conductivity.prm) which tests a steady-state heat problem with a linear thermal conductivity (k= 1+2*T). It converges pretty well. This enabled me to fix some bugs

# Documentation

Documentation has been adapted to take into account the changes.


# Future changes

-  Integrate the locally evaluated density and viscosity for the CFD-DEM models.


