### PR TITLE
Add NonNewtonian assemblers to vof

### DIFF
--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -154,4 +154,103 @@ public:
   const Parameters::SurfaceTensionForce STF_properties;
 };
 
+
+/**
+ * @brief Class that assembles the core of the Navier-Stokes equation
+ * using a Rheological model to predict non Newtonian behaviors
+ *
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+
+
+template <int dim>
+class GLSNavierStokesVOFAssemblerNonNewtonianCore
+  : public NavierStokesAssemblerBase<dim>
+{
+public:
+  GLSNavierStokesVOFAssemblerNonNewtonianCore(
+    std::shared_ptr<SimulationControl> simulation_control)
+    : simulation_control(simulation_control)
+  {}
+
+  /**
+   * @brief Calculates an approximation of the gradient of the viscosity
+   * @param velocity_gradient The velocity gradient tensor on the quadrature point
+     @param velocity_hessians The velocity hessian tensor on the quadrture point
+     @param non_newtonian_viscosity The viscosity at which the gradient is calculated
+     @param d_gamma_dot Th difference in the shear rate magnitude to approximate the
+     viscosity variation with a slight change in the shear_rate magnitude
+   */
+  inline Tensor<1, dim>
+  get_viscosity_gradient(const Tensor<2, dim> &velocity_gradient,
+                         const Tensor<3, dim> &velocity_hessians,
+                         const double          shear_rate_magnitude,
+                         const double          grad_viscosity_shear_rate) const
+  {
+    // Calculates an approximation of the shear rate magnitude gradient using
+    // the derived form, since it does not change with rheological models
+    Tensor<1, dim> grad_shear_rate;
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        if (dim == 2)
+          {
+            for (unsigned int k = 0; k < dim; ++k)
+              {
+                grad_shear_rate[d] +=
+                  2 * (velocity_gradient[k][k] * velocity_hessians[k][d][k]) /
+                  shear_rate_magnitude;
+              }
+            grad_shear_rate[d] +=
+              (velocity_gradient[0][1] + velocity_gradient[1][0]) *
+              (velocity_hessians[0][d][1] + velocity_hessians[1][d][0]) /
+              shear_rate_magnitude;
+          }
+        else
+          {
+            for (unsigned int k = 0; k < dim; ++k)
+              {
+                grad_shear_rate[d] +=
+                  2 * (velocity_gradient[k][k] * velocity_hessians[k][d][k]) /
+                    shear_rate_magnitude +
+                  (velocity_gradient[(k + 1) % dim][(k + 2) % dim] +
+                   velocity_gradient[(k + 2) % dim][(k + 1) % dim]) *
+                    (velocity_hessians[(k + 1) % dim][d][(k + 2) % dim] +
+                     velocity_hessians[(k + 2) % dim][d][(k + 1) % dim]) /
+                    shear_rate_magnitude;
+              }
+          }
+      }
+    return grad_shear_rate * grad_viscosity_shear_rate;
+  };
+
+  /**
+   * @brief assemble_matrix Assembles the matrix
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+                  StabilizedMethodsTensorCopyData<dim> &copy_data) override;
+
+
+  /**
+   * @brief assemble_rhs Assembles the rhs
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+               StabilizedMethodsTensorCopyData<dim> &copy_data) override;
+
+  /**
+   * Enables SUPG stabilization for the Navier-Stokes formulation.
+   * We have not found any scenarios where it is relevant not to use SUPG
+   * stabilization yet.
+   */
+  const bool SUPG = true;
+
+  std::shared_ptr<SimulationControl> simulation_control;
+};
 #endif

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -2363,10 +2363,22 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
             std::make_shared<GLSNavierStokesVOFAssemblerBDF<dim>>(
               this->simulation_control));
         }
-      // Core assembler
-      this->assemblers.push_back(
-        std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
-          this->simulation_control));
+      // Core assemblers
+      if (this->simulation_parameters.physical_properties_manager
+            .is_non_newtonian())
+        {
+          // Core assembler with Non newtonian viscosity
+          this->assemblers.push_back(
+            std::make_shared<GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>>(
+              this->simulation_control));
+        }
+      else
+        {
+          // Core assembler
+          this->assemblers.push_back(
+            std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
+              this->simulation_control));
+        }
     }
   else
     {

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -383,10 +383,21 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
               this->simulation_control));
         }
 
-      // Core assembler
-      this->assemblers.push_back(
-        std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
-          this->simulation_control));
+      if (this->simulation_parameters.physical_properties_manager
+            .is_non_newtonian())
+        {
+          // Core assembler with Non newtonian viscosity
+          this->assemblers.push_back(
+            std::make_shared<GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>>(
+              this->simulation_control));
+        }
+      else
+        {
+          // Core assembler
+          this->assemblers.push_back(
+            std::make_shared<GLSNavierStokesVOFAssemblerCore<dim>>(
+              this->simulation_control));
+        }
 
       // Surface tension force (STF)
       if (this->simulation_parameters.multiphysics.surface_tension_force)

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -630,9 +630,11 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
       const double JxW = JxW_vec[q];
 
       // Calculation of the equivalent properties at the quadrature point
-      double       density_eq           = scratch_data.density[q];
-      double       viscosity_eq         = scratch_data.viscosity[q];
-      const double dynamic_viscosity_eq = density_eq * viscosity_eq;
+      double               density_eq           = scratch_data.density[q];
+      double               viscosity_eq         = scratch_data.viscosity[q];
+      const double         dynamic_viscosity_eq = density_eq * viscosity_eq;
+      const Tensor<1, dim> dynamic_viscosity_gradient =
+        density_eq * viscosity_gradient;
 
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation
@@ -650,7 +652,7 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
       // Calculate the strong residual for GLS stabilization
       auto strong_residual = density_eq * velocity_gradient * velocity +
                              pressure_gradient -
-                             density_eq * shear_rate * viscosity_gradient -
+                             shear_rate * dynamic_viscosity_gradient -
                              dynamic_viscosity_eq * velocity_laplacian -
                              density_eq * force + strong_residual_vec[q];
 
@@ -672,10 +674,10 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
             grad_phi_u_j + transpose(grad_phi_u_j);
 
           strong_jacobian_vec[q][j] +=
-            (density_eq * velocity_gradient * phi_u_j +
-             density_eq * grad_phi_u_j * velocity + grad_phi_p_j -
-             dynamic_viscosity_eq * laplacian_phi_u_j -
-             grad_phi_u_j_non_newtonian * viscosity_gradient);
+            density_eq * velocity_gradient * phi_u_j +
+            density_eq * grad_phi_u_j * velocity + grad_phi_p_j -
+            dynamic_viscosity_eq * laplacian_phi_u_j -
+            grad_phi_u_j_non_newtonian * dynamic_viscosity_gradient;
 
           // Store these temporary products in auxiliary variables for speed
           grad_phi_u_j_x_velocity[j]     = grad_phi_u_j * velocity;
@@ -848,9 +850,11 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_rhs(
       const double JxW = JxW_vec[q];
 
       // Calculation of the equivalent properties at the quadrature point
-      double       density_eq           = scratch_data.density[q];
-      double       viscosity_eq         = scratch_data.viscosity[q];
-      const double dynamic_viscosity_eq = density_eq * viscosity_eq;
+      double               density_eq           = scratch_data.density[q];
+      double               viscosity_eq         = scratch_data.viscosity[q];
+      const double         dynamic_viscosity_eq = density_eq * viscosity_eq;
+      const Tensor<1, dim> dynamic_viscosity_gradient =
+        density_eq * viscosity_gradient;
 
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation
@@ -869,7 +873,7 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_rhs(
       // Calculate the strong residual for GLS stabilization
       auto strong_residual = density_eq * velocity_gradient * velocity +
                              pressure_gradient -
-                             shear_rate * viscosity_gradient -
+                             shear_rate * dynamic_viscosity_gradient -
                              dynamic_viscosity_eq * velocity_laplacian -
                              density_eq * force + strong_residual_vec[q];
 

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -77,7 +77,6 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 
       if (phase_force_cutoff < 0.5 && phase_values[q] < phase_force_cutoff)
         force = 0;
-      // Gravity not applied on phase 1
       if (phase_force_cutoff > 0.5 && phase_values[q] > phase_force_cutoff)
         force = 0;
 
@@ -88,11 +87,9 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
 
-      // Calculation of the equivalent density at the quadrature point
-      double density_eq = scratch_data.density[q];
-
-      double viscosity_eq = scratch_data.viscosity[q];
-
+      // Calculation of the equivalent properties at the quadrature point
+      double       density_eq           = scratch_data.density[q];
+      double       viscosity_eq         = scratch_data.viscosity[q];
       const double dynamic_viscosity_eq = density_eq * viscosity_eq;
 
       // Calculation of the GLS stabilization parameter. The
@@ -275,9 +272,8 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
 
-      // Calculation of the equivalent density at the quadrature point
-      double density_eq = scratch_data.density[q];
-
+      // Calculation of the equivalent properties at the quadrature point
+      double       density_eq           = scratch_data.density[q];
       double       viscosity_eq         = scratch_data.viscosity[q];
       const double dynamic_viscosity_eq = density_eq * viscosity_eq;
 
@@ -532,3 +528,386 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
 
 template class GLSNavierStokesVOFAssemblerSTF<2>;
 template class GLSNavierStokesVOFAssemblerSTF<3>;
+
+
+template <int dim>
+void
+GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
+  NavierStokesScratchData<dim> &        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &copy_data)
+{
+  // Loop and quadrature informations
+  const auto &       JxW_vec    = scratch_data.JxW;
+  const unsigned int n_q_points = scratch_data.n_q_points;
+  const unsigned int n_dofs     = scratch_data.n_dofs;
+  const double       h          = scratch_data.cell_size;
+
+  // Copy data elements
+  auto &strong_residual_vec = copy_data.strong_residual;
+  auto &strong_jacobian_vec = copy_data.strong_jacobian;
+  auto &local_matrix        = copy_data.local_matrix;
+
+  // Time steps and inverse time steps which is used for stabilization constant
+  std::vector<double> time_steps_vector =
+    this->simulation_control->get_time_steps_vector();
+  const double dt  = time_steps_vector[0];
+  const double sdt = 1. / dt;
+
+  // Phase values and limiters
+  std::vector<double> &phase_values = scratch_data.phase_values;
+  // std::vector<double> &phase_values_m1 =
+  // scratch_data.previous_phase_values[0];
+  // std::vector<Tensor<1, dim>> &phase_gradient_values =
+  // scratch_data.phase_gradient_values;
+
+  // Limit force application : not applied if cell density is below
+  // density_ratio of the maximum density (e.g. when one of the fluids is air)
+  const double density_ratio      = 2;
+  double       phase_force_cutoff = 0;
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+
+  if (scratch_data.density_0[0] < scratch_data.density_1[0] &&
+      scratch_data.density_0[0] * density_ratio < scratch_data.density_1[0])
+    {
+      // gravity not will be applied for phase < phase_force_cutoff
+      phase_force_cutoff = 1e-6;
+    }
+  if (scratch_data.density_1[0] < scratch_data.density_0[0] &&
+      scratch_data.density_1[0] * density_ratio < scratch_data.density_0[0])
+    {
+      // gravity not will be applied for phase > phase_force_cutoff
+      phase_force_cutoff = 1 - 1e-6;
+    }
+
+  // Loop over the quadrature points
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      const Tensor<1, dim> &velocity = scratch_data.velocity_values[q];
+      const Tensor<2, dim> &velocity_gradient =
+        scratch_data.velocity_gradients[q];
+      const Tensor<1, dim> &velocity_laplacian =
+        scratch_data.velocity_laplacians[q];
+      const Tensor<3, dim> &velocity_hessian =
+        scratch_data.velocity_hessians[q];
+      const Tensor<1, dim> &pressure_gradient =
+        scratch_data.pressure_gradients[q];
+
+      // Calculate shear rate (at each q)
+      const Tensor<2, dim> shear_rate =
+        velocity_gradient + transpose(velocity_gradient);
+
+      // Calculate the shear rate magnitude
+      double shear_rate_magnitude = calculate_shear_rate_magnitude(shear_rate);
+      // Set the shear rate magnitude to 1e-12 if it is too close to zero,
+      // since the viscosity gradient is undefined for shear_rate_magnitude = 0
+      shear_rate_magnitude =
+        shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12;
+
+      // Calculate viscosity gradient
+      const Tensor<1, dim> viscosity_gradient =
+        this->get_viscosity_gradient(velocity_gradient,
+                                     velocity_hessian,
+                                     shear_rate_magnitude,
+                                     scratch_data.grad_viscosity_shear_rate[q]);
+
+      // Forcing term
+      Tensor<1, dim> force = scratch_data.force[q];
+
+      if (phase_force_cutoff < 0.5 && phase_values[q] < phase_force_cutoff)
+        force = 0;
+      if (phase_force_cutoff > 0.5 && phase_values[q] > phase_force_cutoff)
+        force = 0;
+
+      // Calculation of the magnitude of the velocity for the
+      // stabilization parameter
+      const double u_mag = std::max(velocity.norm(), 1e-12);
+
+      // Store JxW in local variable for faster access;
+      const double JxW = JxW_vec[q];
+
+      // Calculation of the equivalent properties at the quadrature point
+      double       density_eq           = scratch_data.density[q];
+      double       viscosity_eq         = scratch_data.viscosity[q];
+      const double dynamic_viscosity_eq = density_eq * viscosity_eq;
+
+      // Calculation of the GLS stabilization parameter. The
+      // stabilization parameter used is different if the simulation
+      // is steady or unsteady. In the unsteady case it includes the
+      // value of the time-step
+      const double tau =
+        this->simulation_control->get_assembly_method() ==
+            Parameters::SimulationControl::TimeSteppingMethod::steady ?
+          1. / std::sqrt(std::pow(2. * density_eq * u_mag / h, 2) +
+                         9 * std::pow(4 * dynamic_viscosity_eq / (h * h), 2)) :
+          1. / std::sqrt(std::pow(sdt, 2) +
+                         std::pow(2. * density_eq * u_mag / h, 2) +
+                         9 * std::pow(4 * dynamic_viscosity_eq / (h * h), 2));
+
+      // Calculate the strong residual for GLS stabilization
+      auto strong_residual = density_eq * velocity_gradient * velocity +
+                             pressure_gradient -
+                             density_eq * shear_rate * viscosity_gradient -
+                             dynamic_viscosity_eq * velocity_laplacian -
+                             density_eq * force + strong_residual_vec[q];
+
+      std::vector<Tensor<1, dim>> grad_phi_u_j_x_velocity(n_dofs);
+      std::vector<Tensor<1, dim>> velocity_gradient_x_phi_u_j(n_dofs);
+
+
+      // We loop over the column first to prevent recalculation
+      // of the strong jacobian in the inner loop
+      for (unsigned int j = 0; j < n_dofs; ++j)
+        {
+          const auto &phi_u_j           = scratch_data.phi_u[q][j];
+          const auto &grad_phi_u_j      = scratch_data.grad_phi_u[q][j];
+          const auto &laplacian_phi_u_j = scratch_data.laplacian_phi_u[q][j];
+
+          const auto &grad_phi_p_j = scratch_data.grad_phi_p[q][j];
+
+          const auto &grad_phi_u_j_non_newtonian =
+            grad_phi_u_j + transpose(grad_phi_u_j);
+
+          strong_jacobian_vec[q][j] +=
+            (density_eq * velocity_gradient * phi_u_j +
+             density_eq * grad_phi_u_j * velocity + grad_phi_p_j -
+             dynamic_viscosity_eq * laplacian_phi_u_j -
+             grad_phi_u_j_non_newtonian * viscosity_gradient);
+
+          // Store these temporary products in auxiliary variables for speed
+          grad_phi_u_j_x_velocity[j]     = grad_phi_u_j * velocity;
+          velocity_gradient_x_phi_u_j[j] = velocity_gradient * phi_u_j;
+        }
+
+      shear_rate_magnitude =
+        shear_rate_magnitude > 1e-3 ? shear_rate_magnitude : 1e-3;
+
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto &phi_u_i      = scratch_data.phi_u[q][i];
+          const auto &grad_phi_u_i = scratch_data.grad_phi_u[q][i];
+          const auto &div_phi_u_i  = scratch_data.div_phi_u[q][i];
+          const auto &phi_p_i      = scratch_data.phi_p[q][i];
+          const auto &grad_phi_p_i = scratch_data.grad_phi_p[q][i];
+
+          // Store these temporary products in auxiliary variables for speed
+          const auto grad_phi_u_i_x_velocity = grad_phi_u_i * velocity;
+          const auto strong_residual_x_grad_phi_u_i =
+            strong_residual * grad_phi_u_i;
+
+          for (unsigned int j = 0; j < n_dofs; ++j)
+            {
+              const auto &phi_u_j      = scratch_data.phi_u[q][j];
+              const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
+              const auto &div_phi_u_j  = scratch_data.div_phi_u[q][j];
+
+              const auto &grad_phi_u_j_non_newtonian =
+                grad_phi_u_j + transpose(grad_phi_u_j);
+
+              const auto &phi_p_j = scratch_data.phi_p[q][j];
+
+              const auto &strong_jac = strong_jacobian_vec[q][j];
+
+              double local_matrix_ij =
+                dynamic_viscosity_eq *
+                  scalar_product(grad_phi_u_j_non_newtonian, grad_phi_u_i) +
+                0.5 * scratch_data.grad_viscosity_shear_rate[q] /
+                  shear_rate_magnitude *
+                  scalar_product(grad_phi_u_j_non_newtonian, shear_rate) *
+                  scalar_product(shear_rate, grad_phi_u_i) +
+                density_eq * velocity_gradient_x_phi_u_j[j] * 0.5 * phi_u_i +
+                density_eq * grad_phi_u_j_x_velocity[j] * phi_u_i
+                // Continuity
+                - div_phi_u_i * phi_p_j + phi_p_i * div_phi_u_j;
+
+              // PSPG GLS term
+              local_matrix_ij += tau * (strong_jac * grad_phi_p_i);
+
+              // The jacobian matrix for the SUPG formulation
+              // currently does not include the jacobian of the stabilization
+              // parameter tau. Our experience has shown that does not alter the
+              // number of newton iteration for convergence, but greatly
+              // simplifies assembly.
+              if (SUPG)
+                {
+                  local_matrix_ij +=
+                    tau * (strong_jac * grad_phi_u_i_x_velocity +
+                           strong_residual_x_grad_phi_u_i * phi_u_j);
+                }
+              local_matrix_ij *= JxW;
+              local_matrix(i, j) += local_matrix_ij;
+            }
+        }
+    }
+}
+
+template <int dim>
+void
+GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_rhs(
+  NavierStokesScratchData<dim> &        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &copy_data)
+{
+  // Loop and quadrature informations
+  const auto &       JxW_vec    = scratch_data.JxW;
+  const unsigned int n_q_points = scratch_data.n_q_points;
+  const unsigned int n_dofs     = scratch_data.n_dofs;
+  const double       h          = scratch_data.cell_size;
+
+  // Copy data elements
+  auto &strong_residual_vec = copy_data.strong_residual;
+  auto &local_rhs           = copy_data.local_rhs;
+
+  // Time steps and inverse time steps which is used for stabilization constant
+  std::vector<double> time_steps_vector =
+    this->simulation_control->get_time_steps_vector();
+  const double dt  = time_steps_vector[0];
+  const double sdt = 1. / dt;
+
+  // Phase values and limiters
+  std::vector<double> &phase_values = scratch_data.phase_values;
+  // std::vector<double> &phase_values_m1 =
+  // scratch_data.previous_phase_values[0];
+  // std::vector<Tensor<1, dim>> &phase_gradient_values =
+  // scratch_data.phase_gradient_values;
+
+  // Limit force application : not applied if cell density is below
+  // density_ratio of the maximum density (e.g. when one of the fluids is air)
+  const double density_ratio      = 2;
+  double       phase_force_cutoff = 0;
+
+  Assert(
+    scratch_data.properties_manager.density_is_constant(),
+    RequiresConstantDensity(
+      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+
+  if (scratch_data.density_0[0] < scratch_data.density_1[0] &&
+      scratch_data.density_0[0] * density_ratio < scratch_data.density_1[0])
+    {
+      // gravity not will be applied for phase < phase_force_cutoff
+      phase_force_cutoff = 1e-6;
+    }
+  if (scratch_data.density_1[0] < scratch_data.density_0[0] &&
+      scratch_data.density_1[0] * density_ratio < scratch_data.density_0[0])
+    {
+      // gravity not will be applied for phase > phase_force_cutoff
+      phase_force_cutoff = 1 - 1e-6;
+    }
+
+  // Loop over the quadrature points
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      // Velocity
+      const Tensor<1, dim> &velocity   = scratch_data.velocity_values[q];
+      const double velocity_divergence = scratch_data.velocity_divergences[q];
+      const Tensor<2, dim> &velocity_gradient =
+        scratch_data.velocity_gradients[q];
+      const Tensor<1, dim> &velocity_laplacian =
+        scratch_data.velocity_laplacians[q];
+      const Tensor<3, dim> &velocity_hessian =
+        scratch_data.velocity_hessians[q];
+
+      // Calculate shear rate (at each q)
+      const Tensor<2, dim> shear_rate =
+        velocity_gradient + transpose(velocity_gradient);
+
+      // Calculate the shear rate magnitude
+      double shear_rate_magnitude = calculate_shear_rate_magnitude(shear_rate);
+
+      shear_rate_magnitude =
+        shear_rate_magnitude > 1e-12 ? shear_rate_magnitude : 1e-12;
+
+      // Calculate viscosity gradient
+      const Tensor<1, dim> viscosity_gradient =
+        this->get_viscosity_gradient(velocity_gradient,
+                                     velocity_hessian,
+                                     shear_rate_magnitude,
+                                     scratch_data.grad_viscosity_shear_rate[q]);
+
+      // Pressure
+      const double         pressure = scratch_data.pressure_values[q];
+      const Tensor<1, dim> pressure_gradient =
+        scratch_data.pressure_gradients[q];
+
+      // Forcing term
+      Tensor<1, dim> force = scratch_data.force[q];
+
+      if (phase_force_cutoff < 0.5 && phase_values[q] < phase_force_cutoff)
+        force = 0;
+      // Gravity not applied on phase 1
+      if (phase_force_cutoff > 0.5 && phase_values[q] > phase_force_cutoff)
+        force = 0;
+
+      // Calculation of the magnitude of the
+      // velocity for the stabilization parameter
+      const double u_mag = std::max(velocity.norm(), 1e-12);
+
+      // Store JxW in local variable for faster access;
+      const double JxW = JxW_vec[q];
+
+      // Calculation of the equivalent properties at the quadrature point
+      double       density_eq           = scratch_data.density[q];
+      double       viscosity_eq         = scratch_data.viscosity[q];
+      const double dynamic_viscosity_eq = density_eq * viscosity_eq;
+
+      // Calculation of the GLS stabilization parameter. The
+      // stabilization parameter used is different if the simulation
+      // is steady or unsteady. In the unsteady case it includes the
+      // value of the time-step
+      const double tau =
+        this->simulation_control->get_assembly_method() ==
+            Parameters::SimulationControl::TimeSteppingMethod::steady ?
+          1. / std::sqrt(std::pow(2. * density_eq * u_mag / h, 2) +
+                         9 * std::pow(4 * dynamic_viscosity_eq / (h * h), 2)) :
+          1. / std::sqrt(std::pow(sdt, 2) +
+                         std::pow(2. * density_eq * u_mag / h, 2) +
+                         9 * std::pow(4 * dynamic_viscosity_eq / (h * h), 2));
+
+
+      // Calculate the strong residual for GLS stabilization
+      auto strong_residual = density_eq * velocity_gradient * velocity +
+                             pressure_gradient -
+                             shear_rate * viscosity_gradient -
+                             dynamic_viscosity_eq * velocity_laplacian -
+                             density_eq * force + strong_residual_vec[q];
+
+      // Assembly of the right-hand side
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto &phi_u_i      = scratch_data.phi_u[q][i];
+          const auto &grad_phi_u_i = scratch_data.grad_phi_u[q][i];
+          const auto &phi_p_i      = scratch_data.phi_p[q][i];
+          const auto &grad_phi_p_i = scratch_data.grad_phi_p[q][i];
+          const auto &div_phi_u_i  = scratch_data.div_phi_u[q][i];
+
+          double local_rhs_i = 0;
+
+          // Navier-Stokes Residual
+          local_rhs_i +=
+            (
+              // Momentum
+              -dynamic_viscosity_eq * scalar_product(shear_rate, grad_phi_u_i) -
+              density_eq * velocity_gradient * velocity * phi_u_i +
+              pressure * div_phi_u_i + density_eq * force * phi_u_i -
+              // Continuity
+              velocity_divergence * phi_p_i) *
+            JxW;
+
+          // PSPG GLS term
+          local_rhs_i += -tau * (strong_residual * grad_phi_p_i) * JxW;
+
+          // SUPG GLS term
+          if (SUPG)
+            {
+              local_rhs_i +=
+                -tau * (strong_residual * (grad_phi_u_i * velocity)) * JxW;
+            }
+          local_rhs(i) += local_rhs_i;
+        }
+    }
+}
+
+template class GLSNavierStokesVOFAssemblerNonNewtonianCore<2>;
+template class GLSNavierStokesVOFAssemblerNonNewtonianCore<3>;


### PR DESCRIPTION
# Description of the problem

Non-newtonian assemblers were missing in vof

# Description of the solution

Added them by adapting classical non-newtonian assembler to the vof case, similarly to the newtonian assembler.

# How Has This Been Tested?

Not yet but should be before merging (Bruno if you have your prm set, maybe try this out? I will try it tomorrow overwise) 

# Comments

Please check carefully the assembler's equations!
