### PR TITLE
Add none BC to heat_transfer

### DIFF
--- a/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
+++ b/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
@@ -331,25 +331,17 @@ Several adjustments have to be made in the `.prm` to turn the domain clockwise, 
 * in ``subsection mesh``: ``set grid arguments = 0, 0 : 1, 0.5 : true``
 * in ``subsection analytical solution``, ``subsection temperature``: 
    ``set Function expression = Tw+(((rho*nu)*v*v)/(2*K))*(1-(y/B)*(y/B))``
-* and most importantly, the ``boundary conditions`` subsection should state explicitly ``outlet`` for the fluid boundary conditions, as the ``number`` of boundary conditions should be adapted to use the bottom and top wall (see the `deal.II documentation on hyper_rectangle grid generator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html#a56019d263ae45708302d5d7599f0d458>`_ for further details):
+* and most importantly, the ``id`` of ``boundary conditions`` should be adapted to use the bottom and top wall (see the `deal.II documentation on hyper_rectangle grid generator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html#a56019d263ae45708302d5d7599f0d458>`_ for further details):
 
 .. code-block:: text
 
 	subsection boundary conditions
-	  set number                  = 4
+	  set number                  = 2
 	    subsection bc 0
-	    set id = 0
-		set type              = outlet
-	    end
-	    subsection bc 1
-	    set id = 1
-		set type              = outlet
-	    end
-	    subsection bc 2
 	    set id = 2
 		set type              = noslip
 	    end
-	    subsection bc 3
+	    subsection bc 1
 	    set id = 3
 		set type              = function
 		subsection u
@@ -376,8 +368,11 @@ Several adjustments have to be made in the `.prm` to turn the domain clockwise, 
 	    end
 	end
 
-.. tip::
-	Heat transfer boundary conditions are of ``type = none`` by default, so this is the type implicitly used for ``subsection bc 0`` and ``subsection bc 1``.
+.. important::
+	For the fluid ``boundary conditions``, we use ``set number = 2``, whereas for ``boundary conditions heat transfer`` we use ``set number = 4``. These two notations are perfectly equivalent, as the boundary conditions are ``none`` by default (or ``noflux`` in the case of heat transfer, see :doc:`../../../parameters/cfd/boundary_conditions_multiphysics`). However, it is important to make sure that:
+
+	* the index in ``subsection bc ..`` is coherent with the ``number`` set (if ``number = 2``, ``bc 0`` and ``bc 1`` are created but ``bc 2`` does not exist),
+	* the index in ``set id = ..`` is coherent with the ``id`` of the boundary in the mesh (here, the deal.II generated mesh).
 
 
 Possibilities for extension

--- a/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
+++ b/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
@@ -28,7 +28,7 @@ The following schematic describes the simulation.
     :align: center
 
 * bc = 0 : no slip and thermal insulation boundary condition
-* bc = 1 : flow in the y-direction (v=2) and heating at Tw
+* bc = 1 : flow in the y-direction (:math:`v=2`) and heating at Tw
 
 .. important:: 
     The whole simulation is carried out in the frame of one-way coupling: the fluid velocity influences the heat generated through viscous dissipation, but the heat transfer does not influence the fluid velocity. Moreover, fluid state changes are not considered.
@@ -321,6 +321,64 @@ After the fluid has been heated up by the right plate, the temperature is really
 .. image:: images/domain_t7_water_rescale_nodiss.png
     :alt: Rescaled domain with temperature (t = 7)
     :width: 30%
+
+
+Horizontal domain
+~~~~~~~~~~~~~~~~~
+
+Several adjustments have to be made in the `.prm` to turn the domain clockwise, so that it becomes horizontal, with the upper wall being the no slip and thermal insulation boundary condition, and the lower wall with the flow in the y-direction (:math:`v=2`) and heating at Tw:
+
+* in ``subsection mesh``: ``set grid arguments = 0, 0 : 1, 0.5 : true``
+* in ``subsection analytical solution``, ``subsection temperature``: 
+   ``set Function expression = Tw+(((rho*nu)*v*v)/(2*K))*(1-(y/B)*(y/B))``
+* and most importantly, the ``boundary conditions`` subsection should state explicitly ``outlet`` for the fluid boundary conditions, as the ``number`` of boundary conditions should be adapted to use the bottom and top wall (see the `deal.II documentation on hyper_rectangle grid generator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html#a56019d263ae45708302d5d7599f0d458>`_ for further details):
+
+.. code-block:: text
+
+	subsection boundary conditions
+	  set number                  = 4
+	    subsection bc 0
+	    set id = 0
+		set type              = outlet
+	    end
+	    subsection bc 1
+	    set id = 1
+		set type              = outlet
+	    end
+	    subsection bc 2
+	    set id = 2
+		set type              = noslip
+	    end
+	    subsection bc 3
+	    set id = 3
+		set type              = function
+		subsection u
+		    set Function expression = 2
+		end
+		subsection v
+		    set Function expression = 0
+		end
+	    end
+	end
+
+	subsection boundary conditions heat transfer
+	  set number                  = 4
+	    subsection bc 2
+	    set id = 2
+		set type          = convection-radiation
+		set h             = 0
+		set Tinf	  = 0
+	    end
+	    subsection bc 3
+	    set id = 3
+		set type              = temperature
+		set value             = 80
+	    end
+	end
+
+.. tip::
+	Heat transfer boundary conditions are of ``type = none`` by default, so this is the type implicitly used for ``subsection bc 0`` and ``subsection bc 1``.
+
 
 Possibilities for extension
 ----------------------------

--- a/doc/source/parameters/cfd/boundary_conditions_cfd.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_cfd.rst
@@ -3,6 +3,7 @@ Boundary conditions - CFD
 
 This subsection defines the boundary conditions associated with fluid dynamics physics. Lethe supports the following boundary conditions:
 
+* ``none`` boundary condition (default).
 * ``noslip`` boundary conditions strongly impose the velocity on a boundary to be :math:`\mathbf{u}=[0,0]^T` and :math:`\mathbf{u}=[0,0,0]^T` in 2D and 3D respectively.
 * ``slip`` boundary conditions impose :math:`\mathbf{u} \cdot \mathbf{n}=0`, with :math:`\mathbf{n}` the normal vector of the boundary. Imposing slip boundary conditions strongly is not trivial in FEM. We refer the reader to the deal.II `documentation <https://www.dealii.org/current/doxygen/deal.II/group__constraints.html>`_ for explanations on how this is achieved.
 * ``partial slip`` boundary condition simulates an intermediary between ``slip`` and ``noslip`` boundary conditions, in which the fluid feels an attenuated stress due to the walls. The attenuation is controlled by the  boundary layer thickness (m).
@@ -22,7 +23,7 @@ or in Einstein notation :
 
 where `beta` is a constant and  :math:`(\mathbf{u}\cdot n)_{-}` is :math:`min (0,\mathbf{u}\cdot n)`. We refer the reader to the work of `Arndt et al 2015 <https://www.mathsim.eu/~darndt/files/ENUMATH_2015.pdf>`_  for more detail.
 
-* Finally, Lethe also supports not imposing a boundary condition on an ID. Not imposing a boundary condition is equivalent to the *do nothing* boundary condition, which results in a zero net traction on a boundary. This, in fact, imposes :math:`\int_{\Gamma}(-p\mathcal{I} + \mathbf{\tau}) \cdot \mathbf{n}=0` where :math:`p` is the pressure, :math:`\mathcal{I}` is the identity tensor, :math:`\mathbf{\tau}` is the deviatoric stress tensor  and :math:`\Gamma` is the boundary. 
+* Finally, Lethe also supports not imposing a boundary condition on an ID. Not imposing a boundary condition is equivalent to the *do nothing* boundary condition (``none``), which results in a zero net traction on a boundary. This, in fact, imposes :math:`\int_{\Gamma}(-p\mathcal{I} + \mathbf{\tau}) \cdot \mathbf{n}=0` where :math:`p` is the pressure, :math:`\mathcal{I}` is the identity tensor, :math:`\mathbf{\tau}` is the deviatoric stress tensor  and :math:`\Gamma` is the boundary. 
 
 
 .. code-block:: text
@@ -62,22 +63,27 @@ where `beta` is a constant and  :math:`(\mathbf{u}\cdot n)_{-}` is :math:`min (0
 * ``number`` specifies the number of boundary conditions of the problem. Periodicity between 2 boundaries counts as 1 condition even if it requires two distinct boundary ids.
 
 .. warning::
-    The number of boundary conditions must be specified explicitly as the ParameterHandler is not able to deduce the number of boundary conditions from the number of ``bc`` subsections. This is often a source of error.
+    The ``number`` of boundary conditions must be specified explicitly. This is often a source of error.
+
+.. note::
+    The index in ``subsection bc ..`` must be coherent with the ``number`` of boundary conditions set: if ``number = 2``, ``bc 0`` and ``bc 1`` are created but ``bc 2`` does not exist. 
+
+    Likewise, if ``number = 2`` and there is no ``subsection bc 0`` explicitly stated, the boundary is still created, with ``none`` by default.
 
 * ``time dependent`` specifies if a  boundary condition is time dependent (``true``) or steady (``false```). By default, this parameter is set to ``false``. This is there to improve the computational efficiency for transient cases in which the boundary conditions do not change. 
 
-* Each fluid dynamics boundary condition is stored in a ``bc no`` subsection :
-    * ``id``  is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number of the bc. 
+* Each fluid dynamics boundary condition is stored in a ``bc #`` subsection :
+    * ``id``  is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number ``#`` of the bc. 
     
-    * ``type`` is the type of the boundary condition. Only slip, no-slip, periodic and function are enabled.
+    * ``type`` is the type of the boundary condition.
     
     * The subsections ``u``, ``v`` and ``w`` are used to specify the individual components of the velocity at the boundary using function expressions. These functions can depend on position (:math:`x,y,z`) and on time (:math:`t`).
 
     * The ``center of rotation`` subsection is only necessary when calculating the torque applied on a boundary. See  See :doc:`force_and_torque` for more information.
 
-    * ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``ìd=0``, ``periodic_id=1`` and ``periodic_direction=0``.
+    * ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic_id = 1`` and ``periodic_direction = 0``.
 
-    * ``beta`` is a penalization parameter used for both the ``outlet``, ``partial slip``, and ``function weak`` boundary conditions. For the outlet boundary conditions ``beta`` should be close to unity, whereas ``beta`` of 10 or a 100 can be appropriate for the ``function weak`` boundary condition. For the ``partial slip`` condition, use high values of ``beta`` (i.e., > 50).
+    * ``beta`` is a penalization parameter used for both the ``outlet``, ``partial slip``, and ``function weak`` boundary conditions. For the outlet boundary conditions ``beta`` should be close to unity, whereas ``beta`` of 10 or a 100 can be appropriate for the ``function weak`` boundary condition. For the ``partial slip`` condition, use high values of ``beta`` (`i.e.` > 50).
 
     * ``boundary layer thickness`` (:math:`d_w`) is the parameter applied to the ``partial slip`` boundary condition. It is used to estimate the tangential shear stress :math:`\tau_t = -\mu \frac{u}{d_w}`. For very high ``boundary layer thicknes``, the boundary layer should behave exactly like the ``slip`` condition.
 

--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -7,7 +7,7 @@ This subsection's purpose is defining the boundary conditions associated to mult
 Heat Transfer
 ^^^^^^^^^^^^^
 
-For heat transfer boundary conditions, the possible ``types`` are ``none`` (default), ``temperature`` and ``convection-radiation``.
+For heat transfer boundary conditions, the possible ``types`` are ``noflux`` (default), ``temperature`` and ``convection-radiation``.
 The default parameters for ``temperature`` and ``convection-radiation`` are shown: 
 
 .. code-block:: text
@@ -37,7 +37,7 @@ The default parameters for ``temperature`` and ``convection-radiation`` are show
 * ``id`` is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number of the bc.
 
 * ``type``: type of boundary condition being imposed. At the moment, choices are:
-    * ``none`` so that there is no heat transfer boundary condition (nothing happens),
+    * ``noflux`` so that there is no heat transfer boundary condition,
     * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary,
     * ``convection-radiation`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` and emissivity of the boundary :math:`\mathbf{\epsilon}` following Newton's law of cooling (and heating) and Stefan-Boltzmann law of radiation.
 

--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -7,8 +7,8 @@ This subsection's purpose is defining the boundary conditions associated to mult
 Heat Transfer
 ^^^^^^^^^^^^^
 
-For heat transfer boundary conditions, the possible ``types`` are ``temperature`` (default) and ``convection-radiation``.
-The default parameters of each are shown: 
+For heat transfer boundary conditions, the possible ``types`` are ``none`` (default), ``temperature`` and ``convection-radiation``.
+The default parameters for ``temperature`` and ``convection-radiation`` are shown: 
 
 .. code-block:: text
 
@@ -36,8 +36,9 @@ The default parameters of each are shown:
 
 * ``id`` is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number of the bc.
 
-* ``type``: This is the type of boundary condition been imposed. At the moment, choices are:
-    * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary.
+* ``type``: type of boundary condition being imposed. At the moment, choices are:
+    * ``none`` so that there is no heat transfer boundary condition (nothing happens),
+    * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary,
     * ``convection-radiation`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` and emissivity of the boundary :math:`\mathbf{\epsilon}` following Newton's law of cooling (and heating) and Stefan-Boltzmann law of radiation.
 
 .. math::
@@ -47,7 +48,12 @@ The default parameters of each are shown:
 where :math:`\mathbf{\sigma}` is the Stefan-Boltzmann constant.
 
 .. note::
-    By default, the boundary condition type is ``temperature`` with ``value = 0``
+    By default, the boundary condition type is ``none``.
+
+.. seealso::
+
+  The :doc:`../../examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid` example uses heat transfer boundary conditions.
+
 
 Tracer
 ^^^^^^

--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -32,12 +32,17 @@ The default parameters for ``temperature`` and ``convection-radiation`` are show
 * ``number``: This is the number of boundary conditions of the problem. 
 
 .. warning::
-    The number of boundary conditions must be specified explicitly as the ParameterHandler is not able to deduce the number of boundary conditions from the number of ``bc`` subsections. This is often a source of error.
+    The ``number`` of boundary conditions must be specified explicitly. This is often a source of error.
+
+.. note::
+    The index in ``subsection bc ..`` must be coherent with the ``number`` of boundary conditions set: if ``number = 2``, ``bc 0`` and ``bc 1`` are created but ``bc 2`` does not exist. 
+
+    Likewise, if ``number = 2`` and there is no ``subsection bc 0`` explicitly stated, the boundary is still created, with ``noflux`` by default.
 
 * ``id`` is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number of the bc.
 
 * ``type``: type of boundary condition being imposed. At the moment, choices are:
-    * ``noflux`` so that there is no heat transfer boundary condition,
+    * ``noflux`` (default) so that there is no heat transfer boundary condition,
     * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary,
     * ``convection-radiation`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` and emissivity of the boundary :math:`\mathbf{\epsilon}` following Newton's law of cooling (and heating) and Stefan-Boltzmann law of radiation.
 
@@ -46,9 +51,6 @@ The default parameters for ``temperature`` and ``convection-radiation`` are show
 
 
 where :math:`\mathbf{\sigma}` is the Stefan-Boltzmann constant.
-
-.. note::
-    By default, the boundary condition type is ``none``.
 
 .. seealso::
 
@@ -99,6 +101,13 @@ For VOF boundary conditions (multiphase flow), the possible ``types`` are ``none
         end
     end
 
+.. warning::
+    The ``number`` of boundary conditions must be specified explicitly. This is often a source of error.
+
+.. note::
+    The index in ``subsection bc ..`` must be coherent with the ``number`` of boundary conditions set: if ``number = 2``, ``bc 0`` and ``bc 1`` are created but ``bc 2`` does not exist. 
+
+    Likewise, if ``number = 2`` and there is no ``subsection bc 0`` explicitly stated, the boundary is still created, with ``none`` by default.
 
 * ``number``: This is the number of boundary conditions of the problem. 
 

--- a/examples/multiphysics/warming_up_viscous_fluid/warming_up_viscous_fluid.prm
+++ b/examples/multiphysics/warming_up_viscous_fluid/warming_up_viscous_fluid.prm
@@ -116,7 +116,7 @@ subsection boundary conditions heat transfer
   set number                  = 2
     subsection bc 0
     set id = 0
-        set type          = convection
+        set type          = convection-radiation
 	set h             = 0
 	set Tinf	  = 0
     end

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -35,6 +35,8 @@ namespace BoundaryConditions
 {
   enum class BoundaryType
   {
+    // common
+    none,
     // for fluid
     noslip,
     slip,
@@ -51,7 +53,6 @@ namespace BoundaryConditions
     // for tracer
     tracer_dirichlet,
     // for vof
-    none,
     pw,
   };
 
@@ -146,16 +147,17 @@ namespace BoundaryConditions
     void
     parse_parameters(ParameterHandler &prm);
     void
-    createDefaultNoSlip();
+    createNoSlip();
   };
 
 
   /**
-   * @brief Creates a default no-slip boundary condition for id=0
+   * @brief Creates a noslip boundary condition for id=0
+   * Used in tests only
    */
   template <int dim>
   void
-  NSBoundaryConditions<dim>::createDefaultNoSlip()
+  NSBoundaryConditions<dim>::createNoSlip()
   {
     this->id.resize(1);
     this->id[0] = 0;
@@ -181,9 +183,9 @@ namespace BoundaryConditions
   {
     prm.declare_entry(
       "type",
-      "noslip",
+      "none",
       Patterns::Selection(
-        "noslip|slip|function|periodic|pressure|function weak|partial slip|outlet"),
+        "none|noslip|slip|function|periodic|pressure|function weak|partial slip|outlet"),
       "Type of boundary condition"
       "Choices are <noslip|slip|function|periodic|pressure|function weak|partial slip|outlet>.");
 
@@ -259,6 +261,8 @@ namespace BoundaryConditions
                                             unsigned int      i_bc)
   {
     const std::string op = prm.get("type");
+    if (op == "none")
+      this->type[i_bc] = BoundaryType::none;
     if (op == "noslip")
       this->type[i_bc] = BoundaryType::noslip;
     if (op == "slip")

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -35,8 +35,6 @@ namespace BoundaryConditions
 {
   enum class BoundaryType
   {
-    // common
-    none,
     // for fluid
     noslip,
     slip,
@@ -47,11 +45,13 @@ namespace BoundaryConditions
     pressure,
     outlet,
     // for heat transfer
+    noflux,
     temperature,
     convection_radiation,
     // for tracer
     tracer_dirichlet,
     // for vof
+    none,
     pw,
   };
 
@@ -406,7 +406,7 @@ namespace BoundaryConditions
    * coherently.
    * The members "value", "h" and "Tinf" contain double used for bc calculation:
    *
-   *  - if bc type is "none", nothing happens
+   *  - if bc type is "noflux", no flux is assembled at the boundary
    *
    *  - if bc type is "temperature" (Dirichlet condition), "value" is the
    * double passed to the deal.ii ConstantFunction
@@ -451,11 +451,11 @@ namespace BoundaryConditions
                                                  unsigned int      i_bc)
   {
     prm.declare_entry("type",
-                      "none",
+                      "noflux",
                       Patterns::Selection(
-                        "none|temperature|convection-radiation"),
+                        "noflux|temperature|convection-radiation"),
                       "Type of boundary condition for heat transfer"
-                      "Choices are <none|temperature|convection-radiation>.");
+                      "Choices are <noflux|temperature|convection-radiation>.");
 
     prm.declare_entry("id",
                       Utilities::int_to_string(i_bc, 2),
@@ -536,9 +536,9 @@ namespace BoundaryConditions
                                             unsigned int      i_bc)
   {
     const std::string op = prm.get("type");
-    if (op == "none")
+    if (op == "noflux")
       {
-        this->type[i_bc] = BoundaryType::none;
+        this->type[i_bc] = BoundaryType::noflux;
       }
     if (op == "temperature")
       {

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -35,6 +35,8 @@ namespace BoundaryConditions
 {
   enum class BoundaryType
   {
+    // common
+    none,
     // for fluid
     noslip,
     slip,
@@ -45,13 +47,12 @@ namespace BoundaryConditions
     pressure,
     outlet,
     // for heat transfer
-    temperature,          // - Dirichlet
-    convection_radiation, // - Robin
-                          // for tracer
-    tracer_dirichlet,     // - Dirichlet tracer
-                          // for vof
-    none,                 // - none
-    pw,                   // - peeling/wetting
+    temperature,
+    convection_radiation,
+    // for tracer
+    tracer_dirichlet,
+    // for vof
+    pw,
   };
 
   /**
@@ -404,8 +405,12 @@ namespace BoundaryConditions
    * It introduces the boundary functions and declares the boundary conditions
    * coherently.
    * The members "value", "h" and "Tinf" contain double used for bc calculation:
+   *
+   *  - if bc type is "none", nothing happens
+   *
    *  - if bc type is "temperature" (Dirichlet condition), "value" is the
    * double passed to the deal.ii ConstantFunction
+   *
    *  - if bc type is "convection-radiation" (Robin condition), "h" is the
    * convective heat transfer coefficient and "Tinf" is the
    * environment temperature at the boundary, "emissivity" is the emissivity
@@ -435,7 +440,6 @@ namespace BoundaryConditions
 
   /**
    * @brief Declares the default parameters for a boundary condition id i_bc
-   * i.e. Dirichlet condition (ConstantFunction) with value 0
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    *
@@ -447,10 +451,11 @@ namespace BoundaryConditions
                                                  unsigned int      i_bc)
   {
     prm.declare_entry("type",
-                      "temperature",
-                      Patterns::Selection("temperature|convection-radiation"),
+                      "none",
+                      Patterns::Selection(
+                        "none|temperature|convection-radiation"),
                       "Type of boundary condition for heat transfer"
-                      "Choices are <temperature|convection-radiation>.");
+                      "Choices are <none|temperature|convection-radiation>.");
 
     prm.declare_entry("id",
                       Utilities::int_to_string(i_bc, 2),
@@ -531,6 +536,10 @@ namespace BoundaryConditions
                                             unsigned int      i_bc)
   {
     const std::string op = prm.get("type");
+    if (op == "none")
+      {
+        this->type[i_bc] = BoundaryType::none;
+      }
     if (op == "temperature")
       {
         this->type[i_bc]  = BoundaryType::temperature;
@@ -766,7 +775,6 @@ namespace BoundaryConditions
 
   /**
    * @brief Declares the default parameters for a boundary condition id i_bc
-   * i.e. Dirichlet condition (ConstantFunction) with value 0
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    *

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -164,7 +164,7 @@ test()
   NSparam.restart_parameters.frequency  = 1;
   NSparam.non_linear_solver.verbosity   = Parameters::Verbosity::quiet;
   NSparam.linear_solver.verbosity       = Parameters::Verbosity::quiet;
-  NSparam.boundary_conditions.createDefaultNoSlip();
+  NSparam.boundary_conditions.createNoSlip();
 
   RestartNavierStokes<2> problem_2d(NSparam);
   problem_2d.run();


### PR DESCRIPTION
# Description of the problem

- heat transfer BC were by default "temperature", so there was no mean to have nothing happening if say the heat transfer BC were not the first ordered ones

# Description of the solution

- add a "none" BC, by default, similarly to what have been done for the VOF BC

# How Has This Been Tested?

Tested with a modification of the `warming-up-a-viscous-fluid` (domain turned clockwise), which was not possible before this BC existed. This has been added to the example bonuses.

# Documentation

- example `warming-up-a-viscous-fluid`

- parameter: multiphysics boundary condition

# Future changes

@blaisb tell me if you would like the same `none` BC for the tracer (already implemented for VOF).
