### PR TITLE
Radiation heat transfer

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/ggls-stab_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/ggls-stab_gls.prm
@@ -95,7 +95,7 @@ subsection boundary conditions heat transfer
     end
     subsection bc 1
     set id = 1
-	set type	      = convection
+	set type	      = convection-radiation
         set h	      = 1000
         set Tinf	      = 1
     end

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.output
@@ -3,45 +3,29 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3267
    Volume of triangulation:      0.01
    Number of thermal degrees of freedom: 1089
+Minimum and maximum temperatures : 0 , 0
 
 *****************************************************************
 Transient iteration : 1        Time : 0.01     Time step : 0.01     CFL : 0       
 *****************************************************************
-L2 error velocity : 0
-L2 error temperature : 150.231
+Minimum and maximum temperatures : 0.000179891 , 1540.48
 
 *****************************************************************
 Transient iteration : 2        Time : 0.02     Time step : 0.01     CFL : 0       
 *****************************************************************
-L2 error velocity : 0
-L2 error temperature : 278.378
+Minimum and maximum temperatures : 0.0162123 , 1722.86
 
 *****************************************************************
 Transient iteration : 3        Time : 0.03     Time step : 0.01     CFL : 0       
 *****************************************************************
-L2 error velocity : 0
-L2 error temperature : 378.601
+Minimum and maximum temperatures : 0.0911536 , 1726.81
 
 *****************************************************************
 Transient iteration : 4        Time : 0.04     Time step : 0.01     CFL : 0       
 *****************************************************************
-L2 error velocity : 0
-L2 error temperature : 287.622
+Minimum and maximum temperatures : 0.180836 , 1080.52
 
 *****************************************************************
 Transient iteration : 5        Time : 0.05     Time step : 0.01     CFL : 0       
 *****************************************************************
-L2 error velocity : 0
-L2 error temperature : 245.927
- time  error_velocity 
-0.0100 0.000000e+00   
-0.0200 0.000000e+00   
-0.0300 0.000000e+00   
-0.0400 0.000000e+00   
-0.0500 0.000000e+00   
-cells error_temperature 
-1024  1.502310e+02      
-1024  2.783781e+02      
-1024  3.786006e+02      
-1024  2.876222e+02      
-1024  2.459270e+02      
+Minimum and maximum temperatures : 0.281314 , 789.985

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.prm
@@ -39,6 +39,14 @@ subsection laser parameters
 end
 
 #---------------------------------------------------
+# Post-Processing
+#---------------------------------------------------
+subsection post-processing
+    set verbosity = verbose
+    set calculate temperature range = true
+end
+
+#---------------------------------------------------
 # Initial condition
 #---------------------------------------------------
 subsection initial conditions
@@ -82,23 +90,35 @@ end
 # --------------------------------------------------
 # Boundary Conditions
 #---------------------------------------------------
-subsection boundary conditions
+subsection boundary conditions heat transfer
   set number                  = 4
     subsection bc 0
-        set id = 0
-        set type              = noslip
+    	set id = 0
+	set type	      = convection-radiation
+        set h	      	      = 10
+        set Tinf	      = 20
+        set emissivity        = 0.5
     end
     subsection bc 1
-        set id = 1
-        set type              = noslip
+    	set id = 1
+	set type	      = convection-radiation
+        set h	              = 10
+        set Tinf	      = 20
+        set emissivity        = 0.5
     end
     subsection bc 2
-        set id = 2
-        set type              = noslip
+    	set id = 2
+	set type	      = convection-radiation
+        set h	              = 10
+        set Tinf	      = 20
+        set emissivity        = 0.5
     end
     subsection bc 3
-        set id = 3
-        set type              = noslip
+    	set id = 3
+	set type	      = convection-radiation
+        set h	              = 10
+        set Tinf	      = 20
+        set emissivity        = 0.5
     end
 end
 
@@ -108,17 +128,6 @@ end
 subsection FEM
     set velocity order            = 1
     set pressure order            = 1
-end
-
-# --------------------------------------------------
-# Analytical Solution
-#---------------------------------------------------
-subsection analytical solution
-  set enable                 = true
-  set verbosity                = verbose
-    subsection uvwp
-            set Function expression =  0 ; 0 ; 0
-    end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_radiation.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_radiation.output
@@ -1,0 +1,17 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       4
+   Number of degrees of freedom: 27
+   Volume of triangulation:      0.0001
+   Number of thermal degrees of freedom: 9
+Minimum and maximum temperatures : 1000 , 1000
+
+*****************************************************************
+Transient iteration : 1        Time : 0.01     Time step : 0.01     CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 0.000338465
+Minimum and maximum temperatures : 979.082 , 979.232
+ time  error_velocity 
+0.0100 0.000000e+00   
+cells error_temperature 
+4     3.384650e-04      

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_radiation.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_radiation.prm
@@ -1,0 +1,158 @@
+# Listing of Parameters
+# ---------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  		= bdf1
+  set time end                		= 0.01
+  set time step               		= 0.01
+  set adapt 		      		= false
+  set number mesh adapt       		= 0
+  set output name             		= radiation
+  set output frequency        		= 0
+  set subdivision             		= 1
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+	set heat transfer  = true
+end
+
+#---------------------------------------------------
+# Post-Processing
+#---------------------------------------------------
+subsection post-processing
+    set verbosity = verbose
+    set calculate temperature range = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection uvwp
+        set Function expression = 0; 0; 0
+    end
+    subsection temperature
+    	set Function expression = 1000
+    end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+subsection source term
+    set enable = false
+    subsection xyz
+        set Function expression = 0; 0; 0
+    end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+  set number of fluids     = 1
+    subsection fluid 0
+    set density              = 1000
+    set kinematic viscosity  = 1
+    set thermal conductivity model = constant
+    set thermal conductivity = 1000
+    set specific heat model = constant
+    set specific heat = 10
+    end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+        set type = dealii
+        set grid type = subdivided_hyper_rectangle
+        set grid arguments = 1, 1: 0, 0 : 0.01, 0.01 : true
+        set initial refinement = 1
+end
+
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions heat transfer
+  set number                  = 4
+    subsection bc 0
+    	set id = 0
+	set type	      = convection-radiation
+        set h	      	      = 0
+        set Tinf	      = 20
+        set emissivity        = 1
+    end
+    subsection bc 1
+    	set id = 1
+	set type	      = convection-radiation
+        set h	              = 0
+        set Tinf	      = 20
+        set emissivity        = 1
+    end
+    subsection bc 2
+    	set id = 2
+	set type	      = convection-radiation
+        set h	              = 0
+        set Tinf	      = 20
+        set emissivity        = 1
+    end
+    subsection bc 3
+    	set id = 3
+	set type	      = convection-radiation
+        set h	              = 0
+        set Tinf	      = 20
+        set emissivity        = 1
+    end
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable                 = true
+  set verbosity = verbose
+    subsection uvwp
+            set Function expression =  0 ; 0 ; 0
+    end
+    subsection temperature
+            
+            set Function expression =  977.318
+    end
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+subsection FEM
+    set velocity order            = 1
+    set pressure order            = 1
+end
+
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set tolerance               = 1e-8
+  set max iterations          = 100
+  set verbosity               = quiet
+end
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               		     = quiet
+  set method                                 = gmres
+  set max iters                              = 8000
+  set relative residual                      = 1e-3
+  set minimum residual                       = 1e-8
+  set ilu preconditioner fill                = 1
+  set ilu preconditioner absolute tolerance  = 1e-12
+  set ilu preconditioner relative tolerance  = 1.00
+  set max krylov vectors                     = 200
+end

--- a/applications_tests/gls_navier_stokes_2d/mms-conv-bc_gls.prm
+++ b/applications_tests/gls_navier_stokes_2d/mms-conv-bc_gls.prm
@@ -97,7 +97,7 @@ subsection boundary conditions heat transfer
     end
     subsection bc 1
     set id = 1
-	set type	      = convection
+	set type	      = convection-radiation
         set h	      = 1
         set Tinf	      = 10
     end

--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -7,7 +7,7 @@ This subsection's purpose is defining the boundary conditions associated to mult
 Heat Transfer
 ^^^^^^^^^^^^^
 
-For heat transfer boundary conditions, the possible ``types`` are ``temperature`` (default) and ``convection``.
+For heat transfer boundary conditions, the possible ``types`` are ``temperature`` (default) and ``convection-radiation``.
 The default parameters of each are shown: 
 
 .. code-block:: text
@@ -21,10 +21,12 @@ The default parameters of each are shown:
         end
         subsection bc 1
 	    set id 		= 1
-            set type		= convection
-            set h 		= 0
-            set Tinf	   	= 0
+            set type		    = convection-radiation
+            set h 		    = 0
+            set Tinf	   	    = 0
+            set emissivity   = 0
         end
+        set Stefan-Boltzmann constant = 0.000000056703
     end
 
 * ``number``: This is the number of boundary conditions of the problem. 
@@ -36,11 +38,13 @@ The default parameters of each are shown:
 
 * ``type``: This is the type of boundary condition been imposed. At the moment, choices are
     * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary 
-    * ``convection`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` following Newton's law of cooling (and heating)
+    * ``convection-radiation`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` and emissivity of the boundary :math:`\mathbf{\epsilon}` following Newton's law of cooling (and heating) and Stefan-Boltzmann law of radiation
 
 .. math::
-    \frac{ \partial T}{\partial \mathbf{n}} = h (T - T_\textit{inf})
+    \frac{ \partial T}{\partial \mathbf{n}} = h (T - T_{inf}) + \epsilon \sigma (T^4 - T_{inf}^4)
 
+
+where :math:`\mathbf{\sigma}` is the Stefan-Boltzmann constant.
 
 .. note::
     By default, the boundary condition type is ``temperature`` with ``value = 0``

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -475,7 +475,7 @@ namespace BoundaryConditions
       "Temperature (Double) of environment for convection-radiation bc");
 
     prm.declare_entry("emissivity",
-                      "0",
+                      "0.0",
                       Patterns::Double(),
                       "Emissivity of the boundary for convection-radiation bc");
   }
@@ -543,7 +543,7 @@ namespace BoundaryConditions
         this->Tinf[i_bc]       = prm.get_double("Tinf");
         this->emissivity[i_bc] = prm.get_double("emissivity");
 
-        Assert(this->emissivity[i_bc] > 1.0 | this->emissivity[i_bc] < 0.0,
+        Assert(this->emissivity[i_bc] <= 1.0 && this->emissivity[i_bc] >= 0.0,
                EmissivityError(this->emissivity[i_bc]));
       }
 

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -25,6 +25,12 @@
 
 using namespace dealii;
 
+DeclException1(
+  EmissivityError,
+  double,
+  << "Emissivity : " << arg1
+  << " cannot be larger than 1.0 (black body) or smaller than 0.0");
+
 namespace BoundaryConditions
 {
   enum class BoundaryType
@@ -536,6 +542,9 @@ namespace BoundaryConditions
         this->h[i_bc]          = prm.get_double("h");
         this->Tinf[i_bc]       = prm.get_double("Tinf");
         this->emissivity[i_bc] = prm.get_double("emissivity");
+
+        Assert(this->emissivity[i_bc] > 1.0 | this->emissivity[i_bc] < 0.0,
+               EmissivityError(this->emissivity[i_bc]));
       }
 
     this->id[i_bc] = prm.get_integer("id");

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -574,6 +574,9 @@ namespace Parameters
     // Enable pressure drop post-processing
     bool calculate_pressure_drop;
 
+    // Print minimum and maximum temperature
+    bool calculate_min_max_temperature;
+
     // The outlet boundary ID for pressure drop calculation
     unsigned int inlet_boundary_id;
 

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -273,6 +273,23 @@ calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
                     const Mapping<dim> &       mapping);
 
 
+/**
+ * @brief Calculates the minimum and maximum temperature in the simulation domain
+ *
+ * @param dof_handler. The argument used to get finite elements
+ *
+ * @param face_quadrature_formula The face quadrature formula for the calculation
+ *
+ * @param mapping The mapping of the simulation
+ */
+template <int dim, typename VectorType>
+std::pair<double, double>
+calculate_min_max_temperature(const DoFHandler<dim> &dof_handler_ht,
+                              const VectorType &     evaluation_point,
+                              const Quadrature<dim> &quadrature_formula,
+                              const Mapping<dim> &   mapping);
+
+
 
 #  define lethe_postprocessing_cfd_h
 

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -276,11 +276,13 @@ calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
 /**
  * @brief Calculates the minimum and maximum temperature in the simulation domain
  *
- * @param dof_handler. The argument used to get finite elements
+ * @param dof_handler_ht. The dof handler associated with the heat transfer problem
  *
- * @param face_quadrature_formula The face quadrature formula for the calculation
+ * @param evaluation_point Temperature solution
  *
- * @param mapping The mapping of the simulation
+ * @param quadrature_formula The quadrature formula for the calculation
+ *
+ * @param mapping
  */
 template <int dim, typename VectorType>
 std::pair<double, double>

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1007,6 +1007,12 @@ namespace Parameters
                         Patterns::Bool(),
                         "Enable calculation of between two boundaries.");
 
+      prm.declare_entry(
+        "calculate temperature range",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of minimum and maximum temperature.");
+
       prm.declare_entry("inlet boundary id",
                         "0",
                         Patterns::Integer(),
@@ -1084,7 +1090,9 @@ namespace Parameters
         prm.get_bool("calculate apparent viscosity");
       calculate_average_velocities =
         prm.get_bool("calculate average velocities");
-      calculate_pressure_drop        = prm.get_bool("calculate pressure drop");
+      calculate_pressure_drop = prm.get_bool("calculate pressure drop");
+      calculate_min_max_temperature =
+        prm.get_bool("calculate temperature range");
       inlet_boundary_id              = prm.get_integer("inlet boundary id");
       outlet_boundary_id             = prm.get_integer("outlet boundary id");
       initial_time                   = prm.get_double("initial time");

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -468,7 +468,7 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
         }
     }
 
-  // Minimum, maximum and average temperature
+  // Minimum and maximum temperature
   if (simulation_parameters.post_processing.calculate_min_max_temperature)
     {
       std::pair<double, double> min_max_temperature =

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -6,6 +6,7 @@
 #include <solvers/heat_transfer.h>
 #include <solvers/heat_transfer_assemblers.h>
 #include <solvers/heat_transfer_scratch_data.h>
+#include <solvers/postprocessing_cfd.h>
 
 #include <deal.II/base/work_stream.h>
 
@@ -464,6 +465,24 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
         {
           this->pcout << "L2 error temperature : " << temperature_error
                       << std::endl;
+        }
+    }
+
+  // Minimum, maximum and average temperature
+  if (simulation_parameters.post_processing.calculate_min_max_temperature)
+    {
+      std::pair<double, double> min_max_temperature =
+        calculate_min_max_temperature(dof_handler,
+                                      present_solution,
+                                      *cell_quadrature,
+                                      *temperature_mapping);
+
+      if (simulation_parameters.post_processing.verbosity ==
+          Parameters::Verbosity::verbose)
+        {
+          this->pcout << "Minimum and maximum temperatures : "
+                      << min_max_temperature.first << " , "
+                      << min_max_temperature.second << std::endl;
         }
     }
 }

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -376,8 +376,8 @@ HeatTransferAssemblerRobinBC<dim>::assemble_matrix(
     return;
   auto &local_matrix = copy_data.local_matrix;
 
-  // Robin boundary condition, loop on faces (Newton's cooling law)
-  // implementation similar to deal.ii step-7
+  // Robin boundary condition, loop on faces (Newton's cooling law +
+  // Stefan-Boltzmann law) implementation similar to deal.ii step-7
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions_ht.size; ++i_bc)
     {
       if (this->boundary_conditions_ht.type[i_bc] ==
@@ -426,8 +426,14 @@ HeatTransferAssemblerRobinBC<dim>::assemble_rhs(
   const double Stefan_Boltzmann_constant =
     this->boundary_conditions_ht.Stefan_Boltzmann_constant;
 
-  // Robin boundary condition, loop on faces (Newton's cooling law)
-  // implementation similar to deal.ii step-7
+  // Robin boundary condition, loop on faces (Newton's cooling law +
+  // Stefan-Boltzmann law) Convection-radiation BC is a combination of
+  // convection and radiation. If the Stefan-Boltzmann constant (with default
+  // value = 0) is set to 0, only the convection component is considered,
+  // whereas if the convection coefficient, h (with default value = 0), is set
+  // to 0, only the radiation component is considered. Otherwise, both the
+  // convection and radiation are significant on the boundary implementation
+  // similar to deal.ii step-7
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions_ht.size; ++i_bc)
     {
       if (this->boundary_conditions_ht.type[i_bc] ==

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -381,7 +381,7 @@ HeatTransferAssemblerRobinBC<dim>::assemble_matrix(
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions_ht.size; ++i_bc)
     {
       if (this->boundary_conditions_ht.type[i_bc] ==
-          BoundaryConditions::BoundaryType::convection)
+          BoundaryConditions::BoundaryType::convection_radiation)
         {
           const double h = this->boundary_conditions_ht.h[i_bc];
           for (unsigned int f = 0; f < scratch_data.n_faces; ++f)
@@ -422,18 +422,21 @@ HeatTransferAssemblerRobinBC<dim>::assemble_rhs(
   if (!scratch_data.is_boundary_cell)
     return;
 
-  auto &local_rhs = copy_data.local_rhs;
-
+  auto &       local_rhs = copy_data.local_rhs;
+  const double Stefan_Boltzmann_constant =
+    this->boundary_conditions_ht.Stefan_Boltzmann_constant;
 
   // Robin boundary condition, loop on faces (Newton's cooling law)
   // implementation similar to deal.ii step-7
   for (unsigned int i_bc = 0; i_bc < this->boundary_conditions_ht.size; ++i_bc)
     {
       if (this->boundary_conditions_ht.type[i_bc] ==
-          BoundaryConditions::BoundaryType::convection)
+          BoundaryConditions::BoundaryType::convection_radiation)
         {
           const double h     = this->boundary_conditions_ht.h[i_bc];
           const double T_inf = this->boundary_conditions_ht.Tinf[i_bc];
+          const double emissivity =
+            this->boundary_conditions_ht.emissivity[i_bc];
 
           for (unsigned int f = 0; f < scratch_data.n_faces; ++f)
             {
@@ -451,7 +454,12 @@ HeatTransferAssemblerRobinBC<dim>::assemble_rhs(
                           const double phi_face_T_i =
                             scratch_data.phi_face_T[f][q][i];
                           local_rhs(i) -=
-                            phi_face_T_i * h * (T_face - T_inf) * JxW;
+                            phi_face_T_i *
+                            (h * (T_face - T_inf) +
+                             Stefan_Boltzmann_constant * emissivity *
+                               (T_face * T_face * T_face * T_face -
+                                T_inf * T_inf * T_inf * T_inf)) *
+                            JxW;
                         }
                     }
                 }

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -1040,3 +1040,81 @@ calculate_flow_rate(const DoFHandler<3> &                     dof_handler,
                     const unsigned int &                      boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
                     const Mapping<3> &   mapping);
+
+template <int dim, typename VectorType>
+std::pair<double, double>
+calculate_min_max_temperature(const DoFHandler<dim> &dof_handler_ht,
+                              const VectorType &     evaluation_point,
+                              const Quadrature<dim> &quadrature_formula,
+                              const Mapping<dim> &   mapping)
+{
+  const FESystem<dim, dim> fe = dof_handler_ht.get_fe();
+
+  const unsigned int  n_q_points = quadrature_formula.size();
+  std::vector<double> local_temperature_values(n_q_points);
+
+  FEValues<dim> fe_values(mapping,
+                          fe,
+                          quadrature_formula,
+                          update_values | update_quadrature_points |
+                            update_JxW_values);
+
+  double minimum_temperature = DBL_MAX;
+  double maximum_temperature = -DBL_MAX;
+
+  for (const auto &cell : dof_handler_ht.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+          fe_values.get_function_values(evaluation_point,
+                                        local_temperature_values);
+
+          for (unsigned int q = 0; q < n_q_points; q++)
+            {
+              double temperature = local_temperature_values[q];
+
+              if (temperature > maximum_temperature)
+                maximum_temperature = temperature;
+              if (temperature < minimum_temperature)
+                minimum_temperature = temperature;
+            }
+        }
+    }
+
+  const MPI_Comm mpi_communicator = dof_handler_ht.get_communicator();
+  minimum_temperature =
+    Utilities::MPI::min(minimum_temperature, mpi_communicator);
+  maximum_temperature =
+    Utilities::MPI::max(maximum_temperature, mpi_communicator);
+
+  return std::make_pair(minimum_temperature, maximum_temperature);
+}
+
+template std::pair<double, double>
+calculate_min_max_temperature(
+  const DoFHandler<2> &                dof_handler,
+  const TrilinosWrappers::MPI::Vector &evaluation_point,
+  const Quadrature<2> &                quadrature_formula,
+  const Mapping<2> &                   mapping);
+
+template std::pair<double, double>
+calculate_min_max_temperature(
+  const DoFHandler<3> &                dof_handler,
+  const TrilinosWrappers::MPI::Vector &evaluation_point,
+  const Quadrature<3> &                quadrature_formula,
+  const Mapping<3> &                   mapping);
+
+template std::pair<double, double>
+calculate_min_max_temperature(
+  const DoFHandler<2> &                     dof_handler,
+  const TrilinosWrappers::MPI::BlockVector &evaluation_point,
+  const Quadrature<2> &                     quadrature_formula,
+  const Mapping<2> &                        mapping);
+
+template std::pair<double, double>
+calculate_min_max_temperature(
+  const DoFHandler<3> &                     dof_handler,
+  const TrilinosWrappers::MPI::BlockVector &evaluation_point,
+  const Quadrature<3> &                     quadrature_formula,
+  const Mapping<3> &                        mapping);

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -1053,11 +1053,7 @@ calculate_min_max_temperature(const DoFHandler<dim> &dof_handler_ht,
   const unsigned int  n_q_points = quadrature_formula.size();
   std::vector<double> local_temperature_values(n_q_points);
 
-  FEValues<dim> fe_values(mapping,
-                          fe,
-                          quadrature_formula,
-                          update_values | update_quadrature_points |
-                            update_JxW_values);
+  FEValues<dim> fe_values(mapping, fe, quadrature_formula, update_values);
 
   double minimum_temperature = DBL_MAX;
   double maximum_temperature = -DBL_MAX;


### PR DESCRIPTION
# Description of the problem

- This PR modifies the convection heat transfer boundary condition to convection-radiation. This new BC is a combination of convection and radiation. If the Stefan-Boltzmann constant (with default value = 0) is set to 0, only the convection component is considered, whereas if the convection coefficient, h (with default value = 0), is set to 0, only the radiation component is considered. Otherwise, both the convection and radiation are significant on the boundary.

- It also adds "calculate temperature range" option to post-processing. By enabling "calculate temperature range", the solver reports the minimum and maximum temperature in the simulation domain.

# How Has This Been Tested?

- heat_transfer_laser application test is improved to test this new BC.

# Documentation

- boundary_conditions_multiphysics is updated.