### PR TITLE
Updated the initial condition for the Carreau model

### DIFF
--- a/doc/source/parameters/cfd/initial_conditions.rst
+++ b/doc/source/parameters/cfd/initial_conditions.rst
@@ -54,6 +54,9 @@ It is often necessary to set-up complex initial conditions when simulating trans
 .. math::
   \eta_{i+1} = \eta_i + \alpha (\eta_{\text{end}} - \eta_i)
 
+.. note::
+  The ramped up viscosity in the Carreau model in :math:`\eta_0`, and :math:`\eta_{\infty}` stays unchanged. See :doc:`physical_properties` for more details.
+
 
 Likewise, in the ``subection n``, the parameters for ramping on the ``n`` value are the following.
   * The ``initial n`` is the :math:`n` value with which the initial condition starts off. An initial math:`n` of 1.0 is suggested.

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -347,6 +347,19 @@ public:
     n = p_n;
   }
 
+  double
+  get_viscosity() const
+  {
+    return viscosity_0;
+  }
+
+  void
+  set_viscosity(const double &p_viscosity)
+  {
+    viscosity_0 = p_viscosity;
+  }
+
+
 private:
   inline double
   calculate_viscosity(const double shear_rate_magnitude)


### PR DESCRIPTION
# Description of the problem

The initial ramp condition was not yet suited for the Carreau model

# Description of the solution

I fixed it

# How Has This Been Tested?

Since the ramp tests are acting crazy still, I didn't add any

# Documentation

I updated the initial conditions documentation by adding a note that eta_0 is the ramped up viscosity
