### PR TITLE
Clean VOF solver

### DIFF
--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -46,7 +46,7 @@ namespace Parameters
 
     // subparameter for free_surface
     bool conservation_monitoring;
-    int  monitor_fluid_id;
+    int  id_fluid_monitored;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -90,7 +90,7 @@ public:
                           const FiniteElement<dim> &      fe_ht,
                           const Quadrature<dim> &         quadrature,
                           const Mapping<dim> &            mapping,
-                          const FiniteElement<dim> &      fe_navier_stokes,
+                          const FiniteElement<dim> &      fe_fd,
                           const Quadrature<dim - 1> &     face_quadrature)
     : properties_manager(properties_manager)
     , fe_values_T(mapping,
@@ -98,10 +98,7 @@ public:
                   quadrature,
                   update_values | update_quadrature_points | update_JxW_values |
                     update_gradients | update_hessians)
-    , fe_values_navier_stokes(mapping,
-                              fe_navier_stokes,
-                              quadrature,
-                              update_values | update_gradients)
+    , fe_values_fd(mapping, fe_fd, quadrature, update_values | update_gradients)
     , fe_face_values_ht(mapping,
                         fe_ht,
                         face_quadrature,
@@ -132,10 +129,10 @@ public:
                   sd.fe_values_T.get_quadrature(),
                   update_values | update_quadrature_points | update_JxW_values |
                     update_gradients | update_hessians)
-    , fe_values_navier_stokes(sd.fe_values_navier_stokes.get_mapping(),
-                              sd.fe_values_navier_stokes.get_fe(),
-                              sd.fe_values_navier_stokes.get_quadrature(),
-                              update_values | update_gradients)
+    , fe_values_fd(sd.fe_values_fd.get_mapping(),
+                   sd.fe_values_fd.get_fe(),
+                   sd.fe_values_fd.get_quadrature(),
+                   update_values | update_gradients)
     , fe_face_values_ht(sd.fe_face_values_ht.get_mapping(),
                         sd.fe_face_values_ht.get_fe(),
                         sd.fe_face_values_ht.get_quadrature(),
@@ -285,18 +282,18 @@ public:
   reinit_velocity(const typename DoFHandler<dim>::active_cell_iterator &cell,
                   const VectorType &current_solution)
   {
-    this->fe_values_navier_stokes.reinit(cell);
+    this->fe_values_fd.reinit(cell);
 
-    this->fe_values_navier_stokes[velocities].get_function_values(
-      current_solution, velocity_values);
+    this->fe_values_fd[velocities].get_function_values(current_solution,
+                                                       velocity_values_fd);
   }
 
   template <typename VectorType>
   void
   reinit_velocity_gradient(const VectorType &current_solution)
   {
-    this->fe_values_navier_stokes[velocities].get_function_gradients(
-      current_solution, velocity_gradient_values);
+    this->fe_values_fd[velocities].get_function_gradients(
+      current_solution, velocity_gradient_values_fd);
   }
 
 
@@ -427,9 +424,9 @@ public:
    */
   FEValuesExtractors::Vector velocities;
   // This FEValues must mandatorily be instantiated for the velocity
-  FEValues<dim>               fe_values_navier_stokes;
-  std::vector<Tensor<1, dim>> velocity_values;
-  std::vector<Tensor<2, dim>> velocity_gradient_values;
+  FEValues<dim>               fe_values_fd;
+  std::vector<Tensor<1, dim>> velocity_values_fd;
+  std::vector<Tensor<2, dim>> velocity_gradient_values_fd;
   std::vector<double>         shear_rate_values;
 
   // Scratch for the face boundary condition

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -285,7 +285,7 @@ public:
     this->fe_values_fd.reinit(cell);
 
     this->fe_values_fd[velocities].get_function_values(current_solution,
-                                                       velocity_values_fd);
+                                                       velocity_values);
   }
 
   template <typename VectorType>
@@ -293,7 +293,7 @@ public:
   reinit_velocity_gradient(const VectorType &current_solution)
   {
     this->fe_values_fd[velocities].get_function_gradients(
-      current_solution, velocity_gradient_values_fd);
+      current_solution, velocity_gradient_values);
   }
 
 
@@ -425,8 +425,8 @@ public:
   FEValuesExtractors::Vector velocities;
   // This FEValues must mandatorily be instantiated for the velocity
   FEValues<dim>               fe_values_fd;
-  std::vector<Tensor<1, dim>> velocity_values_fd;
-  std::vector<Tensor<2, dim>> velocity_gradient_values_fd;
+  std::vector<Tensor<1, dim>> velocity_values;
+  std::vector<Tensor<2, dim>> velocity_gradient_values;
   std::vector<double>         shear_rate_values;
 
   // Scratch for the face boundary condition

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -81,17 +81,14 @@ public:
                     const FiniteElement<dim> &       fe_tracer,
                     const Quadrature<dim> &          quadrature,
                     const Mapping<dim> &             mapping,
-                    const FiniteElement<dim> &       fe_navier_stokes)
+                    const FiniteElement<dim> &       fe_fd)
     : properties_manager(properties_manager)
     , fe_values_tracer(mapping,
                        fe_tracer,
                        quadrature,
                        update_values | update_quadrature_points |
                          update_JxW_values | update_gradients | update_hessians)
-    , fe_values_navier_stokes(mapping,
-                              fe_navier_stokes,
-                              quadrature,
-                              update_values)
+    , fe_values_fd(mapping, fe_fd, quadrature, update_values)
   {
     allocate();
   }
@@ -116,10 +113,10 @@ public:
                        sd.fe_values_tracer.get_quadrature(),
                        update_values | update_quadrature_points |
                          update_JxW_values | update_gradients | update_hessians)
-    , fe_values_navier_stokes(sd.fe_values_navier_stokes.get_mapping(),
-                              sd.fe_values_navier_stokes.get_fe(),
-                              sd.fe_values_navier_stokes.get_quadrature(),
-                              update_values)
+    , fe_values_fd(sd.fe_values_fd.get_mapping(),
+                   sd.fe_values_fd.get_fe(),
+                   sd.fe_values_fd.get_quadrature(),
+                   update_values)
   {
     allocate();
   }
@@ -216,10 +213,10 @@ public:
   reinit_velocity(const typename DoFHandler<dim>::active_cell_iterator &cell,
                   const VectorType &current_solution)
   {
-    this->fe_values_navier_stokes.reinit(cell);
+    this->fe_values_fd.reinit(cell);
 
-    this->fe_values_navier_stokes[velocities].get_function_values(
-      current_solution, velocity_values);
+    this->fe_values_fd[velocities].get_function_values(current_solution,
+                                                       velocity_values);
   }
 
   /** @brief Calculates the physical properties. This function calculates the physical properties
@@ -270,7 +267,7 @@ public:
    */
   FEValuesExtractors::Vector velocities;
   // This FEValues must mandatorily be instantiated for the velocity
-  FEValues<dim>               fe_values_navier_stokes;
+  FEValues<dim>               fe_values_fd;
   std::vector<Tensor<1, dim>> velocity_values;
 };
 

--- a/include/solvers/vof_assemblers.h
+++ b/include/solvers/vof_assemblers.h
@@ -104,8 +104,6 @@ public:
   assemble_rhs(VOFScratchData<dim> &      scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
-  const bool DCDD = true;
-
   std::shared_ptr<SimulationControl> simulation_control;
   Parameters::FEM                    fem_parameters;
 };

--- a/include/solvers/vof_assemblers.h
+++ b/include/solvers/vof_assemblers.h
@@ -104,6 +104,9 @@ public:
   assemble_rhs(VOFScratchData<dim> &      scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
+  // enable/disable DCDD shock capturing model, for debugging purposes
+  const bool DCDD = true;
+
   std::shared_ptr<SimulationControl> simulation_control;
   Parameters::FEM                    fem_parameters;
 };

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -200,9 +200,9 @@ public:
     fe_values_fd.reinit(cell);
 
     fe_values_fd[velocities_fd].get_function_values(current_solution,
-                                                    velocity_values_fd);
+                                                    velocity_values);
     fe_values_fd[velocities_fd].get_function_gradients(
-      current_solution, velocity_gradient_values_fd);
+      current_solution, velocity_gradient_values);
   }
 
   // FEValues for the VOF problem
@@ -236,8 +236,8 @@ public:
 
   FEValuesExtractors::Vector velocities_fd;
   // This FEValues must mandatorily be instantiated for the velocity
-  std::vector<Tensor<1, dim>> velocity_values_fd;
-  std::vector<Tensor<2, dim>> velocity_gradient_values_fd;
+  std::vector<Tensor<1, dim>> velocity_values;
+  std::vector<Tensor<2, dim>> velocity_gradient_values;
 };
 
 #endif

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -62,26 +62,24 @@ public:
    * necessary memory for all member variables. However, it does not do any
    * evalution, since this needs to be done at the cell level.
    *
-   * @param fe The FESystem used to solve the VOF equations
+   * @param fe_vof The FESystem used to solve the VOF equations
    *
    * @param quadrature The quadrature to use for the assembly
    *
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    *
    */
-  VOFScratchData(const FiniteElement<dim> &fe_fs,
+  VOFScratchData(const FiniteElement<dim> &fe_vof,
                  const Quadrature<dim> &   quadrature,
                  const Mapping<dim> &      mapping,
-                 const FiniteElement<dim> &fe_navier_stokes)
-    : fe_values_fs(mapping,
-                   fe_fs,
-                   quadrature,
-                   update_values | update_gradients | update_quadrature_points |
-                     update_hessians | update_JxW_values)
-    , fe_values_navier_stokes(mapping,
-                              fe_navier_stokes,
-                              quadrature,
-                              update_values | update_gradients)
+                 const FiniteElement<dim> &fe_fd)
+    : fe_values_vof(mapping,
+                    fe_vof,
+                    quadrature,
+                    update_values | update_gradients |
+                      update_quadrature_points | update_hessians |
+                      update_JxW_values)
+    , fe_values_fd(mapping, fe_fd, quadrature, update_values | update_gradients)
   {
     allocate();
   }
@@ -100,15 +98,16 @@ public:
    * @param mapping The mapping of the domain in which the Navier-Stokes equations are solved
    */
   VOFScratchData(const VOFScratchData<dim> &sd)
-    : fe_values_fs(sd.fe_values_fs.get_mapping(),
-                   sd.fe_values_fs.get_fe(),
-                   sd.fe_values_fs.get_quadrature(),
-                   update_values | update_gradients | update_quadrature_points |
-                     update_hessians | update_JxW_values)
-    , fe_values_navier_stokes(sd.fe_values_navier_stokes.get_mapping(),
-                              sd.fe_values_navier_stokes.get_fe(),
-                              sd.fe_values_navier_stokes.get_quadrature(),
-                              update_values | update_gradients)
+    : fe_values_vof(sd.fe_values_vof.get_mapping(),
+                    sd.fe_values_vof.get_fe(),
+                    sd.fe_values_vof.get_quadrature(),
+                    update_values | update_gradients |
+                      update_quadrature_points | update_hessians |
+                      update_JxW_values)
+    , fe_values_fd(sd.fe_values_fd.get_mapping(),
+                   sd.fe_values_fd.get_fe(),
+                   sd.fe_values_fd.get_quadrature(),
+                   update_values | update_gradients)
   {
     allocate();
   }
@@ -136,8 +135,6 @@ public:
    *
    * @param solution_stages The solution at the intermediary stages (for SDIRK methods)
    *
-   * @param source_function The function describing the VOF source term
-   *
    */
 
   template <typename VectorType>
@@ -147,48 +144,49 @@ public:
          const std::vector<VectorType> &previous_solutions,
          const std::vector<VectorType> &solution_stages)
   {
-    this->fe_values_fs.reinit(cell);
-    quadrature_points = this->fe_values_fs.get_quadrature_points();
-    auto &fe_fs       = this->fe_values_fs.get_fe();
+    fe_values_vof.reinit(cell);
+    this->quadrature_points = fe_values_vof.get_quadrature_points();
+    auto &fe_vof            = fe_values_vof.get_fe();
 
     if (dim == 2)
-      this->cell_size = std::sqrt(4. * cell->measure() / M_PI) / fe_fs.degree;
+      this->cell_size = std::sqrt(4. * cell->measure() / M_PI) / fe_vof.degree;
     else if (dim == 3)
-      this->cell_size = pow(6 * cell->measure() / M_PI, 1. / 3.) / fe_fs.degree;
+      this->cell_size =
+        pow(6 * cell->measure() / M_PI, 1. / 3.) / fe_vof.degree;
 
-    this->fe_values_fs.get_function_values(current_solution,
-                                           this->present_phase_values);
-    this->fe_values_fs.get_function_gradients(current_solution,
-                                              this->phase_gradients);
-    this->fe_values_fs.get_function_laplacians(current_solution,
-                                               this->phase_laplacians);
+    fe_values_vof.get_function_values(current_solution,
+                                      this->present_phase_values);
+    fe_values_vof.get_function_gradients(current_solution,
+                                         this->phase_gradients);
+    fe_values_vof.get_function_laplacians(current_solution,
+                                          this->phase_laplacians);
 
 
     // Gather previous fs values
     for (unsigned int p = 0; p < previous_solutions.size(); ++p)
       {
-        this->fe_values_fs.get_function_values(previous_solutions[p],
-                                               previous_phase_values[p]);
+        fe_values_vof.get_function_values(previous_solutions[p],
+                                          this->previous_phase_values[p]);
       }
 
     // Gather fs stages
     for (unsigned int s = 0; s < solution_stages.size(); ++s)
       {
-        this->fe_values_fs.get_function_values(solution_stages[s],
-                                               stages_phase_values[s]);
+        fe_values_vof.get_function_values(solution_stages[s],
+                                          this->stages_phase_values[s]);
       }
 
 
-    for (unsigned int q = 0; q < n_q_points; ++q)
+    for (unsigned int q = 0; q < this->n_q_points; ++q)
       {
-        this->JxW[q] = this->fe_values_fs.JxW(q);
+        this->JxW[q] = fe_values_vof.JxW(q);
 
-        for (unsigned int k = 0; k < n_dofs; ++k)
+        for (unsigned int k = 0; k < this->n_dofs; ++k)
           {
             // Shape function
-            this->phi[q][k]           = this->fe_values_fs.shape_value(k, q);
-            this->grad_phi[q][k]      = this->fe_values_fs.shape_grad(k, q);
-            this->hess_phi[q][k]      = this->fe_values_fs.shape_hessian(k, q);
+            this->phi[q][k]           = fe_values_vof.shape_value(k, q);
+            this->grad_phi[q][k]      = fe_values_vof.shape_grad(k, q);
+            this->hess_phi[q][k]      = fe_values_vof.shape_hessian(k, q);
             this->laplacian_phi[q][k] = trace(this->hess_phi[q][k]);
           }
       }
@@ -199,16 +197,16 @@ public:
   reinit_velocity(const typename DoFHandler<dim>::active_cell_iterator &cell,
                   const VectorType &current_solution)
   {
-    this->fe_values_navier_stokes.reinit(cell);
+    fe_values_fd.reinit(cell);
 
-    this->fe_values_navier_stokes[velocities].get_function_values(
-      current_solution, velocity_values);
-    this->fe_values_navier_stokes[velocities].get_function_gradients(
-      current_solution, velocity_gradient_values);
+    fe_values_fd[velocities_fd].get_function_values(current_solution,
+                                                    velocity_values_fd);
+    fe_values_fd[velocities_fd].get_function_gradients(
+      current_solution, velocity_gradient_values_fd);
   }
 
   // FEValues for the VOF problem
-  FEValues<dim> fe_values_fs;
+  FEValues<dim> fe_values_vof;
   unsigned int  n_dofs;
   unsigned int  n_q_points;
   double        cell_size;
@@ -224,9 +222,6 @@ public:
   std::vector<std::vector<double>> previous_phase_values;
   std::vector<std::vector<double>> stages_phase_values;
 
-  // Source term
-  std::vector<double> source;
-
   // Shape functions
   std::vector<std::vector<double>>         phi;
   std::vector<std::vector<Tensor<1, dim>>> grad_phi;
@@ -237,12 +232,12 @@ public:
   /**
    * Scratch component for the Navier-Stokes component
    */
-  FEValues<dim> fe_values_navier_stokes;
+  FEValues<dim> fe_values_fd;
 
-  FEValuesExtractors::Vector velocities;
+  FEValuesExtractors::Vector velocities_fd;
   // This FEValues must mandatorily be instantiated for the velocity
-  std::vector<Tensor<1, dim>> velocity_values;
-  std::vector<Tensor<2, dim>> velocity_gradient_values;
+  std::vector<Tensor<1, dim>> velocity_values_fd;
+  std::vector<Tensor<2, dim>> velocity_gradient_values_fd;
 };
 
 #endif

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -79,7 +79,7 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
 
     // subparameter for free_surface
     conservation_monitoring = prm.get_bool("conservation monitoring");
-    monitor_fluid_id        = prm.get_integer("fluid monitored");
+    id_fluid_monitored      = prm.get_integer("fluid monitored");
   }
   prm.leave_subsection();
 }

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -54,11 +54,11 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
       // Store JxW in local variable for faster access
       const double JxW = JxW_vec[q];
 
-      const auto velocity_fd = scratch_data.velocity_values_fd[q];
+      const auto velocity = scratch_data.velocity_values[q];
 
       // Calculation of the magnitude of the velocity for the
       // stabilization parameter
-      const double u_mag = std::max(velocity_fd.norm(), 1e-12);
+      const double u_mag = std::max(velocity.norm(), 1e-12);
 
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation is
@@ -91,11 +91,11 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
               // mu*(grad(u)+transpose(grad(u)).transpose(grad(u))
               local_matrix(i, j) +=
                 (thermal_conductivity[q] * grad_phi_T_i * grad_phi_T_j +
-                 rho_cp * phi_T_i * velocity_fd * grad_phi_T_j) *
+                 rho_cp * phi_T_i * velocity * grad_phi_T_j) *
                 JxW;
 
               local_matrix(i, j) += tau * strong_jacobian_vec[q][j] *
-                                    (grad_phi_T_i * velocity_fd) * JxW;
+                                    (grad_phi_T_i * velocity) * JxW;
             }
         }
 
@@ -145,11 +145,11 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
       // Store JxW in local variable for faster access
       const double JxW = scratch_data.fe_values_T.JxW(q);
 
-      const auto velocity_fd = scratch_data.velocity_values_fd[q];
+      const auto velocity = scratch_data.velocity_values[q];
 
       // Calculation of the magnitude of the velocity for the
       // stabilization parameter
-      const double u_mag = std::max(velocity_fd.norm(), 1e-12);
+      const double u_mag = std::max(velocity.norm(), 1e-12);
 
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation is
@@ -164,7 +164,7 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
                       9 * std::pow(4 * alpha / (h * h), 2));
 
       // Calculate the strong residual for GLS stabilization
-      strong_residual_vec[q] += rho_cp * velocity_fd * temperature_gradient -
+      strong_residual_vec[q] += rho_cp * velocity * temperature_gradient -
                                 thermal_conductivity[q] * temperature_laplacian;
 
 
@@ -177,12 +177,12 @@ HeatTransferAssemblerCore<dim>::assemble_rhs(
           // -grad(u)*grad(u) = 0
           local_rhs(i) -=
             (thermal_conductivity[q] * grad_phi_T_i * temperature_gradient +
-             rho_cp * phi_T_i * velocity_fd * temperature_gradient -
+             rho_cp * phi_T_i * velocity * temperature_gradient -
              scratch_data.source[q] * phi_T_i) *
             JxW;
 
           local_rhs(i) -=
-            tau * (strong_residual_vec[q] * (grad_phi_T_i * velocity_fd)) * JxW;
+            tau * (strong_residual_vec[q] * (grad_phi_T_i * velocity)) * JxW;
         }
 
     } // end loop on quadrature points
@@ -497,7 +497,7 @@ HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
       const double JxW = scratch_data.fe_values_T.JxW(q);
 
       const auto velocity_gradient_fd =
-        scratch_data.velocity_gradient_values_fd[q];
+        scratch_data.velocity_gradient_values[q];
 
 
       for (unsigned int i = 0; i < n_dofs; ++i)

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -22,9 +22,9 @@ HeatTransferScratchData<dim>::allocate()
   // Initialize arrays related to velocity and pressure
   this->velocities.first_vector_component = 0;
   // Velocity
-  this->velocity_values          = std::vector<Tensor<1, dim>>(n_q_points);
-  this->velocity_gradient_values = std::vector<Tensor<2, dim>>(n_q_points);
-  this->shear_rate_values        = std::vector<double>(n_q_points);
+  this->velocity_values_fd          = std::vector<Tensor<1, dim>>(n_q_points);
+  this->velocity_gradient_values_fd = std::vector<Tensor<2, dim>>(n_q_points);
+  this->shear_rate_values           = std::vector<double>(n_q_points);
 
 
   // Initialize arrays related to temperature
@@ -127,8 +127,8 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
         {
           // Calculate shear rate (at each q)
           const Tensor<2, dim> shear_rate_tensor =
-            velocity_gradient_values[q] +
-            transpose(velocity_gradient_values[q]);
+            velocity_gradient_values_fd[q] +
+            transpose(velocity_gradient_values_fd[q]);
 
           // Calculate the shear rate magnitude
           shear_rate_values[q] =

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -22,9 +22,9 @@ HeatTransferScratchData<dim>::allocate()
   // Initialize arrays related to velocity and pressure
   this->velocities.first_vector_component = 0;
   // Velocity
-  this->velocity_values_fd          = std::vector<Tensor<1, dim>>(n_q_points);
-  this->velocity_gradient_values_fd = std::vector<Tensor<2, dim>>(n_q_points);
-  this->shear_rate_values           = std::vector<double>(n_q_points);
+  this->velocity_values          = std::vector<Tensor<1, dim>>(n_q_points);
+  this->velocity_gradient_values = std::vector<Tensor<2, dim>>(n_q_points);
+  this->shear_rate_values        = std::vector<double>(n_q_points);
 
 
   // Initialize arrays related to temperature
@@ -127,8 +127,8 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
         {
           // Calculate shear rate (at each q)
           const Tensor<2, dim> shear_rate_tensor =
-            velocity_gradient_values_fd[q] +
-            transpose(velocity_gradient_values_fd[q]);
+            velocity_gradient_values[q] +
+            transpose(velocity_gradient_values[q]);
 
           // Calculate the shear rate magnitude
           shear_rate_values[q] =

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -95,8 +95,6 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 
       const double dynamic_viscosity_eq = density_eq * viscosity_eq;
 
-
-
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation
       // is steady or unsteady. In the unsteady case it includes the
@@ -177,7 +175,6 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
               // PSPG GLS term
               local_matrix_ij += tau * (strong_jac * grad_phi_p_i);
 
-
               // Jacobian is currently incomplete
               if (SUPG)
                 {
@@ -228,7 +225,6 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
   const double density_ratio      = 2;
   double       phase_force_cutoff = 0;
 
-
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
@@ -246,7 +242,6 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
       // gravity not will be applied for phase > phase_force_cutoff
       phase_force_cutoff = 1 - 1e-6;
     }
-
 
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -69,13 +69,13 @@ VolumeOfFluid<dim>::assemble_system_matrix()
   this->system_matrix = 0;
   setup_assemblers();
 
-  const DoFHandler<dim> *dof_handler_fluid =
+  const DoFHandler<dim> *dof_handler_fd =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   auto scratch_data = VOFScratchData<dim>(*this->fe,
                                           *this->cell_quadrature,
-                                          *this->fs_mapping,
-                                          dof_handler_fluid->get_fe());
+                                          *this->mapping,
+                                          dof_handler_fd->get_fe());
 
   WorkStream::run(this->dof_handler.begin_active(),
                   this->dof_handler.end(),
@@ -86,7 +86,7 @@ VolumeOfFluid<dim>::assemble_system_matrix()
                   StabilizedMethodsCopyData(this->fe->n_dofs_per_cell(),
                                             this->cell_quadrature->size()));
 
-  system_matrix.compress(VectorOperation::add);
+  this->system_matrix.compress(VectorOperation::add);
 }
 
 template <int dim>
@@ -106,11 +106,11 @@ VolumeOfFluid<dim>::assemble_local_system_matrix(
                       this->previous_solutions,
                       this->solution_stages);
 
-  const DoFHandler<dim> *dof_handler_fluid =
+  const DoFHandler<dim> *dof_handler_fd =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   typename DoFHandler<dim>::active_cell_iterator velocity_cell(
-    &(*triangulation), cell->level(), cell->index(), dof_handler_fluid);
+    &(*this->triangulation), cell->level(), cell->index(), dof_handler_fd);
 
   if (multiphysics->fluid_dynamics_is_block())
     {
@@ -144,7 +144,7 @@ VolumeOfFluid<dim>::copy_local_matrix_to_global_matrix(
   const AffineConstraints<double> &constraints_used = this->zero_constraints;
   constraints_used.distribute_local_to_global(copy_data.local_matrix,
                                               copy_data.local_dof_indices,
-                                              system_matrix);
+                                              this->system_matrix);
 }
 
 
@@ -156,13 +156,13 @@ VolumeOfFluid<dim>::assemble_system_rhs()
   this->system_rhs = 0;
   setup_assemblers();
 
-  const DoFHandler<dim> *dof_handler_fluid =
+  const DoFHandler<dim> *dof_handler_fd =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   auto scratch_data = VOFScratchData<dim>(*this->fe,
                                           *this->cell_quadrature,
-                                          *this->fs_mapping,
-                                          dof_handler_fluid->get_fe());
+                                          *this->mapping,
+                                          dof_handler_fd->get_fe());
 
   WorkStream::run(this->dof_handler.begin_active(),
                   this->dof_handler.end(),
@@ -192,11 +192,11 @@ VolumeOfFluid<dim>::assemble_local_system_rhs(
                       this->previous_solutions,
                       this->solution_stages);
 
-  const DoFHandler<dim> *dof_handler_fluid =
+  const DoFHandler<dim> *dof_handler_fd =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   typename DoFHandler<dim>::active_cell_iterator velocity_cell(
-    &(*triangulation), cell->level(), cell->index(), dof_handler_fluid);
+    &(*this->triangulation), cell->level(), cell->index(), dof_handler_fd);
 
   if (multiphysics->fluid_dynamics_is_block())
     {
@@ -231,7 +231,7 @@ VolumeOfFluid<dim>::copy_local_rhs_to_global_rhs(
   const AffineConstraints<double> &constraints_used = this->zero_constraints;
   constraints_used.distribute_local_to_global(copy_data.local_rhs,
                                               copy_data.local_dof_indices,
-                                              system_rhs);
+                                              this->system_rhs);
 }
 
 
@@ -240,54 +240,55 @@ template <int dim>
 void
 VolumeOfFluid<dim>::attach_solution_to_output(DataOut<dim> &data_out)
 {
-  data_out.add_data_vector(dof_handler, present_solution, "phase");
+  data_out.add_data_vector(this->dof_handler, this->present_solution, "phase");
 }
 
 template <int dim>
 double
 VolumeOfFluid<dim>::calculate_L2_error()
 {
-  auto mpi_communicator = triangulation->get_communicator();
+  auto mpi_communicator = this->triangulation->get_communicator();
 
-  FEValues<dim> fe_values_fs(*this->fs_mapping,
-                             *fe,
-                             *this->error_quadrature,
-                             update_values | update_gradients |
-                               update_quadrature_points | update_JxW_values);
+  FEValues<dim> fe_values_vof(*this->mapping,
+                              *this->fe,
+                              *this->error_quadrature,
+                              update_values | update_quadrature_points |
+                                update_JxW_values);
 
-  const unsigned int dofs_per_cell = fe->dofs_per_cell;
+  const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
 
-  std::vector<types::global_dof_index> local_dof_indices(
-    dofs_per_cell); //  Local connectivity
+  //  Local connectivity
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
   const unsigned int  n_q_points = this->error_quadrature->size();
   std::vector<double> q_exact_solution(n_q_points);
   std::vector<double> q_scalar_values(n_q_points);
 
   auto &exact_solution = simulation_parameters.analytical_solution->phase;
-  exact_solution.set_time(simulation_control->get_current_time());
+  exact_solution.set_time(this->simulation_control->get_current_time());
 
   double l2error = 0.;
 
-  for (const auto &cell : dof_handler.active_cell_iterators())
+  for (const auto &cell : this->dof_handler.active_cell_iterators())
     {
       if (cell->is_locally_owned())
         {
-          fe_values_fs.reinit(cell);
-          fe_values_fs.get_function_values(present_solution, q_scalar_values);
+          fe_values_vof.reinit(cell);
+          fe_values_vof.get_function_values(this->present_solution,
+                                            q_scalar_values);
 
           // Retrieve the effective "connectivity matrix" for this element
           cell->get_dof_indices(local_dof_indices);
 
           // Get the exact solution at all gauss points
-          exact_solution.value_list(fe_values_fs.get_quadrature_points(),
+          exact_solution.value_list(fe_values_vof.get_quadrature_points(),
                                     q_exact_solution);
 
           for (unsigned int q = 0; q < n_q_points; q++)
             {
               double sim   = q_scalar_values[q];
               double exact = q_exact_solution[q];
-              l2error += (sim - exact) * (sim - exact) * fe_values_fs.JxW(q);
+              l2error += (sim - exact) * (sim - exact) * fe_values_vof.JxW(q);
             }
         }
     }
@@ -297,43 +298,44 @@ VolumeOfFluid<dim>::calculate_L2_error()
 
 template <int dim>
 double
-VolumeOfFluid<dim>::calculate_volume(int monitor_fluid_id)
+VolumeOfFluid<dim>::calculate_volume(int id_fluid_monitored)
 {
-  auto mpi_communicator = triangulation->get_communicator();
+  auto mpi_communicator = this->triangulation->get_communicator();
 
-  FEValues<dim> fe_values_fs(*this->fs_mapping,
-                             *fe,
-                             *this->error_quadrature,
-                             update_values | update_gradients |
-                               update_quadrature_points | update_JxW_values);
+  FEValues<dim> fe_values_vof(*this->mapping,
+                              *this->fe,
+                              *this->error_quadrature,
+                              update_values | update_quadrature_points |
+                                update_JxW_values);
 
   const unsigned int  n_q_points = this->error_quadrature->size();
   std::vector<double> q_scalar_values(n_q_points);
 
   double volume = 0;
 
-  for (const auto &cell : dof_handler.active_cell_iterators())
+  for (const auto &cell : this->dof_handler.active_cell_iterators())
     {
       if (cell->is_locally_owned())
         {
-          fe_values_fs.reinit(cell);
-          fe_values_fs.get_function_values(present_solution, q_scalar_values);
+          fe_values_vof.reinit(cell);
+          fe_values_vof.get_function_values(this->present_solution,
+                                            q_scalar_values);
 
           for (unsigned int q = 0; q < n_q_points; q++)
             {
-              switch (monitor_fluid_id)
+              switch (id_fluid_monitored)
                 {
                   case 0:
                     {
                       if (q_scalar_values[q] < 0.5)
                         volume +=
-                          fe_values_fs.JxW(q) * (1 - q_scalar_values[q]);
+                          fe_values_vof.JxW(q) * (1 - q_scalar_values[q]);
                       break;
                     }
                   case 1:
                     {
                       if (q_scalar_values[q] > 0.5)
-                        volume += fe_values_fs.JxW(q) * q_scalar_values[q];
+                        volume += fe_values_vof.JxW(q) * q_scalar_values[q];
                       break;
                     }
                 }
@@ -348,7 +350,7 @@ template <int dim>
 void
 VolumeOfFluid<dim>::finish_simulation()
 {
-  auto         mpi_communicator = triangulation->get_communicator();
+  auto         mpi_communicator = this->triangulation->get_communicator();
   unsigned int this_mpi_process(
     Utilities::MPI::this_mpi_process(mpi_communicator));
 
@@ -358,14 +360,14 @@ VolumeOfFluid<dim>::finish_simulation()
     {
       if (simulation_parameters.simulation_control.method ==
           Parameters::SimulationControl::TimeSteppingMethod::steady)
-        error_table.omit_column_from_convergence_rate_evaluation("cells");
+        this->error_table.omit_column_from_convergence_rate_evaluation("cells");
       else
-        error_table.omit_column_from_convergence_rate_evaluation("time");
+        this->error_table.omit_column_from_convergence_rate_evaluation("time");
 
-      error_table.set_scientific("error_phase", true);
-      error_table.set_precision("error_phase",
-                                simulation_control->get_log_precision());
-      error_table.write_text(std::cout);
+      this->error_table.set_scientific("error_phase", true);
+      this->error_table.set_precision(
+        "error_phase", this->simulation_control->get_log_precision());
+      this->error_table.write_text(std::cout);
     }
 }
 
@@ -373,11 +375,11 @@ template <int dim>
 void
 VolumeOfFluid<dim>::percolate_time_vectors()
 {
-  for (unsigned int i = previous_solutions.size() - 1; i > 0; --i)
+  for (unsigned int i = this->previous_solutions.size() - 1; i > 0; --i)
     {
-      previous_solutions[i] = previous_solutions[i - 1];
+      this->previous_solutions[i] = this->previous_solutions[i - 1];
     }
-  previous_solutions[0] = this->present_solution;
+  this->previous_solutions[0] = this->present_solution;
 }
 
 template <int dim>
@@ -396,16 +398,17 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
     {
       double phase_error = calculate_L2_error();
 
-      if (simulation_control->is_steady())
+      if (this->simulation_control->is_steady())
         {
-          error_table.add_value("cells",
-                                this->triangulation->n_global_active_cells());
+          this->error_table.add_value(
+            "cells", this->triangulation->n_global_active_cells());
         }
       else
         {
-          error_table.add_value("time", simulation_control->get_current_time());
+          this->error_table.add_value(
+            "time", this->simulation_control->get_current_time());
         }
-      error_table.add_value("error_phase", phase_error);
+      this->error_table.add_value("error_phase", phase_error);
 
       if (simulation_parameters.analytical_solution->verbosity ==
           Parameters::Verbosity::verbose)
@@ -417,36 +420,36 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
   if (simulation_parameters.multiphysics.conservation_monitoring)
     {
       double volume =
-        calculate_volume(simulation_parameters.multiphysics.monitor_fluid_id);
+        calculate_volume(simulation_parameters.multiphysics.id_fluid_monitored);
 
-      auto         mpi_communicator = triangulation->get_communicator();
+      auto         mpi_communicator = this->triangulation->get_communicator();
       unsigned int this_mpi_process(
         Utilities::MPI::this_mpi_process(mpi_communicator));
 
       if (this_mpi_process == 0)
         {
           // Set conservation monitoring table
-          if (simulation_control->is_steady())
+          if (this->simulation_control->is_steady())
             {
-              volume_table_fs.add_value(
+              this->table_monitoring_vof.add_value(
                 "cells", this->triangulation->n_global_active_cells());
             }
           else
             {
-              volume_table_fs.add_value("time",
-                                        simulation_control->get_current_time());
+              this->table_monitoring_vof.add_value(
+                "time", this->simulation_control->get_current_time());
             }
-          volume_table_fs.add_value("fluid_volume", volume);
-          volume_table_fs.set_scientific("fluid_volume", true);
+          this->table_monitoring_vof.add_value("fluid_volume", volume);
+          this->table_monitoring_vof.set_scientific("fluid_volume", true);
 
-          // Save table to free_surface_monitoring.dat
+          // Save table to .dat
           std::string filename =
             "VOF_monitoring_fluid_" +
             Utilities::int_to_string(
-              simulation_parameters.multiphysics.monitor_fluid_id, 1) +
+              simulation_parameters.multiphysics.id_fluid_monitored, 1) +
             ".dat";
           std::ofstream output(filename.c_str());
-          volume_table_fs.write_text(output);
+          this->table_monitoring_vof.write_text(output);
         }
     }
 }
@@ -458,9 +461,9 @@ VolumeOfFluid<dim>::modify_solution()
   if (this->simulation_parameters.multiphysics.interface_sharpening)
     {
       // Limit the phase fractions between 0 and 1
-      update_solution_and_constraints(present_solution);
-      for (unsigned int p = 0; p < previous_solutions.size(); ++p)
-        update_solution_and_constraints(previous_solutions[p]);
+      update_solution_and_constraints(this->present_solution);
+      for (unsigned int p = 0; p < this->previous_solutions.size(); ++p)
+        update_solution_and_constraints(this->previous_solutions[p]);
 
       // Interface sharpening is done at a constant frequency
       if (this->simulation_control->get_step_number() %
@@ -479,22 +482,22 @@ VolumeOfFluid<dim>::modify_solution()
           // Sharpen the interface of all solutions:
           {
             // Assemble matrix and solve the system for interface sharpening
-            assemble_L2_projection_interface_sharpening(present_solution);
-            solve_interface_sharpening(present_solution);
+            assemble_L2_projection_interface_sharpening(this->present_solution);
+            solve_interface_sharpening(this->present_solution);
 
-            for (unsigned int p = 0; p < previous_solutions.size(); ++p)
+            for (unsigned int p = 0; p < this->previous_solutions.size(); ++p)
               {
                 assemble_L2_projection_interface_sharpening(
-                  previous_solutions[p]);
-                solve_interface_sharpening(previous_solutions[p]);
+                  this->previous_solutions[p]);
+                solve_interface_sharpening(this->previous_solutions[p]);
               }
           }
 
           // Re limit the phase fractions between 0 and 1 after interface
           // sharpening
-          update_solution_and_constraints(present_solution);
-          for (unsigned int p = 0; p < previous_solutions.size(); ++p)
-            update_solution_and_constraints(previous_solutions[p]);
+          update_solution_and_constraints(this->present_solution);
+          for (unsigned int p = 0; p < this->previous_solutions.size(); ++p)
+            update_solution_and_constraints(this->previous_solutions[p]);
         }
     }
 }
@@ -503,12 +506,13 @@ template <int dim>
 void
 VolumeOfFluid<dim>::pre_mesh_adaptation()
 {
-  solution_transfer.prepare_for_coarsening_and_refinement(present_solution);
+  this->solution_transfer.prepare_for_coarsening_and_refinement(
+    this->present_solution);
 
-  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+  for (unsigned int i = 0; i < this->previous_solutions.size(); ++i)
     {
-      previous_solutions_transfer[i].prepare_for_coarsening_and_refinement(
-        previous_solutions[i]);
+      this->previous_solutions_transfer[i]
+        .prepare_for_coarsening_and_refinement(this->previous_solutions[i]);
     }
 }
 
@@ -516,28 +520,28 @@ template <int dim>
 void
 VolumeOfFluid<dim>::post_mesh_adaptation()
 {
-  auto mpi_communicator = triangulation->get_communicator();
+  auto mpi_communicator = this->triangulation->get_communicator();
 
   // Set up the vectors for the transfer
-  TrilinosWrappers::MPI::Vector tmp(locally_owned_dofs, mpi_communicator);
+  TrilinosWrappers::MPI::Vector tmp(this->locally_owned_dofs, mpi_communicator);
 
   // Interpolate the solution at time and previous time
-  solution_transfer.interpolate(tmp);
+  this->solution_transfer.interpolate(tmp);
 
   // Distribute constraints
-  nonzero_constraints.distribute(tmp);
+  this->nonzero_constraints.distribute(tmp);
 
   // Fix on the new mesh
-  present_solution = tmp;
+  this->present_solution = tmp;
 
   // Transfer previous solutions
-  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+  for (unsigned int i = 0; i < this->previous_solutions.size(); ++i)
     {
-      TrilinosWrappers::MPI::Vector tmp_previous_solution(locally_owned_dofs,
-                                                          mpi_communicator);
-      previous_solutions_transfer[i].interpolate(tmp_previous_solution);
-      nonzero_constraints.distribute(tmp_previous_solution);
-      previous_solutions[i] = tmp_previous_solution;
+      TrilinosWrappers::MPI::Vector tmp_previous_solution(
+        this->locally_owned_dofs, mpi_communicator);
+      this->previous_solutions_transfer[i].interpolate(tmp_previous_solution);
+      this->nonzero_constraints.distribute(tmp_previous_solution);
+      this->previous_solutions[i] = tmp_previous_solution;
     }
 }
 
@@ -552,13 +556,13 @@ VolumeOfFluid<dim>::compute_kelly(
       const FEValuesExtractors::Scalar phase(0);
 
       KellyErrorEstimator<dim>::estimate(
-        *this->fs_mapping,
-        dof_handler,
+        *this->mapping,
+        this->dof_handler,
         *this->face_quadrature,
         typename std::map<types::boundary_id, const Function<dim, double> *>(),
-        present_solution,
+        this->present_solution,
         estimated_error_per_cell,
-        fe->component_mask(phase));
+        this->fe->component_mask(phase));
     }
 }
 
@@ -568,43 +572,45 @@ VolumeOfFluid<dim>::write_checkpoint()
 {
   std::vector<const TrilinosWrappers::MPI::Vector *> sol_set_transfer;
 
-  sol_set_transfer.push_back(&present_solution);
-  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+  sol_set_transfer.push_back(&this->present_solution);
+  for (unsigned int i = 0; i < this->previous_solutions.size(); ++i)
     {
-      sol_set_transfer.push_back(&previous_solutions[i]);
+      sol_set_transfer.push_back(&this->previous_solutions[i]);
     }
-  solution_transfer.prepare_for_serialization(sol_set_transfer);
+  this->solution_transfer.prepare_for_serialization(sol_set_transfer);
 }
 
 template <int dim>
 void
 VolumeOfFluid<dim>::read_checkpoint()
 {
-  auto mpi_communicator = triangulation->get_communicator();
+  auto mpi_communicator        = this->triangulation->get_communicator();
+  auto previous_solutions_size = this->previous_solutions.size();
   this->pcout << "Reading VOF checkpoint" << std::endl;
 
   std::vector<TrilinosWrappers::MPI::Vector *> input_vectors(
-    1 + previous_solutions.size());
-  TrilinosWrappers::MPI::Vector distributed_system(locally_owned_dofs,
+    1 + previous_solutions_size);
+  TrilinosWrappers::MPI::Vector distributed_system(this->locally_owned_dofs,
                                                    mpi_communicator);
   input_vectors[0] = &distributed_system;
 
 
   std::vector<TrilinosWrappers::MPI::Vector> distributed_previous_solutions;
-  distributed_previous_solutions.reserve(previous_solutions.size());
-  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+  distributed_previous_solutions.reserve(previous_solutions_size);
+  for (unsigned int i = 0; i < previous_solutions_size; ++i)
     {
       distributed_previous_solutions.emplace_back(
-        TrilinosWrappers::MPI::Vector(locally_owned_dofs, mpi_communicator));
+        TrilinosWrappers::MPI::Vector(this->locally_owned_dofs,
+                                      mpi_communicator));
       input_vectors[i + 1] = &distributed_previous_solutions[i];
     }
 
-  solution_transfer.deserialize(input_vectors);
+  this->solution_transfer.deserialize(input_vectors);
 
-  present_solution = distributed_system;
-  for (unsigned int i = 0; i < previous_solutions.size(); ++i)
+  this->present_solution = distributed_system;
+  for (unsigned int i = 0; i < previous_solutions_size; ++i)
     {
-      previous_solutions[i] = distributed_previous_solutions[i];
+      this->previous_solutions[i] = distributed_previous_solutions[i];
     }
 }
 
@@ -613,131 +619,130 @@ template <int dim>
 void
 VolumeOfFluid<dim>::setup_dofs()
 {
-  dof_handler.distribute_dofs(*fe);
+  this->dof_handler.distribute_dofs(*this->fe);
   DoFRenumbering::Cuthill_McKee(this->dof_handler);
 
-  auto mpi_communicator = triangulation->get_communicator();
+  auto mpi_communicator = this->triangulation->get_communicator();
 
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  this->locally_owned_dofs = this->dof_handler.locally_owned_dofs();
+  DoFTools::extract_locally_relevant_dofs(this->dof_handler,
+                                          this->locally_relevant_dofs);
 
-  present_solution.reinit(locally_owned_dofs,
-                          locally_relevant_dofs,
-                          mpi_communicator);
+  this->present_solution.reinit(this->locally_owned_dofs,
+                                this->locally_relevant_dofs,
+                                mpi_communicator);
 
   // Previous solutions for transient schemes
   for (auto &solution : this->previous_solutions)
     {
-      solution.reinit(locally_owned_dofs,
-                      locally_relevant_dofs,
+      solution.reinit(this->locally_owned_dofs,
+                      this->locally_relevant_dofs,
                       mpi_communicator);
     }
 
-  system_rhs.reinit(locally_owned_dofs, mpi_communicator);
+  this->system_rhs.reinit(this->locally_owned_dofs, mpi_communicator);
 
-  newton_update.reinit(locally_owned_dofs, mpi_communicator);
+  this->newton_update.reinit(this->locally_owned_dofs, mpi_communicator);
 
-  local_evaluation_point.reinit(this->locally_owned_dofs, mpi_communicator);
+  this->local_evaluation_point.reinit(this->locally_owned_dofs,
+                                      mpi_communicator);
 
   {
-    nonzero_constraints.clear();
+    this->nonzero_constraints.clear();
     DoFTools::make_hanging_node_constraints(this->dof_handler,
-                                            nonzero_constraints);
+                                            this->nonzero_constraints);
   }
-  nonzero_constraints.close();
+  this->nonzero_constraints.close();
 
   // Boundary conditions for Newton correction
   {
-    zero_constraints.clear();
+    this->zero_constraints.clear();
     DoFTools::make_hanging_node_constraints(this->dof_handler,
-                                            zero_constraints);
+                                            this->zero_constraints);
   }
-  zero_constraints.close();
+  this->zero_constraints.close();
 
   // Sparse matrices initialization
   DynamicSparsityPattern dsp(this->dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
-                                  nonzero_constraints,
+                                  this->nonzero_constraints,
                                   /*keep_constrained_dofs = */ true);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
-                                             locally_owned_dofs,
+                                             this->locally_owned_dofs,
                                              mpi_communicator,
-                                             locally_relevant_dofs);
+                                             this->locally_relevant_dofs);
 
   // Initialization of phase fraction matrices for interface sharpening.
   // system_matrix_phase_fraction is used in
   // assemble_L2_projection_interface_sharpening for assembling the system for
   // sharpening the interface, while complete_system_matrix_phase_fraction is
   // used in update_solution_and_constraints to limit the phase fraction values
-  // between 0 and 1. Accoring to step-41, we compute the Lagrange multiplier
-  // (to limit the phase fractions) as the residual of the original linear
-  // system (given via the variables complete_system_matrix_phase_fraction and
+  // between 0 and 1. Accoring to step-41, to limit the phase fractions we
+  // compute the Lagrange multiplier as the residual of the original linear
+  // system, given via the variables complete_system_matrix_phase_fraction and
   // complete_system_rhs_phase_fraction
-  system_matrix_phase_fraction.reinit(locally_owned_dofs,
-                                      locally_owned_dofs,
+  system_matrix_phase_fraction.reinit(this->locally_owned_dofs,
+                                      this->locally_owned_dofs,
                                       dsp,
                                       mpi_communicator);
 
-  complete_system_matrix_phase_fraction.reinit(locally_owned_dofs,
-                                               locally_owned_dofs,
+  complete_system_matrix_phase_fraction.reinit(this->locally_owned_dofs,
+                                               this->locally_owned_dofs,
                                                dsp,
                                                mpi_communicator);
 
-  complete_system_rhs_phase_fraction.reinit(locally_owned_dofs,
+  complete_system_rhs_phase_fraction.reinit(this->locally_owned_dofs,
                                             mpi_communicator);
 
   // In update_solution_and_constraints (which limits the phase fraction
   // between 0 and 1, nodal_phase_fraction_owned copies the solution, then
   // limits it, and finally updates (rewrites) the solution.
-  nodal_phase_fraction_owned.reinit(locally_owned_dofs, mpi_communicator);
+  nodal_phase_fraction_owned.reinit(this->locally_owned_dofs, mpi_communicator);
 
   // Right hand side of the interface sharpening problem (used in
   // assemble_L2_projection_interface_sharpening).
-  system_rhs_phase_fraction.reinit(locally_owned_dofs, mpi_communicator);
+  system_rhs_phase_fraction.reinit(this->locally_owned_dofs, mpi_communicator);
 
-  active_set.clear();
-  active_set.set_size(dof_handler.n_dofs());
+  this->system_matrix.reinit(this->locally_owned_dofs,
+                             this->locally_owned_dofs,
+                             dsp,
+                             mpi_communicator);
 
-  system_matrix.reinit(locally_owned_dofs,
-                       locally_owned_dofs,
-                       dsp,
-                       mpi_communicator);
-
-  this->pcout << "   Number of VOF degrees of freedom: " << dof_handler.n_dofs()
-              << std::endl;
+  this->pcout << "   Number of VOF degrees of freedom: "
+              << this->dof_handler.n_dofs() << std::endl;
 
   // Provide the VOF dof_handler and solution pointers to the
   // multiphysics interface
-  multiphysics->set_dof_handler(PhysicsID::VOF, &dof_handler);
-  multiphysics->set_solution(PhysicsID::VOF, &present_solution);
+  multiphysics->set_dof_handler(PhysicsID::VOF, &this->dof_handler);
+  multiphysics->set_solution(PhysicsID::VOF, &this->present_solution);
 
   // the fluid at present iteration is solved BEFORE the VOF (see map
   // solve_pre_fluid defined in multiphysics_interface.h), and after percolate
   // is called for the previous iteration.
   // NB: for now, inertia in fluid dynamics is considered with a constant
   // density (see if needed / to be debugged)
-  multiphysics->set_solution_m1(PhysicsID::VOF, &previous_solutions[0]);
+  multiphysics->set_solution_m1(PhysicsID::VOF, &this->previous_solutions[0]);
 
-  mass_matrix.reinit(locally_owned_dofs,
-                     locally_owned_dofs,
-                     dsp,
-                     mpi_communicator);
+  mass_matrix_phase_fraction.reinit(this->locally_owned_dofs,
+                                    this->locally_owned_dofs,
+                                    dsp,
+                                    mpi_communicator);
 
-  assemble_mass_matrix_diagonal(mass_matrix);
+  assemble_mass_matrix_diagonal(mass_matrix_phase_fraction);
 }
 
 template <int dim>
 void
 VolumeOfFluid<dim>::set_initial_conditions()
 {
-  VectorTools::interpolate(*this->fs_mapping,
-                           dof_handler,
+  VectorTools::interpolate(*this->mapping,
+                           this->dof_handler,
                            simulation_parameters.initial_condition->VOF,
-                           newton_update);
-  nonzero_constraints.distribute(newton_update);
-  present_solution = newton_update;
+                           this->newton_update);
+  this->nonzero_constraints.distribute(this->newton_update);
+  this->present_solution = this->newton_update;
 
   finish_time_step();
 }
@@ -747,10 +752,10 @@ void
 VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
                                         const bool /*renewed_matrix*/)
 {
-  auto mpi_communicator = triangulation->get_communicator();
+  auto mpi_communicator = this->triangulation->get_communicator();
 
   const AffineConstraints<double> &constraints_used =
-    initial_step ? nonzero_constraints : this->zero_constraints;
+    initial_step ? this->nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
     simulation_parameters.linear_solver.minimum_residual;
@@ -758,7 +763,7 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
     simulation_parameters.linear_solver.relative_residual;
 
   const double linear_solver_tolerance =
-    std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
+    std::max(relative_residual * this->system_rhs.l2_norm(), absolute_residual);
 
   if (this->simulation_parameters.linear_solver.verbosity !=
       Parameters::Verbosity::quiet)
@@ -775,10 +780,10 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
 
   TrilinosWrappers::PreconditionILU ilu_preconditioner;
 
-  ilu_preconditioner.initialize(system_matrix, preconditionerOptions);
+  ilu_preconditioner.initialize(this->system_matrix, preconditionerOptions);
 
   TrilinosWrappers::MPI::Vector completely_distributed_solution(
-    locally_owned_dofs, mpi_communicator);
+    this->locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(
     simulation_parameters.linear_solver.max_iterations,
@@ -793,9 +798,9 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
 
 
-  solver.solve(system_matrix,
+  solver.solve(this->system_matrix,
                completely_distributed_solution,
-               system_rhs,
+               this->system_rhs,
                ilu_preconditioner);
 
   if (simulation_parameters.linear_solver.verbosity !=
@@ -822,7 +827,7 @@ VolumeOfFluid<dim>::update_solution_and_constraints(
   // there is no convergence using the penalty_parameter = 1)
   const double penalty_parameter = 100;
 
-  TrilinosWrappers::MPI::Vector lambda(locally_owned_dofs);
+  TrilinosWrappers::MPI::Vector lambda(this->locally_owned_dofs);
 
   nodal_phase_fraction_owned = solution;
 
@@ -830,58 +835,58 @@ VolumeOfFluid<dim>::update_solution_and_constraints(
                                                  nodal_phase_fraction_owned,
                                                  system_rhs_phase_fraction);
 
-  bounding_constraints.clear();
-  active_set.clear();
+  this->bounding_constraints.clear();
 
-  std::vector<bool> dof_touched(dof_handler.n_dofs(), false);
+  std::vector<bool> dof_touched(this->dof_handler.n_dofs(), false);
 
-  for (const auto &cell : dof_handler.active_cell_iterators())
+  for (const auto &cell : this->dof_handler.active_cell_iterators())
     {
       if (cell->is_locally_owned())
         {
           for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
                ++v)
             {
-              Assert(dof_handler.get_fe().dofs_per_cell ==
+              Assert(this->dof_handler.get_fe().dofs_per_cell ==
                        GeometryInfo<dim>::vertices_per_cell,
                      ExcNotImplemented());
               const unsigned int dof_index = cell->vertex_dof_index(v, 0);
-              if (locally_owned_dofs.is_element(dof_index))
+              if (this->locally_owned_dofs.is_element(dof_index))
                 {
                   const double solution_value =
                     nodal_phase_fraction_owned(dof_index);
-                  if (lambda(dof_index) + penalty_parameter *
-                                            mass_matrix(dof_index, dof_index) *
-                                            (solution_value - vof_upper_bound) >
+                  if (lambda(dof_index) +
+                        penalty_parameter *
+                          mass_matrix_phase_fraction(dof_index, dof_index) *
+                          (solution_value - this->phase_upper_bound) >
                       0)
                     {
-                      active_set.add_index(dof_index);
-                      bounding_constraints.add_line(dof_index);
-                      bounding_constraints.set_inhomogeneity(dof_index,
-                                                             vof_upper_bound);
-                      nodal_phase_fraction_owned(dof_index) = vof_upper_bound;
-                      lambda(dof_index)                     = 0;
+                      this->bounding_constraints.add_line(dof_index);
+                      this->bounding_constraints.set_inhomogeneity(
+                        dof_index, this->phase_upper_bound);
+                      nodal_phase_fraction_owned(dof_index) =
+                        this->phase_upper_bound;
+                      lambda(dof_index) = 0;
                     }
                   else if (lambda(dof_index) +
                              penalty_parameter *
-                               mass_matrix(dof_index, dof_index) *
-                               (solution_value - vof_lower_bound) <
+                               mass_matrix_phase_fraction(dof_index,
+                                                          dof_index) *
+                               (solution_value - this->phase_lower_bound) <
                            0)
                     {
-                      active_set.add_index(dof_index);
-                      bounding_constraints.add_line(dof_index);
-                      bounding_constraints.set_inhomogeneity(dof_index,
-                                                             vof_lower_bound);
-                      nodal_phase_fraction_owned(dof_index) = vof_lower_bound;
-                      lambda(dof_index)                     = 0;
+                      this->bounding_constraints.add_line(dof_index);
+                      this->bounding_constraints.set_inhomogeneity(
+                        dof_index, this->phase_lower_bound);
+                      nodal_phase_fraction_owned(dof_index) =
+                        this->phase_lower_bound;
+                      lambda(dof_index) = 0;
                     }
                 }
             }
         }
     }
-  active_set.compress();
   solution = nodal_phase_fraction_owned;
-  bounding_constraints.close();
+  this->bounding_constraints.close();
 }
 
 template <int dim>
@@ -894,13 +899,11 @@ VolumeOfFluid<dim>::assemble_L2_projection_interface_sharpening(
   const double interface_sharpness =
     this->simulation_parameters.interface_sharpening.interface_sharpness;
 
-  FEValues<dim> fe_values_phase_fraction(*this->fs_mapping,
-                                         *this->fe,
-                                         *this->cell_quadrature,
-                                         update_values |
-                                           update_quadrature_points |
-                                           update_JxW_values |
-                                           update_gradients);
+  FEValues<dim> fe_values_vof(*this->mapping,
+                              *this->fe,
+                              *this->cell_quadrature,
+                              update_values | update_quadrature_points |
+                                update_JxW_values | update_gradients);
 
 
 
@@ -920,12 +923,12 @@ VolumeOfFluid<dim>::assemble_L2_projection_interface_sharpening(
     {
       if (cell->is_locally_owned())
         {
-          fe_values_phase_fraction.reinit(cell);
+          fe_values_vof.reinit(cell);
 
           local_matrix_phase_fraction = 0;
           local_rhs_phase_fraction    = 0;
 
-          fe_values_phase_fraction.get_function_values(solution, phase_values);
+          fe_values_vof.get_function_values(solution, phase_values);
 
           for (unsigned int q = 0; q < n_q_points; ++q)
             {
@@ -933,7 +936,7 @@ VolumeOfFluid<dim>::assemble_L2_projection_interface_sharpening(
 
               for (unsigned int k = 0; k < dofs_per_cell; ++k)
                 {
-                  phi_phase[k] = fe_values_phase_fraction.shape_value(k, q);
+                  phi_phase[k] = fe_values_vof.shape_value(k, q);
                 }
               for (unsigned int i = 0; i < dofs_per_cell; ++i)
                 {
@@ -941,8 +944,7 @@ VolumeOfFluid<dim>::assemble_L2_projection_interface_sharpening(
                   for (unsigned int j = 0; j < dofs_per_cell; ++j)
                     {
                       local_matrix_phase_fraction(i, j) +=
-                        (phi_phase[j] * phi_phase[i]) *
-                        fe_values_phase_fraction.JxW(q);
+                        (phi_phase[j] * phi_phase[i]) * fe_values_vof.JxW(q);
                     }
 
                   // $$ (if 0 <= \phi <= c)  {\Phi = c ^ (1 - \alpha) * (\phi ^
@@ -954,7 +956,7 @@ VolumeOfFluid<dim>::assemble_L2_projection_interface_sharpening(
                       std::pow(sharpening_threshold,
                                (1 - interface_sharpness)) *
                       std::pow(phase_value, interface_sharpness) *
-                      phi_phase[i] * fe_values_phase_fraction.JxW(q);
+                      phi_phase[i] * fe_values_vof.JxW(q);
                   else
                     {
                       local_rhs_phase_fraction(i) +=
@@ -962,12 +964,12 @@ VolumeOfFluid<dim>::assemble_L2_projection_interface_sharpening(
                          std::pow((1 - sharpening_threshold),
                                   (1 - interface_sharpness)) *
                            std::pow((1 - phase_value), interface_sharpness)) *
-                        phi_phase[i] * fe_values_phase_fraction.JxW(q);
+                        phi_phase[i] * fe_values_vof.JxW(q);
                     }
                 }
             }
           cell->get_dof_indices(local_dof_indices);
-          nonzero_constraints.distribute_local_to_global(
+          this->nonzero_constraints.distribute_local_to_global(
             local_matrix_phase_fraction,
             local_rhs_phase_fraction,
             local_dof_indices,
@@ -1020,7 +1022,8 @@ VolumeOfFluid<dim>::solve_interface_sharpening(
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
-  ilu_preconditioner = std::make_shared<TrilinosWrappers::PreconditionILU>();
+  std::shared_ptr<TrilinosWrappers::PreconditionILU> ilu_preconditioner =
+    std::make_shared<TrilinosWrappers::PreconditionILU>();
 
   ilu_preconditioner->initialize(system_matrix_phase_fraction,
                                  preconditionerOptions);
@@ -1037,7 +1040,7 @@ VolumeOfFluid<dim>::solve_interface_sharpening(
                   << " steps " << std::endl;
     }
 
-  nonzero_constraints.distribute(
+  this->nonzero_constraints.distribute(
     completely_distributed_phase_fraction_solution);
   solution = completely_distributed_phase_fraction_solution;
 }
@@ -1054,30 +1057,29 @@ VolumeOfFluid<dim>::assemble_mass_matrix_diagonal(
 {
   QGauss<dim> quadrature_formula(this->cell_quadrature->size());
 
-  FEValues<dim> fe_values(*fe,
-                          quadrature_formula,
-                          update_values | update_JxW_values);
+  FEValues<dim> fe_values_vof(*this->fe,
+                              quadrature_formula,
+                              update_values | update_JxW_values);
 
 
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   const unsigned int n_qpoints     = quadrature_formula.size();
   FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-  for (const auto &cell : dof_handler.active_cell_iterators())
+  for (const auto &cell : this->dof_handler.active_cell_iterators())
     {
       if (cell->is_locally_owned())
         {
-          fe_values.reinit(cell);
+          fe_values_vof.reinit(cell);
           cell_matrix = 0;
           for (unsigned int q = 0; q < n_qpoints; ++q)
             for (unsigned int i = 0; i < dofs_per_cell; ++i)
               cell_matrix(i, i) +=
-                (fe_values.shape_value(i, q) * fe_values.shape_value(i, q) *
-                 fe_values.JxW(q));
+                (fe_values_vof.shape_value(i, q) *
+                 fe_values_vof.shape_value(i, q) * fe_values_vof.JxW(q));
           cell->get_dof_indices(local_dof_indices);
-          nonzero_constraints.distribute_local_to_global(cell_matrix,
-                                                         local_dof_indices,
-                                                         mass_matrix);
+          this->nonzero_constraints.distribute_local_to_global(
+            cell_matrix, local_dof_indices, mass_matrix);
         }
     }
 }

--- a/source/solvers/vof_scratch_data.cc
+++ b/source/solvers/vof_scratch_data.cc
@@ -8,48 +8,44 @@ void
 VOFScratchData<dim>::allocate()
 {
   // Initialize size of arrays
-  this->n_q_points = fe_values_fs.get_quadrature().size();
-  this->n_dofs     = fe_values_fs.get_fe().n_dofs_per_cell();
+  this->n_q_points = fe_values_vof.get_quadrature().size();
+  this->n_dofs     = fe_values_vof.get_fe().n_dofs_per_cell();
 
   // Initialize arrays related to quadrature
-  this->JxW = std::vector<double>(n_q_points);
-
-  // Forcing term array
-  this->source = std::vector<double>(n_q_points);
-
+  this->JxW = std::vector<double>(this->n_q_points);
 
   // Initialize arrays related to velocity and pressure
-  this->velocities.first_vector_component = 0;
+  this->velocities_fd.first_vector_component = 0;
   // Velocity
-  this->velocity_values          = std::vector<Tensor<1, dim>>(n_q_points);
-  this->velocity_gradient_values = std::vector<Tensor<2, dim>>(n_q_points);
+  this->velocity_values_fd = std::vector<Tensor<1, dim>>(this->n_q_points);
+  this->velocity_gradient_values_fd =
+    std::vector<Tensor<2, dim>>(this->n_q_points);
 
-
-  this->present_phase_values = std::vector<double>(n_q_points);
-  this->phase_gradients      = std::vector<Tensor<1, dim>>(n_q_points);
-  this->phase_laplacians     = std::vector<double>(n_q_points);
+  this->present_phase_values = std::vector<double>(this->n_q_points);
+  this->phase_gradients      = std::vector<Tensor<1, dim>>(this->n_q_points);
+  this->phase_laplacians     = std::vector<double>(this->n_q_points);
 
   // Velocity for BDF schemes
   this->previous_phase_values =
     std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
-                                     std::vector<double>(n_q_points));
-
-
+                                     std::vector<double>(this->n_q_points));
 
   // Velocity for SDIRK schemes
   this->stages_phase_values =
     std::vector<std::vector<double>>(max_number_of_intermediary_stages(),
-                                     std::vector<double>(n_q_points));
+                                     std::vector<double>(this->n_q_points));
 
   // Initialize arrays related to shape functions
   this->phi =
-    std::vector<std::vector<double>>(n_q_points, std::vector<double>(n_dofs));
+    std::vector<std::vector<double>>(this->n_q_points,
+                                     std::vector<double>(this->n_dofs));
   this->grad_phi = std::vector<std::vector<Tensor<1, dim>>>(
-    n_q_points, std::vector<Tensor<1, dim>>(n_dofs));
+    this->n_q_points, std::vector<Tensor<1, dim>>(this->n_dofs));
   this->hess_phi = std::vector<std::vector<Tensor<2, dim>>>(
-    n_q_points, std::vector<Tensor<2, dim>>(n_dofs));
+    this->n_q_points, std::vector<Tensor<2, dim>>(this->n_dofs));
   this->laplacian_phi =
-    std::vector<std::vector<double>>(n_q_points, std::vector<double>(n_dofs));
+    std::vector<std::vector<double>>(this->n_q_points,
+                                     std::vector<double>(this->n_dofs));
 }
 
 

--- a/source/solvers/vof_scratch_data.cc
+++ b/source/solvers/vof_scratch_data.cc
@@ -17,8 +17,8 @@ VOFScratchData<dim>::allocate()
   // Initialize arrays related to velocity and pressure
   this->velocities_fd.first_vector_component = 0;
   // Velocity
-  this->velocity_values_fd = std::vector<Tensor<1, dim>>(this->n_q_points);
-  this->velocity_gradient_values_fd =
+  this->velocity_values = std::vector<Tensor<1, dim>>(this->n_q_points);
+  this->velocity_gradient_values =
     std::vector<Tensor<2, dim>>(this->n_q_points);
 
   this->present_phase_values = std::vector<double>(this->n_q_points);


### PR DESCRIPTION
Clean and homogeneize to make it clear what comes from the vof vs. cfd

# Description of the problem
In vof, it was not obvious to tell what came from the vof solving vs. cfd solving
- parameters coming from fluid had different suffix: none, `_fluid`, `_navier_stokes`
- parameters coming from vof had different suffix/prefix: none, `_fs` (old free surface)

# Description of the solution
Clean and homogenize the code
- when in the VOF files, added `this->` for every vof attributes for extra clarity
- change parameter names where it felt clearer
- minor homogenization in `heat_transfer` and `tracer` physics
- removed old/dead parameters

# How Has This Been Tested?

No tests, and if all tests run in debug we should be good to go. Should I change the names for the vof tests (called `free_surface` for now)?

# Documentation

None, variable names were changed in the code, not the prm.

# Future changes

None except another solver needs clarification as well.

# Comments

I will update the peeling-wetting branch so that the parameters are already in the same fashion.
