### PR TITLE
Fix issues with fluid velocity information CFD-DEM

### DIFF
--- a/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.output
+++ b/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.output
@@ -30,40 +30,40 @@ Transient iteration : 2        Time : 0.0002   Time step : 0.0001   CFL : 0.0050
 Starting DEM iterations at step 2
 Finished 10 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 9.24051567e-12 s^-1
-Max Local Mass Source: 3.473197175e-07 s^-1
+Mass Source: 9.093650237e-12 s^-1
+Max Local Mass Source: 3.4723439e-07 s^-1
 Average Void Fraction in Bed: 0.7836727597
-Total particles kinetic energy: 0.01476214928
+Total particles kinetic energy: 0.01476182728
 
 *****************************************************************
-Transient iteration : 3        Time : 0.0003   Time step : 0.0001   CFL : 0.004561905326
+Transient iteration : 3        Time : 0.0003   Time step : 0.0001   CFL : 0.004560886858
 *****************************************************************
 Starting DEM iterations at step 3
 Finished 10 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: -2.494651785e-12 s^-1
-Max Local Mass Source: 3.32405173e-07 s^-1
+Mass Source: -1.744851505e-12 s^-1
+Max Local Mass Source: 3.274128501e-07 s^-1
 Average Void Fraction in Bed: 0.7836727597
-Total particles kinetic energy: 0.02376255011
+Total particles kinetic energy: 0.02374629103
 
 *****************************************************************
-Transient iteration : 4        Time : 0.0004   Time step : 0.0001   CFL : 0.004395394971
+Transient iteration : 4        Time : 0.0004   Time step : 0.0001   CFL : 0.004371010744
 *****************************************************************
 Starting DEM iterations at step 4
 Finished 10 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.38709241e-14 s^-1
-Max Local Mass Source: 3.273444412e-07 s^-1
+Mass Source: 1.549508744e-13 s^-1
+Max Local Mass Source: 3.155847972e-07 s^-1
 Average Void Fraction in Bed: 0.7836727597
-Total particles kinetic energy: 0.02948227319
+Total particles kinetic energy: 0.02945115834
 
 *****************************************************************
-Transient iteration : 5        Time : 0.0005   Time step : 0.0001   CFL : 0.004278976108
+Transient iteration : 5        Time : 0.0005   Time step : 0.0001   CFL : 0.004227437742
 *****************************************************************
 Starting DEM iterations at step 5
 Finished 10 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 8.312197405e-14 s^-1
-Max Local Mass Source: 3.258128931e-07 s^-1
+Mass Source: -4.704273791e-11 s^-1
+Max Local Mass Source: 3.088571851e-07 s^-1
 Average Void Fraction in Bed: 0.7836727597
-Total particles kinetic energy: 0.03320148139
+Total particles kinetic energy: 0.03316668393


### PR DESCRIPTION
# Description of the problem

- The evaluation of the pressure gradient and other forces that use the FeValues evaluator in the CFD-DEM was wrongly done because the reference location of the partcles was not set correctly

# Description of the solution

-  Fixes this, as well as improves the documentation. This also closes #539. 

# How Has This Been Tested?

- All the regular tests did not change except the liquid one in which the mesh is not trivial and the pressure force plays a role. Even then the changes are minimal.

