### PR TITLE
Add two recent preprints to the documentation

### DIFF
--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -25,4 +25,8 @@ Preprints
 
 This section regroups preprints of journal articles already submitted, but which are still under review.
 
+* `T. E. Geitani, S. Golshan and B. Blais, "A High Order Stabilized Solver for the Volume Averaged Navier-Stokes Equations", June 2022 <https://doi.org/10.48550/arXiv.2206.02842>`_.
+
+* `L. Prieto Saavedra, C. E. N. Radburn, A. Collard-Daigneault and B. Blais, "An implicit large-eddy simulation perspective on the flow over periodic hills", June 2022 <https://doi.org/10.48550/arXiv.2206.08145>`_.
+
 


### PR DESCRIPTION
# Description of the problem

Two recent preprints were missing in the list of publications of Lethe.

# Description of the solution

The two references were added with the appropriate hyperlink leading to the publications. 