### PR TITLE
Add laser beam direction to laser heat source term

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.prm
@@ -32,7 +32,7 @@ subsection laser parameters
 	set beam radius 		= 0.002
 	set start time 			= 0
 	set end time 			= 0.05
-	set beam orientation 		= y negative
+	set beam orientation 		= y-
 	subsection path
 	    set Function expression 	=  3 * t; 0.1
 	end

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.prm
@@ -32,7 +32,7 @@ subsection laser parameters
 	set beam radius 		= 0.002
 	set start time 			= 0
 	set end time 			= 0.05
-	set beam orientation 		= y
+	set beam orientation 		= y negative
 	subsection path
 	    set Function expression 	=  3 * t; 0.1
 	end

--- a/doc/source/examples/multiphysics/laser-melting/laser-melting.rst
+++ b/doc/source/examples/multiphysics/laser-melting/laser-melting.rst
@@ -160,7 +160,7 @@ where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r`
         	set beam radius                = 0.000050
         	set start time                 = 0
         	set end time                   = 0.0034
-        	set beam orientation           = y negative
+        	set beam orientation           = y-
         	subsection path
         		set Function expression    =  0.5 * t; 0.000500
         	end

--- a/doc/source/examples/multiphysics/laser-melting/laser-melting.rst
+++ b/doc/source/examples/multiphysics/laser-melting/laser-melting.rst
@@ -153,16 +153,16 @@ where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r`
     #---------------------------------------------------
     subsection laser parameters
     	set enable = true
-        	set concentration factor 	= 2
-        	set power 			= 100
-        	set absorptivity 		= 0.6
-        	set penetration depth 		= 0.000070
-        	set beam radius 		= 0.000050
-        	set start time 			= 0
-        	set end time 			= 0.0034
-        	set beam orientation 		= y
+        	set concentration factor       = 2
+        	set power 			          = 100
+        	set absorptivity               = 0.6
+        	set penetration depth          = 0.000070
+        	set beam radius                = 0.000050
+        	set start time                 = 0
+        	set end time                   = 0.0034
+        	set beam orientation           = y negative
         	subsection path
-        		set Function expression =  0.5 * t; 0.000500
+        		set Function expression    =  0.5 * t; 0.000500
         	end
     end    
 

--- a/doc/source/parameters/cfd/laser_heat_source.rst
+++ b/doc/source/parameters/cfd/laser_heat_source.rst
@@ -14,7 +14,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
 	set beam radius            = 0.0
 	set start time             = 0.0
 	set end time               = 1.0
-	set beam orientation       = z negative
+	set beam orientation       = z-
 	subsection path
 	  set Function expression  =  0.0; 0.0
 	end
@@ -34,7 +34,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
 
 * The ``start time`` and ``end time`` parameters define the operation time window of the laser.
 
-* The ``beam orientation`` parameter shows the orientation and direction of the laser beam. For instance, if a laser beam is emitted perpendicular to a plane in x-y coordinates, the orientation of the laser beam will be in the z-direction. Negative or positive defines the direction of the laser beam. For instance if the laser beam is emitted in the negative z direction, the value of ``beam orientation`` will be ``z negative``.
+* The ``beam orientation`` parameter shows the orientation and direction of the laser beam. For instance, if a laser beam is emitted perpendicular to a plane in x-y coordinates, the orientation of the laser beam will be in the z-direction. Negative (-) or positive (+) defines the direction of the laser beam. For instance if the laser beam is emitted in the negative z direction, the value of ``beam orientation`` will be ``z-``.
 
 .. note:: 
     In two-dimensional simulations, the laser beam orientation cannot be in the z-direction.

--- a/doc/source/parameters/cfd/laser_heat_source.rst
+++ b/doc/source/parameters/cfd/laser_heat_source.rst
@@ -14,7 +14,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
 	set beam radius            = 0.0
 	set start time             = 0.0
 	set end time               = 1.0
-	set beam orientation       = z
+	set beam orientation       = z negative
 	subsection path
 	  set Function expression  =  0.0; 0.0
 	end
@@ -34,7 +34,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
 
 * The ``start time`` and ``end time`` parameters define the operation time window of the laser.
 
-* The ``beam orientation`` parameter shows the orientation of the laser beam. For instance, if a laser beam is emitted perpendicular to a plane in x-y coordinates, the orientation of the laser beam will be in the z-direction.
+* The ``beam orientation`` parameter shows the orientation and direction of the laser beam. For instance, if a laser beam is emitted perpendicular to a plane in x-y coordinates, the orientation of the laser beam will be in the z-direction. Negative or positive defines the direction of the laser beam. For instance if the laser beam is emitted in the negative z direction, the value of ``beam orientation`` will be ``z negative``.
 
 .. note:: 
     In two-dimensional simulations, the laser beam orientation cannot be in the z-direction.

--- a/examples/multiphysics/laser_melting/laser_melting.prm
+++ b/examples/multiphysics/laser_melting/laser_melting.prm
@@ -30,7 +30,7 @@ subsection laser parameters
 	set beam radius 		= 0.000050
 	set start time 			= 0
 	set end time 			= 0.0034
-	set beam orientation 		= y negative
+	set beam orientation 		= y-
 	subsection path
 		set Function expression =  0.5 * t; 0.000500
 	end

--- a/examples/multiphysics/laser_melting/laser_melting.prm
+++ b/examples/multiphysics/laser_melting/laser_melting.prm
@@ -30,7 +30,7 @@ subsection laser parameters
 	set beam radius 		= 0.000050
 	set start time 			= 0
 	set end time 			= 0.0034
-	set beam orientation 		= y
+	set beam orientation 		= y negative
 	subsection path
 		set Function expression =  0.5 * t; 0.000500
 	end

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -482,15 +482,15 @@ namespace Parameters
     // if a laser beam is emitted perpendicular on a plane in x-y coordinates,
     // the orientation of the laser beam will be in the z direction. Note that
     // this parameter cannot be equal to z in two-dimensional simulations.
-    // Positive and negative shows the direction of the laser beam
+    // Plus and minus shows the direction of the laser beam
     enum class BeamOrientation
     {
-      positive_x,
-      positive_y,
-      positive_z,
-      negative_x,
-      negative_y,
-      negative_z,
+      x_plus,
+      y_plus,
+      z_plus,
+      x_minus,
+      y_minus,
+      z_minus,
     } beam_orientation;
 
     // beam_orientation_coordinate parameter stores the integer (x = 0, y = 1,

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -481,17 +481,25 @@ namespace Parameters
     // Beam orientation shows the orientation of the laser beam. For instance,
     // if a laser beam is emitted perpendicular on a plane in x-y coordinates,
     // the orientation of the laser beam will be in the z direction. Note that
-    // this parameter cannot be equal to z in two-dimensional simulations
+    // this parameter cannot be equal to z in two-dimensional simulations.
+    // Positive and negative shows the direction of the laser beam
     enum class BeamOrientation
     {
-      x,
-      y,
-      z,
+      positive_x,
+      positive_y,
+      positive_z,
+      negative_x,
+      negative_y,
+      negative_z,
     } beam_orientation;
 
     // beam_orientation_coordinate parameter stores the integer (x = 0, y = 1,
     // z =2) value of the beam_orientation parameter
     unsigned int beam_orientation_coordinate;
+
+    // beam_direction shows the direction of laser beam (either in positive (1)
+    // or negative (0) direction
+    bool beam_direction;
 
     // Based on the laser beam orientation, the integer values of a
     // perpendicular plane to the laser beam orientation are stored in the

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -847,7 +847,7 @@ namespace Parameters
       if (op == "x+")
         {
           beam_direction                     = 1;
-          beam_orientation                   = BeamOrientation::positive_x;
+          beam_orientation                   = BeamOrientation::x_plus;
           beam_orientation_coordinate        = 0;
           perpendicular_plane_coordinate_one = 1;
           if constexpr (dim == 3)
@@ -856,7 +856,7 @@ namespace Parameters
       else if (op == "x-")
         {
           beam_direction                     = 0;
-          beam_orientation                   = BeamOrientation::negative_x;
+          beam_orientation                   = BeamOrientation::x_minus;
           beam_orientation_coordinate        = 0;
           perpendicular_plane_coordinate_one = 1;
           if constexpr (dim == 3)
@@ -865,7 +865,7 @@ namespace Parameters
       else if (op == "y+")
         {
           beam_direction                     = 1;
-          beam_orientation                   = BeamOrientation::positive_y;
+          beam_orientation                   = BeamOrientation::y_plus;
           perpendicular_plane_coordinate_one = 0;
           beam_orientation_coordinate        = 1;
           if constexpr (dim == 3)
@@ -874,7 +874,7 @@ namespace Parameters
       else if (op == "y-")
         {
           beam_direction                     = 0;
-          beam_orientation                   = BeamOrientation::negative_y;
+          beam_orientation                   = BeamOrientation::y_minus;
           perpendicular_plane_coordinate_one = 0;
           beam_orientation_coordinate        = 1;
           if constexpr (dim == 3)
@@ -885,7 +885,7 @@ namespace Parameters
           if constexpr (dim == 3)
             {
               beam_direction                     = 1;
-              beam_orientation                   = BeamOrientation::positive_z;
+              beam_orientation                   = BeamOrientation::z_plus;
               perpendicular_plane_coordinate_one = 0;
               perpendicular_plane_coordinate_two = 1;
               beam_orientation_coordinate        = 2;
@@ -898,7 +898,7 @@ namespace Parameters
           if constexpr (dim == 3)
             {
               beam_direction                     = 0;
-              beam_orientation                   = BeamOrientation::negative_z;
+              beam_orientation                   = BeamOrientation::z_minus;
               perpendicular_plane_coordinate_one = 0;
               perpendicular_plane_coordinate_two = 1;
               beam_orientation_coordinate        = 2;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -812,13 +812,11 @@ namespace Parameters
                         Patterns::Double(),
                         "End time of laser");
 
-      prm.declare_entry(
-        "beam orientation",
-        "z negative",
-        Patterns::Selection(
-          "x positive|x negative|y positive|y negative|z positive|z negative"),
-        "Laser beam orientation "
-        "Choices are <x positive|x negative|y positive|y negative|z positive|z negative>.");
+      prm.declare_entry("beam orientation",
+                        "z-",
+                        Patterns::Selection("x+|x-|y+|y-|z+|z-"),
+                        "Laser beam orientation "
+                        "Choices are <x+|x-|y+|y-|z+|z->.");
     }
     prm.leave_subsection();
   }
@@ -846,7 +844,7 @@ namespace Parameters
 
       std::string op;
       op = prm.get("beam orientation");
-      if (op == "x positive")
+      if (op == "x+")
         {
           beam_direction                     = 1;
           beam_orientation                   = BeamOrientation::positive_x;
@@ -855,7 +853,7 @@ namespace Parameters
           if constexpr (dim == 3)
             perpendicular_plane_coordinate_two = 2;
         }
-      else if (op == "x negative")
+      else if (op == "x-")
         {
           beam_direction                     = 0;
           beam_orientation                   = BeamOrientation::negative_x;
@@ -864,7 +862,7 @@ namespace Parameters
           if constexpr (dim == 3)
             perpendicular_plane_coordinate_two = 2;
         }
-      else if (op == "y positive")
+      else if (op == "y+")
         {
           beam_direction                     = 1;
           beam_orientation                   = BeamOrientation::positive_y;
@@ -873,7 +871,7 @@ namespace Parameters
           if constexpr (dim == 3)
             perpendicular_plane_coordinate_two = 2;
         }
-      else if (op == "y negative")
+      else if (op == "y-")
         {
           beam_direction                     = 0;
           beam_orientation                   = BeamOrientation::negative_y;
@@ -882,7 +880,7 @@ namespace Parameters
           if constexpr (dim == 3)
             perpendicular_plane_coordinate_two = 2;
         }
-      else if (op == "z positive")
+      else if (op == "z+")
         {
           if constexpr (dim == 3)
             {
@@ -895,7 +893,7 @@ namespace Parameters
           else if constexpr (dim == 2)
             Assert(dim == 2, TwoDimensionalLaserError(dim));
         }
-      else if (op == "z negative")
+      else if (op == "z-")
         {
           if constexpr (dim == 3)
             {

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -812,11 +812,13 @@ namespace Parameters
                         Patterns::Double(),
                         "End time of laser");
 
-      prm.declare_entry("beam orientation",
-                        "z",
-                        Patterns::Selection("x|y|z"),
-                        "Laser beam orientation "
-                        "Choices are <x|y|z>.");
+      prm.declare_entry(
+        "beam orientation",
+        "z negative",
+        Patterns::Selection(
+          "x positive|x negative|y positive|y negative|z positive|z negative"),
+        "Laser beam orientation "
+        "Choices are <x positive|x negative|y positive|y negative|z positive|z negative>.");
     }
     prm.leave_subsection();
   }
@@ -844,27 +846,61 @@ namespace Parameters
 
       std::string op;
       op = prm.get("beam orientation");
-      if (op == "x")
+      if (op == "x positive")
         {
-          beam_orientation                   = BeamOrientation::x;
+          beam_direction                     = 1;
+          beam_orientation                   = BeamOrientation::positive_x;
           beam_orientation_coordinate        = 0;
           perpendicular_plane_coordinate_one = 1;
           if constexpr (dim == 3)
             perpendicular_plane_coordinate_two = 2;
         }
-      else if (op == "y")
+      else if (op == "x negative")
         {
-          beam_orientation                   = BeamOrientation::y;
+          beam_direction                     = 0;
+          beam_orientation                   = BeamOrientation::negative_x;
+          beam_orientation_coordinate        = 0;
+          perpendicular_plane_coordinate_one = 1;
+          if constexpr (dim == 3)
+            perpendicular_plane_coordinate_two = 2;
+        }
+      else if (op == "y positive")
+        {
+          beam_direction                     = 1;
+          beam_orientation                   = BeamOrientation::positive_y;
           perpendicular_plane_coordinate_one = 0;
           beam_orientation_coordinate        = 1;
           if constexpr (dim == 3)
             perpendicular_plane_coordinate_two = 2;
         }
-      else if (op == "z")
+      else if (op == "y negative")
+        {
+          beam_direction                     = 0;
+          beam_orientation                   = BeamOrientation::negative_y;
+          perpendicular_plane_coordinate_one = 0;
+          beam_orientation_coordinate        = 1;
+          if constexpr (dim == 3)
+            perpendicular_plane_coordinate_two = 2;
+        }
+      else if (op == "z positive")
         {
           if constexpr (dim == 3)
             {
-              beam_orientation                   = BeamOrientation::z;
+              beam_direction                     = 1;
+              beam_orientation                   = BeamOrientation::positive_z;
+              perpendicular_plane_coordinate_one = 0;
+              perpendicular_plane_coordinate_two = 1;
+              beam_orientation_coordinate        = 2;
+            }
+          else if constexpr (dim == 2)
+            Assert(dim == 2, TwoDimensionalLaserError(dim));
+        }
+      else if (op == "z negative")
+        {
+          if constexpr (dim == 3)
+            {
+              beam_direction                     = 0;
+              beam_orientation                   = BeamOrientation::negative_z;
               perpendicular_plane_coordinate_one = 0;
               perpendicular_plane_coordinate_two = 1;
               beam_orientation_coordinate        = 2;

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -572,6 +572,7 @@ HeatTransferAssemblerLaser<dim>::assemble_rhs(
   const double laser_start_time     = laser_parameters->start_time;
   const double laser_end_time       = laser_parameters->end_time;
   const double beam_radius          = laser_parameters->beam_radius;
+  const bool   beam_direction       = laser_parameters->beam_direction;
   const double current_time = this->simulation_control->get_current_time();
 
   if (current_time >= laser_start_time && current_time <= laser_end_time)
@@ -648,8 +649,19 @@ HeatTransferAssemblerLaser<dim>::assemble_rhs(
           const double quadrature_point_depth =
             scratch_data.quadrature_points[q][laser_parameters
                                                 ->beam_orientation_coordinate];
-          const double laser_quadrature_point_distance_in_depth =
-            std::abs(quadrature_point_depth - laser_location_in_depth);
+
+          // if the laser beam is in negative direction and
+          // quadrature_point_depth is smaller than the laser_location_in_depth,
+          // or the laser beam is in positive direction and
+          // quadrature_point_depth is larger then laser_location_in_depth we
+          // need to apply the laser on the quadrate point, otherwise it is zero
+          double laser_quadrature_point_distance_in_depth = 0.0;
+          if ((beam_direction == 0 &&
+               quadrature_point_depth <= laser_location_in_depth) |
+              (beam_direction == 1 &&
+               quadrature_point_depth >= laser_location_in_depth))
+            laser_quadrature_point_distance_in_depth =
+              std::abs(quadrature_point_depth - laser_location_in_depth);
 
           // Store JxW in local variable for faster access
           const double JxW = scratch_data.fe_values_T.JxW(q);


### PR DESCRIPTION
# Description of the problem

- Previously we did not have any parameters to define the laser beam direction of emission. I noticed it while working in VOF meltpool example. In this example, both air and the solid were heated by the laser as there were no parameter to limit the laser heat source to its direction of emission. In this PR, I have modified the laser heat source parameters to take the emission direction into account. Corresponding application test and example are updated, as well as the documentation.