### PR TITLE
Use get_local_index instead of get_id in the dem solver

### DIFF
--- a/examples/dem/simulation_time_evaluation/benchmark_simulation_time
+++ b/examples/dem/simulation_time_evaluation/benchmark_simulation_time
@@ -4,3 +4,4 @@ ________________________________________________________________________________
 |Branch					      |	SHA					   |	date		|	time_1p (s)	|	time_8p (s)	|	time_12p (s) |
 |Introduce PhysicalPropertiesManager	      |	32b2a3aba365f1bf822068e7a4a8e05aa2be319e   |	Feb  3, 2022	|	566		|	307		|	253	     |
 |Refactor dem 2d			      |	f04ad3de89ebaf501a06d61dc4e00505f975abae   |	Feb 10, 2022	|	567		|	312		|	255	     |
+|DEM_revision				      | 317adcb94d3fcfc3463d14d5b00629a9d0f778c0   |    Apr 21, 2022    |       579             |       314             |       260          |

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -335,10 +335,7 @@ private:
                      particle_point_line_contact_info_struct<dim>>
     particle_points_in_contact, particle_lines_in_contact;
 
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    particle_container;
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    ghost_particle_container;
+  std::vector<Particles::ParticleIterator<dim>> particle_container;
   std::map<unsigned int, std::pair<Tensor<1, 3>, Point<3>>>
                                            updated_boundary_points_and_normal_vectors;
   DEM::DEMProperties<dim>                  properties_class;

--- a/include/dem/locate_local_particles.h
+++ b/include/dem/locate_local_particles.h
@@ -56,9 +56,8 @@ using namespace dealii;
 template <int dim>
 void
 locate_local_particles_in_cells(
-  const Particles::ParticleHandler<dim> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container,
+  const Particles::ParticleHandler<dim> &        particle_handler,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container,
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index,

--- a/include/dem/particle_particle_fine_search.h
+++ b/include/dem/particle_particle_fine_search.h
@@ -97,10 +97,9 @@ public:
       types::particle_index,
       std::unordered_map<types::particle_index,
                          particle_particle_contact_info_struct<dim>>>
-      &ghost_adjacent_particles,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-      &          particle_container,
-    const double neighborhood_threshold);
+      &                                            ghost_adjacent_particles,
+    std::vector<Particles::ParticleIterator<dim>> &particle_container,
+    const double                                   neighborhood_threshold);
 };
 
 #endif /* particle_particle_fine_search_h */

--- a/include/dem/update_ghost_particle_particle_contact_container.h
+++ b/include/dem/update_ghost_particle_particle_contact_container.h
@@ -38,8 +38,7 @@ update_ghost_particle_particle_contact_container_iterators(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+    &                                            ghost_adjacent_particles,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container);
 
 #endif /* update_ghost_particle_particle_contact_container_h */

--- a/include/dem/update_local_particle_particle_contact_container.h
+++ b/include/dem/update_local_particle_particle_contact_container.h
@@ -38,8 +38,7 @@ update_local_particle_particle_contact_container_iterators(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+    &                                            local_adjacent_particles,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container);
 
 #endif /* update_local_particle_particle_contact_container_h */

--- a/include/dem/update_particle_container.h
+++ b/include/dem/update_particle_container.h
@@ -27,7 +27,7 @@ using namespace dealii;
  * Updates the iterators to local particles in a map of particles
  * (particle_container)
  *
- * @param particle_container A map of particles which is used to update
+ * @param particle_container A vector of particles which is used to update
  * the iterators to particles in particle-particle and particle-wall fine search
  * outputs after calling sort particles into cells function
  * @param particle_handler Particle handler to access all the particles in the
@@ -37,8 +37,7 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &                                    particle_container,
-  const Particles::ParticleHandler<dim> *particle_handler);
+  std::vector<Particles::ParticleIterator<dim>> &particle_container,
+  const Particles::ParticleHandler<dim> *        particle_handler);
 
 #endif /* update_particle_container_h */

--- a/include/dem/update_particle_point_line_contact_container.h
+++ b/include/dem/update_particle_point_line_contact_container.h
@@ -40,8 +40,7 @@ update_particle_point_line_contact_container_iterators(
     &particle_points_in_contact,
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+    &                                            particle_lines_in_contact,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container);
 
 #endif /* update_particle_point_line_contact_container_h */

--- a/include/dem/update_particle_wall_contact_container.h
+++ b/include/dem/update_particle_wall_contact_container.h
@@ -37,8 +37,7 @@ update_particle_wall_contact_container_iterators(
   std::unordered_map<
     types::particle_index,
     std::map<types::particle_index, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+    &                                            particle_wall_pairs_in_contact,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container);
 
 #endif /* update_particle_wall_contact_container_h */

--- a/include/fem-dem/cfd_dem_coupling.h
+++ b/include/fem-dem/cfd_dem_coupling.h
@@ -260,11 +260,8 @@ private:
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>>
-    pfw_contact_candidates;
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    particle_container;
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    ghost_particle_container;
+                                                pfw_contact_candidates;
+  std::vector<Particles::ParticleIterator<dim>> particle_container;
   std::map<unsigned int, std::map<unsigned int, Tensor<1, 3>>>
     forces_boundary_information;
   std::map<unsigned int, std::map<unsigned int, Tensor<1, 3>>>

--- a/source/dem/locate_local_particles.cc
+++ b/source/dem/locate_local_particles.cc
@@ -5,9 +5,8 @@ using namespace dealii;
 template <int dim>
 void
 locate_local_particles_in_cells(
-  const Particles::ParticleHandler<dim> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container,
+  const Particles::ParticleHandler<dim> &        particle_handler,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container,
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index,
@@ -54,9 +53,8 @@ locate_local_particles_in_cells(
 
 template void
 locate_local_particles_in_cells(
-  const Particles::ParticleHandler<2> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container,
+  const Particles::ParticleHandler<2> &        particle_handler,
+  std::vector<Particles::ParticleIterator<2>> &particle_container,
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index,
@@ -84,9 +82,8 @@ locate_local_particles_in_cells(
 
 template void
 locate_local_particles_in_cells(
-  const Particles::ParticleHandler<3> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container,
+  const Particles::ParticleHandler<3> &        particle_handler,
+  std::vector<Particles::ParticleIterator<3>> &particle_container,
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index,

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -54,8 +54,13 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                particles_in_main_cell.end();
                ++particles_in_main_cell_iterator_one)
             {
-              const unsigned int particle_one_id =
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+              const types::particle_index particle_one_id =
+                particles_in_main_cell_iterator_one->get_local_index();
+#else
+              const types::particle_index particle_one_id =
                 particles_in_main_cell_iterator_one->get_id();
+#endif
 
               std::vector<types::particle_index> &particle_candidate_container =
                 local_contact_pair_candidates[particle_one_id];
@@ -76,8 +81,13 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                 {
                   // Capturing all the local-local particle pairs in the
                   // main cell
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+                  particle_candidate_container.emplace_back(
+                    particles_in_main_cell_iterator_two->get_local_index());
+#else
                   particle_candidate_container.emplace_back(
                     particles_in_main_cell_iterator_two->get_id());
+#endif
                 }
             }
 
@@ -102,9 +112,16 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                    particles_in_main_cell.end();
                    ++particles_in_main_cell_iterator)
                 {
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+                  std::vector<types::particle_index> &
+                    particle_candidate_container = local_contact_pair_candidates
+                      [particles_in_main_cell_iterator->get_local_index()];
+#else
                   std::vector<types::particle_index> &
                     particle_candidate_container = local_contact_pair_candidates
                       [particles_in_main_cell_iterator->get_id()];
+#endif
+
                   if (particle_candidate_container.empty())
                     particle_candidate_container.reserve(40);
 
@@ -116,8 +133,13 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                        particles_in_neighbor_cell.end();
                        ++particles_in_neighbor_cell_iterator)
                     {
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+                      particle_candidate_container.emplace_back(
+                        particles_in_neighbor_cell_iterator->get_local_index());
+#else
                       particle_candidate_container.emplace_back(
                         particles_in_neighbor_cell_iterator->get_id());
+#endif
                     }
                 }
             }
@@ -169,8 +191,13 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                    particles_in_main_cell.end();
                    ++particles_in_main_cell_iterator)
                 {
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+                  types::particle_index particle_one_id =
+                    particles_in_main_cell_iterator->get_local_index();
+#else
                   types::particle_index particle_one_id =
                     particles_in_main_cell_iterator->get_id();
+#endif
 
                   std::vector<types::particle_index>
                     &particle_candidate_container =
@@ -185,8 +212,13 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                        particles_in_neighbor_cell.end();
                        ++particles_in_neighbor_cell_iterator)
                     {
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+                      particle_candidate_container.emplace_back(
+                        particles_in_neighbor_cell_iterator->get_local_index());
+#else
                       particle_candidate_container.emplace_back(
                         particles_in_neighbor_cell_iterator->get_id());
+#endif
                     }
                 }
             }

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -24,10 +24,9 @@ ParticleParticleFineSearch<dim>::particle_particle_fine_search(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &          particle_container,
-  const double neighborhood_threshold)
+    &                                            ghost_adjacent_particles,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container,
+  const double                                   neighborhood_threshold)
 {
   // First iterating over local adjacent_particles
   for (auto &&adjacent_particles_list :

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -175,9 +175,15 @@ ParticleParticleFineSearch<dim>::particle_particle_fine_search(
           if (square_distance < neighborhood_threshold)
             {
               // Getting the particle one contact list and particle two id
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+              auto particle_one_contact_list =
+                &ghost_adjacent_particles[particle_one->get_local_index()];
+              unsigned int particle_two_id = particle_two->get_local_index();
+#else
               auto particle_one_contact_list =
                 &ghost_adjacent_particles[particle_one->get_id()];
               unsigned int particle_two_id = particle_two->get_id();
+#endif
 
               Tensor<1, 3> tangential_overlap;
               tangential_overlap = 0;

--- a/source/dem/particle_point_line_fine_search.cc
+++ b/source/dem/particle_point_line_fine_search.cc
@@ -75,8 +75,13 @@ ParticlePointLineFineSearch<dim>::particle_point_fine_search(
           contact_info.particle  = particle;
           contact_info.point_one = vertex_location_3d;
 
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+          particle_point_pairs_in_contact.insert(
+            {particle->get_local_index(), contact_info});
+#else
           particle_point_pairs_in_contact.insert(
             {particle->get_id(), contact_info});
+#endif
         }
     }
   return particle_point_pairs_in_contact;
@@ -165,8 +170,13 @@ ParticlePointLineFineSearch<dim>::particle_line_fine_search(
           contact_info.point_one = vertex_one_location_3d;
           contact_info.point_two = vertex_two_location_3d;
 
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+          particle_line_pairs_in_contact.insert(
+            {particle->get_local_index(), contact_info});
+#else
           particle_line_pairs_in_contact.insert(
             {particle->get_id(), contact_info});
+#endif
         }
     }
   return particle_line_pairs_in_contact;

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -65,9 +65,15 @@ ParticleWallBroadSearch<dim>::find_particle_wall_contact_pairs(
                                 boundary_cells_content.boundary_id,
                                 boundary_cells_content.global_face_id);
 
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+              particle_wall_contact_candidates[particles_in_cell_iterator
+                                                 ->get_local_index()]
+                .insert({boundary_cells_content.global_face_id, map_content});
+#else
               particle_wall_contact_candidates[particles_in_cell_iterator
                                                  ->get_id()]
                 .insert({boundary_cells_content.global_face_id, map_content});
+#endif
             }
         }
     }
@@ -135,9 +141,15 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
                        particles_in_cell_iterator != particles_in_cell.end();
                        ++particles_in_cell_iterator)
                     {
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+                      pfw_contact_candidates[particles_in_cell_iterator
+                                               ->get_local_index()]
+                        .insert({floating_wall_id, particles_in_cell_iterator});
+#else
                       pfw_contact_candidates[particles_in_cell_iterator
                                                ->get_id()]
                         .insert({floating_wall_id, particles_in_cell_iterator});
+#endif
                     }
                 }
             }

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -186,7 +186,11 @@ ParticleWallLinearForce<dim>::calculate_particle_wall_contact_force(
                     contact_information, particle_properties);
 
               // Getting particle's torque and force
-              unsigned int  particle_id     = particle->get_id();
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+              unsigned int particle_id = particle->get_local_index();
+#else
+              unsigned int particle_id = particle->get_id();
+#endif
               Tensor<1, 3> &particle_torque = torque[particle_id];
               Tensor<1, 3> &particle_force  = force[particle_id];
 

--- a/source/dem/update_ghost_particle_container.cc
+++ b/source/dem/update_ghost_particle_container.cc
@@ -15,7 +15,12 @@ update_ghost_particle_container(
        particle_iterator != particle_handler->end_ghost();
        ++particle_iterator)
     {
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+      ghost_particle_container[particle_iterator->get_local_index()] =
+        particle_iterator;
+#else
       ghost_particle_container[particle_iterator->get_id()] = particle_iterator;
+#endif
     }
 }
 

--- a/source/dem/update_ghost_particle_particle_contact_container.cc
+++ b/source/dem/update_ghost_particle_particle_contact_container.cc
@@ -9,9 +9,8 @@ update_ghost_particle_particle_contact_container_iterators(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+    &                                            ghost_adjacent_particles,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container)
 {
   for (auto adjacent_particles_iterator = ghost_adjacent_particles.begin();
        adjacent_particles_iterator != ghost_adjacent_particles.end();
@@ -37,15 +36,13 @@ template void update_ghost_particle_particle_contact_container_iterators(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<2>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+    &                                          ghost_adjacent_particles,
+  std::vector<Particles::ParticleIterator<2>> &particle_container);
 
 template void update_ghost_particle_particle_contact_container_iterators(
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<3>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+    &                                          ghost_adjacent_particles,
+  std::vector<Particles::ParticleIterator<3>> &particle_container);

--- a/source/dem/update_local_particle_particle_contact_container.cc
+++ b/source/dem/update_local_particle_particle_contact_container.cc
@@ -9,9 +9,8 @@ update_local_particle_particle_contact_container_iterators(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+    &                                            local_adjacent_particles,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container)
 {
   for (auto adjacent_particles_iterator = local_adjacent_particles.begin();
        adjacent_particles_iterator != local_adjacent_particles.end();
@@ -39,15 +38,13 @@ template void update_local_particle_particle_contact_container_iterators(
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<2>>>
-    &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+    &                                          local_adjacent_particles,
+  std::vector<Particles::ParticleIterator<2>> &particle_container);
 
 template void update_local_particle_particle_contact_container_iterators(
   std::unordered_map<
     types::particle_index,
     std::unordered_map<types::particle_index,
                        particle_particle_contact_info_struct<3>>>
-    &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+    &                                          local_adjacent_particles,
+  std::vector<Particles::ParticleIterator<3>> &particle_container);

--- a/source/dem/update_particle_container.cc
+++ b/source/dem/update_particle_container.cc
@@ -15,14 +15,24 @@ update_particle_container(
        particle_iterator != particle_handler->end();
        ++particle_iterator)
     {
-      particle_container[particle_iterator->get_id()] = particle_iterator;
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+      particle_container[particle_iterator->get_local_index()] =
+#else
+      particle_container[particle_iterator->get_id()] =
+#endif
+        particle_iterator;
     }
 
   for (auto particle_iterator = particle_handler->begin_ghost();
        particle_iterator != particle_handler->end_ghost();
        ++particle_iterator)
     {
-      particle_container[particle_iterator->get_id()] = particle_iterator;
+#if DEAL_II_VERSION_GTE(10, 0, 0)
+      particle_container[particle_iterator->get_local_index()] =
+#else
+      particle_container[particle_iterator->get_id()] =
+#endif
+        particle_iterator;
     }
 }
 

--- a/source/dem/update_particle_container.cc
+++ b/source/dem/update_particle_container.cc
@@ -5,11 +5,11 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &                                    particle_container,
-  const Particles::ParticleHandler<dim> *particle_handler)
+  std::vector<Particles::ParticleIterator<dim>> &particle_container,
+  const Particles::ParticleHandler<dim> *        particle_handler)
 {
   particle_container.clear();
+  particle_container.resize(particle_handler->n_global_particles());
 
   for (auto particle_iterator = particle_handler->begin();
        particle_iterator != particle_handler->end();
@@ -37,11 +37,9 @@ update_particle_container(
 }
 
 template void update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &                                  particle_container,
-  const Particles::ParticleHandler<2> *particle_handler);
+  std::vector<Particles::ParticleIterator<2>> &particle_container,
+  const Particles::ParticleHandler<2> *        particle_handler);
 
 template void update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &                                  particle_container,
-  const Particles::ParticleHandler<3> *particle_handler);
+  std::vector<Particles::ParticleIterator<3>> &particle_container,
+  const Particles::ParticleHandler<3> *        particle_handler);

--- a/source/dem/update_particle_point_line_contact_container.cc
+++ b/source/dem/update_particle_point_line_contact_container.cc
@@ -10,9 +10,8 @@ update_particle_point_line_contact_container_iterators(
     &particle_points_in_contact,
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+    &                                            particle_lines_in_contact,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container)
 {
   for (auto particle_point_pairs_in_contact_iterator =
          particle_points_in_contact.begin();
@@ -46,9 +45,8 @@ template void update_particle_point_line_contact_container_iterators(
     &particle_points_in_contact,
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<2>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+    &                                          particle_lines_in_contact,
+  std::vector<Particles::ParticleIterator<2>> &particle_container);
 
 template void update_particle_point_line_contact_container_iterators(
   std::unordered_map<types::particle_index,
@@ -56,6 +54,5 @@ template void update_particle_point_line_contact_container_iterators(
     &particle_points_in_contact,
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<3>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+    &                                          particle_lines_in_contact,
+  std::vector<Particles::ParticleIterator<3>> &particle_container);

--- a/source/dem/update_particle_wall_contact_container.cc
+++ b/source/dem/update_particle_wall_contact_container.cc
@@ -8,9 +8,8 @@ update_particle_wall_contact_container_iterators(
   std::unordered_map<
     types::particle_index,
     std::map<types::particle_index, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+    &                                            particle_wall_pairs_in_contact,
+  std::vector<Particles::ParticleIterator<dim>> &particle_container)
 {
   for (auto particle_wall_pairs_in_contact_iterator =
          particle_wall_pairs_in_contact.begin();
@@ -37,14 +36,12 @@ template void update_particle_wall_contact_container_iterators(
   std::unordered_map<
     types::particle_index,
     std::map<types::particle_index, particle_wall_contact_info_struct<2>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+    &                                          particle_wall_pairs_in_contact,
+  std::vector<Particles::ParticleIterator<2>> &particle_container);
 
 template void update_particle_wall_contact_container_iterators(
   std::unordered_map<
     types::particle_index,
     std::map<types::particle_index, particle_wall_contact_info_struct<3>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+    &                                          particle_wall_pairs_in_contact,
+  std::vector<Particles::ParticleIterator<3>> &particle_container);


### PR DESCRIPTION
# Description of the problem

- This PR updates the DEM solver to use get_local_index function instead of get_id, according to the deal_II version. After Martin's changes in the DEM solver, in some of the functions, get_local_index() function is being used to get the local id of particles, while in some others we are still using get_id() function which returns the global id of the particles. This PR resolves this inconsistency.
- Particle_container which is used to get the iterator to the particles using their ids is changed from an unordered_map of particles to a vector of particles.

# Future changes

- This is a first step in the DEM modification/optimization project.

