### PR TITLE
Remove comment that does not apply anymore

### DIFF
--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -43,9 +43,6 @@ using namespace dealii;
  * independent components of the Reynolds stresses tensor (<u'u'>, <v'v'>,
  * <w'w'>, <u'v'>, <v'w'>, <w'u'>). The generated vectors are displayable of
  * visualization software.
- *
- * Important : Time-averaging velocities and calculating reynolds stresses are
- * currently unavailable for mesh adaptation.
  */
 template <int dim, typename VectorType, typename DofsType>
 class AverageVelocities


### PR DESCRIPTION
# Description of the problem

- There was a comment indicating that velocity averaging could not be used with mesh adaptation. This is false

# Description of the solution

- Removed comment

Closes #511 