### PR TITLE
Fix bug with time output

### DIFF
--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -193,6 +193,7 @@ namespace Parameters
       output_folder     = prm.get("output path");
       output_name       = prm.get("output name");
       output_frequency  = prm.get_integer("output frequency");
+      output_time       = prm.get_double("output time");
       output_boundaries = prm.get_bool("output boundaries");
 
       subdivision   = prm.get_integer("subdivision");

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -283,6 +283,7 @@ SimulationControlTransientDynamicOutput::
   SimulationControlTransientDynamicOutput(Parameters::SimulationControl param)
   : SimulationControlTransient(param)
   , time_step_forced_output(false)
+  // To be fixed for restarts
   , last_output_time(0.)
 {}
 


### PR DESCRIPTION
# Description of the problem

- Time controlled output were using an uninitialized output time variable which breaks the output

# Description of the solution

- Actually parse the input parameter

# How Has This Been Tested?

- Any application can be switched to this output control mode now and works. There is also a unit test for this

# Documentation

- Documentation was already ok

