### PR TITLE
Fix vof ht

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/gls_droplet_marangoni_effect.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_droplet_marangoni_effect.output
@@ -16,23 +16,23 @@ Kinetic energy : 2.06454e-05
 *****************************************************************
 Transient iteration : 2        Time : 0.002    Time step : 0.001    CFL : 0.00936298
 *****************************************************************
-Enstrophy  : 91.7191
-Kinetic energy : 0.001354
+Enstrophy  : 50.4139
+Kinetic energy : 0.000761582
 
 *****************************************************************
-Transient iteration : 3        Time : 0.003    Time step : 0.001    CFL : 0.160143
+Transient iteration : 3        Time : 0.003    Time step : 0.001    CFL : 0.122855
 *****************************************************************
-Enstrophy  : 291.448
-Kinetic energy : 0.00504483
+Enstrophy  : 189.088
+Kinetic energy : 0.00325828
 
 *****************************************************************
-Transient iteration : 4        Time : 0.004    Time step : 0.001    CFL : 0.279504
+Transient iteration : 4        Time : 0.004    Time step : 0.001    CFL : 0.232129
 *****************************************************************
-Enstrophy  : 507.019
-Kinetic energy : 0.00983761
+Enstrophy  : 371.442
+Kinetic energy : 0.0071153
 
 *****************************************************************
-Transient iteration : 5        Time : 0.005    Time step : 0.001    CFL : 0.35994 
+Transient iteration : 5        Time : 0.005    Time step : 0.001    CFL : 0.317114
 *****************************************************************
-Enstrophy  : 711.921
-Kinetic energy : 0.014945
+Enstrophy  : 566.914
+Kinetic energy : 0.0117275

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_ht_heated-walls.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_ht_heated-walls.output
@@ -1,0 +1,59 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      0.2
+   Number of VOF degrees of freedom: 1089
+   Number of thermal degrees of freedom: 1089
+
+*****************************************************************
+Transient iteration : 1        Time : 0.2      Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error phase : 0.195496
+L2 error temperature : 0.413192
+
+*****************************************************************
+Transient iteration : 2        Time : 0.4      Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error phase : 0.195451
+L2 error temperature : 0.0934076
+
+*****************************************************************
+Transient iteration : 3        Time : 0.6      Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error phase : 0.195637
+L2 error temperature : 0.0223098
+
+*****************************************************************
+Transient iteration : 4        Time : 0.8      Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error phase : 0.195636
+L2 error temperature : 0.00467604
+
+*****************************************************************
+Transient iteration : 5        Time : 1        Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error phase : 0.195636
+L2 error temperature : 0.000923592
+ time  error_velocity error_pressure 
+0.2000 0.000000e+00   0.0000         
+0.4000 0.000000e+00   0.0000         
+0.6000 0.000000e+00   0.0000         
+0.8000 0.000000e+00   0.0000         
+1.0000 0.000000e+00   0.0000         
+ time  error_phase  
+0.2000 1.954964e-01 
+0.4000 1.954506e-01 
+0.6000 1.956370e-01 
+0.8000 1.956360e-01 
+1.0000 1.956358e-01 
+cells error_temperature 
+1024  4.131918e-01      
+1024  9.340759e-02      
+1024  2.230979e-02      
+1024  4.676035e-03      
+1024  9.235920e-04      

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_ht_heated-walls.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_ht_heated-walls.prm
@@ -1,0 +1,190 @@
+# Listing of Parameters
+# ---------------------
+# --------------------------------------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  = bdf1
+  set number mesh adapt       = 0
+  set time end                = 1
+  set time step               = 0.2
+  set output name             = vof_ht_heated-walls
+  set output frequency        = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+	set heat transfer = true
+	set viscous dissipation = true
+	set VOF 		= true
+end
+
+#---------------------------------------------------
+# VOF
+#---------------------------------------------------
+subsection VOF	
+	subsection interface sharpening
+		set enable = true
+		set frequency   = 1
+		set interface sharpness    = 1.5
+	end
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection uvwp
+            set Function expression = 0; 0; 0
+    end
+    subsection VOF
+	set Function expression = if (x<=0,1,0)
+    end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+subsection source term
+    set enable = false
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+  set number of fluids     = 2
+  subsection fluid 1
+    set density              = 1
+    set specific heat 	     = 1
+    set thermal conductivity = 2
+    set kinematic viscosity  = 1
+  end
+  subsection fluid 0
+    set density              = 1
+    set specific heat 	     = 1
+    set thermal conductivity = 0.1
+    set kinematic viscosity  = 1
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+  set type = dealii
+  set grid type = hyper_rectangle
+  set grid arguments = -0.5, -0.1 : 0.5, 0.1 : true
+  set initial refinement = 5
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable     = true
+  set verbosity  = verbose
+  subsection temperature
+    set Function constants = k1=2, k0=0.1, T1=5, T0=1, L=0.5
+    #temperature for fluid 1 (x<=0) : T = k0*(T0-T1)/(L*(k1+k0)) * x + T1+(T0-T1)*k0/(k1+k0)
+    #temperature for fluid 0 (x>0) : T = k1*(T0-T1)/(L*(k1+k0)) * x + T1+(T0-T1)*k0/(k1+k0)
+    set Function expression = if(x<=0, k0*(T0-T1)/(L*(k1+k0)) * x + T1+(T0-T1)*k0/(k1+k0), k1*(T0-T1)/(L*(k1+k0)) * x + T1+(T0-T1)*k0/(k1+k0) )
+  end  
+  subsection phase
+    set Function expression = if(x<=0,0,1)
+  end
+end
+
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+subsection timer
+   set type = none
+end
+
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions
+  set number                  = 4
+    subsection bc 0
+        set id = 0
+        set type              = noslip
+    end
+    subsection bc 1
+	set id = 1
+        set type              = noslip
+    end
+    subsection bc 2
+        set id = 2
+        set type              = noslip
+    end
+    subsection bc 3
+        set id = 3
+        set type              = noslip
+    end
+end
+subsection boundary conditions heat transfer
+  set number                = 2
+    subsection bc 0  #left wall
+      set id = 0
+      set type		    = temperature
+      set value		    = 5
+    end
+    subsection bc 1  #right wall
+      set id = 1
+      set type		    = temperature
+      set value		    = 1
+    end
+end
+
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+subsection FEM
+    set velocity order            = 1
+    set pressure order            = 1
+end
+
+
+# --------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+subsection mesh adaptation
+    set type                    = none #kelly
+    set variable                = phase
+    set fraction type           = fraction
+    set max refinement level    = 5
+    set min refinement level    = 3
+    set frequency               = 1
+    set fraction refinement     = 0.95
+    set fraction coarsening     = 0.02
+end
+
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set tolerance               = 1e-8
+  set max iterations          = 100
+  set verbosity               = quiet 
+end
+
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               = quiet
+  set method                                 = gmres
+  set max iters                              = 8000
+  set relative residual                      = 1e-3
+  set minimum residual                       = 1e-8
+  set ilu preconditioner fill                = 1
+  set ilu preconditioner absolute tolerance  = 1e-12
+  set ilu preconditioner relative tolerance  = 1.00
+  set max krylov vectors                     = 200
+end

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -348,32 +348,25 @@ public:
    * This cell must be compatible with the VOF FE and not the
    * Fluid Dynamics FE
    *
-   * @param current_solution The present value of the solution for [alpha]
+   * @param current_solution The present solution for the phase value
    *
-   * @param previous_solutions The solutions at the previous time steps for [alpha]
+   * @param solution_stages The solution at the intermediary stages
+   * (for SDIRK methods) for the phase value
    *
-   * @param solution_stages The solution at the intermediary stages (for SDIRK methods) for [alpha]
-   *
+   * NB: the previous_solutions are not used in heat_transfer_assemblers,
+   * contrary to navier_stokes_assemblers
    */
 
   template <typename VectorType>
   void
   reinit_vof(const typename DoFHandler<dim>::active_cell_iterator &cell,
-             const VectorType &             current_solution,
-             const std::vector<VectorType> &previous_solutions,
+             const VectorType &current_solution,
              const std::vector<VectorType> & /*solution_stages*/)
   {
     this->fe_values_vof->reinit(cell);
     // Gather phase fraction (values, gradient)
     this->fe_values_vof->get_function_values(current_solution,
                                              this->phase_values);
-
-    // Gather previous phase fraction values
-    for (unsigned int p = 0; p < previous_solutions.size(); ++p)
-      {
-        this->fe_values_vof->get_function_values(previous_solutions[p],
-                                                 previous_phase_values[p]);
-      }
   }
 
 
@@ -404,11 +397,13 @@ public:
   std::vector<double> thermal_conductivity_0;
   std::vector<double> density_0;
   std::vector<double> viscosity_0;
+  std::vector<double> grad_specific_heat_temperature_0;
 
   std::vector<double> specific_heat_1;
   std::vector<double> thermal_conductivity_1;
   std::vector<double> density_1;
   std::vector<double> viscosity_1;
+  std::vector<double> grad_specific_heat_temperature_1;
 
 
   // FEValues for the HT problem
@@ -445,12 +440,11 @@ public:
   /**
    * Scratch component for the VOF auxiliary physics
    */
-  bool                             gather_vof;
-  unsigned int                     n_dofs_vof;
-  std::vector<std::vector<double>> previous_phase_values;
+  bool                gather_vof;
+  unsigned int        n_dofs_vof;
+  std::vector<double> phase_values;
   // This is stored as a shared_ptr because it is only instantiated when needed
   std::shared_ptr<FEValues<dim>> fe_values_vof;
-  std::vector<double>            phase_values;
 
   /**
    * Scratch component for the Navier-Stokes component

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -25,14 +25,6 @@
 #ifndef lethe_heat_transfer_scratch_data_h
 #define lethe_heat_transfer_scratch_data_h
 
-#include <core/density_model.h>
-#include <core/multiphysics.h>
-#include <core/physical_property_model.h>
-#include <core/specific_heat_model.h>
-#include <core/thermal_conductivity_model.h>
-
-#include <solvers/multiphysics_interface.h>
-
 #include <deal.II/base/quadrature.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -43,6 +35,13 @@
 #include <deal.II/fe/mapping.h>
 
 #include <deal.II/numerics/vector_tools.h>
+
+#include <core/density_model.h>
+#include <core/multiphysics.h>
+#include <core/physical_property_model.h>
+#include <core/specific_heat_model.h>
+#include <core/thermal_conductivity_model.h>
+#include <solvers/multiphysics_interface.h>
 
 using namespace dealii;
 
@@ -367,13 +366,13 @@ public:
     this->fe_values_vof->reinit(cell);
     // Gather phase fraction (values, gradient)
     this->fe_values_vof->get_function_values(current_solution,
-                                             this->vof_values);
+                                             this->phase_values);
 
     // Gather previous phase fraction values
     for (unsigned int p = 0; p < previous_solutions.size(); ++p)
       {
         this->fe_values_vof->get_function_values(previous_solutions[p],
-                                                 previous_vof_values[p]);
+                                                 previous_phase_values[p]);
       }
   }
 
@@ -448,8 +447,7 @@ public:
    */
   bool                             gather_vof;
   unsigned int                     n_dofs_vof;
-  std::vector<double>              vof_values;
-  std::vector<std::vector<double>> previous_vof_values;
+  std::vector<std::vector<double>> previous_phase_values;
   // This is stored as a shared_ptr because it is only instantiated when needed
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            phase_values;

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -25,6 +25,14 @@
 #ifndef lethe_heat_transfer_scratch_data_h
 #define lethe_heat_transfer_scratch_data_h
 
+#include <core/density_model.h>
+#include <core/multiphysics.h>
+#include <core/physical_property_model.h>
+#include <core/specific_heat_model.h>
+#include <core/thermal_conductivity_model.h>
+
+#include <solvers/multiphysics_interface.h>
+
 #include <deal.II/base/quadrature.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -35,13 +43,6 @@
 #include <deal.II/fe/mapping.h>
 
 #include <deal.II/numerics/vector_tools.h>
-
-#include <core/density_model.h>
-#include <core/multiphysics.h>
-#include <core/physical_property_model.h>
-#include <core/specific_heat_model.h>
-#include <core/thermal_conductivity_model.h>
-#include <solvers/multiphysics_interface.h>
 
 using namespace dealii;
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1,13 +1,3 @@
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-
-#include <solvers/heat_transfer.h>
-#include <solvers/heat_transfer_assemblers.h>
-#include <solvers/heat_transfer_scratch_data.h>
-#include <solvers/postprocessing_cfd.h>
-
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -25,6 +15,15 @@
 
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
+
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+#include <solvers/heat_transfer.h>
+#include <solvers/heat_transfer_assemblers.h>
+#include <solvers/heat_transfer_scratch_data.h>
+#include <solvers/postprocessing_cfd.h>
 
 template <int dim>
 void
@@ -169,13 +168,8 @@ HeatTransfer<dim>::assemble_local_system_matrix(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
@@ -301,14 +295,8 @@ HeatTransfer<dim>::assemble_local_system_rhs(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1,3 +1,13 @@
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+
+#include <solvers/heat_transfer.h>
+#include <solvers/heat_transfer_assemblers.h>
+#include <solvers/heat_transfer_scratch_data.h>
+#include <solvers/postprocessing_cfd.h>
+
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -15,15 +25,6 @@
 
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
-
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-#include <solvers/heat_transfer.h>
-#include <solvers/heat_transfer_assemblers.h>
-#include <solvers/heat_transfer_scratch_data.h>
-#include <solvers/postprocessing_cfd.h>
 
 template <int dim>
 void

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -1,7 +1,6 @@
 #include <core/bdf.h>
 #include <core/sdirk.h>
 #include <core/utilities.h>
-
 #include <solvers/heat_transfer_scratch_data.h>
 
 
@@ -90,7 +89,7 @@ HeatTransferScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
 
   // VOF
   phase_values = std::vector<double>(this->n_q_points);
-  previous_vof_values =
+  previous_phase_values =
     std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
                                      std::vector<double>(this->n_q_points));
 

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -1,6 +1,7 @@
 #include <core/bdf.h>
 #include <core/sdirk.h>
 #include <core/utilities.h>
+
 #include <solvers/heat_transfer_scratch_data.h>
 
 

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -63,7 +63,7 @@ HeatTransferScratchData<dim>::allocate()
   this->laplacian_phi_T =
     std::vector<std::vector<double>>(n_q_points, std::vector<double>(n_dofs));
 
-  // Allocate memory for the physical properties
+  // Physical properties
   fields.insert(
     std::pair<field, std::vector<double>>(field::temperature, n_q_points));
   fields.insert(
@@ -87,24 +87,21 @@ HeatTransferScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
   fe_values_vof = std::make_shared<FEValues<dim>>(
     mapping, fe, quadrature, update_values | update_gradients);
 
-  // VOF
+  // Allocate VOF values
   phase_values = std::vector<double>(this->n_q_points);
-  previous_phase_values =
-    std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
-                                     std::vector<double>(this->n_q_points));
 
+  // Allocate physical properties
+  specific_heat_0                  = std::vector<double>(n_q_points);
+  density_0                        = std::vector<double>(n_q_points);
+  thermal_conductivity_0           = std::vector<double>(n_q_points);
+  viscosity_0                      = std::vector<double>(n_q_points);
+  grad_specific_heat_temperature_0 = std::vector<double>(n_q_points);
 
-  // Properties of fluid 0 (VOF)
-  specific_heat_0        = std::vector<double>(n_q_points);
-  density_0              = std::vector<double>(n_q_points);
-  thermal_conductivity_0 = std::vector<double>(n_q_points);
-  viscosity_0            = std::vector<double>(n_q_points);
-
-  // Properties of fluid 1 (VOF)
-  specific_heat_1        = std::vector<double>(n_q_points);
-  density_1              = std::vector<double>(n_q_points);
-  thermal_conductivity_1 = std::vector<double>(n_q_points);
-  viscosity_1            = std::vector<double>(n_q_points);
+  specific_heat_1                  = std::vector<double>(n_q_points);
+  density_1                        = std::vector<double>(n_q_points);
+  thermal_conductivity_1           = std::vector<double>(n_q_points);
+  viscosity_1                      = std::vector<double>(n_q_points);
+  grad_specific_heat_temperature_1 = std::vector<double>(n_q_points);
 }
 
 
@@ -174,6 +171,8 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
           thermal_conductivity_models[0]->vector_value(fields,
                                                        thermal_conductivity_0);
           rheology_models[0]->vector_value(fields, viscosity_0);
+          specific_heat_models[0]->vector_jacobian(
+            fields, field::temperature, grad_specific_heat_temperature_0);
 
 
           density_models[1]->vector_value(fields, density_1);
@@ -181,6 +180,8 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
           thermal_conductivity_models[1]->vector_value(fields,
                                                        thermal_conductivity_1);
           rheology_models[1]->vector_value(fields, viscosity_1);
+          specific_heat_models[1]->vector_jacobian(
+            fields, field::temperature, grad_specific_heat_temperature_1);
 
           // Blend the physical properties using the VOF field
           for (unsigned int q = 0; q < this->n_q_points; ++q)
@@ -202,6 +203,11 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
               viscosity[q] = calculate_point_property(this->phase_values[q],
                                                       this->viscosity_0[q],
                                                       this->viscosity_1[q]);
+
+              grad_specific_heat_temperature[q] = calculate_point_property(
+                this->phase_values[q],
+                this->grad_specific_heat_temperature_0[q],
+                this->grad_specific_heat_temperature_1[q]);
             }
           break;
         }

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -1,9 +1,11 @@
 #include <core/bdf.h>
 #include <core/sdirk.h>
 #include <core/utilities.h>
+
+#include <solvers/navier_stokes_scratch_data.h>
+
 #include <dem/dem.h>
 #include <dem/dem_properties.h>
-#include <solvers/navier_stokes_scratch_data.h>
 
 template <int dim>
 void

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -1,11 +1,9 @@
 #include <core/bdf.h>
 #include <core/sdirk.h>
 #include <core/utilities.h>
-
-#include <solvers/navier_stokes_scratch_data.h>
-
 #include <dem/dem.h>
 #include <dem/dem_properties.h>
+#include <solvers/navier_stokes_scratch_data.h>
 
 template <int dim>
 void
@@ -71,9 +69,6 @@ NavierStokesScratchData<dim>::allocate()
     n_q_points, std::vector<Tensor<1, dim>>(n_dofs));
 
   // Physical properties
-
-  // Allocate memory for the physical properties
-
   fields.insert(
     std::pair<field, std::vector<double>>(field::shear_rate, n_q_points));
 
@@ -81,12 +76,6 @@ NavierStokesScratchData<dim>::allocate()
   viscosity                 = std::vector<double>(n_q_points);
   thermal_expansion         = std::vector<double>(n_q_points);
   grad_viscosity_shear_rate = std::vector<double>(n_q_points);
-
-
-  density_0   = std::vector<double>(n_q_points);
-  density_1   = std::vector<double>(n_q_points);
-  viscosity_0 = std::vector<double>(n_q_points);
-  viscosity_1 = std::vector<double>(n_q_points);
 
   previous_density =
     std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
@@ -103,12 +92,18 @@ NavierStokesScratchData<dim>::enable_vof(const FiniteElement<dim> &fe,
   fe_values_vof = std::make_shared<FEValues<dim>>(
     mapping, fe, quadrature, update_values | update_gradients);
 
-  // VOF
+  // Allocate VOF values
   phase_values = std::vector<double>(this->n_q_points);
   previous_phase_values =
     std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
                                      std::vector<double>(this->n_q_points));
   phase_gradient_values = std::vector<Tensor<1, dim>>(this->n_q_points);
+
+  // Allocate physical properties
+  density_0   = std::vector<double>(n_q_points);
+  density_1   = std::vector<double>(n_q_points);
+  viscosity_0 = std::vector<double>(n_q_points);
+  viscosity_1 = std::vector<double>(n_q_points);
 }
 
 template <int dim>


### PR DESCRIPTION
# Description of the problem

Heat transfer did not consider multiple fluid parameters when used with VOF

# Description of the solution

- Solve the bug (silly parameter naming)
- Add test with analytical solution

# How Has This Been Tested?

Test with analytical solution: two fluids with different `k` and between two walls at fixed temperature.

# Future changes

I could see that the documentation pages on `initial condition` and `analytical solution` could use another check: `temperature` subsection is missing on `initial condition`, a few typos, and `analytical solution` could be clarified. 

Also I think it would be clearer to rename the `subsection VOF` in `initial condition` to `subsection phase`, so that it is coherent with `temperature` and `subsection phase` in the `analytical solution`. 

I will do that in another documentation PR as it is not directly related.

# Comments

I changed the `output` for the marangoni effect test with @shahabgol approval. We are not sure if it is better now, it will be addressed by Shahab in his next example.