### PR TITLE
Fix ht vof

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/gls_free-surface_heat-transfer_hydrostat.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_free-surface_heat-transfer_hydrostat.output
@@ -1,0 +1,39 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      1
+   Number of VOF degrees of freedom: 1089
+   Number of thermal degrees of freedom: 1089
+
+*****************************************************************
+Transient iteration : 1        Time : 0.02     Time step : 0.02     CFL : 0       
+*****************************************************************
+L2 error velocity : 3.07121e-05
+L2 error phase : 0.00369306
+L2 error temperature : 0
+
+*****************************************************************
+Transient iteration : 2        Time : 0.04     Time step : 0.02     CFL : 8.8806e-05
+*****************************************************************
+L2 error velocity : 6.37551e-05
+L2 error phase : 0.00369372
+L2 error temperature : 0
+
+*****************************************************************
+Transient iteration : 3        Time : 0.06     Time step : 0.02     CFL : 0.000119786
+*****************************************************************
+L2 error velocity : 4.05131e-05
+L2 error phase : 0.00369437
+L2 error temperature : 0
+ time  error_velocity error_pressure 
+0.0200 3.071207e-05   0.0541         
+0.0400 6.375508e-05   0.0349         
+0.0600 4.051310e-05   0.0236         
+ time  error_phase  
+0.0200 3.693057e-03 
+0.0400 3.693720e-03 
+0.0600 3.694369e-03 
+cells error_temperature 
+1024  0.000000e+00      
+1024  0.000000e+00      
+1024  0.000000e+00 

--- a/applications_tests/gls_navier_stokes_2d/gls_free-surface_heat-transfer_hydrostat.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_free-surface_heat-transfer_hydrostat.prm
@@ -1,0 +1,172 @@
+# Listing of Parameters
+# ---------------------
+# --------------------------------------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  = bdf1
+  set time end                = 0.06
+  set time step               = 0.02
+  set output name             = hydrostat_VOF
+  set output frequency        = 1
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+	set VOF = true
+	set heat transfer = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection uvwp
+            set Function expression = 0; 0; 0
+    end
+    subsection VOF
+            set Function expression = if (y<0.4, 1, 0)
+    end
+    subsection temperature
+            set Function expression = 20
+    end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+subsection source term
+    set enable = true
+
+    subsection xyz
+        set Function expression = 0; -9.81; 0
+    end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+    set number of fluids = 2
+    subsection fluid 1 #bottom fluid
+        set density = 2.
+	set specific heat = 500
+	set thermal conductivity = 0.5
+    end
+    subsection fluid 0 #top fluid
+        set density = .5
+	set specific heat = 100
+	set thermal conductivity = 0.03
+    end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+		set type = dealii
+		set grid type = hyper_rectangle
+		set grid arguments = 0, 0 : 1, 1 : true
+		set initial refinement = 5
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable     	= true
+  set verbosity 	= verbose
+    subsection uvwp
+	set Function constants = rho=2., g=9.81, h=0.4
+        set Function expression =  0 ; 0 ; if (y<h, rho*g*(h-y), 0)
+    end
+    subsection phase
+	set Function constants = h=0.4
+    	set Function expression = if (y<h, 1, 0)
+    end
+    subsection temperature
+	set Function expression = 20
+    end
+end
+
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+subsection timer
+   set type = none
+end
+
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions
+  set number                  = 4
+    subsection bc 0
+        set id = 0
+        set type              = slip
+    end
+    subsection bc 1
+	set id = 1
+        set type              = slip
+    end
+    subsection bc 2
+        set id = 2
+        set type              = slip
+    end
+    subsection bc 3
+        set id = 3
+        set type              = slip
+    end
+end
+subsection boundary conditions heat transfer
+  set number                = 1
+    subsection bc 0
+      set id = 2
+      set type		    = temperature
+      set value		    = 20
+    end
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+subsection FEM
+    set velocity order            = 1
+    set pressure order            = 1
+end
+
+
+# --------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+subsection mesh adaptation
+  set type                    = none
+end
+
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set verbosity               = quiet 
+  set tolerance               = 1e-9
+  set max iterations          = 10
+  set residual precision      = 2
+end
+
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               = quiet
+  set method                                 = gmres
+  set max iters                              = 5000
+  set relative residual                      = 1e-10
+  set minimum residual                       = 1e-10
+  set ilu preconditioner fill                = 1
+  set ilu preconditioner absolute tolerance  = 1e-11
+  set ilu preconditioner relative tolerance  = 1.00
+  set max krylov vectors                     = 200
+end

--- a/include/core/multiphysics.h
+++ b/include/core/multiphysics.h
@@ -29,9 +29,9 @@
 enum PhysicsID : unsigned int
 {
   fluid_dynamics = 0,
-  heat_transfer  = 1,
-  tracer         = 2,
-  VOF            = 3
+  VOF            = 1,
+  heat_transfer  = 2,
+  tracer         = 3
 };
 
 #endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -354,7 +354,7 @@ namespace Parameters
     double phase_fraction_gradient_filter_value;
     double curvature_filter_value;
 
-    bool output_VOF_auxiliary_fields;
+    bool output_vof_auxiliary_fields;
 
     // Type of verbosity for the surface tension force calculation
     Verbosity verbosity;

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -113,6 +113,7 @@ public:
                           update_JxW_values)
   {
     gather_vof = false;
+
     allocate();
   }
 
@@ -144,6 +145,10 @@ public:
   {
     gather_vof = sd.gather_vof;
     allocate();
+    if (sd.gather_vof)
+      enable_vof(sd.fe_values_vof->get_fe(),
+                 sd.fe_values_vof->get_quadrature(),
+                 sd.fe_values_vof->get_mapping());
   }
 
 

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -122,11 +122,13 @@ public:
         else
           {
             pcout
-              << "Solution order is not specified for this auxiliary physic :"
+              << "Solution order is not specified for this auxiliary physic "
               << std::endl
               << "will be solved after the fluid dynamics by default."
               << std::endl
-              << "For clarity, please specify a solution order in the map solve_pre_fluid defined in multiphysics_interface.h"
+              << "For clarity, please specify a solution order for this physic "
+              << std::endl
+              << "in the map solve_pre_fluid, member of multiphysics_interface.h"
               << std::endl
               << "-------------" << std::endl;
           }
@@ -692,9 +694,9 @@ private:
 
   // Map that states if the physics are solved before the fluid dynamics
   std::map<PhysicsID, bool> solve_pre_fluid{{fluid_dynamics, false},
+                                            {VOF, false},
                                             {heat_transfer, false},
-                                            {tracer, false},
-                                            {VOF, false}};
+                                            {tracer, false}};
 
   // Auxiliary physics are stored within a map of shared pointer to ensure
   // proper memory management.

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -107,7 +107,7 @@ public:
 
     // By default, the assembly of variables belonging to auxiliary physics is
     // disabled.
-    gather_VOF                   = false;
+    gather_vof                   = false;
     gather_void_fraction         = false;
     gather_particles_information = false;
     gather_temperature           = false;
@@ -141,16 +141,11 @@ public:
                        update_JxW_values | update_gradients | update_hessians |
                        update_normal_vectors)
   {
-    gather_VOF                   = false;
-    gather_void_fraction         = false;
-    gather_particles_information = false;
-    gather_temperature           = false;
-
     allocate();
-    if (sd.gather_VOF)
-      enable_VOF(sd.fe_values_VOF->get_fe(),
-                 sd.fe_values_VOF->get_quadrature(),
-                 sd.fe_values_VOF->get_mapping());
+    if (sd.gather_vof)
+      enable_vof(sd.fe_values_vof->get_fe(),
+                 sd.fe_values_vof->get_quadrature(),
+                 sd.fe_values_vof->get_mapping());
 
     if (sd.gather_void_fraction)
       enable_void_fraction(sd.fe_values_void_fraction->get_fe(),
@@ -433,7 +428,7 @@ public:
 
 
   /**
-   * @brief enable_VOF Enables the collection of the VOF data by the scratch
+   * @brief enable_vof Enables the collection of the VOF data by the scratch
    *
    * @param fe FiniteElement associated with the VOF.
    *
@@ -443,11 +438,11 @@ public:
    */
 
   void
-  enable_VOF(const FiniteElement<dim> &fe,
+  enable_vof(const FiniteElement<dim> &fe,
              const Quadrature<dim> &   quadrature,
              const Mapping<dim> &      mapping);
 
-  /** @brief Reinitialize the content of the scratch for the VOF
+  /** @brief Reinitialize the content of the scratch for the vof
    *
    * @param cell The cell over which the assembly is being carried.
    * This cell must be compatible with the VOF FE and not the
@@ -463,22 +458,22 @@ public:
 
   template <typename VectorType>
   void
-  reinit_VOF(const typename DoFHandler<dim>::active_cell_iterator &cell,
+  reinit_vof(const typename DoFHandler<dim>::active_cell_iterator &cell,
              const VectorType &             current_solution,
              const std::vector<VectorType> &previous_solutions,
              const std::vector<VectorType> & /*solution_stages*/)
   {
-    this->fe_values_VOF->reinit(cell);
+    this->fe_values_vof->reinit(cell);
     // Gather phase fraction (values, gradient)
-    this->fe_values_VOF->get_function_values(current_solution,
+    this->fe_values_vof->get_function_values(current_solution,
                                              this->phase_values);
-    this->fe_values_VOF->get_function_gradients(current_solution,
+    this->fe_values_vof->get_function_gradients(current_solution,
                                                 this->phase_gradient_values);
 
     // Gather previous phase fraction values
     for (unsigned int p = 0; p < previous_solutions.size(); ++p)
       {
-        this->fe_values_VOF->get_function_values(previous_solutions[p],
+        this->fe_values_vof->get_function_values(previous_solutions[p],
                                                  previous_phase_values[p]);
       }
   }
@@ -800,13 +795,13 @@ public:
   /**
    * Scratch component for the VOF auxiliary physics
    */
-  bool                             gather_VOF;
-  unsigned int                     n_dofs_VOF;
+  bool                             gather_vof;
+  unsigned int                     n_dofs_vof;
   std::vector<double>              phase_values;
   std::vector<std::vector<double>> previous_phase_values;
   std::vector<Tensor<1, dim>>      phase_gradient_values;
   // This is stored as a shared_ptr because it is only instantiated when needed
-  std::shared_ptr<FEValues<dim>> fe_values_VOF;
+  std::shared_ptr<FEValues<dim>> fe_values_vof;
 
 
   /**

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -440,12 +440,12 @@ private:
    *
    * @param i_bc peeling-wetting boundary index
    *
-   * @param current_solution_cfd current solution for the fluid dynamics
+   * @param current_solution_fd current solution for the fluid dynamics
    */
   template <typename VectorType>
   void
   apply_peeling_wetting(const unsigned int i_bc,
-                        const VectorType & current_solution_cfd);
+                        const VectorType & current_solution_fd);
 
   /**
    * @brief Change cell phase, small method called to avoid code repetition and reduce sloppy

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -423,7 +423,7 @@ namespace Parameters
         prm.get_double("phase fraction gradient filter");
       curvature_filter_value = prm.get_double("curvature filter");
 
-      output_VOF_auxiliary_fields = prm.get_bool("output auxiliary fields");
+      output_vof_auxiliary_fields = prm.get_bool("output auxiliary fields");
 
       const std::string op = prm.get("verbosity");
       if (op == "verbose")

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -2496,19 +2496,19 @@ GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
                       this->beta);
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
       typename DoFHandler<dim>::active_cell_iterator phase_cell(
         &(*(this->triangulation)),
         cell->level(),
         cell->index(),
-        dof_handler_fs);
+        dof_handler_vof);
 
       std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
       previous_solutions.push_back(
         *this->multiphysics->get_solution_m1(PhysicsID::VOF));
 
-      scratch_data.reinit_VOF(phase_cell,
+      scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
                               previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());
@@ -2589,20 +2589,20 @@ GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
       typename DoFHandler<dim>::active_cell_iterator phase_cell(
         &(*(this->triangulation)),
         cell->level(),
         cell->index(),
-        dof_handler_fs);
+        dof_handler_vof);
 
       std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
       previous_solutions.push_back(
         *this->multiphysics->get_solution_m1(PhysicsID::VOF));
 
 
-      scratch_data.reinit_VOF(phase_cell,
+      scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
                               previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -144,9 +144,9 @@ GDNavierStokesSolver<dim>::assemble_system_matrix()
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
-      scratch_data.enable_VOF(dof_handler_fs->get_fe(),
+      scratch_data.enable_vof(dof_handler_vof->get_fe(),
                               *this->cell_quadrature,
                               *this->mapping);
     }
@@ -199,19 +199,19 @@ GDNavierStokesSolver<dim>::assemble_local_system_matrix(
                       this->beta);
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
       typename DoFHandler<dim>::active_cell_iterator phase_cell(
         &(*(this->triangulation)),
         cell->level(),
         cell->index(),
-        dof_handler_fs);
+        dof_handler_vof);
 
       std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
       previous_solutions.push_back(
         *this->multiphysics->get_solution_m1(PhysicsID::VOF));
 
-      scratch_data.reinit_VOF(phase_cell,
+      scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
                               previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());
@@ -273,9 +273,9 @@ GDNavierStokesSolver<dim>::assemble_system_rhs()
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
-      scratch_data.enable_VOF(dof_handler_fs->get_fe(),
+      scratch_data.enable_vof(dof_handler_vof->get_fe(),
                               *this->cell_quadrature,
                               *this->mapping);
     }
@@ -327,20 +327,20 @@ GDNavierStokesSolver<dim>::assemble_local_system_rhs(
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
       typename DoFHandler<dim>::active_cell_iterator phase_cell(
         &(*(this->triangulation)),
         cell->level(),
         cell->index(),
-        dof_handler_fs);
+        dof_handler_vof);
 
       std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
       previous_solutions.push_back(
         *this->multiphysics->get_solution_m1(PhysicsID::VOF));
 
 
-      scratch_data.reinit_VOF(phase_cell,
+      scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
                               previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -469,9 +469,9 @@ GLSNavierStokesSolver<dim>::assemble_system_matrix_without_preconditioner()
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
-      scratch_data.enable_VOF(dof_handler_fs->get_fe(),
+      scratch_data.enable_vof(dof_handler_vof->get_fe(),
                               *this->cell_quadrature,
                               *this->mapping);
     }
@@ -516,19 +516,19 @@ GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
                       this->beta);
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
       typename DoFHandler<dim>::active_cell_iterator phase_cell(
         &(*(this->triangulation)),
         cell->level(),
         cell->index(),
-        dof_handler_fs);
+        dof_handler_vof);
 
       std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
       previous_solutions.push_back(
         *this->multiphysics->get_solution_m1(PhysicsID::VOF));
 
-      scratch_data.reinit_VOF(phase_cell,
+      scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
                               previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());
@@ -597,9 +597,9 @@ GLSNavierStokesSolver<dim>::assemble_system_rhs()
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
-      scratch_data.enable_VOF(dof_handler_fs->get_fe(),
+      scratch_data.enable_vof(dof_handler_vof->get_fe(),
                               *this->cell_quadrature,
                               *this->mapping);
     }
@@ -650,20 +650,20 @@ GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
 
   if (this->simulation_parameters.multiphysics.VOF)
     {
-      const DoFHandler<dim> *dof_handler_fs =
+      const DoFHandler<dim> *dof_handler_vof =
         this->multiphysics->get_dof_handler(PhysicsID::VOF);
       typename DoFHandler<dim>::active_cell_iterator phase_cell(
         &(*(this->triangulation)),
         cell->level(),
         cell->index(),
-        dof_handler_fs);
+        dof_handler_vof);
 
       std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
       previous_solutions.push_back(
         *this->multiphysics->get_solution_m1(PhysicsID::VOF));
 
 
-      scratch_data.reinit_VOF(phase_cell,
+      scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
                               previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -95,12 +95,12 @@ NavierStokesScratchData<dim>::allocate()
 
 template <int dim>
 void
-NavierStokesScratchData<dim>::enable_VOF(const FiniteElement<dim> &fe,
+NavierStokesScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
                                          const Quadrature<dim> &   quadrature,
                                          const Mapping<dim> &      mapping)
 {
-  gather_VOF    = true;
-  fe_values_VOF = std::make_shared<FEValues<dim>>(
+  gather_vof    = true;
+  fe_values_vof = std::make_shared<FEValues<dim>>(
     mapping, fe, quadrature, update_values | update_gradients);
 
   // VOF
@@ -192,73 +192,79 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
       set_field_vector(field::shear_rate, shear_rate, this->fields);
     }
 
-  // Case where you have one fluid
-  if (properties_manager.get_number_of_fluids() == 1)
+  switch (properties_manager.get_number_of_fluids())
     {
-      // In this case, only viscosity is the required property
-      const auto rheology_model = properties_manager.get_rheology();
-      rheology_model->vector_value(fields, viscosity);
-
-      const auto density_model = properties_manager.get_density();
-      density_model->vector_value(fields, density);
-
-
-      if (properties_manager.is_non_newtonian())
+      case 1:
         {
-          // Calculate derivative of viscosity with respect to shear rate
-          rheology_model->vector_jacobian(fields,
-                                          field::shear_rate,
-                                          grad_viscosity_shear_rate);
+          // In this case, only viscosity is the required property
+          const auto rheology_model = properties_manager.get_rheology();
+          rheology_model->vector_value(fields, viscosity);
+
+          const auto density_model = properties_manager.get_density();
+          density_model->vector_value(fields, density);
+
+
+          if (properties_manager.is_non_newtonian())
+            {
+              // Calculate derivative of viscosity with respect to shear rate
+              rheology_model->vector_jacobian(fields,
+                                              field::shear_rate,
+                                              grad_viscosity_shear_rate);
+            }
+
+          if (gather_temperature)
+            {
+              const auto thermal_expansion_model =
+                properties_manager.get_thermal_expansion();
+              thermal_expansion_model->vector_value(fields, thermal_expansion);
+            }
+          break;
         }
-
-      if (gather_temperature)
+      case 2:
         {
-          const auto thermal_expansion_model =
-            properties_manager.get_thermal_expansion();
-          thermal_expansion_model->vector_value(fields, thermal_expansion);
-        }
-    }
-  else // properties_manager.get_number_of_fluids() == 2
-    {
-      // In this case,  we need both density and viscosity
-      const auto density_model_0  = properties_manager.get_density(0);
-      const auto rheology_model_0 = properties_manager.get_rheology(0);
-      const auto density_model_1  = properties_manager.get_density(1);
-      const auto rheology_model_1 = properties_manager.get_rheology(1);
+          // In this case,  we need both density and viscosity
+          const auto density_model_0  = properties_manager.get_density(0);
+          const auto rheology_model_0 = properties_manager.get_rheology(0);
+          const auto density_model_1  = properties_manager.get_density(1);
+          const auto rheology_model_1 = properties_manager.get_rheology(1);
 
-      density_model_0->vector_value(fields, density_0);
-      rheology_model_0->vector_value(fields, viscosity_0);
+          density_model_0->vector_value(fields, density_0);
+          rheology_model_0->vector_value(fields, viscosity_0);
 
-      density_model_1->vector_value(fields, density_1);
-      rheology_model_1->vector_value(fields, viscosity_1);
+          density_model_1->vector_value(fields, density_1);
+          rheology_model_1->vector_value(fields, viscosity_1);
 
-      // Blend the physical properties using the VOF field
-      for (unsigned int q = 0; q < this->n_q_points; ++q)
-        {
-          density[q] = calculate_point_property(this->phase_values[q],
-                                                this->density_0[q],
-                                                this->density_1[q]);
-
-          viscosity[q] = calculate_point_property(this->phase_values[q],
-                                                  this->viscosity_0[q],
-                                                  this->viscosity_1[q]);
-        }
-
-
-
-      for (unsigned p = 0; p < previous_phase_values.size(); ++p)
-        {
           // Blend the physical properties using the VOF field
           for (unsigned int q = 0; q < this->n_q_points; ++q)
             {
-              // Calculate previous density (right now assumes constant density
-              // model per phase)
-              previous_density[p][q] =
-                calculate_point_property(this->previous_phase_values[p][q],
-                                         this->density_0[q],
-                                         this->density_1[q]);
+              density[q] = calculate_point_property(this->phase_values[q],
+                                                    this->density_0[q],
+                                                    this->density_1[q]);
+
+              viscosity[q] = calculate_point_property(this->phase_values[q],
+                                                      this->viscosity_0[q],
+                                                      this->viscosity_1[q]);
             }
+
+
+
+          for (unsigned p = 0; p < previous_phase_values.size(); ++p)
+            {
+              // Blend the physical properties using the VOF field
+              for (unsigned int q = 0; q < this->n_q_points; ++q)
+                {
+                  // Calculate previous density (right now assumes constant
+                  // density model per phase)
+                  previous_density[p][q] =
+                    calculate_point_property(this->previous_phase_values[p][q],
+                                             this->density_0[q],
+                                             this->density_1[q]);
+                }
+            }
+          break;
         }
+      default:
+        throw std::runtime_error("Unsupported number of fluids (>2)");
     }
 }
 

--- a/tests/solvers/multiphysics_interface_01.output
+++ b/tests/solvers/multiphysics_interface_01.output
@@ -1,14 +1,14 @@
 
 DEAL::Active physics (expected: fluid, heat)
 DEAL::0
-DEAL::1
+DEAL::2
 DEAL::Active physics (expected: fluid)
 DEAL::0
 DEAL::Active physics (expected: fluid, which should always be on)
 DEAL::0
 DEAL::Active physics (expected: fluid, heat)
 DEAL::0
-DEAL::1
+DEAL::2
 DEAL::Active physics (expected: fluid)
 DEAL::0
 DEAL::Active physics (expected: fluid, which should always be on)


### PR DESCRIPTION
# Description of the problem

Launching a simulation with both VOF and heat transfer resulted in seg-fault error.

# Description of the solution

- Fix the heat transfer solver issue: VOF scratch_data was never gathered
- Add a test with both VOF and heat transfer, to assess that similar problem will be catched in the future

# How Has This Been Tested?

Test added : gls_free-surface_heat-transfer_hydrostat

The dumbest test you can think of: free surface that is supposed to stay static, and heat transfer mechanism called for no heat transfer mechanism happening (homogeneous temperature at the start). Still it guarantees that both physics can be called in the same simulation!

# Documentation

Not directly linked to this PR, but I saw that there are things missing in the `initial_condition` part of the documentation (namely initial condition on the temperature). I will open another PR for that.

# Comments

While I was at it, I cleaned what I saw in the code.