### PR TITLE
Add invitation to cite deal.II when citing Lethe

### DIFF
--- a/doc/source/referencing.rst
+++ b/doc/source/referencing.rst
@@ -2,7 +2,7 @@
 Referencing Lethe
 ###################
 
- If you write a paper using results obtained with the help of Lethe, please cite the main Lethe reference as well as the reference that pertain to the features you used.
+If you write a paper using results obtained with the help of Lethe or use Lethe in your research, please cite the main Lethe reference as well as the reference that pertain to the features you used. Lethe relies heavily on deal.II and its active and vibrant community. When citing Lethe, please ensure that you also cite the `latest version deal.II <https://www.dealii.org/publications.html>`_.
 
 Main articles
 ---------------


### PR DESCRIPTION
# Description of the problem

- Our referencing Lethe section discusses how to cite Lethe, but it omits to encourage the citation of the deal.II library. Without deal.II this code does not exist, so it should be natural that every citation of Lethe comes with a citation of deal.II

# Description of the solution

- Added an invitation to cite deal.II as well as the motivation for it. Including a link to the "citing deal.II" page"

# Comments

- I think it's important to remain grateful to all these things we are inheriting from deal.II and using without even really thinking about it :). 
