### PR TITLE
Doc restart

### DIFF
--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -15,13 +15,15 @@ The default parameters of each are shown:
     subsection boundary conditions heat transfer
     set number                  = 2
         subsection bc 0
+	    set id 		= 0
             set type	        = temperature
             set value	        = 0
         end
         subsection bc 1
-            set type		    = convection
-            set h 		    = 0
-            set Tinf	   	    = 0
+	    set id 		= 1
+            set type		= convection
+            set h 		= 0
+            set Tinf	   	= 0
         end
     end
 
@@ -29,6 +31,8 @@ The default parameters of each are shown:
 
 .. warning::
     The number of boundary conditions must be specified explicitly as the ParameterHandler is not able to deduce the number of boundary conditions from the number of ``bc`` subsections. This is often a source of error.
+
+* ``id`` is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number of the bc.
 
 * ``type``: This is the type of boundary condition been imposed. At the moment, choices are
     * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary 
@@ -51,7 +55,8 @@ For tracer boundary conditions, the defaults parameters are:
     subsection boundary conditions tracer
     set number                  = 1
         subsection bc 0
-                set type              = dirichlet
+	        set id 		= 0
+                set type        = dirichlet
                 subsection dirichlet
                     set Function expression = 0
                 end
@@ -59,6 +64,8 @@ For tracer boundary conditions, the defaults parameters are:
     end
 
 * ``number``: This is the number of boundary conditions of the problem. 
+
+* ``id`` is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number of the bc.
 
 * ``type``: This is the type of boundary condition been imposed. At the moment, only dirichlet boundary conditions can be imposed for tracer.
 

--- a/doc/source/parameters/cfd/restart.rst
+++ b/doc/source/parameters/cfd/restart.rst
@@ -1,30 +1,47 @@
-Finite element interpolation (FEM)
+Restart
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This subsection controls the restart and checkpointing of the simulation. 
-This feature is used to restart a time-dependent simulation using the data written on the last checkpoint before the simulation stopped or crashed.
+This subsection controls the checkpointing and restarting of time-dependent simulations.
+
+This feature is used both to write data at checkpoints (`checkpointing`) and restart a simulation (`restarting`) using data from the last checkpoint.
+
+.. tip::
+  It is highly advised to use it if you fear you might either run out of memory/simulation time during the simulation.
+
 The default parameters are:
 
 .. code-block:: text
 
   subsection restart
+    # Checkpointing parameters
     set checkpoint = false
-    set restart    = false
-    set filename   = restart
     set frequency  = 1
+
+    # Output/input files
+    set filename   = restart
+
+    # Restarting parameters
+    set restart    = false
   end
 
-* The ``checkpoint`` option enables creating a checkpoint of the simulation when it is set to ``true``. 
+* ``checkpoint``: controls if a checkpoint of the simulation is created. All the files needed to restart the simulation from this checkpoint (such as ``.pvdhandler``, ``.triangulation``) will be written.
+
+* ``frequency``: number of iteration before the first checkpoint, and between each subsequent checkpoint. 
 
 .. tip::
-  You may want to enable it when launching a time-dependent simulation if you fear you might either run out of memory/simulation time during the simulation.
-
-* The ``restart`` option controls if the simulation will be restarted from a previous checkpoint. Turn this parameter to ``false`` for the first checkpoint creation. The simulation will start from the last checkpoint when the parameter is set to ``true`` and will finish at the provided time end (see `Simulation Control <https://lethe-cfd.github.io/lethe/parameters/cfd/simulation_control.html>`_).
-
-* The ``filename`` parameter fixes the prefix of all the checkpointing files. 
+  Checkpointing is very intensive from an I/O point of view, consequently it should not be done at every iteration. The checkpointing frequency is in accordance to the number of ``time step`` (see :doc:`simulation_control`).
 
 .. warning::
+  Each checkpoint erases the previous one, so a simulation can only be restarted from the last check-point.
 
-  Restart files are searched for in the output path specified in subsection simulation control.
+* ``filename``: prefix for the files. This parameter is used to output checkpoint files as well as to load files during a restart.
 
-* The ``frequency`` parameter controls the checkpointing frequency. Checkpointing is very intensive from an I/O point of view, consequently it should not be done at every iteration. The checkpointing frequency is is accordance to the number of ``time step`` (see `Simulation Control <https://lethe-cfd.github.io/lethe/parameters/cfd/simulation_control.html>`_).
+.. warning::
+  Files are saved (when checkpointing) and searched for (when restarting) in the ``output path`` specified in subsection :doc:`simulation_control`.
+
+* ``restart``: controls if the simulation is to be restarted from a previous checkpoint. 
+   * ``set restart = false``: for the first checkpoint creation. 
+   * ``set restart = true``: the simulation will start from the last checkpoint and will finish at the provided ``time end`` (see :doc:`simulation_control`).
+
+
+


### PR DESCRIPTION
# Description of the problem

- Restart documentation page had changed name! (not sure when it happened)

# Description of the solution

- Fix Retart doc page name
- Refashion it (in accordance to my "refashion documentation" project)
- Fix bug #384 while I was at it

# Documentation

- Restart

- Boundary conditions - Multiphysics

# Future changes

I will refashion BC - Multiphysics page as well, will be done in another PR when I add the VOF BC (next week)

# Comments

As always, open in a web browser to really see the difference :)