### PR TITLE
Cleanup headers in core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ add_compile_options(-pedantic-errors)
 add_compile_options(-Wextra)
 add_compile_options(-Wunused-variable)
 add_compile_options(-Wdisabled-optimization)
+add_compile_options(-Wall)
+
+
 # Disabled by default, used to be necessary on the Cedar cluster of Compute Canada
 #add_compile_options(-fext-numeric-literals)
 
@@ -41,6 +44,8 @@ ENDIF()
 
 #set(PROTOTYPES "FALSE" CACHE BOOL)
 option(PROTOTYPES "Enable prototypes applications" OFF)
+option(MARCH_NATIVE "Enable prototypes applications" OFF)
+
 
 Project(lethe)
 SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
@@ -53,6 +58,11 @@ IF(PROTOTYPES)
     MESSAGE("Adding prototypes")
     ADD_SUBDIRECTORY(prototypes)
  ENDIF()
+ IF(MARCH_NATIVE)
+    MESSAGE("  Enabling -march=native flag. This may cause some tests to break.")
+    add_compile_options(-march=native)
+ ENDIF()
+
 
 set(missing_dealii_features)
 

--- a/include/core/bdf.h
+++ b/include/core/bdf.h
@@ -61,8 +61,8 @@ bdf_coefficients(unsigned int order, const std::vector<double> time_steps);
  * dt_2.
  */
 Vector<double>
-bdf_coefficients(Parameters::SimulationControl::TimeSteppingMethod method,
-                 const std::vector<double>                         time_steps);
+bdf_coefficients(const Parameters::SimulationControl::TimeSteppingMethod method,
+                 const std::vector<double> time_steps);
 
 
 /**
@@ -79,7 +79,10 @@ bdf_coefficients(Parameters::SimulationControl::TimeSteppingMethod method,
  * t, t-dt_1 and t-dt_2.
  */
 Vector<double>
-delta(unsigned int order, unsigned int n, unsigned int j, Vector<double> times);
+delta(const unsigned int   order,
+      const unsigned int   n,
+      const unsigned int   j,
+      const Vector<double> times);
 
 
 

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -722,19 +722,18 @@ NavierStokesFunctionDefined<dim>::value(const Point<dim> & p,
                                         const unsigned int component) const
 {
   Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components));
-  if (component == 0)
-    {
-      return u->value(p);
-    }
+         ExcIndexRange(component, 0, this->n_components)) if (component == 0)
+  {
+    return u->value(p);
+  }
   else if (component == 1)
-    {
-      return v->value(p);
-    }
+  {
+    return v->value(p);
+  }
   else if (component == 2)
-    {
-      return w->value(p);
-    }
+  {
+    return w->value(p);
+  }
   return 0.;
 }
 

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -59,7 +59,7 @@ public:
   value(const std::map<field, double> & /*fields_value*/) override
   {
     return density;
-  };
+  }
 
   /**
    * @brief vector_value Calculates the vector of density.
@@ -86,7 +86,7 @@ public:
            field /*id*/) override
   {
     return 0;
-  };
+  }
 
   /**
    * @brief vector_jacobian Calculates the derivative of the density with respect to a field.
@@ -102,7 +102,7 @@ public:
     std::vector<double> &jacobian_vector) override
   {
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
-  };
+  }
 
 private:
   const double density;

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -24,15 +24,7 @@
 #include <core/manifolds.h>
 #include <core/parameters.h>
 
-#include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/tria_base.h>
-
-#include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/grid_in.h>
-#include <deal.II/grid/grid_out.h>
-#include <deal.II/grid/tria.h>
-
-
 
 using namespace dealii;
 

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -19,6 +19,8 @@
 #include <deal.II/base/parsed_function.h>
 #include <deal.II/base/point.h>
 
+#include <vector>
+
 #ifndef lethe_ib_particle_h
 #  define lethe_ib_particle_h
 

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -16,23 +16,14 @@
  * Author: Lucka Barbeau, Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
-#ifndef lethe_ib_stencils_h
-#define lethe_ib_stencils_h
+#ifndef lethe_ib_stencil_h
+#define lethe_ib_stencil_h
 
 #include <core/ib_particle.h>
 
-#include <deal.II/base/table_handler.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/dofs/dof_handler.h>
-
-#include <deal.II/fe/fe.h>
-#include <deal.II/fe/mapping.h>
-#include <deal.II/fe/mapping_manifold.h>
-#include <deal.II/fe/mapping_q1.h>
-
-#include <deal.II/lac/trilinos_parallel_block_vector.h>
-#include <deal.II/lac/trilinos_vector.h>
+#include <vector>
 
 
 

--- a/include/core/inexact_newton_non_linear_solver.h
+++ b/include/core/inexact_newton_non_linear_solver.h
@@ -17,7 +17,6 @@
 #ifndef lethe_inexact_newton_iteration_non_linear_solver_h
 #define lethe_inexact_newton_iteration_non_linear_solver_h
 
-#include <core/multiphysics.h>
 #include <core/non_linear_solver.h>
 
 /**

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -17,7 +17,6 @@
 #ifndef kinsol_non_linear_solver_h
 #define kinsol_non_linear_solver_h
 
-#include <core/multiphysics.h>
 #include <core/non_linear_solver.h>
 #include <core/parameters.h>
 

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -20,13 +20,7 @@
 #ifndef lethe_manifolds_h
 #define lethe_manifolds_h
 
-#include <deal.II/base/data_out_base.h>
 #include <deal.II/base/parameter_handler.h>
-
-#include <deal.II/distributed/tria.h>
-#include <deal.II/distributed/tria_base.h>
-
-#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/numerics/data_postprocessor.h>
 

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -20,7 +20,6 @@
 #ifndef lethe_newton_non_linear_solver_h
 #define lethe_newton_non_linear_solver_h
 
-#include <core/multiphysics.h>
 #include <core/non_linear_solver.h>
 
 /**

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -146,13 +146,15 @@ public:
    *
    **/
 
-  SimulationControl(Parameters::SimulationControl param);
+  SimulationControl(const Parameters::SimulationControl param);
 
   /**
    * @brief Pure virtual function to control the progression of the simulation.
    * As long as integrate returns true, a simulation should proceed. The
    * criteria used to stop/continue the simulation in iterate is a property of
-   * each individual time stepping control.
+   * each individual time stepping control. For example, steady-state simulation
+   * will proceed until the number of required mesh adaptation has been
+   *performed.
    **/
   virtual bool
   integrate() = 0;
@@ -201,7 +203,7 @@ public:
 
   /**
    * @brief Calculates the next value of the time step. The base function returns
-   * the value of the time step, but derived class implement adaptative time
+   * the value of the time step, but derived class may implement adaptative time
    * stepping
    */
   virtual double
@@ -234,7 +236,7 @@ public:
   get_output_boundaries()
   {
     return output_boundaries;
-  };
+  }
 
   /**
    * @brief Check if the present iteration is a verbose iteration where
@@ -254,7 +256,7 @@ public:
     bool return_value = first_assembly;
     first_assembly    = false;
     return return_value;
-  };
+  }
 
   /**
    * @brief Define the assembly method to use while integrating. Use to start bdf 2 and bdf 3 scheme.
@@ -324,68 +326,68 @@ public:
   }
 
   std::string
-  get_output_name()
+  get_output_name() const
   {
     return output_name;
   }
 
   std::string
-  get_output_path()
+  get_output_path() const
   {
     return output_path;
   }
 
   unsigned int
-  get_group_files()
+  get_group_files() const
   {
     return group_files;
   }
 
   unsigned int
-  get_log_precision()
+  get_log_precision() const
   {
     return log_precision;
   }
 
   double
-  get_current_time()
+  get_current_time() const
   {
     return current_time;
   }
 
   double
-  get_previous_time()
+  get_previous_time() const
   {
     return previous_time;
   }
 
 
   std::vector<double>
-  get_time_steps_vector()
+  get_time_steps_vector() const
   {
     return time_step_vector;
   }
 
   double
-  get_CFL()
+  get_CFL() const
   {
     return CFL;
   }
 
   unsigned int
-  get_step_number()
+  get_step_number() const
   {
     return iteration_number;
   }
 
   unsigned int
-  get_number_subdivision()
+  get_number_subdivision() const
   {
     return subdivision;
   }
 
   Parameters::SimulationControl::TimeSteppingMethod
-  get_assembly_method()
+  get_assembly_method() const
   {
     return assembly_method;
   }

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -38,10 +38,7 @@
 
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_simplex_p.h>
-#include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_fe.h>
-
-#include <deal.II/grid/grid_generator.h>
 
 #include <deal.II/lac/trilinos_vector.h>
 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -25,14 +25,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/fe/mapping_manifold.h>
-#include <deal.II/fe/mapping_q1.h>
-
 using namespace dealii;
-
-
-// Utility function to create tables from vectors of scalars/tensors as
-// dependent or independent variables.
 
 
 
@@ -155,7 +148,7 @@ calculate_point_property(const double phase,
  */
 void
 fill_table_from_file(TableHandler &    table,
-                     std::string       file,
+                     const std::string file_name,
                      const std::string delimiter = " ");
 
 /**
@@ -170,7 +163,7 @@ fill_table_from_file(TableHandler &    table,
  */
 void
 fill_vectors_from_file(std::map<std::string, std::vector<double>> &map,
-                       std::string                                 file,
+                       const std::string                           file_name,
                        const std::string delimiter = " ");
 
 

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -31,9 +31,6 @@
 #include <solvers/physical_properties_manager.h>
 #include <solvers/source_terms.h>
 
-#include <dem/dem_solver_parameters.h>
-#include <fem-dem/parameters_cfd_dem.h>
-
 template <int dim>
 class SimulationParameters
 {

--- a/source/core/bdf.cc
+++ b/source/core/bdf.cc
@@ -16,30 +16,11 @@
 
 #include "core/bdf.h"
 
-Vector<double>
-delta(unsigned int p, unsigned int n, unsigned int j, Vector<double> times)
-{
-  if (j == 0)
-    {
-      Vector<double> arr(p + 1);
-      arr    = 0.;
-      arr[n] = 1;
-      return arr;
-    }
-  else
-    {
-      Vector<double> delta_1 = delta(p, n, j - 1, times);
-      Vector<double> delta_2 = delta(p, n + 1, j - 1, times);
-      Vector<double> delta_sol(p + 1);
-      for (unsigned int i_del = 0; i_del < p + 1; ++i_del)
-        delta_sol[i_del] =
-          (delta_1[i_del] - delta_2[i_del]) / (times[n] - times[n + j]);
-      return delta_sol;
-    }
-}
+#include <deal.II/lac/vector.h>
+
 
 Vector<double>
-bdf_coefficients(unsigned int p, const std::vector<double> dt)
+bdf_coefficients(const unsigned int p, const std::vector<double> dt)
 {
   // There should be at least p time steps
   assert(dt.size() >= p);
@@ -71,8 +52,8 @@ bdf_coefficients(unsigned int p, const std::vector<double> dt)
 }
 
 Vector<double>
-bdf_coefficients(Parameters::SimulationControl::TimeSteppingMethod method,
-                 const std::vector<double>                         dt)
+bdf_coefficients(const Parameters::SimulationControl::TimeSteppingMethod method,
+                 const std::vector<double>                               dt)
 {
   switch (method)
     {
@@ -88,5 +69,30 @@ bdf_coefficients(Parameters::SimulationControl::TimeSteppingMethod method,
         throw(std::runtime_error(
           "BDF coefficients were requested without a BDF method"));
         break;
+    }
+}
+
+Vector<double>
+delta(const unsigned int   p,
+      const unsigned int   n,
+      const unsigned int   j,
+      const Vector<double> times)
+{
+  if (j == 0)
+    {
+      Vector<double> arr(p + 1);
+      arr    = 0.;
+      arr[n] = 1;
+      return arr;
+    }
+  else
+    {
+      Vector<double> delta_1 = delta(p, n, j - 1, times);
+      Vector<double> delta_2 = delta(p, n + 1, j - 1, times);
+      Vector<double> delta_sol(p + 1);
+      for (unsigned int i_del = 0; i_del < p + 1; ++i_del)
+        delta_sol[i_del] =
+          (delta_1[i_del] - delta_2[i_del]) / (times[n] - times[n + j]);
+      return delta_sol;
     }
 }

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -5,9 +5,10 @@
 #include <core/periodic_hills_grid.h>
 
 // Deal.II includes
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
 
 // Std
 #include <fstream>
@@ -72,7 +73,8 @@ attach_grid_to_triangulation(
             mesh_parameters.grid_arguments);
 
           // initial refinement
-          const int initial_refinement = mesh_parameters.initial_refinement;
+          const unsigned int initial_refinement =
+            mesh_parameters.initial_refinement;
           temporary_quad_triangulation.refine_global(initial_refinement);
           // flatten the triangulation
           Triangulation<dim, spacedim> flat_temp_quad_triangulation;

--- a/source/core/ib_stencil.cc
+++ b/source/core/ib_stencil.cc
@@ -1,5 +1,9 @@
 #include <core/ib_stencil.h>
 
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+
 
 template <int dim>
 unsigned int

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -4,7 +4,7 @@
 #include <fstream>
 
 
-SimulationControl::SimulationControl(Parameters::SimulationControl param)
+SimulationControl::SimulationControl(const Parameters::SimulationControl param)
   : method(param.method)
   , assembly_method(param.method)
   , current_time(0)

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -30,6 +30,7 @@
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping.h>
 

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -96,11 +96,11 @@ make_table_tensors_scalars(
 
 void
 fill_table_from_file(TableHandler &    table,
-                     std::string       file,
+                     const std::string file_name,
                      const std::string delimiter)
 {
   table.clear();
-  std::ifstream myfile(file);
+  std::ifstream myfile(file_name);
   // open the file
   if (myfile.is_open())
     {

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -37,6 +37,7 @@
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_simplex_p.h>
 
+#include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria_iterator.h>
 

--- a/tests/solvers/multiphysics_interface_01.cc
+++ b/tests/solvers/multiphysics_interface_01.cc
@@ -22,6 +22,9 @@
  */
 
 // Deal.II includes
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/tria.h>
 // Lethe
 #include <core/multiphysics.h>
 #include <core/parameters.h>


### PR DESCRIPTION
# Description of the problem

- Some headers have far too many includes which are not necessary

# Description of the solution

- This PR cleans up the includes to minimize the amount

# How Has This Been Tested?

- No tests are required. If CI passes it is all good. Tested on my machine

# Comments

It would be a good practice to be careful about setting function arguments to const when they are const and etc. I did my best in this case to do this. 