### PR TITLE
Add the partial slip boundary condition to the VANS assembler

### DIFF
--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -527,6 +527,14 @@ GLSVANSSolver<dim>::setup_assemblers()
           this->simulation_control,
           this->simulation_parameters.boundary_conditions));
     }
+  if (this->check_existance_of_bc(
+        BoundaryConditions::BoundaryType::partial_slip))
+    {
+      this->assemblers.push_back(
+        std::make_shared<PartialSlipDirichletBoundaryCondition<dim>>(
+          this->simulation_control,
+          this->simulation_parameters.boundary_conditions));
+    }
   if (this->check_existance_of_bc(BoundaryConditions::BoundaryType::outlet))
     {
       this->assemblers.push_back(std::make_shared<OutletBoundaryCondition<dim>>(


### PR DESCRIPTION
# Description of the problem

- Partial slip boundary condition was not in the VANS assembler.

# Description of the solution

- Added partial slip boundary condition to the VANS assembler

# How Has This Been Tested?

- Liquid fluidized bed simulation. Worked just fine.
