### PR TITLE
Add abort feature for non-linear solver + fix

### DIFF
--- a/doc/source/parameters/cfd/non-linear_solver_control.rst
+++ b/doc/source/parameters/cfd/non-linear_solver_control.rst
@@ -34,6 +34,9 @@ The Navier-Stokes equations (and other) are non-linear equations. The parameters
 
 	  # State if the RHS must be calulated at the beginning of every newton iteration
 	  set force rhs calculation = false
+
+	  # Force the simulation to stop and throw an error if a non-linear solution has failed to converge
+	  set abort at convergence failure = false
 	end
 
 * The ``solver`` parameter enables to choose the nonlinear solver used. Currently, Lethe supports three non-linear solvers:
@@ -79,4 +82,6 @@ The Navier-Stokes equations (and other) are non-linear equations. The parameters
 
 * The ``residual precision`` parameter enables to change the number of digits displayed when showing residuals (with ``set verbosity = verbose``).
 * The ``force_rhs_calculation``: Force RHS recalculation at the beginning of every non-linear steps, This is required if there is a fixed point component to the non-linear solver that is changed at the beginning of every newton iteration. This is notably the case of the sharp edge method. The default value of this parameter is false.
+* The ``abort at convergence failure`` allows the user to stop the simulation and throw an error if the non-linear solver has failed to converge. Setting ``abort at convergence failure = true`` will enable this feature. This is generally useful when launching a large batch of simulation to quickly identify which one have failed.
+
 

--- a/include/core/inexact_newton_non_linear_solver.h
+++ b/include/core/inexact_newton_non_linear_solver.h
@@ -182,6 +182,16 @@ InexactNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
       last_res         = current_res;
       ++outer_iteration;
     }
+
+  // If the non-linear solver has not converged abort simulation if
+  // abort_at_convergence_failure=true
+  if ((global_res > this->params.tolerance) &&
+      outer_iteration >= this->params.max_iterations &&
+      this->params.abort_at_convergence_failure)
+    {
+      throw(std::runtime_error(
+        "Stopping simulation because the non-linear solver has failed to converge"));
+    }
 }
 
 #endif

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -168,6 +168,16 @@ NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
       last_res         = current_res;
       ++outer_iteration;
     }
+
+  // If the non-linear solver has not converged abort simulation if
+  // abort_at_convergence_failure=true
+  if ((global_res > this->params.tolerance) &&
+      outer_iteration >= this->params.max_iterations &&
+      this->params.abort_at_convergence_failure)
+    {
+      throw(std::runtime_error(
+        "Stopping simulation because the non-linear solver has failed to converge"));
+    }
 }
 
 #endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -617,6 +617,9 @@ namespace Parameters
     // Carry jacobian matrix over to the new non-linear problem
     bool reuse_matrix;
 
+    // Abort solver if non-linear solution has not reached tolerance
+    bool abort_at_convergence_failure;
+
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -615,8 +615,8 @@ public:
   void
   reinit_particle_fluid_interactions(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType                                      current_solution,
-    const VectorType                                      previous_solution,
+    const VectorType /*current_solution*/,
+    const VectorType                       previous_solution,
     const VectorType                       void_fraction_solution,
     const Particles::ParticleHandler<dim> &particle_handler,
     DoFHandler<dim> &                      dof_handler,

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1019,6 +1019,12 @@ namespace Parameters
         "false",
         Patterns::Bool(),
         "Reuse the last jacobian matrix for the next non-linear problem solution");
+
+      prm.declare_entry(
+        "abort at convergence failure",
+        "false",
+        Patterns::Bool(),
+        "Aborts Lethe by throwing an exception if non-linear solver convergence has failed");
     }
     prm.leave_subsection();
   }
@@ -1064,6 +1070,8 @@ namespace Parameters
       display_precision     = prm.get_integer("residual precision");
       force_rhs_calculation = prm.get_bool("force rhs calculation");
       reuse_matrix          = prm.get_bool("reuse matrix");
+      abort_at_convergence_failure =
+        prm.get_bool("abort at convergence failure");
     }
     prm.leave_subsection();
   }


### PR DESCRIPTION
# Description of the problem

-Sometimes it is desirable to stop a simulation and throw an error if it has not converged

# Description of the solution

- Add an additional parameter to the non-linear solver to crash the solver if it has not converged
This PR closes #424 

# How Has This Been Tested?

- I tested it manually, but it's hard to add a test for something that breaks... I don't think it's really worth the efforts.

# Documentation

- Documentation was updated to have the new parameter

