### PR TITLE
Non newtonian jacobian assembler

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.output
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.output
@@ -21,6 +21,6 @@ Steady iteration :        3/3
    Number of degrees of freedom: 12675
    Volume of triangulation:      4
 cells  error_velocity    error_pressure   
-  256 4.753900e-02    - 4.218425e-02    - 
- 1024 1.242881e-02 1.94 1.986227e-02 1.09 
- 4096 3.139533e-03 1.99 6.657495e-03 1.58 
+  256 4.744285e-02    - 4.216426e-02    - 
+ 1024 1.242291e-02 1.93 1.986165e-02 1.09 
+ 4096 3.137888e-03 1.99 6.657419e-03 1.58 

--- a/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.output
+++ b/applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.output
@@ -21,6 +21,6 @@ Steady iteration :        3/3
    Number of degrees of freedom: 9539
    Volume of triangulation:      4
 cells  error_velocity    error_pressure   
-   64 1.275602e-02    - 4.964849e-02    - 
-  256 1.682342e-03 2.92 1.184358e-02 2.07 
- 1024 2.062486e-04 3.03 2.896776e-03 2.03 
+   64 1.269375e-02    - 4.964863e-02    - 
+  256 1.681548e-03 2.92 1.184349e-02 2.07 
+ 1024 2.062271e-04 3.03 2.896755e-03 2.03 

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -416,10 +416,10 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
               double local_matrix_ij =
                 viscosity *
                   scalar_product(grad_phi_u_j_non_newtonian, grad_phi_u_i) +
-                scratch_data.grad_viscosity_shear_rate[q] /
+                0.5 * scratch_data.grad_viscosity_shear_rate[q] /
                   shear_rate_magnitude *
                   scalar_product(grad_phi_u_j_non_newtonian, shear_rate) *
-                  scalar_product(velocity_gradient, grad_phi_u_i) +
+                  scalar_product(shear_rate, grad_phi_u_i) +
                 velocity_gradient_x_phi_u_j[j] * 0.5 * phi_u_i +
                 grad_phi_u_j_x_velocity[j] * phi_u_i - div_phi_u_i * phi_p_j +
                 mass_source * phi_u_j * phi_u_i +

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -384,7 +384,8 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
           velocity_gradient_x_phi_u_j[j] = velocity_gradient * phi_u_j;
         }
 
-
+      shear_rate_magnitude =
+        shear_rate_magnitude > 1e-3 ? shear_rate_magnitude : 1e-3;
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
@@ -415,7 +416,11 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
               double local_matrix_ij =
                 viscosity *
                   scalar_product(grad_phi_u_j_non_newtonian, grad_phi_u_i) +
-                velocity_gradient_x_phi_u_j[j] * phi_u_i +
+                scratch_data.grad_viscosity_shear_rate[q] /
+                  shear_rate_magnitude *
+                  scalar_product(grad_phi_u_j_non_newtonian, shear_rate) *
+                  scalar_product(velocity_gradient, grad_phi_u_i) +
+                velocity_gradient_x_phi_u_j[j] * 0.5 * phi_u_i +
                 grad_phi_u_j_x_velocity[j] * phi_u_i - div_phi_u_i * phi_p_j +
                 mass_source * phi_u_j * phi_u_i +
                 // Continuity


### PR DESCRIPTION
# Description of the problem

Previously, all non-Newtonian simulations converged, but the jacobian matrix was ill-posed since it didn't take into account the jacobian of the viscosity (since it changes with velocity). 

# Description of the solution

A small addition was made to the jacobian matrix.

# How Has This Been Tested?

There were no added tests, but these two tests were slightly changed

- applications_tests/gls_navier_stokes_2d/mms2d_carreau_1st-order_gls.output
- applications_tests/gls_navier_stokes_2d/mms2d_carreau_2nd-order_gls.output

# Documentation

No documentation changes