### PR TITLE
Use average velocity field for multiphysics

### DIFF
--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -9,7 +9,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
     set heat transfer 		= false
     set viscous dissipation 	= false
     set buoyancy force 		= false
-    set use average velocity field =false
+    set use average velocity field = false
 
     # Tracer
     set tracer 			= false

--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -9,6 +9,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
     set heat transfer 		= false
     set viscous dissipation 	= false
     set buoyancy force 		= false
+    set use average velocity field =false
 
     # Tracer
     set tracer 			= false
@@ -38,6 +39,11 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 * ``VOF``: enables multiphase flow simulations, with two fluids separated by a free surface, using the Volume-of-Fluid method. 
 
   See :doc:`volume_of_fluid` for advanced VOF parameters, :doc:`initial_conditions` for the definition of the VOF conditions and `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#two-phase-simulations>`_ for the definition of the physical properties of both fluids.
+  
+* ``use average velocity field``: controls if the advection of the physics is done using the average velocity field instead of the current velocity field.
+
+.. note::
+	At this point, the average velocity field is only implemented in the heat transfer physic.
 
 .. seealso::
 

--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -6,6 +6,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 
   subsection multiphysics
     # Thermal physics
+    set fluid mechanics 	= true
     set heat transfer 		= false
     set viscous dissipation 	= false
     set buoyancy force 		= false
@@ -40,7 +41,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 
   See :doc:`volume_of_fluid` for advanced VOF parameters, :doc:`initial_conditions` for the definition of the VOF conditions and `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#two-phase-simulations>`_ for the definition of the physical properties of both fluids.
   
-* ``use average velocity field``: controls if the advection of the subphysics is done using the average velocity field instead of the current velocity field. This is useful when the flow dynamics and the subphysics reach a pseudo-steady state at different time scales.
+* ``use average velocity field``:  controls if the advection of the subphysics is done using the average velocity field instead of the current velocity field. This is useful when the flow dynamics and the subphysics reach a pseudo-steady state at different time scales. To use this feature, the user should launch a simulation with the fluid mechanics solver and use the time averaging feature. Once the time average of the velocity field is sufficiently established, the simulation should be stopped and restarted without the fluid mechanics solver. The subphysics can then be solved using a larger time step.
 
 .. note::
 	Currently, this mechanism is only implemented in the heat transfer physic.

--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -40,11 +40,14 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 
   See :doc:`volume_of_fluid` for advanced VOF parameters, :doc:`initial_conditions` for the definition of the VOF conditions and `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#two-phase-simulations>`_ for the definition of the physical properties of both fluids.
   
-* ``use average velocity field``: controls if the advection of the physics is done using the average velocity field instead of the current velocity field.
+* ``use average velocity field``: controls if the advection of the subphysics is done using the average velocity field instead of the current velocity field. This is useful when the flow dynamics and the subphysics reach a pseudo-steady state at different time scales.
 
 .. note::
-	At this point, the average velocity field is only implemented in the heat transfer physic.
-
+	Currently, this mechanism is only implemented in the heat transfer physic.
+	
+.. important::
+   The subphysic must also be enabled (for example, ``set heat transfer = true``)
+   
 .. seealso::
 
   The VOF solver is used in the example :doc:`../../examples/multiphysics/dam-break-VOF/dam-break-VOF`.

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -233,7 +233,7 @@ namespace Parameters
     bool tracer;
     bool VOF;
 
-    bool use_average_velocity_field;
+    bool use_time_average_velocity_field;
 
     // subparameters for heat_transfer
     bool viscous_dissipation;

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -233,6 +233,8 @@ namespace Parameters
     bool tracer;
     bool VOF;
 
+    bool use_average_velocity_field;
+
     // subparameters for heat_transfer
     bool viscous_dissipation;
     bool buoyancy_force;

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -100,6 +100,12 @@ private:
   void
   assemble_system_rhs();
 
+  /**
+   * @brief  Update the average velocity field solution in the multiphyscics interface
+   */
+  virtual void
+  update_multiphysics_average_solution() override;
+
 
   /**
    * @brief Assemble the local matrix for a given cell.

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -104,7 +104,7 @@ private:
    * @brief  Update the average velocity field solution in the multiphyscics interface
    */
   virtual void
-  update_multiphysics_average_solution() override;
+  update_multiphysics_time_average_solution() override;
 
 
   /**

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -111,7 +111,7 @@ protected:
    * @brief  Updates the average velocity field solution in the multiphyscics interface
    */
   virtual void
-  update_multiphysics_average_solution() override;
+  update_multiphysics_time_average_solution() override;
 
   /**
    * @brief  Set-up the appropriate preconditioner

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -107,12 +107,19 @@ protected:
   virtual void
   assemble_system_rhs() override;
 
+  /**
+   * @brief  Update the average velocity field solution in the multiphyscics interface
+   */
+  virtual void
+  update_multiphysics_average_solution() override;
 
   /**
    * @brief  Set-up the appropriate preconditioner
    */
   void
   setup_preconditioner();
+
+
 
   /**
    * @brief  defined the non zero constraints used to solved the problem.

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -108,7 +108,7 @@ protected:
   assemble_system_rhs() override;
 
   /**
-   * @brief  Update the average velocity field solution in the multiphyscics interface
+   * @brief  Updates the average velocity field solution in the multiphyscics interface
    */
   virtual void
   update_multiphysics_average_solution() override;
@@ -118,7 +118,6 @@ protected:
    */
   void
   setup_preconditioner();
-
 
 
   /**

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -505,7 +505,7 @@ public:
                            active_physics.end(),
                            physics_id) != active_physics.end()),
                 ExcInternalError());
-    return physics_average_solutions[physics_id];
+    return physics_time_average_solutions[physics_id];
   }
 
   /**
@@ -520,7 +520,7 @@ public:
                            active_physics.end(),
                            physics_id) != active_physics.end()),
                 ExcInternalError());
-    return block_physics_average_solutions[physics_id];
+    return block_physics_time_average_solutions[physics_id];
   }
 
 
@@ -647,21 +647,21 @@ public:
   }
 
   /**
-   * @brief Sets the reference to the average solution of the physics in the multiphysics interface
+   * @brief Sets the reference to the time-average solution of the physics in the multiphysics interface
    *
    * @param physics_id The physics of the DOF handler being requested
    *
    * @param solution_vector The reference to the solution vector of the physics
    */
   void
-  set_average_solution(PhysicsID                      physics_id,
-                       TrilinosWrappers::MPI::Vector *solution_vector)
+  set_time_average_solution(PhysicsID                      physics_id,
+                            TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
                            physics_id) != active_physics.end()),
                 ExcInternalError());
-    physics_average_solutions[physics_id] = solution_vector;
+    physics_time_average_solutions[physics_id] = solution_vector;
   }
 
 
@@ -681,7 +681,7 @@ public:
                            active_physics.end(),
                            physics_id) != active_physics.end()),
                 ExcInternalError());
-    physics_average_solutions[physics_id] = solution_vector;
+    physics_time_average_solutions[physics_id] = solution_vector;
   }
 
 
@@ -705,14 +705,14 @@ public:
   }
 
   /**
-   * @brief Sets the reference to the average solution of the physics in the multiphysics interface
+   * @brief Sets the reference to the time-average solution of the physics in the multiphysics interface
    *
    * @param physics_id The physics of the DOF handler being requested
    *
    * @param solution_vector The reference to the solution vector of the physics
    */
   void
-  set_block_average_solution(
+  set_block_time_average_solution(
     PhysicsID                           physics_id,
     TrilinosWrappers::MPI::BlockVector *solution_vector)
   {
@@ -720,7 +720,7 @@ public:
                            active_physics.end(),
                            physics_id) != active_physics.end()),
                 ExcInternalError());
-    block_physics_average_solutions[physics_id] = solution_vector;
+    block_physics_time_average_solutions[physics_id] = solution_vector;
   }
 
   /**
@@ -845,11 +845,11 @@ private:
 
   // average solution
   std::map<PhysicsID, TrilinosWrappers::MPI::Vector *>
-    physics_average_solutions;
+    physics_time_average_solutions;
 
   // average solution
   std::map<PhysicsID, TrilinosWrappers::MPI::BlockVector *>
-    block_physics_average_solutions;
+    block_physics_time_average_solutions;
 
   // reynolds stress solution. This is WIP and is not yet implemented in the
   // solver.

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -494,6 +494,36 @@ public:
   }
 
   /**
+   * @brief Request the average solution of a given physics
+   *
+   * @param physics_id The physics of the solution being requested
+   */
+  TrilinosWrappers::MPI::Vector *
+  get_average_solution(PhysicsID physics_id)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    return physics_average_solutions[physics_id];
+  }
+
+  /**
+   * @brief Request the reynolds_stress solution of a given physics
+   *
+   * @param physics_id The physics of the solution being requested
+   */
+  TrilinosWrappers::MPI::Vector *
+  get_reynolds_stress_solution(PhysicsID physics_id)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    return reynolds_stress_solutions;
+  }
+
+  /**
    * @brief Request the present solution of the filtered phase fraction gradient (PFG)
    */
   TrilinosWrappers::MPI::Vector *
@@ -598,6 +628,44 @@ public:
                 ExcInternalError());
     physics_solutions[physics_id] = solution_vector;
   }
+
+  /**
+   * @brief Sets the reference to the average solution of the physics in the multiphysics interface
+   *
+   * @param physics_id The physics of the DOF handler being requested
+   *
+   * @param solution_vector The reference to the solution vector of the physics
+   */
+  void
+  set_average_solution(PhysicsID                      physics_id,
+               TrilinosWrappers::MPI::Vector *solution_vector)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    physics_average_solutions[physics_id] = solution_vector;
+  }
+
+  /**
+   * @brief Sets the reference to the Reynolds stress of the physics in the multiphysics interface
+   *
+   * @param physics_id The physics of the DOF handler being requested
+   *
+   * @param solution_vector The reference to the solution vector of the physics
+   */
+  void
+  set_reynolds_stress_solutions(PhysicsID                      physics_id,
+                       TrilinosWrappers::MPI::Vector *solution_vector)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    physics_average_solutions[physics_id] = solution_vector;
+  }
+
+
 
   /**
    * @brief Sets the reference to the solution of the physics in the multiphysics interface
@@ -736,6 +804,13 @@ private:
 
   // present solution
   std::map<PhysicsID, TrilinosWrappers::MPI::Vector *> physics_solutions;
+
+  // average solution
+  std::map<PhysicsID, TrilinosWrappers::MPI::Vector *> physics_average_solutions;
+
+  // reynolds stress solution
+  TrilinosWrappers::MPI::Vector * reynolds_stress_solutions;
+
   std::map<PhysicsID, TrilinosWrappers::MPI::BlockVector *>
     block_physics_solutions;
 

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -525,7 +525,8 @@ public:
 
 
   /**
-   * @brief Request the reynolds_stress solution of a given physics. This is WIP and is not yet implemented in the solver.
+   * @brief Request the reynolds_stress solution of a given physics.
+   * WIP for an upcoming PR, not yet implemented in the solver.
    *
    * @param physics_id The physics of the solution being requested
    */
@@ -666,7 +667,7 @@ public:
 
   /**
    * @brief Sets the reference to the Reynolds stress of the physics in the multiphysics interface.
-   * This is WIP and is not yet implemented in the solver.
+   * WIP for an upcoming PR, not yet implemented in the solver.
    *
    * @param physics_id The physics of the DOF handler being requested
    *

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -638,7 +638,7 @@ public:
    */
   void
   set_average_solution(PhysicsID                      physics_id,
-               TrilinosWrappers::MPI::Vector *solution_vector)
+                      TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -663,23 +663,6 @@ public:
     physics_average_solutions[physics_id] = solution_vector;
   }
 
-  /**
-   * @brief Sets the reference to the average solution of the physics in the multiphysics interface
-   *
-   * @param physics_id The physics of the DOF handler being requested
-   *
-   * @param solution_vector The reference to the solution vector of the physics
-   */
-  void
-  set_average_block_solution(PhysicsID                      physics_id,
-                             TrilinosWrappers::MPI::Vector *solution_vector)
-  {
-    AssertThrow((std::find(active_physics.begin(),
-                           active_physics.end(),
-                           physics_id) != active_physics.end()),
-                ExcInternalError());
-    physics_average_solutions[physics_id] = solution_vector;
-  }
 
   /**
    * @brief Sets the reference to the Reynolds stress of the physics in the multiphysics interface.

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -655,7 +655,7 @@ public:
    */
   void
   set_time_average_solution(PhysicsID                      physics_id,
-                       TrilinosWrappers::MPI::Vector *solution_vector)
+                            TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -509,7 +509,23 @@ public:
   }
 
   /**
-   * @brief Request the reynolds_stress solution of a given physics
+   * @brief Request the present block average solution of a given physics
+   *
+   * @param physics_id The physics of the solution being requested
+   */
+  TrilinosWrappers::MPI::BlockVector *
+  get_block_average_solution(PhysicsID physics_id)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    return block_physics_average_solutions[physics_id];
+  }
+
+
+  /**
+   * @brief Request the reynolds_stress solution of a given physics. This is WIP and is not yet implemented in the solver.
    *
    * @param physics_id The physics of the solution being requested
    */
@@ -638,7 +654,7 @@ public:
    */
   void
   set_average_solution(PhysicsID                      physics_id,
-                      TrilinosWrappers::MPI::Vector *solution_vector)
+                       TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -648,7 +664,26 @@ public:
   }
 
   /**
-   * @brief Sets the reference to the Reynolds stress of the physics in the multiphysics interface
+   * @brief Sets the reference to the average solution of the physics in the multiphysics interface
+   *
+   * @param physics_id The physics of the DOF handler being requested
+   *
+   * @param solution_vector The reference to the solution vector of the physics
+   */
+  void
+  set_average_block_solution(PhysicsID                      physics_id,
+                             TrilinosWrappers::MPI::Vector *solution_vector)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    physics_average_solutions[physics_id] = solution_vector;
+  }
+
+  /**
+   * @brief Sets the reference to the Reynolds stress of the physics in the multiphysics interface.
+   * This is WIP and is not yet implemented in the solver.
    *
    * @param physics_id The physics of the DOF handler being requested
    *
@@ -656,7 +691,7 @@ public:
    */
   void
   set_reynolds_stress_solutions(PhysicsID                      physics_id,
-                       TrilinosWrappers::MPI::Vector *solution_vector)
+                                TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -683,6 +718,25 @@ public:
                            physics_id) != active_physics.end()),
                 ExcInternalError());
     block_physics_solutions[physics_id] = solution_vector;
+  }
+
+  /**
+   * @brief Sets the reference to the average solution of the physics in the multiphysics interface
+   *
+   * @param physics_id The physics of the DOF handler being requested
+   *
+   * @param solution_vector The reference to the solution vector of the physics
+   */
+  void
+  set_block_average_solution(
+    PhysicsID                           physics_id,
+    TrilinosWrappers::MPI::BlockVector *solution_vector)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    block_physics_average_solutions[physics_id] = solution_vector;
   }
 
   /**
@@ -806,10 +860,16 @@ private:
   std::map<PhysicsID, TrilinosWrappers::MPI::Vector *> physics_solutions;
 
   // average solution
-  std::map<PhysicsID, TrilinosWrappers::MPI::Vector *> physics_average_solutions;
+  std::map<PhysicsID, TrilinosWrappers::MPI::Vector *>
+    physics_average_solutions;
 
-  // reynolds stress solution
-  TrilinosWrappers::MPI::Vector * reynolds_stress_solutions;
+  // average solution
+  std::map<PhysicsID, TrilinosWrappers::MPI::BlockVector *>
+    block_physics_average_solutions;
+
+  // reynolds stress solution. This is WIP and is not yet implemented in the
+  // solver.
+  TrilinosWrappers::MPI::Vector *reynolds_stress_solutions;
 
   std::map<PhysicsID, TrilinosWrappers::MPI::BlockVector *>
     block_physics_solutions;

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -494,12 +494,12 @@ public:
   }
 
   /**
-   * @brief Request the average solution of a given physics
+   * @brief Request the time-average solution of a given physics
    *
    * @param physics_id The physics of the solution being requested
    */
   TrilinosWrappers::MPI::Vector *
-  get_average_solution(PhysicsID physics_id)
+  get_time_average_solution(PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -514,7 +514,7 @@ public:
    * @param physics_id The physics of the solution being requested
    */
   TrilinosWrappers::MPI::BlockVector *
-  get_block_average_solution(PhysicsID physics_id)
+  get_block_time_average_solution(PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -655,7 +655,7 @@ public:
    */
   void
   set_time_average_solution(PhysicsID                      physics_id,
-                            TrilinosWrappers::MPI::Vector *solution_vector)
+                       TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -257,6 +257,12 @@ protected:
   virtual void
   setup_dofs_fd() = 0;
 
+  /**
+   * @brief  Update the average velocity field solution
+   */
+  virtual void
+  update_multiphysics_average_solution() = 0;
+
   virtual void
   set_initial_condition_fd(
     Parameters::InitialConditionType initial_condition_type,

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -258,10 +258,10 @@ protected:
   setup_dofs_fd() = 0;
 
   /**
-   * @brief  Update the average velocity field solution
+   * @brief  Update the time average velocity field solution
    */
   virtual void
-  update_multiphysics_average_solution() = 0;
+  update_multiphysics_time_average_solution() = 0;
 
   virtual void
   set_initial_condition_fd(

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -97,12 +97,6 @@ public:
   {
     return get_av = average_velocities;
   }
-  VectorType *
-  get_average_velocities_pointer()
-  {
-    get_av = average_velocities;
-    return &get_av;
-  }
 
   /**
    * @brief get_reynolds_normal_stresses. Gives the time-averaged Reynolds

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -92,18 +92,17 @@ public:
    * @brief get_average_velocities. Gives the average of solutions with ghost
    * cells.
    */
-  const VectorType &
+  VectorType &
   get_average_velocities()
   {
-    get_av = average_velocities;
-    return get_av;
+    return get_av = average_velocities;
   }
-  /*VectorType *
+  VectorType *
   get_average_velocities_pointer()
   {
     get_av = average_velocities;
     return &get_av;
-  }*/
+  }
 
   /**
    * @brief get_reynolds_normal_stresses. Gives the time-averaged Reynolds

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -111,7 +111,7 @@ public:
   const VectorType &
   get_reynolds_normal_stresses()
   {
-    return get_rns =reynolds_normal_stresses;
+    return get_rns = reynolds_normal_stresses;
   }
 
   /**
@@ -121,7 +121,7 @@ public:
   const VectorType &
   get_reynolds_shear_stresses()
   {
-    return get_rss =reynolds_shear_stresses;
+    return get_rss = reynolds_shear_stresses;
   }
 
   /**
@@ -217,8 +217,6 @@ private:
   double       total_time_for_average;
   bool         average_calculation;
   unsigned int n_dofs_per_vertex;
-
-
 };
 
 #endif

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -74,6 +74,10 @@ public:
     const double &                    current_time,
     const double &                    time_step);
 
+
+  void
+  update_average_velocities();
+
   /**
    * @brief calculate_reynolds_stress. This function calculates normal and
    * other resolved time-averaged Reynold stresses (<u'u'>, <v'v'>, <w'w'>
@@ -91,8 +95,15 @@ public:
   const VectorType &
   get_average_velocities()
   {
-    return  average_velocities;
+    get_av = average_velocities;
+    return get_av;
   }
+  /*VectorType *
+  get_average_velocities_pointer()
+  {
+    get_av = average_velocities;
+    return &get_av;
+  }*/
 
   /**
    * @brief get_reynolds_normal_stresses. Gives the time-averaged Reynolds
@@ -101,7 +112,7 @@ public:
   const VectorType &
   get_reynolds_normal_stresses()
   {
-    return reynolds_normal_stresses;
+    return get_rns =reynolds_normal_stresses;
   }
 
   /**
@@ -111,7 +122,7 @@ public:
   const VectorType &
   get_reynolds_shear_stresses()
   {
-    return reynolds_shear_stresses;
+    return get_rss =reynolds_shear_stresses;
   }
 
   /**
@@ -179,7 +190,6 @@ private:
   VectorType sum_velocity_dt;
   VectorType average_velocities;
   VectorType get_av;
-  VectorType get_average;
 
   VectorType reynolds_normal_stress_dt;
   VectorType sum_reynolds_normal_stress_dt;
@@ -194,7 +204,6 @@ private:
   VectorType sum_velocity_dt_with_ghost_cells;
   VectorType sum_rns_dt_with_ghost_cells;
   VectorType sum_rss_dt_with_ghost_cells;
-  VectorType average_velocities_with_ghost_cells;
 
   // Solution transfer for the three permanent velocity storage
   parallel::distributed::SolutionTransfer<dim, VectorType>
@@ -203,13 +212,14 @@ private:
     solution_transfer_sum_reynolds_normal_stress_dt;
   parallel::distributed::SolutionTransfer<dim, VectorType>
     solution_transfer_sum_reynolds_shear_stress_dt;
-  parallel::distributed::SolutionTransfer<dim, VectorType>
-    solution_transfer_average_velocity;
 
   double       dt;
   double       real_initial_time;
+  double       total_time_for_average;
   bool         average_calculation;
   unsigned int n_dofs_per_vertex;
+
+
 };
 
 #endif

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -91,7 +91,7 @@ public:
   const VectorType &
   get_average_velocities()
   {
-    return get_av = average_velocities;
+    return  average_velocities;
   }
 
   /**
@@ -101,7 +101,7 @@ public:
   const VectorType &
   get_reynolds_normal_stresses()
   {
-    return get_rns = reynolds_normal_stresses;
+    return reynolds_normal_stresses;
   }
 
   /**
@@ -111,7 +111,7 @@ public:
   const VectorType &
   get_reynolds_shear_stresses()
   {
-    return get_rss = reynolds_shear_stresses;
+    return reynolds_shear_stresses;
   }
 
   /**
@@ -179,6 +179,7 @@ private:
   VectorType sum_velocity_dt;
   VectorType average_velocities;
   VectorType get_av;
+  VectorType get_average;
 
   VectorType reynolds_normal_stress_dt;
   VectorType sum_reynolds_normal_stress_dt;
@@ -193,6 +194,7 @@ private:
   VectorType sum_velocity_dt_with_ghost_cells;
   VectorType sum_rns_dt_with_ghost_cells;
   VectorType sum_rss_dt_with_ghost_cells;
+  VectorType average_velocities_with_ghost_cells;
 
   // Solution transfer for the three permanent velocity storage
   parallel::distributed::SolutionTransfer<dim, VectorType>
@@ -201,6 +203,8 @@ private:
     solution_transfer_sum_reynolds_normal_stress_dt;
   parallel::distributed::SolutionTransfer<dim, VectorType>
     solution_transfer_sum_reynolds_shear_stress_dt;
+  parallel::distributed::SolutionTransfer<dim, VectorType>
+    solution_transfer_average_velocity;
 
   double       dt;
   double       real_initial_time;

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -67,10 +67,11 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
                       Patterns::Bool(),
                       "VOF calculation <true|false>");
 
-    prm.declare_entry("use average velocity field",
-                      "false",
-                      Patterns::Bool(),
-                      "Use the average velocity field instead of the present velocity field <true|false>");
+    prm.declare_entry(
+      "use average velocity field",
+      "false",
+      Patterns::Bool(),
+      "Use the average velocity field instead of the present velocity field <true|false>");
 
     // subparameters for heat_transfer
     prm.declare_entry("viscous dissipation",
@@ -93,11 +94,11 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
 {
   prm.enter_subsection("multiphysics");
   {
-    fluid_dynamics = prm.get_bool("fluid dynamics");
-    heat_transfer  = prm.get_bool("heat transfer");
-    tracer         = prm.get_bool("tracer");
-    VOF            = prm.get_bool("VOF");
-    use_average_velocity_field=prm.get_bool("use average velocity field");
+    fluid_dynamics             = prm.get_bool("fluid dynamics");
+    heat_transfer              = prm.get_bool("heat transfer");
+    tracer                     = prm.get_bool("tracer");
+    VOF                        = prm.get_bool("VOF");
+    use_average_velocity_field = prm.get_bool("use average velocity field");
 
     // subparameter for heat_transfer
     viscous_dissipation = prm.get_bool("viscous dissipation");

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -99,7 +99,7 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
     tracer         = prm.get_bool("tracer");
     VOF            = prm.get_bool("VOF");
     use_time_average_velocity_field =
-      prm.get_bool("use the average velocity field");
+      prm.get_bool("use time average velocity field");
 
     // subparameter for heat_transfer
     viscous_dissipation = prm.get_bool("viscous dissipation");

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -71,7 +71,7 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
       "use average velocity field",
       "false",
       Patterns::Bool(),
-      "Use the average velocity field instead of the present velocity field <true|false>");
+      "Use the average velocity field in subphysics, instead of the present velocity field <true|false>");
 
     // subparameters for heat_transfer
     prm.declare_entry("viscous dissipation",

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -68,7 +68,7 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
                       "VOF calculation <true|false>");
 
     prm.declare_entry(
-      "use average velocity field",
+      "use time average velocity field",
       "false",
       Patterns::Bool(),
       "Use the average velocity field in subphysics, instead of the present velocity field <true|false>");
@@ -94,11 +94,12 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
 {
   prm.enter_subsection("multiphysics");
   {
-    fluid_dynamics             = prm.get_bool("fluid dynamics");
-    heat_transfer              = prm.get_bool("heat transfer");
-    tracer                     = prm.get_bool("tracer");
-    VOF                        = prm.get_bool("VOF");
-    use_average_velocity_field = prm.get_bool("use average velocity field");
+    fluid_dynamics = prm.get_bool("fluid dynamics");
+    heat_transfer  = prm.get_bool("heat transfer");
+    tracer         = prm.get_bool("tracer");
+    VOF            = prm.get_bool("VOF");
+    use_time_average_velocity_field =
+      prm.get_bool("use the average velocity field");
 
     // subparameter for heat_transfer
     viscous_dissipation = prm.get_bool("viscous dissipation");

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -67,6 +67,11 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
                       Patterns::Bool(),
                       "VOF calculation <true|false>");
 
+    prm.declare_entry("use average velocity field",
+                      "false",
+                      Patterns::Bool(),
+                      "Use the average velocity field instead of the present velocity field <true|false>");
+
     // subparameters for heat_transfer
     prm.declare_entry("viscous dissipation",
                       "false",
@@ -92,6 +97,7 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
     heat_transfer  = prm.get_bool("heat transfer");
     tracer         = prm.get_bool("tracer");
     VOF            = prm.get_bool("VOF");
+    use_average_velocity_field=prm.get_bool("use average velocity field");
 
     // subparameter for heat_transfer
     viscous_dissipation = prm.get_bool("viscous dissipation");

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -136,7 +136,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::update_multiphysics_average_solution()
+GDNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 {
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {
@@ -1202,7 +1202,7 @@ GDNavierStokesSolver<dim>::solve()
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);
-  this->update_multiphysics_average_solution();
+  this->update_multiphysics_time_average_solution();
 
   while (this->simulation_control->integrate())
     {

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -136,6 +136,18 @@ GDNavierStokesSolver<dim>::setup_assemblers()
 
 template <int dim>
 void
+GDNavierStokesSolver<dim>::update_multiphysics_average_solution()
+{
+  if (this->simulation_parameters.post_processing.calculate_average_velocities)
+    {
+      this->multiphysics->set_block_average_solution(
+        PhysicsID::fluid_dynamics,
+        &this->average_velocities->get_average_velocities());
+    }
+}
+
+template <int dim>
+void
 GDNavierStokesSolver<dim>::assemble_system_matrix()
 {
   TimerOutput::Scope t(this->computing_timer, "Assemble matrix");
@@ -1190,6 +1202,7 @@ GDNavierStokesSolver<dim>::solve()
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);
+  this->update_multiphysics_average_solution();
 
   while (this->simulation_control->integrate())
     {

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -140,7 +140,7 @@ GDNavierStokesSolver<dim>::update_multiphysics_average_solution()
 {
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {
-      this->multiphysics->set_block_average_solution(
+      this->multiphysics->set_block_time_average_solution(
         PhysicsID::fluid_dynamics,
         &this->average_velocities->get_average_velocities());
     }

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -175,11 +175,10 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                                    &this->present_solution);
   if(this->simulation_parameters.post_processing.calculate_average_velocities){
       this->average_velocities->update_average_velocities();
-      auto average_velocity =const_cast<TrilinosWrappers::MPI::Vector *>(
-                                &this->average_velocities->get_average_velocities());
+      TrilinosWrappers::MPI::Vector * average_velocity=this->average_velocities->get_average_velocities_pointer();
       this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
                                                                          average_velocity);
-      this->pcout<<"velocity "<< average_velocity->max() <<std::endl;
+
     }
 
 }

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -173,13 +173,8 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                                       &this->dof_handler);
   this->multiphysics->set_solution(PhysicsID::fluid_dynamics,
                                    &this->present_solution);
-  if(this->simulation_parameters.post_processing.calculate_average_velocities){
-      this->average_velocities->update_average_velocities();
-      TrilinosWrappers::MPI::Vector * average_velocity=this->average_velocities->get_average_velocities_pointer();
-      this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
-                                                                         average_velocity);
 
-    }
+
 
 }
 
@@ -1590,12 +1585,26 @@ GLSNavierStokesSolver<dim>::solve()
 
       if (this->simulation_control->is_at_start())
         {
+          if(this->simulation_parameters.post_processing.calculate_average_velocities){
+              this->average_velocities->update_average_velocities();
+              //TrilinosWrappers::MPI::Vector* average_velocity=;
+              this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
+                                                       &this->average_velocities->get_average_velocities());
+
+            }
           this->iterate();
         }
       else
         {
           NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
             refine_mesh();
+          if(this->simulation_parameters.post_processing.calculate_average_velocities){
+              this->average_velocities->update_average_velocities();
+              //TrilinosWrappers::MPI::Vector* average_velocity=;
+              this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
+                                                       &this->average_velocities->get_average_velocities());
+
+            }
           this->iterate();
         }
       this->postprocess(false);

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -176,7 +176,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
 }
 template <int dim>
 void
-GLSNavierStokesSolver<dim>::update_multiphysics_average_solution()
+GLSNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 {
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {
@@ -1570,7 +1570,7 @@ GLSNavierStokesSolver<dim>::solve()
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);
-  this->update_multiphysics_average_solution();
+  this->update_multiphysics_time_average_solution();
 
   while (this->simulation_control->integrate())
     {

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -173,6 +173,12 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
                                       &this->dof_handler);
   this->multiphysics->set_solution(PhysicsID::fluid_dynamics,
                                    &this->present_solution);
+  if(this->simulation_parameters.post_processing.calculate_average_velocities){
+      this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
+        const_cast<TrilinosWrappers::MPI::Vector *>(
+          &this->average_velocities->get_average_velocities()));
+    }
+
 }
 
 template <int dim>

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1586,7 +1586,6 @@ GLSNavierStokesSolver<dim>::solve()
       if (this->simulation_control->is_at_start())
         {
           if(this->simulation_parameters.post_processing.calculate_average_velocities){
-              this->average_velocities->update_average_velocities();
               //TrilinosWrappers::MPI::Vector* average_velocity=;
               this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
                                                        &this->average_velocities->get_average_velocities());
@@ -1599,7 +1598,6 @@ GLSNavierStokesSolver<dim>::solve()
           NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
             refine_mesh();
           if(this->simulation_parameters.post_processing.calculate_average_velocities){
-              this->average_velocities->update_average_velocities();
               //TrilinosWrappers::MPI::Vector* average_velocity=;
               this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
                                                        &this->average_velocities->get_average_velocities());

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -174,9 +174,12 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->multiphysics->set_solution(PhysicsID::fluid_dynamics,
                                    &this->present_solution);
   if(this->simulation_parameters.post_processing.calculate_average_velocities){
+      this->average_velocities->update_average_velocities();
+      auto average_velocity =const_cast<TrilinosWrappers::MPI::Vector *>(
+                                &this->average_velocities->get_average_velocities());
       this->multiphysics->set_average_solution(PhysicsID::fluid_dynamics,
-        const_cast<TrilinosWrappers::MPI::Vector *>(
-          &this->average_velocities->get_average_velocities()));
+                                                                         average_velocity);
+      this->pcout<<"velocity "<< average_velocity->max() <<std::endl;
     }
 
 }

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -180,7 +180,7 @@ GLSNavierStokesSolver<dim>::update_multiphysics_average_solution()
 {
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {
-      this->multiphysics->set_average_solution(
+      this->multiphysics->set_time_average_solution(
         PhysicsID::fluid_dynamics,
         &this->average_velocities->get_average_velocities());
     }

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -161,7 +161,8 @@ HeatTransfer<dim>::assemble_local_system_matrix(
 
   if (multiphysics->fluid_dynamics_is_block())
     {
-      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
+      if (this->simulation_parameters.multiphysics
+            .use_time_average_velocity_field)
         {
           scratch_data.reinit_velocity(
             velocity_cell,
@@ -177,7 +178,8 @@ HeatTransfer<dim>::assemble_local_system_matrix(
     }
   else
     {
-      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
+      if (this->simulation_parameters.multiphysics
+            .use_time_average_velocity_field)
         {
           scratch_data.reinit_velocity(velocity_cell,
                                        *multiphysics->get_average_solution(
@@ -302,7 +304,8 @@ HeatTransfer<dim>::assemble_local_system_rhs(
 
   if (multiphysics->fluid_dynamics_is_block())
     {
-      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
+      if (this->simulation_parameters.multiphysics
+            .use_time_average_velocity_field)
         {
           scratch_data.reinit_velocity(
             velocity_cell,
@@ -320,7 +323,8 @@ HeatTransfer<dim>::assemble_local_system_rhs(
     }
   else
     {
-      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
+      if (this->simulation_parameters.multiphysics
+            .use_time_average_velocity_field)
         {
           scratch_data.reinit_velocity(velocity_cell,
                                        *multiphysics->get_average_solution(

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -98,8 +98,6 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_system_matrix()
 {
-  this->pcout<<"velocity "<<this->multiphysics->get_average_solution(PhysicsID::fluid_dynamics)->max() <<std::endl;
-
   this->system_matrix = 0;
   setup_assemblers();
 
@@ -163,25 +161,34 @@ HeatTransfer<dim>::assemble_local_system_matrix(
 
   if (multiphysics->fluid_dynamics_is_block())
     {
-
-      scratch_data.reinit_velocity(velocity_cell,
-                                   *multiphysics->get_block_solution(
-                                     PhysicsID::fluid_dynamics));
+      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
+        {
+          scratch_data.reinit_velocity(
+            velocity_cell,
+            *multiphysics->get_block_average_solution(
+              PhysicsID::fluid_dynamics));
+        }
+      else
+        {
+          scratch_data.reinit_velocity(velocity_cell,
+                                       *multiphysics->get_block_solution(
+                                         PhysicsID::fluid_dynamics));
+        }
     }
   else
     {
-      if(this->simulation_parameters.multiphysics.use_average_velocity_field)
+      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
         {
           scratch_data.reinit_velocity(velocity_cell,
                                        *multiphysics->get_average_solution(
                                          PhysicsID::fluid_dynamics));
         }
-      else{
+      else
+        {
           scratch_data.reinit_velocity(velocity_cell,
                                        *multiphysics->get_solution(
                                          PhysicsID::fluid_dynamics));
         }
-
     }
 
   if (this->simulation_parameters.multiphysics.VOF)
@@ -295,22 +302,32 @@ HeatTransfer<dim>::assemble_local_system_rhs(
 
   if (multiphysics->fluid_dynamics_is_block())
     {
-      scratch_data.reinit_velocity(velocity_cell,
-                                   *multiphysics->get_block_solution(
-                                     PhysicsID::fluid_dynamics));
-
+      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
+        {
+          scratch_data.reinit_velocity(
+            velocity_cell,
+            *multiphysics->get_block_average_solution(
+              PhysicsID::fluid_dynamics));
+        }
+      else
+        {
+          scratch_data.reinit_velocity(velocity_cell,
+                                       *multiphysics->get_block_solution(
+                                         PhysicsID::fluid_dynamics));
+        }
       scratch_data.reinit_velocity_gradient(
         *multiphysics->get_block_solution(PhysicsID::fluid_dynamics));
     }
   else
     {
-      if(this->simulation_parameters.multiphysics.use_average_velocity_field)
+      if (this->simulation_parameters.multiphysics.use_average_velocity_field)
         {
           scratch_data.reinit_velocity(velocity_cell,
                                        *multiphysics->get_average_solution(
                                          PhysicsID::fluid_dynamics));
         }
-      else{
+      else
+        {
           scratch_data.reinit_velocity(velocity_cell,
                                        *multiphysics->get_solution(
                                          PhysicsID::fluid_dynamics));

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -98,6 +98,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_system_matrix()
 {
+  this->pcout<<"velocity "<<this->multiphysics->get_average_solution(PhysicsID::fluid_dynamics)->max() <<std::endl;
+
   this->system_matrix = 0;
   setup_assemblers();
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -161,14 +161,25 @@ HeatTransfer<dim>::assemble_local_system_matrix(
 
   if (multiphysics->fluid_dynamics_is_block())
     {
+
       scratch_data.reinit_velocity(velocity_cell,
                                    *multiphysics->get_block_solution(
                                      PhysicsID::fluid_dynamics));
     }
   else
     {
-      scratch_data.reinit_velocity(
-        velocity_cell, *multiphysics->get_solution(PhysicsID::fluid_dynamics));
+      if(this->simulation_parameters.multiphysics.use_average_velocity_field)
+        {
+          scratch_data.reinit_velocity(velocity_cell,
+                                       *multiphysics->get_average_solution(
+                                         PhysicsID::fluid_dynamics));
+        }
+      else{
+          scratch_data.reinit_velocity(velocity_cell,
+                                       *multiphysics->get_solution(
+                                         PhysicsID::fluid_dynamics));
+        }
+
     }
 
   if (this->simulation_parameters.multiphysics.VOF)

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -166,7 +166,7 @@ HeatTransfer<dim>::assemble_local_system_matrix(
         {
           scratch_data.reinit_velocity(
             velocity_cell,
-            *multiphysics->get_block_average_solution(
+            *multiphysics->get_block_time_average_solution(
               PhysicsID::fluid_dynamics));
         }
       else
@@ -182,7 +182,7 @@ HeatTransfer<dim>::assemble_local_system_matrix(
             .use_time_average_velocity_field)
         {
           scratch_data.reinit_velocity(velocity_cell,
-                                       *multiphysics->get_average_solution(
+                                       *multiphysics->get_time_average_solution(
                                          PhysicsID::fluid_dynamics));
         }
       else
@@ -309,7 +309,7 @@ HeatTransfer<dim>::assemble_local_system_rhs(
         {
           scratch_data.reinit_velocity(
             velocity_cell,
-            *multiphysics->get_block_average_solution(
+            *multiphysics->get_block_time_average_solution(
               PhysicsID::fluid_dynamics));
         }
       else
@@ -327,7 +327,7 @@ HeatTransfer<dim>::assemble_local_system_rhs(
             .use_time_average_velocity_field)
         {
           scratch_data.reinit_velocity(velocity_cell,
-                                       *multiphysics->get_average_solution(
+                                       *multiphysics->get_time_average_solution(
                                          PhysicsID::fluid_dynamics));
         }
       else

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -302,8 +302,17 @@ HeatTransfer<dim>::assemble_local_system_rhs(
     }
   else
     {
-      scratch_data.reinit_velocity(
-        velocity_cell, *multiphysics->get_solution(PhysicsID::fluid_dynamics));
+      if(this->simulation_parameters.multiphysics.use_average_velocity_field)
+        {
+          scratch_data.reinit_velocity(velocity_cell,
+                                       *multiphysics->get_average_solution(
+                                         PhysicsID::fluid_dynamics));
+        }
+      else{
+          scratch_data.reinit_velocity(velocity_cell,
+                                       *multiphysics->get_solution(
+                                         PhysicsID::fluid_dynamics));
+        }
 
       scratch_data.reinit_velocity_gradient(
         *multiphysics->get_solution(PhysicsID::fluid_dynamics));

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -980,6 +980,8 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   multiphysics->post_mesh_adaptation();
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     average_velocities->post_mesh_adaptation();
+
+  this->update_multiphysics_average_solution();
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -1043,6 +1045,10 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
     }
 
   multiphysics->post_mesh_adaptation();
+  if (this->simulation_parameters.post_processing.calculate_average_velocities)
+    average_velocities->post_mesh_adaptation();
+
+  this->update_multiphysics_average_solution();
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -981,7 +981,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     average_velocities->post_mesh_adaptation();
 
-  this->update_multiphysics_average_solution();
+  this->update_multiphysics_time_average_solution();
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -1048,7 +1048,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     average_velocities->post_mesh_adaptation();
 
-  this->update_multiphysics_average_solution();
+  this->update_multiphysics_time_average_solution();
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -40,8 +40,8 @@ AverageVelocities<dim, VectorType, DofsType>::calculate_average_velocities(
   // Get the inverse of the total time with the first time step since
   // the weighted velocities are calculated with the first velocity when
   // total time = 0.
-  total_time_for_average=(current_time - real_initial_time) + dt_0;
-  inv_range_time = 1. / total_time_for_average;
+  total_time_for_average = (current_time - real_initial_time) + dt_0;
+  inv_range_time         = 1. / total_time_for_average;
 
   // Calculate the average velocities.
   average_velocities.equ(inv_range_time, sum_velocity_dt);
@@ -54,11 +54,10 @@ template <int dim, typename VectorType, typename DofsType>
 void
 AverageVelocities<dim, VectorType, DofsType>::update_average_velocities()
 {
-
   // Get the inverse of the total time with the first time step since
   // the weighted velocities are calculated with the first velocity when
   // total time = 0.
-  if(total_time_for_average>0)
+  if (total_time_for_average > 0)
     {
       inv_range_time = 1.0 / total_time_for_average;
 
@@ -68,7 +67,6 @@ AverageVelocities<dim, VectorType, DofsType>::update_average_velocities()
                                    sum_reynolds_normal_stress_dt);
       reynolds_shear_stresses.equ(inv_range_time, sum_reynolds_shear_stress_dt);
     }
-
 }
 
 // Since Trilinos vectors and block vectors data doesn't have the same
@@ -234,7 +232,6 @@ AverageVelocities<dim, VectorType, DofsType>::post_mesh_adaptation()
   sum_rss_dt_with_ghost_cells      = sum_reynolds_shear_stress_dt;
 
   update_average_velocities();
-
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -255,7 +252,6 @@ AverageVelocities<dim, VectorType, DofsType>::initialize_checkpoint_vectors(
   sum_rss_dt_with_ghost_cells.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,
                                      mpi_communicator);
-
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -37,9 +37,7 @@ AverageVelocities<dim, VectorType, DofsType>::calculate_average_velocities(
   velocity_dt.equ(dt, local_evaluation_point);
   sum_velocity_dt += velocity_dt;
 
-  // Get the inverse of the total time with the first time step since
-  // the weighted velocities are calculated with the first velocity when
-  // total time = 0.
+  // Get the inverse of the time since the beginning of the time averaging
   total_time_for_average = (current_time - real_initial_time) + dt_0;
   inv_range_time         = 1. / total_time_for_average;
 
@@ -54,9 +52,8 @@ template <int dim, typename VectorType, typename DofsType>
 void
 AverageVelocities<dim, VectorType, DofsType>::update_average_velocities()
 {
-  // Get the inverse of the total time with the first time step since
-  // the weighted velocities are calculated with the first velocity when
-  // total time = 0.
+  // Use the inverse of the time since the beginning of the time averaging to
+  // reevaluate the average velocity field and Reynolds stress.
   if (total_time_for_average > 0)
     {
       inv_range_time = 1.0 / total_time_for_average;

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -287,7 +287,7 @@ AverageVelocities<dim, VectorType, DofsType>::read(std::string prefix)
   sum_vectors.push_back(&sum_velocity_dt);
   sum_vectors.push_back(&sum_reynolds_normal_stress_dt);
   sum_vectors.push_back(&sum_reynolds_shear_stress_dt);
-  sum_vectors.push_back(&average_velocities);
+
 
   std::string   filename = prefix + ".averagevelocities";
   std::ifstream input(filename.c_str());


### PR DESCRIPTION
# Description of the problem

- Different physics need to be studied at different time scales. This PR allows the use of the average velocity field to study heat transfer.

# Description of the solution

- Allow the heat transfer solver to use the average solution.

# How Has This Been Tested?

- Using a transient case.

# Documentation

- added documentation related to the new parameter in the multiphysics to enable the use of the average velocity field.

# Future changes

-In a future update, we could use the Reynolds stress to adjust the diffusion coefficient.


