### PR TITLE
Add Koch and Hill drag model 

### DIFF
--- a/doc/source/parameters/unresolved_cfd-dem/cfd_dem.rst
+++ b/doc/source/parameters/unresolved_cfd-dem/cfd_dem.rst
@@ -23,7 +23,7 @@ This subsection includes parameters related to multiphase flow simulations using
 * The ``grad div`` parameter allows the enabling of the grad div stabilization for the Volume Averaged Navier Stokes equations [1]. This allows for a much better mass conservation of the system.
 * The ``void fraction time derivative`` parameters allows us to choose whether or not we want to account for the time derivative of the void fraction or take it equal to zero.
 * The ``drag force``, ``buoyancy force``, ``shear force``, and ``pressure force`` parameters allow us to enable or disable the respective forces in a cfd-dem simulation.
-* The ``drag model`` parameter allows one to choose the type of drag model to be implemented for the calculation of the drag force between the particles and the fluids. Available drag models at the time of writing are: Difelice [2], Rong [3], and Dallavalle [4].
+* The ``drag model`` parameter allows one to choose the type of drag model to be implemented for the calculation of the drag force between the particles and the fluids. Available drag models at the time of writing are: Difelice [2], Rong [3], Dallavalle [4], and Koch and Hill [5].
 * The ``post processing`` parameter, when enabled, allows the calculation of the pressure drop, void fraction in the packed region, and the mass conservation in a packed bed at each time step.
 * The ``coupling frequency`` parameter is only applicable for the cfd-dem solver and it determines the number of DEM iterations per 1 CFD iteration.
 
@@ -42,3 +42,5 @@ This subsection includes parameters related to multiphase flow simulations using
 [3] L. Rong, K. Dong, A. Yu, Lattice-boltzmann simulation of fluid flow through packed beds of uniform spheres: Effect of porosity, Chemical engineering science 99 (2013) 44–58.
 
 [4] Sobieski, Wojciech. (2011). Drag Coefficient in Solid–Fluid System Modeling with the Eulerian Multiphase Model. Drying Technology. 29. 111-125. 10.1080/07373937.2010.482714. 
+
+[5]  D. Jajcevic, E. Siegmann, C. Radeke, J. G. Khinast, Large-scale cfd–dem simulations of fluidized granular systems, Chemical Engineering Science 98 (2013) 298–310

--- a/include/fem-dem/parameters_cfd_dem.h
+++ b/include/fem-dem/parameters_cfd_dem.h
@@ -20,11 +20,11 @@
 #ifndef lethe_parameters_cfd_dem_h
 #define lethe_parameters_cfd_dem_h
 
-#include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/parsed_function.h>
-
 #include <core/parameters.h>
 #include <core/parameters_lagrangian.h>
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
 
 
 using namespace dealii;

--- a/include/fem-dem/parameters_cfd_dem.h
+++ b/include/fem-dem/parameters_cfd_dem.h
@@ -20,11 +20,11 @@
 #ifndef lethe_parameters_cfd_dem_h
 #define lethe_parameters_cfd_dem_h
 
-#include <core/parameters.h>
-#include <core/parameters_lagrangian.h>
-
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/parsed_function.h>
+
+#include <core/parameters.h>
+#include <core/parameters_lagrangian.h>
 
 
 using namespace dealii;
@@ -50,7 +50,8 @@ namespace Parameters
   {
     difelice,
     rong,
-    dallavalle
+    dallavalle,
+    kochhill
   };
 
   enum class VANSModel

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -316,7 +316,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculted the solid_fluid interactions
+   * @brief calculate_particle_fluid_interactions  calculates the solid-fluid interaction of the Koch-Hill drag model.
    * @param scratch_data (see base class)
    */
   virtual void

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -280,9 +280,29 @@ public:
 };
 
 /**
- * @brief Class that assembles the drag force using a constant model for the
+ * @brief Class that assembles the drag force using the Koch and Hill drag model for the
  * VANS equations where the momentum exchange coefficient
- *  beta = constant * particle_volume
+ *  beta =   ((18 * mu * cell_void_fraction^2 *
+          (1 - cell_void_fraction)) / pow(dp, 2)) *
+        (f0 + 0.5 * f3 * cell_void_fraction * re) *
+        Vp /(1 - cell_void_fraction) where f0 and f3 are functions given by:
+      if ((1 - cell_void_fraction) < 0.4)
+        {
+          f0 = (1 + 3 * sqrt((1 - cell_void_fraction) / 2) +
+                (135.0 / 64) * (1 - cell_void_fraction) *
+                  log(1 - cell_void_fraction) +
+                16.14 * (1 - cell_void_fraction)) /
+               (1 + 0.681 * (1 - cell_void_fraction) -
+                8.48 * (1 - cell_void_fraction)^2 +
+                8.14 * (1 - cell_void_fraction)^3);
+        }
+      else if ((1 - cell_void_fraction) >= 0.4)
+        {
+          f0 = 10 * (1 - cell_void_fraction) / cell_void_fraction^3;
+        }
+
+      f3 = 0.0673 + 0.212 * (1 - cell_void_fraction) +
+           0.0232 / pow(cell_void_fraction, 5);
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
  * @ingroup assemblers

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -14,13 +14,15 @@
  * ---------------------------------------------------------------------*/
 
 
-#include <deal.II/particles/particle_handler.h>
-
 #include <core/simulation_control.h>
-#include <fem-dem/cfd_dem_simulation_parameters.h>
+
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
+
+#include <fem-dem/cfd_dem_simulation_parameters.h>
+
+#include <deal.II/particles/particle_handler.h>
 
 #ifndef lethe_vans_assemblers_h
 #  define lethe_vans_assemblers_h

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -402,8 +402,8 @@ template <int dim>
 class GLSVansAssemblerShearForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerShearForce()
-
+  GLSVansAssemblerShearForce(Parameters::CFDDEM cfd_dem)
+    : cfd_dem(cfd_dem)
   {}
 
   /**
@@ -414,6 +414,8 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
+
+  Parameters::CFDDEM cfd_dem;
 };
 
 /**

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -318,7 +318,6 @@ public:
   /**
    * @brief calculate_particle_fluid_interactions calculted the solid_fluid interactions
    * @param scratch_data (see base class)
-   * @param copy_data (see base class)
    */
   virtual void
   calculate_particle_fluid_interactions(

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -14,15 +14,13 @@
  * ---------------------------------------------------------------------*/
 
 
-#include <core/simulation_control.h>
+#include <deal.II/particles/particle_handler.h>
 
+#include <core/simulation_control.h>
+#include <fem-dem/cfd_dem_simulation_parameters.h>
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
-
-#include <fem-dem/cfd_dem_simulation_parameters.h>
-
-#include <deal.II/particles/particle_handler.h>
 
 #ifndef lethe_vans_assemblers_h
 #  define lethe_vans_assemblers_h
@@ -267,6 +265,32 @@ class GLSVansAssemblerDallavalle : public ParticleFluidAssemblerBase<dim>
 {
 public:
   GLSVansAssemblerDallavalle()
+  {}
+
+  /**
+   * @brief calculate_particle_fluid_interactions calculted the solid_fluid interactions
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  calculate_particle_fluid_interactions(
+    NavierStokesScratchData<dim> &scratch_data) override;
+};
+
+/**
+ * @brief Class that assembles the drag force using a constant model for the
+ * VANS equations where the momentum exchange coefficient
+ *  beta = constant * particle_volume
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+
+template <int dim>
+class GLSVansAssemblerKochHill : public ParticleFluidAssemblerBase<dim>
+{
+public:
+  GLSVansAssemblerKochHill()
   {}
 
   /**

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1,12 +1,12 @@
+#include "solvers/postprocessing_cfd.h"
+
+#include <fem-dem/gls_vans.h>
+
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/numerics/vector_tools.h>
-
-#include <fem-dem/gls_vans.h>
-
-#include "solvers/postprocessing_cfd.h"
 
 
 // Constructor for class GLS_VANS

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1,12 +1,12 @@
-#include "solvers/postprocessing_cfd.h"
-
-#include <fem-dem/gls_vans.h>
-
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/numerics/vector_tools.h>
+
+#include <fem-dem/gls_vans.h>
+
+#include "solvers/postprocessing_cfd.h"
 
 
 // Constructor for class GLS_VANS
@@ -544,6 +544,14 @@ GLSVANSSolver<dim>::setup_assemblers()
           // Dallavalle Model drag Assembler
           particle_fluid_assemblers.push_back(
             std::make_shared<GLSVansAssemblerDallavalle<dim>>());
+        }
+
+      if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
+          Parameters::DragModel::kochhill)
+        {
+          // Koch and Hill Model drag Assembler
+          particle_fluid_assemblers.push_back(
+            std::make_shared<GLSVansAssemblerKochHill<dim>>());
         }
     }
 

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -571,7 +571,8 @@ GLSVANSSolver<dim>::setup_assemblers()
   if (this->cfd_dem_simulation_parameters.cfd_dem.shear_force == true)
     // Shear Force
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerShearForce<dim>>());
+      std::make_shared<GLSVansAssemblerShearForce<dim>>(
+        this->cfd_dem_simulation_parameters.cfd_dem));
 
   // Time-stepping schemes
   if (is_bdf(this->simulation_control->get_assembly_method()))

--- a/source/fem-dem/parameters_cfd_dem.cc
+++ b/source/fem-dem/parameters_cfd_dem.cc
@@ -98,7 +98,7 @@ namespace Parameters
                       "Choose whether or not to apply pressure force");
     prm.declare_entry("drag model",
                       "difelice",
-                      Patterns::Selection("difelice|rong|dallavalle"),
+                      Patterns::Selection("difelice|rong|dallavalle|kochhill"),
                       "The drag model used to determine the drag coefficient");
     prm.declare_entry("post processing",
                       "false",
@@ -146,6 +146,8 @@ namespace Parameters
       drag_model = Parameters::DragModel::rong;
     else if (op == "dallavalle")
       drag_model = Parameters::DragModel::dallavalle;
+    else if (op == "kochhill")
+      drag_model = Parameters::DragModel::kochhill;
     else
       throw(std::runtime_error("Invalid drag model"));
 

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1172,8 +1172,8 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
           particle_properties[DEM::PropertiesIndex::fem_force_x + d] +=
             pressure_force[d] * density;
 
-          // Only apply pressure force to the particle if we are solving model A
-          // of the VANS
+          // Apply pressure force to the particles only, when we are solving
+          // model A of the VANS
           if (cfd_dem.vans_model == Parameters::VANSModel::modelB)
             {
               undisturbed_flow_force[d] +=
@@ -1233,8 +1233,14 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
         {
           particle_properties[DEM::PropertiesIndex::fem_force_x + d] +=
             shear_force[d] * density;
-          undisturbed_flow_force[d] +=
-            shear_force[d] / scratch_data.cell_volume;
+
+          // Apply shear force to the particles only, when we are solving
+          // model A of the VANS
+          if (cfd_dem.vans_model == Parameters::VANSModel::modelB)
+            {
+              undisturbed_flow_force[d] +=
+                shear_force[d] / scratch_data.cell_volume;
+            }
         }
 
       particle_number += 1;

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -3,7 +3,6 @@
 #include <core/simulation_control.h>
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
-
 #include <fem-dem/vans_assemblers.h>
 
 template <int dim>
@@ -999,6 +998,101 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
 
 template class GLSVansAssemblerDallavalle<2>;
 template class GLSVansAssemblerDallavalle<3>;
+
+template <int dim>
+void
+GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
+  NavierStokesScratchData<dim> &scratch_data)
+{
+  unsigned int particle_number;
+  auto &       beta_drag = scratch_data.beta_drag;
+
+  Tensor<1, dim> relative_velocity;
+  Tensor<1, dim> drag_force;
+
+  // Physical Properties
+  Assert(
+    !scratch_data.properties_manager.is_non_newtonian(),
+    RequiresConstantViscosity(
+      "GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
+  const double viscosity = scratch_data.properties_manager.viscosity_scale;
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
+  const double density = scratch_data.properties_manager.density_scale;
+
+  const auto pic  = scratch_data.pic;
+  beta_drag       = 0;
+  particle_number = 0;
+
+  double f0 = 0;
+  double f3 = 0;
+
+  // Loop over particles in cell
+  for (auto &particle : pic)
+    {
+      auto particle_properties = particle.get_properties();
+
+      relative_velocity =
+        scratch_data.fluid_velocity_at_particle_location[particle_number] -
+        scratch_data.particle_velocity[particle_number];
+
+      double cell_void_fraction =
+        scratch_data.cell_void_fraction[particle_number];
+
+      // Particle's Reynolds number
+      double re = 1e-1 + relative_velocity.norm() *
+                           particle_properties[DEM::PropertiesIndex::dp] /
+                           viscosity;
+
+      // Koch and Hill Drag Model Calculation
+      if ((1 - cell_void_fraction) < 0.4)
+        {
+          f0 = (1 + 3 * sqrt((1 - cell_void_fraction) / 2) +
+                (135.0 / 64) * (1 - cell_void_fraction) *
+                  log(1 - cell_void_fraction) +
+                16.14 * (1 - cell_void_fraction)) /
+               (1 + 0.681 * (1 - cell_void_fraction) -
+                8.48 * pow(1 - cell_void_fraction, 2) +
+                8.14 * pow(1 - cell_void_fraction, 3));
+        }
+      else if ((1 - cell_void_fraction) >= 0.4)
+        {
+          f0 = 10 * (1 - cell_void_fraction) / pow(cell_void_fraction, 3);
+        }
+
+      f3 = 0.0673 + 0.212 * (1 - cell_void_fraction) +
+           0.0232 / pow(cell_void_fraction, 5);
+
+      double momentum_transfer_coefficient =
+        ((18 * viscosity * pow(cell_void_fraction, 2) *
+          (1 - cell_void_fraction)) /
+         pow(particle_properties[DEM::PropertiesIndex::dp], 2)) *
+        (f0 + 0.5 * f3 * cell_void_fraction * re) *
+        (M_PI * pow(particle_properties[DEM::PropertiesIndex::dp], dim) /
+         (2 * dim)) /
+        (1 - cell_void_fraction);
+
+      beta_drag += momentum_transfer_coefficient;
+
+      drag_force = density * momentum_transfer_coefficient * relative_velocity;
+
+      for (int d = 0; d < dim; ++d)
+        {
+          particle_properties[DEM::PropertiesIndex::fem_force_x + d] +=
+            drag_force[d];
+        }
+
+      particle_number += 1;
+    }
+
+  beta_drag = beta_drag / scratch_data.cell_volume;
+}
+
+template class GLSVansAssemblerKochHill<2>;
+template class GLSVansAssemblerKochHill<3>;
 
 template <int dim>
 void

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1064,7 +1064,7 @@ GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
         }
 
       double f3 = 0.0673 + 0.212 * (1 - cell_void_fraction) +
-           0.0232 / pow(cell_void_fraction, 5);
+                  0.0232 / pow(cell_void_fraction, 5);
 
       double momentum_transfer_coefficient =
         ((18 * viscosity * pow(cell_void_fraction, 2) *
@@ -1172,8 +1172,9 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
             pressure_force[d] * density;
 
           // Apply pressure force to the particles only, when we are solving
-          // model A of the VANS. When are solving Model B, apply the pressure
-          // force back on the fluid by lumping it in the undisturbed_flow_force.
+          // model A of the VANS. When we are solving Model B, apply the
+          // pressure force back on the fluid by lumping it in the
+          // undisturbed_flow_force.
           if (cfd_dem.vans_model == Parameters::VANSModel::modelB)
             {
               undisturbed_flow_force[d] +=
@@ -1235,8 +1236,9 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
             shear_force[d] * density;
 
           // Apply shear force to the particles only, when we are solving
-          // model A of the VANS. When are solving Model B, apply the shear
-          // force back on the fluid by lumping it in the undisturbed_flow_force.
+          // model A of the VANS. When we are solving Model B, apply the shear
+          // force back on the fluid by lumping it in the
+          // undisturbed_flow_force.
           if (cfd_dem.vans_model == Parameters::VANSModel::modelB)
             {
               undisturbed_flow_force[d] +=

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1029,7 +1029,6 @@ GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   particle_number = 0;
 
   double f0 = 0;
-  double f3 = 0;
 
   // Loop over particles in cell
   for (auto &particle : pic)

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1172,7 +1172,8 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
             pressure_force[d] * density;
 
           // Apply pressure force to the particles only, when we are solving
-          // model A of the VANS
+          // model A of the VANS. When are solving Model B, apply the pressure
+          // force back on the fluid by lumping it in the undisturbed_flow_force.
           if (cfd_dem.vans_model == Parameters::VANSModel::modelB)
             {
               undisturbed_flow_force[d] +=

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -3,6 +3,7 @@
 #include <core/simulation_control.h>
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
+
 #include <fem-dem/vans_assemblers.h>
 
 template <int dim>

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1235,7 +1235,8 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
             shear_force[d] * density;
 
           // Apply shear force to the particles only, when we are solving
-          // model A of the VANS
+          // model A of the VANS. When are solving Model B, apply the shear
+          // force back on the fluid by lumping it in the undisturbed_flow_force.
           if (cfd_dem.vans_model == Parameters::VANSModel::modelB)
             {
               undisturbed_flow_force[d] +=

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1063,7 +1063,7 @@ GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
           f0 = 10 * (1 - cell_void_fraction) / pow(cell_void_fraction, 3);
         }
 
-      f3 = 0.0673 + 0.212 * (1 - cell_void_fraction) +
+      double f3 = 0.0673 + 0.212 * (1 - cell_void_fraction) +
            0.0232 / pow(cell_void_fraction, 5);
 
       double momentum_transfer_coefficient =


### PR DESCRIPTION
# Description of the problem

-The Koch and Hill drag model was added as it was used in the paper which I will be comparing the spouted bed results with. They use the Koch and Hill drag models. I added the Koch and Hill as a first step and will later add the Beestra drag model in a future PR.
- Discrepancy between models A and B solution in liquid fluidized beds.

# Description of the solution

-The added code comprise mainly a new particle fluid assembler where the momentum exchange coefficient is calculated using the Koch and Hill drag model.
- The pressure force was applied correctly on the fluid for model B only however, the shear force was always applied on the fluid. For model A, it is implicitly applied and should not be added explicitly.

# How Has This Been Tested?

The results using this model for the packed bed test case and the fluidized bed test case have been compared. For the fluidized bed test case, the difelice and koch and hill gave very close results, however, the difeclice exhibited a negative pressure drop at the third time step while the koch and hill did not. Its value was close to zero.

For the packed bed test case, the song model and the koch and hill model initially gave a close value where the fifference was around 10 Pa but then as the values became steady the difference between the two models was around 35 Pa.

# Documentation

- The CFD-DEM file was changed to add the Koch and Hill drag model as an available model.

# Future changes

- The Beestra drag model is to be added in a future PR as the comparison for spouted beds is to be achieved using these two models.