### PR TITLE
Fix preconditioner when L2 projection is used

### DIFF
--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -735,7 +735,14 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
            Parameters::InitialConditionType::L2projection)
     {
       assemble_L2_projection();
-      solve_system_GMRES(true, 1e-15, 1e-15);
+      setup_preconditioner();
+
+      if (this->simulation_parameters.linear_solver.solver ==
+          Parameters::LinearSolver::SolverType::amg)
+        solve_system_AMG(true, 1e-15, 1e-15);
+      else
+        solve_system_GMRES(true, 1e-15, 1e-15);
+
       this->present_solution = this->newton_update;
       this->finish_time_step_fd();
     }


### PR DESCRIPTION
# Description of the problem

-Setting up initial condition using L2 projection and using an AMG preconditioner would break down into a segfault. See #409 

# Description of the solution

- Fixes this issue by calling the right linear solver for L2 projection when starting the simulation

# How Has This Been Tested?

- I don't think this needs a test in particular, but if needed I could add one.


