### PR TITLE
Add VOF auxiliary physics calculations

### DIFF
--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -339,6 +339,26 @@ namespace Parameters
   };
 
   /**
+   * @brief SurfaceTensionForce - Defines the parameters for
+   * the calculation of surface tension force in the VOF solver.
+   */
+  struct SurfaceTensionForce
+  {
+    double phase_fraction_gradient_filter_value;
+    double curvature_filter_value;
+
+    bool output_VOF_auxiliary_fields;
+
+    // Type of verbosity for the surface tension force calculation
+    Verbosity verbosity;
+
+    void
+    declare_parameters(ParameterHandler &prm);
+    void
+    parse_parameters(ParameterHandler &prm);
+  };
+
+  /**
    * @brief PhysicalProperties - Define the possible physical properties.
    * All continuum equations share the same physical properties object but only
    * take the subset of properties they require
@@ -355,6 +375,9 @@ namespace Parameters
     std::vector<Fluid>        fluids;
     unsigned int              number_of_fluids;
     static const unsigned int max_fluids = 2;
+
+    // Surface tension coefficient
+    double surface_tension_coef;
 
     void
     declare_parameters(ParameterHandler &prm);

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -40,6 +40,7 @@ namespace Parameters
     bool VOF;
     bool interface_sharpening;
     bool buoyancy_force;
+    bool continuum_surface_force;
 
     // subparameter for heat_transfer
     bool viscous_dissipation;

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -62,6 +62,7 @@ public:
   std::shared_ptr<Parameters::IBParticles<dim>>     particlesParameters;
   Parameters::DynamicFlowControl                    flow_control;
   Parameters::InterfaceSharpening                   interface_sharpening;
+  Parameters::SurfaceTensionForce                   surface_tension_force;
   Parameters::Multiphysics                          multiphysics;
 
   PhysicalPropertiesManager physical_properties_manager;
@@ -99,6 +100,7 @@ public:
     particlesParameters->declare_parameters(prm);
     manifolds_parameters.declare_parameters(prm);
     interface_sharpening.declare_parameters(prm);
+    surface_tension_force.declare_parameters(prm);
 
     analytical_solution = new AnalyticalSolutions::AnalyticalSolution<dim>;
     analytical_solution->declare_parameters(prm);
@@ -129,6 +131,7 @@ public:
     post_processing.parse_parameters(prm);
     flow_control.parse_parameters(prm);
     interface_sharpening.parse_parameters(prm);
+    surface_tension_force.parse_parameters(prm);
     restart_parameters.parse_parameters(prm);
     boundary_conditions.parse_parameters(prm);
     boundary_conditions_ht.parse_parameters(prm);

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -65,6 +65,8 @@ public:
     , triangulation(p_triangulation)
     , simulation_control(p_simulation_control)
     , dof_handler(*triangulation)
+    , pfg_dof_handler(*triangulation)
+    , curvature_dof_handler(*triangulation)
     , solution_transfer(dof_handler)
   {
     if (simulation_parameters.mesh.simplex)
@@ -83,6 +85,13 @@ public:
         fe      = std::make_shared<FE_Q<dim>>(1);
         mapping = std::make_shared<MappingQ<dim>>(
           fe->degree, simulation_parameters.fem_parameters.qmapping_all);
+        fe_pfg = std::make_shared<FESystem<dim>>(FE_Q<dim>(fe->degree), dim);
+        fe_curvature = std::make_shared<FE_Q<dim>>(1);
+        pfg_mapping  = std::make_shared<MappingQ<dim>>(
+          fe_pfg->degree, simulation_parameters.fem_parameters.qmapping_all);
+        curvature_mapping = std::make_shared<MappingQ<dim>>(
+          fe_curvature->degree,
+          simulation_parameters.fem_parameters.qmapping_all);
         cell_quadrature  = std::make_shared<QGauss<dim>>(fe->degree + 1);
         face_quadrature  = std::make_shared<QGauss<dim - 1>>(fe->degree + 1);
         error_quadrature = std::make_shared<QGauss<dim>>(fe->degree + 2);
@@ -422,6 +431,65 @@ private:
   void
   assemble_mass_matrix_diagonal(TrilinosWrappers::SparseMatrix &mass_matrix);
 
+  /**
+   * @brief Carries out interface sharpening. It is called in the modify solution function.
+   */
+  void
+  sharpen_interface();
+
+  /**
+   * @brief Carries out finding the gradients of phase fraction. Obtained gradients of phase
+   * fraction is used in find_filtered_interface_curvature to find interface
+   * curvature (k).
+   */
+  void
+  find_filtered_pfg();
+
+  /**
+   * @brief Carries out finding the interface curvature.
+   */
+  void
+  find_filtered_interface_curvature();
+
+  /**
+   * @brief Assembles the matrix and rhs for calculation of filtered phase gradient (fpg).
+   *
+   * Solves:
+   * $$ v . \psi + \eta * \nabla v . \nabla \psi = v . \nabla \phi $$
+   * where $$v$$, $$\psi$$, $$\eta$$, and $$\phi$$ are test function, fpg,
+   * filter value, and phase fraction.
+   *
+   * @param solution VOF solution (phase fraction)
+   */
+  void
+  assemble_pfg_matrix_and_rhs(TrilinosWrappers::MPI::Vector &solution);
+
+  /**
+   * @brief Solves phase fraction gradient system.
+   */
+  void
+  solve_pfg();
+
+  /**
+   * @brief Assembles the matrix and rhs for calculation of the curvature.
+   *
+   * Solves:
+   * $$ v * k + \eta * \nabla v . \nabla k = \nabla v . (\psi / |\psi|) $$
+   * where $$v$$, $$psi$$, $$eta$$, and $$k$$ are test function, fpg, filter
+   * value, and curvature.
+   *
+   * @param present_pfg_solution
+   */
+  void
+  assemble_curvature_matrix_and_rhs(
+    TrilinosWrappers::MPI::Vector &present_pfg_solution);
+
+  /**
+   * @brief Solves curvature system.
+   */
+  void
+  solve_curvature();
+
   TrilinosWrappers::MPI::Vector nodal_phase_fraction_owned;
 
   MultiphysicsInterface<dim> *     multiphysics;
@@ -429,14 +497,19 @@ private:
 
   // Core elements for the VOF simulation
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> triangulation;
-  std::shared_ptr<SimulationControl> simulation_control;
-  DoFHandler<dim>                    dof_handler;
-
+  std::shared_ptr<SimulationControl>  simulation_control;
+  DoFHandler<dim>                     dof_handler;
+  DoFHandler<dim>                     pfg_dof_handler;
+  DoFHandler<dim>                     curvature_dof_handler;
   std::shared_ptr<FiniteElement<dim>> fe;
+  std::shared_ptr<FESystem<dim>>      fe_pfg;
+  std::shared_ptr<FiniteElement<dim>> fe_curvature;
   ConvergenceTable                    error_table;
 
   // Mapping and Quadrature
   std::shared_ptr<Mapping<dim>>        mapping;
+  std::shared_ptr<Mapping<dim>>        pfg_mapping;
+  std::shared_ptr<Mapping<dim>>        curvature_mapping;
   std::shared_ptr<Quadrature<dim>>     cell_quadrature;
   std::shared_ptr<Quadrature<dim - 1>> face_quadrature;
   std::shared_ptr<Quadrature<dim>>     error_quadrature;
@@ -472,6 +545,37 @@ private:
   TrilinosWrappers::MPI::Vector  system_rhs_phase_fraction;
   TrilinosWrappers::MPI::Vector  complete_system_rhs_phase_fraction;
   TrilinosWrappers::SparseMatrix mass_matrix_phase_fraction;
+
+  // Filtered phase fraction gradient (pfg) solution
+  TrilinosWrappers::MPI::Vector present_pfg_solution;
+  IndexSet                      locally_owned_dofs_pfg;
+  IndexSet                      locally_relevant_dofs_pfg;
+  AffineConstraints<double>     pfg_constraints;
+  TrilinosWrappers::MPI::Vector nodal_pfg_relevant;
+  TrilinosWrappers::MPI::Vector nodal_pfg_owned;
+
+  TrilinosWrappers::SparseMatrix system_matrix_pfg;
+  TrilinosWrappers::SparseMatrix complete_system_matrix_pfg;
+  TrilinosWrappers::MPI::Vector  system_rhs_pfg;
+  TrilinosWrappers::MPI::Vector  complete_system_rhs_pfg;
+
+  // Filtered curvature solution
+  TrilinosWrappers::MPI::Vector present_curvature_solution;
+  IndexSet                      locally_owned_dofs_curvature;
+  IndexSet                      locally_relevant_dofs_curvature;
+  AffineConstraints<double>     curvature_constraints;
+  TrilinosWrappers::MPI::Vector nodal_curvature_relevant;
+  TrilinosWrappers::MPI::Vector nodal_curvature_owned;
+
+  std::vector<Tensor<1, dim>> pfg_values;
+  std::vector<double>         curvature_values;
+
+  TrilinosWrappers::SparseMatrix system_matrix_curvature;
+  TrilinosWrappers::SparseMatrix complete_system_matrix_curvature;
+  TrilinosWrappers::MPI::Vector  system_rhs_curvature;
+  TrilinosWrappers::MPI::Vector  complete_system_rhs_curvature;
+
+  std::shared_ptr<TrilinosWrappers::PreconditionILU> ilu_preconditioner;
 
   // Lower and upper bounds of phase fraction
   const double phase_upper_bound = 1.0;

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -555,9 +555,7 @@ private:
   TrilinosWrappers::MPI::Vector nodal_pfg_owned;
 
   TrilinosWrappers::SparseMatrix system_matrix_pfg;
-  TrilinosWrappers::SparseMatrix complete_system_matrix_pfg;
   TrilinosWrappers::MPI::Vector  system_rhs_pfg;
-  TrilinosWrappers::MPI::Vector  complete_system_rhs_pfg;
 
   // Filtered curvature solution
   TrilinosWrappers::MPI::Vector present_curvature_solution;
@@ -571,9 +569,7 @@ private:
   std::vector<double>         curvature_values;
 
   TrilinosWrappers::SparseMatrix system_matrix_curvature;
-  TrilinosWrappers::SparseMatrix complete_system_matrix_curvature;
   TrilinosWrappers::MPI::Vector  system_rhs_curvature;
-  TrilinosWrappers::MPI::Vector  complete_system_rhs_curvature;
 
   std::shared_ptr<TrilinosWrappers::PreconditionILU> ilu_preconditioner;
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -383,6 +383,60 @@ namespace Parameters
   }
 
   void
+  SurfaceTensionForce::declare_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection("surface tension force");
+    {
+      prm.declare_entry("output auxiliary fields",
+                        "false",
+                        Patterns::Bool(),
+                        "Output the phase fraction gradient and curvature");
+
+      prm.declare_entry(
+        "phase fraction gradient filter",
+        "0.5",
+        Patterns::Double(),
+        "The filter value for phase fraction gradient calculations to damp high-frequency errors");
+
+      prm.declare_entry(
+        "curvature filter",
+        "0.5",
+        Patterns::Double(),
+        "The filter value for curvature calculations to damp high-frequency errors");
+
+      prm.declare_entry(
+        "verbosity",
+        "quiet",
+        Patterns::Selection("quiet|verbose"),
+        "State whether from the surface tension force calculations should be printed "
+        "Choices are <quiet|verbose>.");
+    }
+    prm.leave_subsection();
+  }
+
+  void
+  SurfaceTensionForce::parse_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection("surface tension force");
+    {
+      phase_fraction_gradient_filter_value =
+        prm.get_double("phase fraction gradient filter");
+      curvature_filter_value = prm.get_double("curvature filter");
+
+      output_VOF_auxiliary_fields = prm.get_bool("output auxiliary fields");
+
+      const std::string op = prm.get("verbosity");
+      if (op == "verbose")
+        verbosity = Parameters::Verbosity::verbose;
+      else if (op == "quiet")
+        verbosity = Parameters::Verbosity::quiet;
+      else
+        throw(std::runtime_error("Invalid verbosity level"));
+    }
+    prm.leave_subsection();
+  }
+
+  void
   PhaseChange::parse_parameters(ParameterHandler &prm)
   {
     prm.enter_subsection("phase change");
@@ -445,7 +499,10 @@ namespace Parameters
                         Patterns::Integer(),
                         "Number of fluids");
 
-
+      prm.declare_entry("surface tension coefficient",
+                        "0.0",
+                        Patterns::Double(),
+                        "Surface tension coefficient");
 
       // Multiphasic simulations parameters definition
       for (unsigned int i_fluid = 0; i_fluid < max_fluids; ++i_fluid)
@@ -461,6 +518,9 @@ namespace Parameters
   {
     prm.enter_subsection("physical properties");
     {
+      // Surface tension coefficient
+      surface_tension_coef = prm.get_double("surface tension coefficient");
+
       // Multiphasic simulations parameters definition
       number_of_fluids = prm.get_integer("number of fluids");
       Assert(number_of_fluids == 1 || number_of_fluids == 2,

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -40,6 +40,11 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
                       Patterns::Bool(),
                       "Buoyant force calculation <true|false>");
 
+    prm.declare_entry("continuum surface force",
+                      "false",
+                      Patterns::Bool(),
+                      "Continuum surface force calculation <true|false>");
+
     // subparameter for heat_transfer
     prm.declare_entry("viscous dissipation",
                       "false",
@@ -67,12 +72,13 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
 {
   prm.enter_subsection("multiphysics");
   {
-    fluid_dynamics       = prm.get_bool("fluid dynamics");
-    heat_transfer        = prm.get_bool("heat transfer");
-    tracer               = prm.get_bool("tracer");
-    VOF                  = prm.get_bool("VOF");
-    interface_sharpening = prm.get_bool("interface sharpening");
-    buoyancy_force       = prm.get_bool("buoyancy force");
+    fluid_dynamics          = prm.get_bool("fluid dynamics");
+    heat_transfer           = prm.get_bool("heat transfer");
+    tracer                  = prm.get_bool("tracer");
+    VOF                     = prm.get_bool("VOF");
+    interface_sharpening    = prm.get_bool("interface sharpening");
+    buoyancy_force          = prm.get_bool("buoyancy force");
+    continuum_surface_force = prm.get_bool("continuum surface force");
 
     // subparameter for heat_transfer
     viscous_dissipation = prm.get_bool("viscous dissipation");

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -241,6 +241,28 @@ void
 VolumeOfFluid<dim>::attach_solution_to_output(DataOut<dim> &data_out)
 {
   data_out.add_data_vector(this->dof_handler, this->present_solution, "phase");
+
+  if (this->simulation_parameters.multiphysics.continuum_surface_force &&
+      simulation_parameters.surface_tension_force.output_VOF_auxiliary_fields)
+    {
+      std::vector<DataComponentInterpretation::DataComponentInterpretation>
+        pfg_component_interpretation(
+          dim + 1, DataComponentInterpretation::component_is_scalar);
+      for (unsigned int i = 0; i < dim; ++i)
+        pfg_component_interpretation[i] =
+          DataComponentInterpretation::component_is_part_of_vector;
+
+      std::vector<std::string> solution_names(dim, "phase fraction gradient");
+
+      data_out.add_data_vector(pfg_dof_handler,
+                               present_pfg_solution,
+                               solution_names,
+                               pfg_component_interpretation);
+
+      data_out.add_data_vector(curvature_dof_handler,
+                               present_curvature_solution,
+                               "curvature");
+    }
 }
 
 template <int dim>
@@ -459,47 +481,393 @@ void
 VolumeOfFluid<dim>::modify_solution()
 {
   if (this->simulation_parameters.multiphysics.interface_sharpening)
-    {
-      // Limit the phase fractions between 0 and 1
-      update_solution_and_constraints(this->present_solution);
-      for (unsigned int p = 0; p < this->previous_solutions.size(); ++p)
-        update_solution_and_constraints(this->previous_solutions[p]);
+    sharpen_interface();
 
-      // Interface sharpening is done at a constant frequency
-      if (this->simulation_control->get_step_number() %
-            this->simulation_parameters.interface_sharpening
-              .sharpening_frequency ==
-          0)
+  if (this->simulation_parameters.multiphysics.continuum_surface_force)
+    {
+      find_filtered_pfg();
+      find_filtered_interface_curvature();
+    }
+}
+
+template <int dim>
+void
+VolumeOfFluid<dim>::sharpen_interface()
+{
+  // Limit the phase fractions between 0 and 1
+  update_solution_and_constraints(present_solution);
+  for (unsigned int p = 0; p < previous_solutions.size(); ++p)
+    update_solution_and_constraints(previous_solutions[p]);
+
+  // Interface sharpening is done at a constant frequency
+  if (this->simulation_control->get_step_number() %
+        this->simulation_parameters.interface_sharpening.sharpening_frequency ==
+      0)
+    {
+      if (simulation_parameters.linear_solver.verbosity ==
+          Parameters::Verbosity::verbose)
         {
-          if (simulation_parameters.linear_solver.verbosity ==
-              Parameters::Verbosity::verbose)
+          this->pcout << "Sharpening interface at step "
+                      << this->simulation_control->get_step_number()
+                      << std::endl;
+        }
+
+      // Sharpen the interface of all solutions:
+      {
+        // Assemble matrix and solve the system for interface sharpening
+        assemble_L2_projection_interface_sharpening(present_solution);
+        solve_interface_sharpening(present_solution);
+
+        for (unsigned int p = 0; p < previous_solutions.size(); ++p)
+          {
+            assemble_L2_projection_interface_sharpening(previous_solutions[p]);
+            solve_interface_sharpening(previous_solutions[p]);
+          }
+      }
+
+      // Re limit the phase fractions between 0 and 1 after interface
+      // sharpening
+      update_solution_and_constraints(present_solution);
+      for (unsigned int p = 0; p < previous_solutions.size(); ++p)
+        update_solution_and_constraints(previous_solutions[p]);
+    }
+}
+
+template <int dim>
+void
+VolumeOfFluid<dim>::find_filtered_pfg()
+{
+  assemble_pfg_matrix_and_rhs(present_solution);
+  solve_pfg();
+}
+
+template <int dim>
+void
+VolumeOfFluid<dim>::find_filtered_interface_curvature()
+{
+  assemble_curvature_matrix_and_rhs(present_pfg_solution);
+  solve_curvature();
+}
+
+template <int dim>
+void
+VolumeOfFluid<dim>::assemble_pfg_matrix_and_rhs(
+  TrilinosWrappers::MPI::Vector &solution)
+{
+  FEValues<dim> fe_values_phase_fraction(*this->mapping,
+                                         *this->fe,
+                                         *this->cell_quadrature,
+                                         update_values |
+                                           update_quadrature_points |
+                                           update_JxW_values |
+                                           update_gradients);
+
+  FEValues<dim> fe_values_pfg(*this->mapping,
+                              *this->fe_pfg,
+                              *this->cell_quadrature,
+                              update_values | update_quadrature_points |
+                                update_JxW_values | update_gradients);
+
+
+  // const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
+  const unsigned int dofs_per_cell = this->fe_pfg->dofs_per_cell;
+
+  const unsigned int n_q_points = this->cell_quadrature->size();
+  FullMatrix<double> local_matrix_pfg(dofs_per_cell, dofs_per_cell);
+  Vector<double>     local_rhs_pfg(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  std::vector<Tensor<1, dim>> phi_pfg(dofs_per_cell);
+  std::vector<Tensor<2, dim>> phi_pfg_gradient(dofs_per_cell);
+
+  const FEValuesExtractors::Vector pfg(0);
+
+  std::vector<Tensor<1, dim>> phase_gradient_values(n_q_points);
+  std::vector<Tensor<1, dim>> pfg_values(n_q_points);
+  std::vector<Tensor<2, dim>> pfg_gradient_values(n_q_points);
+
+
+  system_rhs_pfg    = 0;
+  system_matrix_pfg = 0;
+
+  for (const auto &pfg_cell : this->pfg_dof_handler.active_cell_iterators())
+    {
+      if (pfg_cell->is_locally_owned())
+        {
+          typename DoFHandler<dim>::active_cell_iterator cell(
+            &(*this->triangulation),
+            pfg_cell->level(),
+            pfg_cell->index(),
+            &this->dof_handler);
+
+          fe_values_phase_fraction.reinit(cell);
+          fe_values_pfg.reinit(pfg_cell);
+
+          local_matrix_pfg = 0;
+          local_rhs_pfg    = 0;
+
+          fe_values_phase_fraction.get_function_gradients(
+            solution, phase_gradient_values);
+
+          fe_values_pfg[pfg].get_function_values(present_pfg_solution,
+                                                 pfg_values);
+
+          fe_values_pfg[pfg].get_function_gradients(present_pfg_solution,
+                                                    pfg_gradient_values);
+
+          for (unsigned int q = 0; q < n_q_points; ++q)
             {
-              this->pcout << "Sharpening interface at step "
-                          << this->simulation_control->get_step_number()
-                          << std::endl;
+              for (unsigned int k = 0; k < dofs_per_cell; ++k)
+                {
+                  phi_pfg[k]          = fe_values_pfg[pfg].value(k, q);
+                  phi_pfg_gradient[k] = fe_values_pfg[pfg].gradient(k, q);
+                }
+
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                {
+                  // Matrix assembly
+                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                    {
+                      local_matrix_pfg(i, j) +=
+                        (phi_pfg[j] * phi_pfg[i] +
+                         simulation_parameters.surface_tension_force
+                             .phase_fraction_gradient_filter_value *
+                           scalar_product(phi_pfg_gradient[i],
+                                          phi_pfg_gradient[j])) *
+                        fe_values_pfg.JxW(q);
+                    }
+
+                  // rhs
+                  local_rhs_pfg(i) -=
+                    (phi_pfg[i] * pfg_values[q] +
+                     simulation_parameters.surface_tension_force
+                         .phase_fraction_gradient_filter_value *
+                       scalar_product(phi_pfg_gradient[i],
+                                      pfg_gradient_values[q]) -
+                     phi_pfg[i] * phase_gradient_values[q]) *
+                    fe_values_pfg.JxW(q);
+                }
             }
 
-          // Sharpen the interface of all solutions:
-          {
-            // Assemble matrix and solve the system for interface sharpening
-            assemble_L2_projection_interface_sharpening(this->present_solution);
-            solve_interface_sharpening(this->present_solution);
-
-            for (unsigned int p = 0; p < this->previous_solutions.size(); ++p)
-              {
-                assemble_L2_projection_interface_sharpening(
-                  this->previous_solutions[p]);
-                solve_interface_sharpening(this->previous_solutions[p]);
-              }
-          }
-
-          // Re limit the phase fractions between 0 and 1 after interface
-          // sharpening
-          update_solution_and_constraints(this->present_solution);
-          for (unsigned int p = 0; p < this->previous_solutions.size(); ++p)
-            update_solution_and_constraints(this->previous_solutions[p]);
+          pfg_cell->get_dof_indices(local_dof_indices);
+          pfg_constraints.distribute_local_to_global(local_matrix_pfg,
+                                                     local_rhs_pfg,
+                                                     local_dof_indices,
+                                                     system_matrix_pfg,
+                                                     system_rhs_pfg);
         }
     }
+  system_matrix_pfg.compress(VectorOperation::add);
+  system_rhs_pfg.compress(VectorOperation::add);
+}
+
+
+template <int dim>
+void
+VolumeOfFluid<dim>::solve_pfg()
+{
+  // Solve the L2 projection system
+  const double linear_solver_tolerance = 1e-10;
+
+  TrilinosWrappers::MPI::Vector completely_distributed_pfg_solution(
+    this->locally_owned_dofs_pfg, triangulation->get_communicator());
+
+  completely_distributed_pfg_solution = present_pfg_solution;
+
+  SolverControl solver_control(
+    this->simulation_parameters.linear_solver.max_iterations,
+    linear_solver_tolerance,
+    true,
+    true);
+
+  TrilinosWrappers::SolverCG solver(solver_control);
+
+  const double ilu_fill =
+    this->simulation_parameters.linear_solver.ilu_precond_fill;
+  const double ilu_atol =
+    this->simulation_parameters.linear_solver.ilu_precond_atol;
+  const double ilu_rtol =
+    this->simulation_parameters.linear_solver.ilu_precond_rtol;
+
+  TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
+    ilu_fill, ilu_atol, ilu_rtol, 0);
+
+  ilu_preconditioner = std::make_shared<TrilinosWrappers::PreconditionILU>();
+
+  ilu_preconditioner->initialize(system_matrix_pfg, preconditionerOptions);
+  solver.solve(system_matrix_pfg,
+               completely_distributed_pfg_solution,
+               system_rhs_pfg,
+               *ilu_preconditioner);
+
+  if (this->simulation_parameters.surface_tension_force.verbosity !=
+      Parameters::Verbosity::quiet)
+    {
+      this->pcout << "  -Iterative solver (phase fraction gradient) took : "
+                  << solver_control.last_step() << " steps " << std::endl;
+    }
+
+  pfg_constraints.distribute(completely_distributed_pfg_solution);
+
+  present_pfg_solution = completely_distributed_pfg_solution;
+}
+
+template <int dim>
+void
+VolumeOfFluid<dim>::assemble_curvature_matrix_and_rhs(
+  TrilinosWrappers::MPI::Vector &present_pfg_solution)
+{
+  FEValues<dim> fe_values_curvature(*this->curvature_mapping,
+                                    *this->fe_curvature,
+                                    *this->cell_quadrature,
+                                    update_values | update_quadrature_points |
+                                      update_JxW_values | update_gradients);
+
+  FEValues<dim> fe_values_pfg(*this->mapping,
+                              *this->fe_pfg,
+                              *this->cell_quadrature,
+                              update_values | update_quadrature_points |
+                                update_JxW_values | update_gradients);
+
+  const unsigned int dofs_per_cell = this->fe_curvature->dofs_per_cell;
+
+  const unsigned int n_q_points = this->cell_quadrature->size();
+  FullMatrix<double> local_matrix_curvature(dofs_per_cell, dofs_per_cell);
+  Vector<double>     local_rhs_curvature(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  std::vector<double>         phi_curvature(dofs_per_cell);
+  std::vector<Tensor<1, dim>> phi_curvature_gradient(dofs_per_cell);
+
+  pfg_values       = std::vector<Tensor<1, dim>>(n_q_points);
+  curvature_values = std::vector<double>(n_q_points);
+  std::vector<Tensor<1, dim>>      curvature_gradient_values(n_q_points);
+  const FEValuesExtractors::Vector pfg(0);
+
+  system_rhs_curvature    = 0;
+  system_matrix_curvature = 0;
+
+  for (const auto &curvature_cell :
+       this->curvature_dof_handler.active_cell_iterators())
+    {
+      if (curvature_cell->is_locally_owned())
+        {
+          typename DoFHandler<dim>::active_cell_iterator pfg_cell(
+            &(*this->triangulation),
+            curvature_cell->level(),
+            curvature_cell->index(),
+            &this->pfg_dof_handler);
+
+          fe_values_pfg.reinit(pfg_cell);
+          fe_values_curvature.reinit(curvature_cell);
+
+          local_matrix_curvature = 0;
+          local_rhs_curvature    = 0;
+
+          fe_values_pfg[pfg].get_function_values(present_pfg_solution,
+                                                 pfg_values);
+
+          fe_values_curvature.get_function_values(present_curvature_solution,
+                                                  curvature_values);
+
+          fe_values_curvature.get_function_gradients(present_curvature_solution,
+                                                     curvature_gradient_values);
+
+          for (unsigned int q = 0; q < n_q_points; ++q)
+            {
+              for (unsigned int k = 0; k < dofs_per_cell; ++k)
+                {
+                  phi_curvature[k] = fe_values_curvature.shape_value(k, q);
+                  phi_curvature_gradient[k] =
+                    fe_values_curvature.shape_grad(k, q);
+                }
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                {
+                  // Matrix assembly
+                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                    {
+                      local_matrix_curvature(i, j) +=
+                        (phi_curvature[j] * phi_curvature[i] +
+                         simulation_parameters.surface_tension_force
+                             .curvature_filter_value *
+                           scalar_product(phi_curvature_gradient[i],
+                                          phi_curvature_gradient[j])) *
+                        fe_values_curvature.JxW(q);
+                    }
+                  // rhs
+                  local_rhs_curvature(i) -=
+                    (phi_curvature[i] * curvature_values[q] +
+                     simulation_parameters.surface_tension_force
+                         .curvature_filter_value *
+                       scalar_product(phi_curvature_gradient[i],
+                                      curvature_gradient_values[q]) -
+                     phi_curvature_gradient[i] *
+                       (pfg_values[q] / (pfg_values[q].norm() + DBL_MIN))) *
+                    fe_values_curvature.JxW(q);
+                }
+            }
+
+          curvature_cell->get_dof_indices(local_dof_indices);
+          curvature_constraints.distribute_local_to_global(
+            local_matrix_curvature,
+            local_rhs_curvature,
+            local_dof_indices,
+            system_matrix_curvature,
+            system_rhs_curvature);
+        }
+    }
+  system_matrix_curvature.compress(VectorOperation::add);
+  system_rhs_curvature.compress(VectorOperation::add);
+}
+
+template <int dim>
+void
+VolumeOfFluid<dim>::solve_curvature()
+{
+  const double linear_solver_tolerance = 1e-10;
+
+  TrilinosWrappers::MPI::Vector completely_distributed_curvature_solution(
+    this->locally_owned_dofs_curvature, triangulation->get_communicator());
+
+  completely_distributed_curvature_solution = present_curvature_solution;
+
+  SolverControl solver_control(
+    this->simulation_parameters.linear_solver.max_iterations,
+    linear_solver_tolerance,
+    true,
+    true);
+
+  TrilinosWrappers::SolverCG solver(solver_control);
+
+  const double ilu_fill =
+    this->simulation_parameters.linear_solver.ilu_precond_fill;
+  const double ilu_atol =
+    this->simulation_parameters.linear_solver.ilu_precond_atol;
+  const double ilu_rtol =
+    this->simulation_parameters.linear_solver.ilu_precond_rtol;
+
+  TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
+    ilu_fill, ilu_atol, ilu_rtol, 0);
+
+  ilu_preconditioner = std::make_shared<TrilinosWrappers::PreconditionILU>();
+
+  ilu_preconditioner->initialize(system_matrix_curvature,
+                                 preconditionerOptions);
+  solver.solve(system_matrix_curvature,
+               completely_distributed_curvature_solution,
+               system_rhs_curvature,
+               *ilu_preconditioner);
+
+  if (this->simulation_parameters.surface_tension_force.verbosity !=
+      Parameters::Verbosity::quiet)
+    {
+      this->pcout << " -Iterative solver (curvature) took : "
+                  << solver_control.last_step() << " steps " << std::endl;
+    }
+
+  curvature_constraints.distribute(completely_distributed_curvature_solution);
+
+  present_curvature_solution = completely_distributed_curvature_solution;
 }
 
 template <int dim>
@@ -619,10 +987,117 @@ template <int dim>
 void
 VolumeOfFluid<dim>::setup_dofs()
 {
+  auto mpi_communicator = triangulation->get_communicator();
+
+  pfg_dof_handler.distribute_dofs(*fe_pfg);
+
+  locally_owned_dofs_pfg = pfg_dof_handler.locally_owned_dofs();
+
+  DoFTools::extract_locally_relevant_dofs(pfg_dof_handler,
+                                          locally_relevant_dofs_pfg);
+
+  pfg_constraints.clear();
+  pfg_constraints.reinit(locally_relevant_dofs_pfg);
+  DoFTools::make_hanging_node_constraints(pfg_dof_handler, pfg_constraints);
+  pfg_constraints.close();
+
+  nodal_pfg_relevant.reinit(locally_owned_dofs_pfg,
+                            locally_relevant_dofs_pfg,
+                            mpi_communicator);
+
+  nodal_pfg_owned.reinit(locally_owned_dofs_pfg, mpi_communicator);
+
+
+
+  DynamicSparsityPattern dsp_pfg(locally_relevant_dofs_pfg);
+  DoFTools::make_sparsity_pattern(pfg_dof_handler,
+                                  dsp_pfg,
+                                  pfg_constraints,
+                                  false);
+
+  SparsityTools::distribute_sparsity_pattern(dsp_pfg,
+                                             locally_owned_dofs_pfg,
+                                             mpi_communicator,
+                                             locally_relevant_dofs_pfg);
+
+
+  // Initialization of phase fraction gradient matrice and rhs for the
+  // calculation surface tension force
+  system_matrix_pfg.reinit(locally_owned_dofs_pfg,
+                           locally_owned_dofs_pfg,
+                           dsp_pfg,
+                           mpi_communicator);
+
+  complete_system_matrix_pfg.reinit(locally_owned_dofs_pfg,
+                                    locally_owned_dofs_pfg,
+                                    dsp_pfg,
+                                    mpi_communicator);
+
+  system_rhs_pfg.reinit(locally_owned_dofs_pfg, mpi_communicator);
+
+  complete_system_rhs_pfg.reinit(locally_owned_dofs_pfg, mpi_communicator);
+
+  present_pfg_solution.reinit(locally_owned_dofs_pfg,
+                              locally_relevant_dofs_pfg,
+                              mpi_communicator);
+
+  // Curvature
+  curvature_dof_handler.distribute_dofs(*fe_curvature);
+
+  locally_owned_dofs_curvature = curvature_dof_handler.locally_owned_dofs();
+
+  DoFTools::extract_locally_relevant_dofs(curvature_dof_handler,
+                                          locally_relevant_dofs_curvature);
+
+  curvature_constraints.clear();
+  curvature_constraints.reinit(locally_relevant_dofs_curvature);
+  DoFTools::make_hanging_node_constraints(curvature_dof_handler,
+                                          curvature_constraints);
+  curvature_constraints.close();
+
+  nodal_curvature_relevant.reinit(locally_owned_dofs_curvature,
+                                  locally_relevant_dofs_curvature,
+                                  mpi_communicator);
+
+  nodal_curvature_owned.reinit(locally_owned_dofs_curvature, mpi_communicator);
+
+
+
+  DynamicSparsityPattern dsp_curvature(locally_relevant_dofs_curvature);
+  DoFTools::make_sparsity_pattern(curvature_dof_handler,
+                                  dsp_curvature,
+                                  curvature_constraints,
+                                  false);
+
+  SparsityTools::distribute_sparsity_pattern(dsp_curvature,
+                                             locally_owned_dofs_curvature,
+                                             mpi_communicator,
+                                             locally_relevant_dofs_curvature);
+
+
+  // Initialization of curvature matrice and rhs for the
+  // calculation surface tension force
+  system_matrix_curvature.reinit(locally_owned_dofs_curvature,
+                                 locally_owned_dofs_curvature,
+                                 dsp_curvature,
+                                 mpi_communicator);
+
+  complete_system_matrix_curvature.reinit(locally_owned_dofs_curvature,
+                                          locally_owned_dofs_curvature,
+                                          dsp_curvature,
+                                          mpi_communicator);
+
+  system_rhs_curvature.reinit(locally_owned_dofs_curvature, mpi_communicator);
+
+  complete_system_rhs_curvature.reinit(locally_owned_dofs_curvature,
+                                       mpi_communicator);
+
+  present_curvature_solution.reinit(locally_owned_dofs_curvature,
+                                    locally_relevant_dofs_curvature,
+                                    mpi_communicator);
+
   this->dof_handler.distribute_dofs(*this->fe);
   DoFRenumbering::Cuthill_McKee(this->dof_handler);
-
-  auto mpi_communicator = this->triangulation->get_communicator();
 
   this->locally_owned_dofs = this->dof_handler.locally_owned_dofs();
   DoFTools::extract_locally_relevant_dofs(this->dof_handler,


### PR DESCRIPTION
# Description of the problem

- Adds two VOF auxiliary physics (phase fraction gradient and curvature) to the VOF solver. These variables can be outputted.

# Future changes

- These auxiliary variables will be used in the calculation of the surface tension force.

