### PR TITLE
Stabilization theory guide

### DIFF
--- a/doc/source/theory/fluid_dynamics/fem_formulation.rst
+++ b/doc/source/theory/fluid_dynamics/fem_formulation.rst
@@ -21,7 +21,7 @@ on :math:`\Gamma`. We multiply by two test functions :math:`q` and :math:`\mathb
   &\int_{\Omega}  v_k \left(\partial_t u_k+ u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) d\Omega =0
 
 
-Because we want the pressure to be in :math:`\mathcal{L}^2` and the velocity to be in :math:`\mathcal{H}^1`, we integrate by part the viscous stress and the pressure gradient. We thus obtain the weak form:
+Because we want the pressure to be in :math:`\mathcal{L}^2` and the velocity to be in :math:`\mathcal{H}^1`, we integrate by parts the viscous stress and the pressure gradient terms. We thus obtain the weak form:
 
 
 .. math::
@@ -36,7 +36,7 @@ Because we want the pressure to be in :math:`\mathcal{L}^2` and the velocity to 
   &  + \int_{\Gamma} \left( v_k \right) \left( \partial_l u_k  +\delta_{lk} p \right) n_l \mathrm{d}\Gamma
    =0
 
-where :math:`\delta_{lk}` is the Kronecker delta and :math:`n_j` is the outward pointing normal vector to a surface. Since we assume Dirichlet boundary conditions or zero stress  conditions 
+where :math:`\delta_{lk}` is the Kronecker delta and :math:`n_l` is the outward pointing normal vector to a surface. Since we assume Dirichlet boundary conditions or zero stress  conditions 
 on :math:`\Gamma`, this term may be discarded. Thus, when no boundary condition is applied, the boundary condition applied is:
 
 .. math::
@@ -58,7 +58,7 @@ To solve non-linear problem, Lethe uses the `Newton-Raphson method <https://en.w
 
     \mathbf{\mathcal{J}} \mathbf{\delta x} = - \mathbf{\mathcal{R}}
 
-For the incompressible Navier-Stokes equation, this leads to a saddle point problem of the form :
+For the incompressible Navier-Stokes equation, this leads to a saddle point problem of the form:
 
 .. math::
     

--- a/doc/source/theory/fluid_dynamics/fluid_dynamics.rst
+++ b/doc/source/theory/fluid_dynamics/fluid_dynamics.rst
@@ -10,4 +10,5 @@ Fluid dynamics
     navier-stokes
     fem_formulation
     stabilization
+    linear_solvers
     rheology

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -1,0 +1,4 @@
+Linear solvers
+##############
+
+**Under construction**

--- a/doc/source/theory/fluid_dynamics/navier-stokes.rst
+++ b/doc/source/theory/fluid_dynamics/navier-stokes.rst
@@ -1,7 +1,7 @@
 The Incompressible Navier-Stokes equations
 #############################################
 
-Lethe was designed to solve the incompressible Navier-Stokes equations. For the physics in Lethe, we generally try to follow the convention of the `BSL <https://en.wikipedia.org/wiki/Transport_Phenomena_(book)>`_ Assuming a constant density :math:`\rho` and kinematic viscosity :math:`\nu`, these equations take the following form:
+Lethe was designed to solve the incompressible Navier-Stokes equations. For the physics in Lethe, we generally try to follow the convention of the `BSL <https://en.wikipedia.org/wiki/Transport_Phenomena_(book)>`_. Assuming a constant density :math:`\rho` and kinematic viscosity :math:`\nu`, these equations take the following form:
 
 .. math::
     \nabla \cdot \mathbf{u} &= 0   \\

--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -51,13 +51,13 @@ This approach builds on the work of `Heister et al. (2012) <https://onlinelibrar
   \\
   &+ \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  + \sum_K \gamma \int_{\Omega_k} \partial_l u_l \partial_k v_k = 0
 
-where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reduce oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classic weak formulation. Therefore, a good preconditioning is necessary to solve the linear system at each non linear iteration. More this on this topic are found in the linear solvers section.
+where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reduce oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classic weak formulation. Therefore, a good preconditioning is necessary to solve the linear system at each nonlinear iteration. More this on this topic are found in the linear solvers section.
 
 
 Galerkin Least-Squares formulation
 -----------------------------------
 
-The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes oth the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
+The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes both the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
 
 .. math::
 

--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -7,23 +7,23 @@ It is well known that, in the absence of stabilization, the choice of the veloci
 SUPG/PSPG monolithic formulation
 -----------------------------------
 
-This approach consists of two new terms that are added to the classical weak formulation. The first one is known as SUPG (Streamline-Upwind/ Petro-Galerkin) formulation and it is in charge of stabilizing the formulation for convection-dominated flows. The second one is known as PSPG (Pressure-Stabilizing/ Petrov-Galerkin) and as its name indicates, it is in charge of reducing pressure oscillations when using equal order elements. Thus, the new weak form of the Navier-Stokes equation is given by:
+This approach consists of two new terms that are added to the classic weak formulation. The first one is known as SUPG (Streamline-Upwind/ Petro-Galerkin) formulation and it is in charge of stabilizing the formulation for convection-dominated flows. The second one is known as PSPG (Pressure-Stabilizing/ Petrov-Galerkin) and as its name indicates, it reduces pressure oscillations when using equal order elements. Thus, the new weak form of the Navier-Stokes equation is given by:
 
 .. math::
 
-  &\int_{\Omega}  q  \partial_l u_l \mathrm{d}\Omega + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{PSPG} \partial_l q \right) \mathrm{d}\Omega_k  = 0 
+  &\int_{\Omega}  q  \partial_l u_l \mathrm{d}\Omega + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{PSPG} \partial_l q \right) \mathrm{d}\Omega_k  = 0 
   \\
   &\int_{\Omega}  v_k \left(\partial_t u_k+ u_l \partial_l u_k - f_k \right) \mathrm{d}\Omega - \int_{\Omega} \left( \partial_k \right) v_k p \mathrm{d}\Omega  + \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega   
   \\
-  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k =0
+  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k =0
 
-This formulation is consistent as the added terms involve the residual and if we substitute the exact solution the stabilization term vanishes. In literature, one can find different definitions of the stabilization parameters :math:`\tau_{SUPG}` and :math:`\tau_{PSPG}`. Lethe uses the definition by `Tezduyar (1991) <https://linkinghub.elsevier.com/retrieve/pii/S0065215608701534>`_ for both stabilization parameters:
+This formulation is consistent as the added terms involve the residual and if we substitute the exact solution the stabilization terms vanish. In literature, one can find different definitions of the stabilization parameters :math:`\tau_{SUPG}` and :math:`\tau_{PSPG}`. Lethe uses the definition by `Tezduyar (1991) <https://linkinghub.elsevier.com/retrieve/pii/S0065215608701534>`_ for both stabilization parameters. In the case of a transient problem:
 
 .. math::
 
    \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + 9 \left( \frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
 
-where :math:`\Delta t` is the time step, :math:`h_{conv}` and :math:`h_{diff}` are the size of the element realted to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere of a volume equivalent to that of the cell. In the case of stationary problems, the following expression is used: 
+where :math:`\Delta t` is the time step, and :math:`h_{conv}` and :math:`h_{diff}` are the size of the element related to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere of a volume equivalent to that of the cell. In the case of stationary problems, the following expression is used: 
 
 .. math::
 
@@ -41,7 +41,7 @@ As it can be seen there is an additional matrix :math:`S^*` that appears in the 
 Grad-Div block formulation
 ------------------------------------
 
-This approach builds on the work of `Heister et al. (2012) <https://onlinelibrary.wiley.com/doi/10.1002/fld.3654>`_. and can be seens a natural parallel extension of the `Step-57 of deal.ii <https://www.dealii.org/current/doxygen/deal.II/step_57.html>`_. An additional term is added to the classical weak form: 
+This approach builds on the work of `Heister et al. (2012) <https://onlinelibrary.wiley.com/doi/10.1002/fld.3654>`_. and can be seen as a natural parallel extension of the `Step-57 of deal.ii <https://www.dealii.org/current/doxygen/deal.II/step_57.html>`_. An additional term is added to the classic weak form of the Navier-Stokes equations: 
 
 .. math::
 
@@ -51,23 +51,23 @@ This approach builds on the work of `Heister et al. (2012) <https://onlinelibrar
   \\
   &+ \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  + \sum_K \gamma \int_{\Omega_k} \partial_l u_l \partial_k v_k = 0
 
-where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reducing oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classical formulation. Therefore, a good preconditioning is necessary to solve the linear system at each non linear iteration. In Lethe this is done using the Schur complement.
+where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reduce oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classic weak formulation. Therefore, a good preconditioning is necessary to solve the linear system at each non linear iteration. More this on this topic are found in the linear solvers section.
 
 
 Galerkin Least-Squares formulation
 -----------------------------------
 
-The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
+The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes oth the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
 
 .. math::
 
-  &\int_{\Omega}  q  \partial_l u_l \mathrm{d}\Omega + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{PSPG} \partial_l q \right) \mathrm{d}\Omega_k  = 0 
+  &\int_{\Omega}  q  \partial_l u_l \mathrm{d}\Omega + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{PSPG} \partial_l q \right) \mathrm{d}\Omega_k  = 0 
   \\
   &\int_{\Omega}  v_k \left(\partial_t u_k+ u_l \partial_l u_k - f_k \right) \mathrm{d}\Omega - \int_{\Omega} \left( \partial_k \right) v_k p \mathrm{d}\Omega  + \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega   
   \\
-  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k 
+  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k 
   \\
-  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu \partial_l \partial_l u_k \right) \mathrm{d}\Omega_k  =0
+  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu \partial_l \partial_l u_k \right) \mathrm{d}\Omega_k  =0
 
-This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used. The stabilization parameters are taken to be the same in all cases and given by the same :math:`\tau` expressions presented in the SUPG/PSPG section. The non-linear problem is solved in the same fashion and the structure of the Jacobian is the same one as the SUPG/PSPG formulation.
+This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used as is the case in Lethe. The stabilization parameters are taken to be the same in all cases and given by the same :math:`\tau` expressions presented in the SUPG/PSPG section. The non-linear problem is solved in the same fashion and the structure of the Jacobian is the same one as the SUPG/PSPG formulation.
 

--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -7,7 +7,7 @@ It is well known that, in the absence of stabilization, the choice of the veloci
 SUPG/PSPG monolithic formulation
 -----------------------------------
 
-This approach consists of two new terms that are added to the classic weak formulation. The first one is known as SUPG (Streamline-Upwind/ Petro-Galerkin) formulation and it is in charge of stabilizing the formulation for convection-dominated flows. The second one is known as PSPG (Pressure-Stabilizing/ Petrov-Galerkin) and as its name indicates, it reduces pressure oscillations when using equal order elements. Thus, the new weak form of the Navier-Stokes equation is given by:
+This approach consists of two new terms that are added to the classic weak formulation. The first one is known as SUPG (Streamline-Upwind/ Petro-Galerkin) formulation and it is in charge of stabilizing the formulation for convection-dominated flows. The second one is known as PSPG (Pressure-Stabilizing/ Petrov-Galerkin) and as its name indicates, it reduces pressure oscillations when using equal order elements (e.g. Q1 elements for the velocity and Q1 elements for the pressure). Thus, the new weak form of the Navier-Stokes equation is given by:
 
 .. math::
 

--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -21,13 +21,13 @@ This formulation is consistent as the added terms involve the residual and if we
 
 .. math::
 
-   \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + \left( 9 \frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
+   \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + 9 \left( \frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
 
 where :math:`\Delta t` is the time step, :math:`h_{conv}` and :math:`h_{diff}` are the size of the element realted to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere of a volume equivalent to that of the cell. In the case of stationary problems, the following expression is used: 
 
 .. math::
 
-   \tau = \left[ \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + \left( 9 \frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
+   \tau = \left[ \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + 9 \left(\frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
 
 To solve the non-linear problem Lethe uses again the Newton-Raphson method, however, the Jacobian and the residual are now of the following form: 
 
@@ -49,9 +49,9 @@ This approach builds on the work of `Heister et al. (2012) <https://onlinelibrar
   \\
   &\int_{\Omega}  v_k \left(\partial_t u_k+ u_l \partial_l u_k - f_k \right) \mathrm{d}\Omega  - \int_{\Omega} \left( \partial_k \right) v_k p \mathrm{d}\Omega  
   \\
-  &+ \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  + \sum_K \gamma \int_{\Omega_k} \partial_l u_l \partial_k v_l = 0
+  &+ \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  + \sum_K \gamma \int_{\Omega_k} \partial_l u_l \partial_k v_k = 0
 
-where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reducing oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classical formulation. Therefore, a good preconditioning is necessary to solve the linear system at each non linear iteration. In Lethe this is done using the Schur complement.
+where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reducing oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classical formulation. Therefore, a good preconditioning is necessary to solve the linear system at each non linear iteration. In Lethe this is done using the Schur complement.
 
 
 Galerkin Least-Squares formulation

--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -17,26 +17,26 @@ This approach consists of two new terms that are added to the classic weak formu
   \\
   & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k =0
 
-This formulation is consistent as the added terms involve the residual and if we substitute the exact solution the stabilization terms vanish. In literature, one can find different definitions of the stabilization parameters :math:`\tau_{SUPG}` and :math:`\tau_{PSPG}`. Lethe uses the definition by `Tezduyar (1991) <https://linkinghub.elsevier.com/retrieve/pii/S0065215608701534>`_ for both stabilization parameters. In the case of a transient problem:
+This formulation is consistent as the added terms involve the residual and if we substitute the exact solution, the stabilization terms vanish. In the literature, one can find different definitions of the stabilization parameters :math:`\tau_{SUPG}` and :math:`\tau_{PSPG}`. Lethe uses the definition by `Tezduyar (1991) <https://linkinghub.elsevier.com/retrieve/pii/S0065215608701534>`_ for both stabilization parameters. In the case of a transient problem:
 
 .. math::
 
    \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + 9 \left( \frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
 
-where :math:`\Delta t` is the time step, and :math:`h_{conv}` and :math:`h_{diff}` are the size of the element related to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere of a volume equivalent to that of the cell. In the case of stationary problems, the following expression is used: 
+where :math:`\Delta t` is the time step, and :math:`h_{conv}` and :math:`h_{diff}` are the size of the element related to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere having a volume equivalent to that of the cell. In the case of stationary problems, the following expression is used: 
 
 .. math::
 
    \tau = \left[ \left( \frac{2 |\mathrm{u}|}{h_{conv}} \right)^{2} + 9 \left(\frac{4 \nu}{h^2_{diff}} \right)^{2} \right]^{-1/2}
 
-To solve the non-linear problem Lethe uses again the Newton-Raphson method, however, the Jacobian and the residual are now of the following form: 
+To solve the non-linear problem, Lethe uses again the Newton-Raphson method, however, the Jacobian and the residual are now of the following form: 
 
 .. math::
     
   \mathbf{\mathcal{J}} &= \left[ \begin{matrix} 	A^* & B^{*T}  \\[0.3em]	B^* & S^* \end{matrix} \right] \\
   \mathbf{\mathcal{R}} &=  \left[ \begin{matrix} \mathbf{\mathcal{R}}_{v}^*   \\[0.3em]		\mathbf{\mathcal{R}}_{q}^*  \end{matrix} \right]
   
-As it can be seen there is an additional matrix :math:`S^*` that appears in the linear system and eliminates the zero block on the diagonal of the Jacobian matrix.
+As it can be seen, there is an additional matrix :math:`S^*` that appears in the linear system and eliminates the zero block on the diagonal of the Jacobian matrix.
 
 Grad-Div block formulation
 ------------------------------------
@@ -51,13 +51,13 @@ This approach builds on the work of `Heister et al. (2012) <https://onlinelibrar
   \\
   &+ \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  + \sum_K \gamma \int_{\Omega_k} \partial_l u_l \partial_k v_k = 0
 
-where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reduce oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classic weak formulation. Therefore, a good preconditioning is necessary to solve the linear system at each nonlinear iteration. More this on this topic are found in the linear solvers section.
+where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reduce oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In Lethe the value of :math:`\gamma` is equal to :math:`1`. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classic weak formulation. Therefore, a good preconditioning is necessary to solve the linear system at each nonlinear iteration. More on this topic is found in the linear solvers section.
 
 
 Galerkin Least-Squares formulation
 -----------------------------------
 
-The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes both the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
+The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes both the SUPG and PSPG terms as well as an additional term that can be seen in the weak form:
 
 .. math::
 
@@ -69,5 +69,5 @@ The GLS formulation is built as a generalization of the stabilization procedure 
   \\
   & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu \partial_l \partial_l u_k \right) \mathrm{d}\Omega_k  =0
 
-This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used as is the case in Lethe. The stabilization parameters are taken to be the same in all cases and given by the same :math:`\tau` expressions presented in the SUPG/PSPG section. The non-linear problem is solved in the same fashion and the structure of the Jacobian is the same one as the SUPG/PSPG formulation.
+This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used as is the case in Lethe. The stabilization parameters are taken to be the same in all cases and given by the same :math:`\tau` expressions presented in the SUPG/PSPG section. The non-linear problem is solved in the same fashion and the structure of the Jacobian is the same one as that of the SUPG/PSPG formulation.
 

--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -17,7 +17,7 @@ This approach consists of two new terms that are added to the classical weak for
   \\
   & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k =0
 
-This formulation is consistent as the added terms involve the residual and if we substitute the exact solution the stabilization term vanishes. In literature, one can find different definitions of the stabilization parameters :math:`\tau_{SUPG}` and :math:`\tau_{PSPG}`. Lethe uses the definition by `Tezudyar (1991) <https://linkinghub.elsevier.com/retrieve/pii/S0065215608701534>`_ for both stabilization parameters:
+This formulation is consistent as the added terms involve the residual and if we substitute the exact solution the stabilization term vanishes. In literature, one can find different definitions of the stabilization parameters :math:`\tau_{SUPG}` and :math:`\tau_{PSPG}`. Lethe uses the definition by `Tezduyar (1991) <https://linkinghub.elsevier.com/retrieve/pii/S0065215608701534>`_ for both stabilization parameters:
 
 .. math::
 
@@ -41,7 +41,7 @@ As it can be seen there is an additional matrix :math:`S^*` that appears in the 
 Grad-Div block formulation
 ------------------------------------
 
-This approach builds on the work of Heister et al. [REF] and can be seens a natural parallel extension of the Step-57 of deal.ii [REF]. An additional term is added to the classical weak form: 
+This approach builds on the work of `Heister et al. (2012) <https://onlinelibrary.wiley.com/doi/10.1002/fld.3654>`_. and can be seens a natural parallel extension of the `Step-57 of deal.ii <https://www.dealii.org/current/doxygen/deal.II/step_57.html>`_. An additional term is added to the classical weak form: 
 
 .. math::
 
@@ -51,19 +51,13 @@ This approach builds on the work of Heister et al. [REF] and can be seens a natu
   \\
   &+ \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  + \sum_K \gamma \int_{\Omega_k} \partial_l u_l \partial_k v_l = 0
 
-where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. In this case, the linear system to be solved in each non-linear iteration is not affected by the stabilization. To solve the non-linear problem Lethe uses again the Newton-Raphson method, however, the Jacobian and the residual are now of the following form: 
-
-.. math::
-    
-  \mathbf{\mathcal{J}} &= \left[ \begin{matrix} 	A + \gamma B^{T} W^{-1} B  & B^{T}  \\[0.3em]	B & 0 \end{matrix} \right] \\
-  \mathbf{\mathcal{R}} &=  \left[ \begin{matrix} \mathbf{\mathcal{R}}_{v}^*   \\[0.3em]		\mathbf{\mathcal{R}}_{q}^*  \end{matrix} \right]
-  
+where :math:`\gamma` is an additional parameter that can be related to the augmented lagrangian formulation. The additional stabilization term improves the numerical accuracy of the solution and helps reducing oscillations for convection-dominated flows. In general, the optimal value for :math:`\gamma` depends on the solution on each element and it is therefore, problem dependent. In this case, the linear system to be solved in each non-linear iteration has the same structure as the one obtained with the classical formulation. Therefore, a good preconditioning is necessary to solve the linear system at each non linear iteration. In Lethe this is done using the Schur complement.
 
 
 Galerkin Least-Squares formulation
 -----------------------------------
 
-The GLS formulation is built as a generalization of the stabbilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
+The GLS formulation is built as a generalization of the stabilization procedure in the SUPG/PSPG formulation. It is based on a Least-Squares term based on the momentum equation. It includes the SUPG and PSPG terms but adds an additional one as it can be seen in its weak form:
 
 .. math::
 
@@ -73,7 +67,7 @@ The GLS formulation is built as a generalization of the stabbilization procedure
   \\
   & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k 
   \\
-  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu v \partial_l \partial_l u_k \right) \mathrm{d}\Omega_k  =0
+  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - v \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu \partial_l \partial_l u_k \right) \mathrm{d}\Omega_k  =0
 
-This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used. 
+This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used. The stabilization parameters are taken to be the same in all cases and given by the same :math:`\tau` expressions presented in the SUPG/PSPG section. The non-linear problem is solved in the same fashion and the structure of the Jacobian is the same one as the SUPG/PSPG formulation.
 


### PR DESCRIPTION
# Description of the problem

The part on stabilization methods in the theory section of the documentation was incomplete. 

# Description of the solution

This PR adds a basic description of each of the stabilization methods available in Lethe for the Navier-Stokes equations. 

# How Has This Been Tested?

NA

# Documentation

Some small typos were corrected in previous theory sections:
- `doc/source/theory/fluid_dynamics/navier-stokes.rst`
- `doc/source/theory/fluid_dynamics/fem_formulation.rst`

The main file modified in this PR is given by:
- `doc/source/theory/fluid_dynamics/stabilization.rst`

# Future changes

An additional section called linear solvers was added to the documentation. This section is empty for now, but should be filled soon as it explains the difference on solving the linear system depending on the stabilization technique. 

