### PR TITLE
Split CI for debug, warnings and release

### DIFF
--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -1,0 +1,79 @@
+name: CI-Debug
+
+on:
+  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request_target:
+    paths-ignore:
+      - 'doc/**'
+
+env:
+  COMPILE_JOBS: 2
+  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+
+jobs:
+  build:
+    name: Build (deal.ii:${{ matrix.dealii_version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dealii_version: ["master", "v9.4.0"]
+    
+    # Run steps in container of dealii's master branch
+    container:
+      image: dealii/dealii:${{ matrix.dealii_version }}-focal
+      options: --user root
+
+    steps:
+      - name: Setup
+        run: |
+          # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nodejs
+
+
+
+          echo "Github actions is sane!"
+          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+
+      # Checks-out Lethe with branch of triggering commit
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      #
+      # Debug
+      #
+      - name: Compile Lethe (Debug-deal.ii:${{ matrix.dealii_version }})
+        run: |
+          mkdir build-debug
+          cd build-debug
+          cmake ../ -DCMAKE_BUILD_TYPE=Debug
+          make -j${{ env.COMPILE_JOBS }}
+
+      # These tests require a single core each so we will run them in parallel
+      - name: Run Lethe tests (Debug-deal.ii:${{ matrix.dealii_version }})
+        run: |
+          #Allow OMPI to run as root
+          export OMPI_ALLOW_RUN_AS_ROOT=1
+          export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+          cd build-debug
+          # Print the tests to be executed
+          ctest -N --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          # Run in parallel
+          ctest -V -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+
+      # These tests require two cores each so we will run them sequencially
+      - name: Run multi-core Lethe tests (Debug-deal.ii:${{ matrix.dealii_version }})
+        run: |
+          #Allow OMPI to run as root
+          export OMPI_ALLOW_RUN_AS_ROOT=1
+          export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+          cd build-debug
+          # Print the tests to be executed
+          ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          # Run sequencially
+          ctest -V --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-Release
 
 on:
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
@@ -73,50 +73,6 @@ jobs:
           export OMPI_ALLOW_RUN_AS_ROOT=1
           export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
           cd build-release
-          # Print the tests to be executed
-          ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
-          # Run sequencially
-          ctest -V --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
-
-      #
-      # Warnings
-      #
-      - name: Compile Lethe to check for warnings (deal.ii:${{ matrix.dealii_version }})
-        run: |
-          mkdir build-warnings
-          cd build-warnings
-          cmake ../ -DCMAKE_BUILD_TYPE=Debug -DWARNINGERROR=ON
-          make -j${{ env.COMPILE_JOBS }}
-
-      #
-      # Debug
-      #
-      - name: Compile Lethe (Debug-deal.ii:${{ matrix.dealii_version }})
-        run: |
-          mkdir build-debug
-          cd build-debug
-          cmake ../ -DCMAKE_BUILD_TYPE=Debug
-          make -j${{ env.COMPILE_JOBS }}
-
-      # These tests require a single core each so we will run them in parallel
-      - name: Run Lethe tests (Debug-deal.ii:${{ matrix.dealii_version }})
-        run: |
-          #Allow OMPI to run as root
-          export OMPI_ALLOW_RUN_AS_ROOT=1
-          export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-          cd build-debug
-          # Print the tests to be executed
-          ctest -N --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
-          # Run in parallel
-          ctest -V -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
-
-      # These tests require two cores each so we will run them sequencially
-      - name: Run multi-core Lethe tests (Debug-deal.ii:${{ matrix.dealii_version }})
-        run: |
-          #Allow OMPI to run as root
-          export OMPI_ALLOW_RUN_AS_ROOT=1
-          export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-          cd build-debug
           # Print the tests to be executed
           ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
           # Run sequencially

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -1,0 +1,55 @@
+name: CI-Warnings
+
+on:
+  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request_target:
+    paths-ignore:
+      - 'doc/**'
+
+env:
+  COMPILE_JOBS: 2
+  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+
+jobs:
+  build:
+    name: Build (deal.ii:${{ matrix.dealii_version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dealii_version: ["master", "v9.4.0"]
+    
+    # Run steps in container of dealii's master branch
+    container:
+      image: dealii/dealii:${{ matrix.dealii_version }}-focal
+      options: --user root
+
+    steps:
+      - name: Setup
+        run: |
+          # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nodejs
+
+
+
+          echo "Github actions is sane!"
+          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+
+      # Checks-out Lethe with branch of triggering commit
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      #
+      # Warnings
+      #
+      - name: Compile Lethe to check for warnings (deal.ii:${{ matrix.dealii_version }})
+        run: |
+          mkdir build-warnings
+          cd build-warnings
+          cmake ../ -DCMAKE_BUILD_TYPE=Debug -DWARNINGERROR=ON
+          make -j${{ env.COMPILE_JOBS }}


### PR DESCRIPTION
# Description of the problem

- The CI is taking a lot of time to run and this can be frustrating when the issues arise from the Debug version of a solver

# Description of the solution

- Split debug, release and warnings into three seperate instances.

