### PR TITLE
Update docker image to 9.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dealii_version: ["master", "v9.3.0"]
+        dealii_version: ["master", "v9.4.0"]
     
     # Run steps in container of dealii's master branch
     container:


### PR DESCRIPTION
# Description of the problem

- We currently test Lethe using deal.II master and deal.II 9.3. A lot of the features we use leverage 9.4 (or the current master version). Maintaining 9.3 compatibility is starting to be a burden that is not necessary (around 10-15 #ifdef)

# Description of the solution

- Now that 9.4 has been release, migrate the docker to use 9.4 and master.

# How Has This Been Tested?

- If CI passes we are good to go.
