### PR TITLE
Add publication and referencing Lethe sections

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -49,6 +49,8 @@ Contents
    parameters/parameters
    examples/examples
    theory/theory
+   publications
+   referencing
    contributing
 
 Installation

--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -2,7 +2,7 @@
 Publications
 ############
 
-This section regroups the peer-reviewed journal articles that **describe** core functionnalities of Lethe or that **use** Lethe. The publications are grouped by the year of the publications and displayed in the Chicago format.
+This section regroups the peer-reviewed journal articles that **describe** core functionalities of Lethe or that **use** Lethe. The publications are grouped by the year of the publications and displayed in the Chicago format.
 
 
 
@@ -24,6 +24,6 @@ This section regroups the peer-reviewed journal articles that **describe** core 
 Preprints
 ---------
 
-This sections regroups preprints of journal articles already submitted, but which are still under review.
+This section regroups preprints of journal articles already submitted, but which are still under review.
 
 

--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -9,17 +9,16 @@ This section regroups the peer-reviewed journal articles that **describe** core 
 2022
 ----
 
-* `Barbeau, Lucka, Stéphane Étienne, Cédric Béguin, and Bruno Blais. "Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems." Computers & Fluids 239 (2022): 105415. <https://doi.org/10.1016/j.compfluid.2022.105415>`_
+* `L. Barbeau, S. Étienne, C. Béguin, and B. Blais, "Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems", Computers & Fluids, 239, 105415, 2022 <https://www.sciencedirect.com/science/article/pii/S0045793022000780?via%3Dihub>`_. 
 
-* `Golshan, Shahab, Peter Munch, Rene Gassmoller, Martin Kronbichler, and Bruno Blais. "Lethe-DEM: An open-source parallel discrete element solver with load balancing." Comp. Part. Mech. (2022). <https://doi.org/10.1007/s40571-022-00478-6>`_
+* `S. Golshan, P. Munch, R. Gassmoller, M. Kronbichler, and B. Blais, “Lethe-Dem: An open-source parallel discrete element solver with load balancing - computational particle mechanics”, Comp. Part. Mech., 2022 <https://link.springer.com/article/10.1007/s40571-022-00478-6>`_.
 
-* `Golshan, Shahab, and Bruno Blais. "Load-Balancing Strategies in Discrete Element Method Simulations." Processes 10, no. 1 (2022): 79. <https://doi.org/10.3390/pr10010079>`_
+* `S. Golshan and B. Blais, “Load-balancing strategies in discrete element method simulations”, Processes, 10, 1, 2022 <https://www.mdpi.com/2227-9717/10/1/79>`_. 
 
 2020
 ----
 
-* `Blais, Bruno, Lucka Barbeau, Valérie Bibeau, Simon Gauvin, Toni El Geitani, Shahab Golshan, Rajeshwari Kamble, Ghazaleh Mirakhori, and Jamal Chaouki. "Lethe: An open-source parallel high-order adaptative CFD solver for incompressible flows." SoftwareX 12 (2020): 100579. <https://doi.org/10.1016/j.softx.2020.100579>`_
-
+* `B. Blais, L. Barbeau, V. Bibeau, S. Gauvin, T. E. Geitani, S. Golshan, R. Kamble, G. Mirakhori, and J. Chaouki, “Lethe: An open-source parallel high-order adaptative CFD solver for Incompressible flows”, SoftwareX, 12, 100579, 2020 <https://www.sciencedirect.com/science/article/pii/S2352711020302922?via%3Dihub>`_. 
 
 Preprints
 ---------

--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -2,7 +2,7 @@
 Publications
 ############
 
-This section regroups the peer-reviewed journal articles that **describe** core functionalities of Lethe or that **use** Lethe. The publications are grouped by the year of the publications and displayed in the Chicago format.
+This section regroups the peer-reviewed journal articles that **describe** core functionalities of Lethe or that **use** Lethe. The publications are grouped by the year of the publications and displayed in the IEEE format.
 
 
 

--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -1,0 +1,29 @@
+############
+Publications
+############
+
+This section regroups the peer-reviewed journal articles that **describe** core functionnalities of Lethe or that **use** Lethe. The publications are grouped by the year of the publications and displayed in the Chicago format.
+
+
+
+2022
+----
+
+* `Barbeau, Lucka, Stéphane Étienne, Cédric Béguin, and Bruno Blais. "Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems." Computers & Fluids 239 (2022): 105415. <https://doi.org/10.1016/j.compfluid.2022.105415>`_
+
+* `Golshan, Shahab, Peter Munch, Rene Gassmoller, Martin Kronbichler, and Bruno Blais. "Lethe-DEM: An open-source parallel discrete element solver with load balancing." Comp. Part. Mech. (2022). <https://doi.org/10.1007/s40571-022-00478-6>`_
+
+* `Golshan, Shahab, and Bruno Blais. "Load-Balancing Strategies in Discrete Element Method Simulations." Processes 10, no. 1 (2022): 79. <https://doi.org/10.3390/pr10010079>`_
+
+2020
+----
+
+* `Blais, Bruno, Lucka Barbeau, Valérie Bibeau, Simon Gauvin, Toni El Geitani, Shahab Golshan, Rajeshwari Kamble, Ghazaleh Mirakhori, and Jamal Chaouki. "Lethe: An open-source parallel high-order adaptative CFD solver for incompressible flows." SoftwareX 12 (2020): 100579. <https://doi.org/10.1016/j.softx.2020.100579>`_
+
+
+Preprints
+---------
+
+This sections regroups preprints of journal articles already submitted, but which are still under review.
+
+

--- a/doc/source/referencing.rst
+++ b/doc/source/referencing.rst
@@ -1,0 +1,24 @@
+###################
+Referencing Lethe
+###################
+
+ If you write a paper using results obtained with the help of Lethe, please cite the main Lethe reference as well as the reference that pertain to the features you used.
+
+Main articles
+---------------
+
+* `Blais, Bruno, Lucka Barbeau, Valérie Bibeau, Simon Gauvin, Toni El Geitani, Shahab Golshan, Rajeshwari Kamble, Ghazaleh Mirakhori, and Jamal Chaouki. "Lethe: An open-source parallel high-order adaptative CFD solver for incompressible flows." SoftwareX 12 (2020): 100579. <https://doi.org/10.1016/j.softx.2020.100579>`_
+
+Discrete Element Method
+-----------------------
+
+* `Golshan, Shahab, Peter Munch, Rene Gassmoller, Martin Kronbichler, and Bruno Blais. "Lethe-DEM: An open-source parallel discrete element solver with load balancing." Comp. Part. Mech. (2022). <https://doi.org/10.1007/s40571-022-00478-6>`_
+
+* `Golshan, Shahab, and Bruno Blais. "Load-Balancing Strategies in Discrete Element Method Simulations." Processes 10, no. 1 (2022): 79. <https://doi.org/10.3390/pr10010079>`_
+
+Sharp-Edge Immersed Boundary Method
+------------------------------------
+
+* `Barbeau, Lucka, Stéphane Étienne, Cédric Béguin, and Bruno Blais. "Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems." Computers & Fluids 239 (2022): 105415. <https://doi.org/10.1016/j.compfluid.2022.105415>`_
+
+

--- a/doc/source/referencing.rst
+++ b/doc/source/referencing.rst
@@ -7,18 +7,18 @@ Referencing Lethe
 Main articles
 ---------------
 
-* `Blais, Bruno, Lucka Barbeau, Valérie Bibeau, Simon Gauvin, Toni El Geitani, Shahab Golshan, Rajeshwari Kamble, Ghazaleh Mirakhori, and Jamal Chaouki. "Lethe: An open-source parallel high-order adaptative CFD solver for incompressible flows." SoftwareX 12 (2020): 100579. <https://doi.org/10.1016/j.softx.2020.100579>`_
+* `B. Blais, L. Barbeau, V. Bibeau, S. Gauvin, T. E. Geitani, S. Golshan, R. Kamble, G. Mirakhori, and J. Chaouki, “Lethe: An open-source parallel high-order adaptative CFD solver for Incompressible flows”, SoftwareX, 12, 100579, 2020 <https://www.sciencedirect.com/science/article/pii/S2352711020302922?via%3Dihub>`_. 
 
 Discrete Element Method
 -----------------------
 
-* `Golshan, Shahab, Peter Munch, Rene Gassmoller, Martin Kronbichler, and Bruno Blais. "Lethe-DEM: An open-source parallel discrete element solver with load balancing." Comp. Part. Mech. (2022). <https://doi.org/10.1007/s40571-022-00478-6>`_
+* `S. Golshan, P. Munch, R. Gassmoller, M. Kronbichler, and B. Blais, “Lethe-Dem: An open-source parallel discrete element solver with load balancing - computational particle mechanics”, Comp. Part. Mech., 2022 <https://link.springer.com/article/10.1007/s40571-022-00478-6>`_.
 
-* `Golshan, Shahab, and Bruno Blais. "Load-Balancing Strategies in Discrete Element Method Simulations." Processes 10, no. 1 (2022): 79. <https://doi.org/10.3390/pr10010079>`_
+* `S. Golshan and B. Blais, “Load-balancing strategies in discrete element method simulations”, Processes, 10, 1, 2022 <https://www.mdpi.com/2227-9717/10/1/79>`_. 
 
 Sharp-Edge Immersed Boundary Method
 ------------------------------------
 
-* `Barbeau, Lucka, Stéphane Étienne, Cédric Béguin, and Bruno Blais. "Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems." Computers & Fluids 239 (2022): 105415. <https://doi.org/10.1016/j.compfluid.2022.105415>`_
+* `L. Barbeau, S. Étienne, C. Béguin, and B. Blais, "Development of a high-order continuous Galerkin sharp-interface immersed boundary method and its application to incompressible flow problems", Computers & Fluids, 239, 105415, 2022 <https://www.sciencedirect.com/science/article/pii/S0045793022000780?via%3Dihub>`_. 
 
 


### PR DESCRIPTION
# Description of the problem

- Although Lethe has now been featured in 4 peer-reviewed journal articles, we failed to mention that anywhere in the documentation.

# Description of the solution

- Add publication and referencing Lethe sections to the doc

# Comments

-  It should be pretty easy to maintain if we are careful. It's not like we are publishing 10 papers per year on Lethe anyway, even though next year should be pretty busy!
