### PR TITLE
Organize dem data structure

### DIFF
--- a/include/core/data_containers.h
+++ b/include/core/data_containers.h
@@ -16,6 +16,7 @@
  *
  */
 
+#include <dem/boundary_cells_info_struct.h>
 #include <dem/particle_particle_contact_info_struct.h>
 #include <dem/particle_point_line_contact_info_struct.h>
 #include <dem/particle_wall_contact_info_struct.h>
@@ -178,6 +179,10 @@ namespace dem_data_containers
 
     typedef std::map<unsigned int, std::map<types::boundary_id, Tensor<1, 3>>>
       vector_on_boundary;
+
+    typedef std::map<types::global_cell_index,
+                     periodic_boundaries_cells_info_struct<dim>>
+      periodic_boundaries_cells_info;
   };
 
 } // namespace dem_data_containers

--- a/include/core/data_containers.h
+++ b/include/core/data_containers.h
@@ -16,6 +16,10 @@
  *
  */
 
+#include <dem/particle_particle_contact_info_struct.h>
+#include <dem/particle_point_line_contact_info_struct.h>
+#include <dem/particle_wall_contact_info_struct.h>
+
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/distributed/tria.h>
@@ -88,6 +92,92 @@ namespace dem_data_containers
       return cell_1->global_active_cell_index() <
              cell_2->global_active_cell_index();
     }
+  };
+
+  template <int dim>
+  struct dem_data_structures
+  {
+    typedef std::unordered_map<types::particle_index,
+                               Particles::ParticleIterator<dim>>
+      particle_index_iterator_map;
+
+    typedef std::unordered_map<types::particle_index,
+                               particle_point_line_contact_info_struct<dim>>
+      particle_point_line_contact_info;
+
+    typedef std::unordered_map<
+      types::particle_index,
+      std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
+      particle_line_candidates;
+
+    typedef std::unordered_map<
+      types::particle_index,
+      std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
+      particle_point_candidates;
+
+    typedef std::unordered_map<
+      types::particle_index,
+      std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
+      particle_floating_wall_candidates;
+
+    typedef std::unordered_map<
+      types::particle_index,
+      std::unordered_map<types::boundary_id,
+                         std::tuple<Particles::ParticleIterator<dim>,
+                                    Tensor<1, dim>,
+                                    Point<dim>,
+                                    types::boundary_id,
+                                    types::global_cell_index>>>
+      particle_wall_candidates;
+
+    typedef std::unordered_map<
+      types::particle_index,
+      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
+      particle_wall_in_contact;
+
+    typedef std::unordered_map<
+      types::particle_index,
+      std::unordered_map<types::particle_index,
+                         particle_particle_contact_info_struct<dim>>>
+      adjacent_particle_pairs;
+
+    typedef std::vector<
+      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
+               std::unordered_map<types::particle_index,
+                                  Particles::ParticleIterator<dim>>,
+               cut_cell_comparison<dim>>>
+      particle_floating_mesh_candidates;
+
+    typedef std::vector<
+      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
+               std::unordered_map<types::particle_index,
+                                  particle_wall_contact_info_struct<dim>>,
+               cut_cell_comparison<dim>>>
+      particle_floating_mesh_in_contact;
+
+    typedef std::unordered_map<types::particle_index,
+                               std::vector<types::particle_index>>
+      particle_particle_candidates;
+
+    typedef std::vector<
+      std::vector<typename Triangulation<dim>::active_cell_iterator>>
+      cells_neighbor_list;
+
+    typedef std::vector<std::vector<
+      std::pair<typename Triangulation<dim>::active_cell_iterator,
+                typename Triangulation<dim - 1, dim>::active_cell_iterator>>>
+      floating_mesh_information;
+
+    typedef std::unordered_map<
+      types::global_cell_index,
+      std::vector<typename Triangulation<dim>::active_cell_iterator>>
+      cells_total_neighbor_list;
+
+    typedef std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
+      boundary_points_and_normal_vectors;
+
+    typedef std::map<unsigned int, std::map<types::boundary_id, Tensor<1, 3>>>
+      vector_on_boundary;
   };
 
 } // namespace dem_data_containers

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -35,7 +35,6 @@
 #include <dem/particle_particle_fine_search.h>
 #include <dem/particle_point_line_broad_search.h>
 #include <dem/particle_point_line_contact_force.h>
-#include <dem/particle_point_line_contact_info_struct.h>
 #include <dem/particle_point_line_fine_search.h>
 #include <dem/particle_wall_broad_search.h>
 #include <dem/particle_wall_contact_force.h>
@@ -58,6 +57,8 @@
 
 #ifndef Lethe_DEM_h
 #  define Lethe_DEM_h
+
+using namespace dem_data_containers;
 
 /**
  * The DEM class which initializes all the required parameters and iterates over
@@ -277,100 +278,51 @@ private:
   Tensor<1, 3>                         g;
   double                               triangulation_cell_diameter;
 
-  // Simulation control for time stepping and I/Os
-  std::shared_ptr<SimulationControl> simulation_control;
-
-  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    cells_local_neighbor_list;
-
-  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+  typename dem_data_structures<dim>::cells_total_neighbor_list
+    total_neighbor_list;
+  typename dem_data_structures<dim>::floating_mesh_information
+    floating_mesh_info;
+  typename dem_data_structures<dim>::cells_neighbor_list
     cells_ghost_neighbor_list;
-
-  std::unordered_map<
-    types::global_cell_index,
-    std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    cells_total_neighbor_list;
-
-  BoundaryCellsInformation<dim> boundary_cell_object;
-
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    local_contact_pair_candidates;
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    ghost_contact_pair_candidates;
-
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-    pfw_contact_candidates;
-
-  std::vector<std::vector<
-    std::pair<typename Triangulation<dim>::active_cell_iterator,
-              typename Triangulation<dim - 1, dim>::active_cell_iterator>>>
-    floating_mesh_information;
-
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
+  typename dem_data_structures<dim>::cells_neighbor_list
+    cells_local_neighbor_list;
+  typename dem_data_structures<dim>::particle_floating_mesh_candidates
+    particle_floating_mesh_candidates;
+  typename dem_data_structures<dim>::particle_floating_mesh_in_contact
     particle_floating_mesh_in_contact;
-
-  std::vector<std::map<
-    typename Triangulation<dim - 1, dim>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>,
-    dem_data_containers::cut_cell_comparison<dim>>>
-    particle_floating_mesh_contact_candidates;
-
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
+  typename dem_data_structures<dim>::particle_floating_wall_candidates
+    particle_floating_wall_candidates;
+  typename dem_data_structures<dim>::particle_wall_in_contact
+    particle_floating_wall_in_contact;
+  typename dem_data_structures<dim>::particle_wall_candidates
+    particle_wall_candidates;
+  typename dem_data_structures<dim>::particle_wall_in_contact
+    particle_wall_in_contact;
+  typename dem_data_structures<dim>::particle_point_candidates
+    particle_point_candidates;
+  typename dem_data_structures<dim>::particle_line_candidates
+    particle_line_candidates;
+  typename dem_data_structures<dim>::particle_point_line_contact_info
+    particle_points_in_contact;
+  typename dem_data_structures<dim>::particle_point_line_contact_info
+    particle_lines_in_contact;
+  typename dem_data_structures<dim>::particle_particle_candidates
+    ghost_contact_pair_candidates;
+  typename dem_data_structures<dim>::particle_particle_candidates
+    local_contact_pair_candidates;
+  typename dem_data_structures<dim>::adjacent_particle_pairs
     local_adjacent_particles;
-
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
+  typename dem_data_structures<dim>::adjacent_particle_pairs
     ghost_adjacent_particles;
-
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    particle_wall_pairs_in_contact;
-
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    pfw_pairs_in_contact;
-
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<dim>,
-                                  Tensor<1, dim>,
-                                  Point<dim>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
-    particle_wall_contact_candidates;
-
-  std::unordered_map<types::particle_index,
-                     std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
-    particle_point_contact_candidates;
-
-  std::unordered_map<
-    types::particle_index,
-    std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
-    particle_line_contact_candidates;
-
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    particle_points_in_contact, particle_lines_in_contact;
-
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
+  typename dem_data_structures<dim>::particle_index_iterator_map
     particle_container;
+  typename dem_data_structures<dim>::boundary_points_and_normal_vectors
+    updated_boundary_points_and_normal_vectors;
+  typename dem_data_structures<dim>::vector_on_boundary
+    forces_boundary_information;
+  typename dem_data_structures<dim>::vector_on_boundary
+    torques_boundary_information;
 
-  std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
-                                           updated_boundary_points_and_normal_vectors;
   DEM::DEMProperties<dim>                  properties_class;
   std::vector<std::pair<std::string, int>> properties =
     properties_class.get_properties_name();
@@ -380,6 +332,8 @@ private:
   const unsigned int insertion_frequency;
 
   // Initilization of classes and building objects
+  std::shared_ptr<SimulationControl> simulation_control;
+  BoundaryCellsInformation<dim>      boundary_cell_object;
   std::shared_ptr<GridMotion<dim>>   grid_motion_object;
   ParticleParticleBroadSearch<dim>   particle_particle_broad_search_object;
   ParticleParticleFineSearch<dim>    particle_particle_fine_search_object;
@@ -391,8 +345,6 @@ private:
   std::shared_ptr<Integrator<dim>>   integrator_object;
   std::shared_ptr<Insertion<dim>>    insertion_object;
   PeriodicBoundariesManipulator<dim> periodic_boundaries_object;
-
-
   std::shared_ptr<ParticleParticleContactForce<dim>>
     particle_particle_contact_force_object;
   std::shared_ptr<ParticleWallContactForce<dim>>
@@ -407,11 +359,6 @@ private:
   std::vector<Tensor<1, 3>> force;
   std::vector<double>       displacement;
   std::vector<double>       MOI;
-
-  std::map<unsigned int, std::map<types::boundary_id, Tensor<1, 3>>>
-    forces_boundary_information;
-  std::map<unsigned int, std::map<types::boundary_id, Tensor<1, 3>>>
-    torques_boundary_information;
 
   // Information for parallel grid processing
   DoFHandler<dim> background_dh;

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -212,7 +212,7 @@ private:
   find_boundary_cells_for_floating_walls(
     const parallel::distributed::Triangulation<dim> & triangulation,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-    const double &                                    maximum_cell_diameter);
+    const double                                      maximum_cell_diameter);
 
   /**
    * Carries out adding new elements with the boundary cells (cells with

--- a/include/dem/find_cell_neighbors.h
+++ b/include/dem/find_cell_neighbors.h
@@ -17,14 +17,11 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/data_containers.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/grid/grid_tools.h>
-
-#include <iostream>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
 
 
 using namespace dealii;
@@ -67,9 +64,9 @@ public:
   void
   find_cell_neighbors(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+    typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
       &cells_local_neighbor_list,
-    std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+    typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
       &cells_ghost_neighbor_list);
 
   /**
@@ -87,10 +84,8 @@ public:
   void
   find_full_cell_neighbors(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    std::unordered_map<
-      types::global_cell_index,
-      std::vector<typename Triangulation<dim>::active_cell_iterator>>
-      &cells_total_neighbor_list);
+    typename dem_data_containers::dem_data_structures<
+      dim>::cells_total_neighbor_list &cells_total_neighbor_list);
 };
 
 #endif /* find_cell_neighbors_h */

--- a/include/dem/find_contact_detection_step.h
+++ b/include/dem/find_contact_detection_step.h
@@ -48,10 +48,10 @@ using namespace dealii;
 template <int dim>
 bool
 find_contact_detection_step(Particles::ParticleHandler<dim> &particle_handler,
-                            const double &                   dt,
-                            const double &smallest_contact_search_criterion,
-                            MPI_Comm &    mpi_communicator,
-                            bool &        sorting_in_subdomains_step,
+                            const double                     dt,
+                            const double smallest_contact_search_criterion,
+                            MPI_Comm &   mpi_communicator,
+                            bool         sorting_in_subdomains_step,
                             std::vector<double> &displacement);
 
 #endif

--- a/include/dem/find_maximum_particle_size.h
+++ b/include/dem/find_maximum_particle_size.h
@@ -42,7 +42,7 @@
 double
 find_maximum_particle_size(
   const Parameters::Lagrangian::LagrangianPhysicalProperties
-    &           lagrangian_physical_properties,
-  const double &standard_deviation_multiplier);
+    &          lagrangian_physical_properties,
+  const double standard_deviation_multiplier);
 
 #endif

--- a/include/dem/find_maximum_particle_size.h
+++ b/include/dem/find_maximum_particle_size.h
@@ -32,7 +32,9 @@
  *
  * @param lagrangian_physical_properties DEM physical properties declared in the
  * .prm file
- * @param standard_deviation_multiplier Constant standard deviation multiplier. It is defined in the dem constructor and it is equal to 2.5 to cover 99% of the particle size distribution
+ * @param standard_deviation_multiplier Constant standard deviation multiplier.
+ * It is defined in the dem constructor and it is equal to 2.5 to cover 99% of
+ * the particle size distribution
  * @return Maximum particle size
  *
  */

--- a/include/dem/grid_motion.h
+++ b/include/dem/grid_motion.h
@@ -56,7 +56,7 @@ public:
    */
   GridMotion(
     const Parameters::Lagrangian::GridMotion<spacedim> &grid_motion_parameters,
-    const double &                                      dem_time_step);
+    const double                                        dem_time_step);
 
   /**
    * Calls the desired grid motion.

--- a/include/dem/input_parameter_inspection.h
+++ b/include/dem/input_parameter_inspection.h
@@ -41,6 +41,6 @@ template <int dim>
 void
 input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
                            const ConditionalOStream &      pcout,
-                           const double &standard_deviation_multiplier);
+                           const double standard_deviation_multiplier);
 
 #endif /* input_parameter_inspection_h */

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -152,9 +152,9 @@ private:
    */
   void
   particle_size_sampling(std::vector<double> &particle_sizes,
-                         const double &       average,
-                         const double &       standard_deviation,
-                         const double &       particle_number);
+                         const double         average,
+                         const double         standard_deviation,
+                         const double         particle_number);
 
   std::vector<double> particle_sizes;
 };

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -93,8 +93,8 @@ public:
     const parallel::distributed::Triangulation<dim> &triangulation,
     PVDHandler &                                     grid_pvdhandler,
     const DEMSolverParameters<dim> &                 dem_parameters,
-    const double &                                   time,
-    const unsigned int &                             step_number,
+    const double                                     time,
+    const unsigned int                               step_number,
     const MPI_Comm &                                 mpi_communicator);
 
   /**
@@ -112,8 +112,8 @@ public:
     const parallel::distributed::Triangulation<dim> &triangulation,
     PVDHandler &                                     grid_pvdhandler,
     const DEMSolverParameters<dim> &                 dem_parameters,
-    const double &                                   time,
-    const unsigned int &                             step_number,
+    const double                                     time,
+    const unsigned int                               step_number,
     const MPI_Comm &                                 mpi_communicator);
 
 

--- a/include/dem/localize_contacts.h
+++ b/include/dem/localize_contacts.h
@@ -22,8 +22,6 @@
 #include <dem/particle_particle_contact_info_struct.h>
 #include <dem/particle_wall_contact_info_struct.h>
 
-#include <unordered_map>
-
 using namespace std;
 
 #ifndef localize_contacts_h
@@ -56,51 +54,26 @@ using namespace std;
 template <int dim>
 void
 localize_contacts(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &pfw_pairs_in_contact,
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &particle_floating_mesh_in_contact,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &local_contact_pair_candidates,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &ghost_contact_pair_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<dim>,
-                                  Tensor<1, dim>,
-                                  Point<dim>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
-    &particle_wall_contact_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-    &pfw_contact_candidates,
-  std::vector<std::map<
-    typename Triangulation<dim - 1, dim>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>,
-    dem_data_containers::cut_cell_comparison<dim>>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &local_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &ghost_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_candidates &particle_wall_contact_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_wall_candidates &pfw_contact_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);
 
 #endif /* localize_contacts_h */

--- a/include/dem/localize_contacts.h
+++ b/include/dem/localize_contacts.h
@@ -41,12 +41,12 @@ using namespace std;
  * @param local_adjacent_particles Local-local adjacent particle pairs
  * @param ghost_adjacent_particles Local-ghost adjacent particle pairs
  * @param particle_wall_pairs_in_contact Particle-wall contact pairs
- * @param pfw_pairs_in_contact Particle-floating wall contact pairs
+ * @param particle_floating_wall_in_contact Particle-floating wall contact pairs
  * @param particle_floating_mesh_in_contact Particle-floating mesh contact pairs
  * @param local_contact_pair_candidates Local-local particle-particle contact candidates
  * @param ghost_contact_pair_candidates Local-ghost particle-particle contact candidates
  * @param particle_wall_contact_candidates Particle-wall contact candidates
- * @param pfw_contact_candidates Particle-floating wall contact candidates
+ * @param particle_floating_wall_contact_candidates Particle-floating wall contact candidates
  * @param particle_floating_mesh_contact_candidates Particle-floating mesh contact candidates
  *
  */
@@ -61,7 +61,7 @@ localize_contacts(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
+    dim>::particle_wall_in_contact &particle_floating_wall_in_contact,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
   typename dem_data_containers::dem_data_structures<
@@ -71,7 +71,8 @@ localize_contacts(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_wall_candidates &particle_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates &pfw_contact_candidates,
+    dim>::particle_floating_wall_candidates
+    &particle_floating_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);

--- a/include/dem/locate_local_particles.h
+++ b/include/dem/locate_local_particles.h
@@ -61,37 +61,21 @@ template <int dim>
 void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<dim> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::particle_index, particle_wall_contact_info_struct<dim>>>
-    &pfw_pairs_in_contact,
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &pfm_pairs_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_lines_in_contact);
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_lines_in_contact);
 
 #endif /* locate_local_particles_h */

--- a/include/dem/locate_local_particles.h
+++ b/include/dem/locate_local_particles.h
@@ -46,9 +46,9 @@ using namespace dealii;
  * information of adjacent local-local particles
  * @param particle_wall_pairs_in_contact Container that contains all the contact
  * information of particle-wall contacts
- * @param pfw_pairs_in_contact Container that contains all the contact
+ * @param particle_floating_wall_pairs_in_contact Container that contains all the contact
  * information of particle-floating wall contacts
- * @param pfm_pairs_in_contact Container that contains all the contact
+ * @param particle_floating_mesh_pairs_in_contact Container that contains all the contact
  * information of particle-floating mesh contacts
  * @param particle_points_in_contact Container that contains all the contact
  * information of particle-point contacts
@@ -70,9 +70,9 @@ locate_local_particles_in_cells(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+    dim>::particle_wall_in_contact &particle_floating_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<dim>::
+    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_point_line_contact_info &particle_points_in_contact,
   typename dem_data_containers::dem_data_structures<

--- a/include/dem/non_uniform_insertion.h
+++ b/include/dem/non_uniform_insertion.h
@@ -52,7 +52,7 @@ public:
    * defined in the parameter handler
    */
   NonUniformInsertion<dim>(const DEMSolverParameters<dim> &dem_parameters,
-                           const double &maximum_particle_diameter);
+                           const double maximum_particle_diameter);
 
   /**
    * Carries out the non-uniform insertion of particles.
@@ -81,8 +81,8 @@ private:
    */
   void
   create_random_number_container(std::vector<double> &random_container,
-                                 const double &       random_number_range,
-                                 const int &          random_number_seed);
+                                 const double         random_number_range,
+                                 const int            random_number_seed);
 
   /**
    * Converts id of particles to non-uniform insertion location
@@ -97,9 +97,9 @@ private:
   void
   find_insertion_location_nonuniform(
     Point<dim> &                                 insertion_location,
-    const unsigned int &                         id,
-    const double &                               random_number1,
-    const double &                               random_number2,
+    const unsigned int                           id,
+    const double                                 random_number1,
+    const double                                 random_number2,
     const Parameters::Lagrangian::InsertionInfo &insertion_information);
 
   unsigned int current_inserting_particle_type;

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -16,20 +16,16 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
+#include <core/data_containers.h>
+
 #include <dem/find_boundary_cells_information.h>
 #include <dem/particle_particle_contact_info_struct.h>
-
-#include <deal.II/base/timer.h>
 
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/particles/particle_iterator.h>
-
-#include <iostream>
-#include <unordered_map>
-#include <vector>
 
 using namespace dealii;
 
@@ -78,18 +74,14 @@ public:
   void
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    const std::vector<
-      std::vector<typename Triangulation<dim>::active_cell_iterator>>
-      *cells_local_neighbor_list,
-    const std::vector<
-      std::vector<typename Triangulation<dim>::active_cell_iterator>>
-      *cells_ghost_neighbor_list,
-    std::unordered_map<types::particle_index,
-                       std::vector<types::particle_index>>
-      &local_contact_pair_candidates,
-    std::unordered_map<types::particle_index,
-                       std::vector<types::particle_index>>
-      &ghost_contact_pair_candidates);
+    const typename dem_data_containers::dem_data_structures<
+      dim>::cells_neighbor_list *cells_local_neighbor_list,
+    const typename dem_data_containers::dem_data_structures<
+      dim>::cells_neighbor_list *cells_ghost_neighbor_list,
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_particle_candidates &local_contact_pair_candidates,
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_particle_candidates &ghost_contact_pair_candidates);
 };
 
 #endif /* particle_particle_broad_search_h */

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -75,9 +75,9 @@ public:
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
     const typename dem_data_containers::dem_data_structures<
-      dim>::cells_neighbor_list *cells_local_neighbor_list,
+      dim>::cells_neighbor_list &cells_local_neighbor_list,
     const typename dem_data_containers::dem_data_structures<
-      dim>::cells_neighbor_list *cells_ghost_neighbor_list,
+      dim>::cells_neighbor_list &cells_ghost_neighbor_list,
     typename dem_data_containers::dem_data_structures<
       dim>::particle_particle_candidates &local_contact_pair_candidates,
     typename dem_data_containers::dem_data_structures<

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -18,6 +18,7 @@
  */
 
 #include <core/auxiliary_math_functions.h>
+#include <core/data_containers.h>
 
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
@@ -65,19 +66,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &local_adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) = 0;
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &local_adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force) = 0;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -99,7 +99,7 @@ public:
    */
   virtual void
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -111,10 +111,10 @@ public:
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass) = 0;
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass) = 0;
 
 protected:
   /**

--- a/include/dem/particle_particle_fine_search.h
+++ b/include/dem/particle_particle_fine_search.h
@@ -17,6 +17,8 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/data_containers.h>
+
 #include <dem/dem_properties.h>
 #include <dem/particle_particle_contact_info_struct.h>
 
@@ -26,10 +28,6 @@
 #include <deal.II/particles/particle_handler.h>
 
 #include <boost/range/adaptor/map.hpp>
-
-#include <iostream>
-#include <unordered_map>
-#include <vector>
 
 using namespace dealii;
 
@@ -83,25 +81,17 @@ public:
 
   void
   particle_particle_fine_search(
-    const std::unordered_map<types::particle_index,
-                             std::vector<types::particle_index>>
-      &local_contact_pair_candidates,
-    const std::unordered_map<types::particle_index,
-                             std::vector<types::particle_index>>
-      &ghost_contact_pair_candidates,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &local_adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &ghost_adjacent_particles,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-      &          particle_container,
-    const double neighborhood_threshold);
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_particle_candidates &local_contact_pair_candidates,
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_particle_candidates &ghost_contact_pair_candidates,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &local_adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_index_iterator_map &particle_container,
+    const double                         neighborhood_threshold);
 };
 
 #endif /* particle_particle_fine_search_h */

--- a/include/dem/particle_particle_linear_force.h
+++ b/include/dem/particle_particle_linear_force.h
@@ -62,19 +62,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &local_adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) override;
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &local_adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This

--- a/include/dem/particle_particle_linear_force.h
+++ b/include/dem/particle_particle_linear_force.h
@@ -95,7 +95,7 @@ public:
    */
   virtual void
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -107,10 +107,10 @@ public:
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass) override;
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass) override;
 
 private:
   /**
@@ -133,9 +133,9 @@ private:
   void
   calculate_linear_contact_force_and_torque(
     particle_particle_contact_info_struct<dim> &contact_info,
-    const double &                              normal_relative_velocity_value,
+    const double                                normal_relative_velocity_value,
     const Tensor<1, 3> &                        normal_unit_vector,
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     const ArrayView<const double> &             particle_one_properties,
     const ArrayView<const double> &             particle_two_properties,
     Tensor<1, 3> &                              normal_force,

--- a/include/dem/particle_particle_nonlinear_force.h
+++ b/include/dem/particle_particle_nonlinear_force.h
@@ -65,19 +65,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) override;
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This
@@ -204,19 +198,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) override;
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This
@@ -344,19 +332,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) override;
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This

--- a/include/dem/particle_particle_nonlinear_force.h
+++ b/include/dem/particle_particle_nonlinear_force.h
@@ -98,7 +98,7 @@ public:
    */
   virtual void
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -110,10 +110,10 @@ public:
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass) override;
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass) override;
 
 private:
   /**
@@ -136,9 +136,9 @@ private:
   void
   calculate_hertz_mindlin_limit_overlap_contact(
     particle_particle_contact_info_struct<dim> &contact_info,
-    const double &                              normal_relative_velocity_value,
+    const double                                normal_relative_velocity_value,
     const Tensor<1, 3> &                        normal_unit_vector,
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     const ArrayView<const double> &             particle_one_properties,
     const ArrayView<const double> &             particle_two_propertie,
     Tensor<1, 3> &                              normal_force,
@@ -231,7 +231,7 @@ public:
    */
   virtual void
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -243,10 +243,10 @@ public:
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass) override;
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass) override;
 
 
 private:
@@ -269,9 +269,9 @@ private:
   void
   calculate_hertz_mindlin_limit_force_contact(
     particle_particle_contact_info_struct<dim> &contact_info,
-    const double &                              normal_relative_velocity_value,
+    const double                                normal_relative_velocity_value,
     const Tensor<1, 3> &                        normal_unit_vector,
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     const ArrayView<const double> &             particle_one_properties,
     const ArrayView<const double> &             particle_two_propertie,
     Tensor<1, 3> &                              normal_force,
@@ -365,7 +365,7 @@ public:
    */
   virtual void
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -377,10 +377,10 @@ public:
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass) override;
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass) override;
 
 
 private:
@@ -403,9 +403,9 @@ private:
   void
   calculate_hertz_contact(
     particle_particle_contact_info_struct<dim> &contact_info,
-    const double &                              normal_relative_velocity_value,
+    const double                                normal_relative_velocity_value,
     const Tensor<1, 3> &                        normal_unit_vector,
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     const ArrayView<const double> &             particle_one_properties,
     const ArrayView<const double> &             particle_two_propertie,
     Tensor<1, 3> &                              normal_force,

--- a/include/dem/particle_point_line_broad_search.h
+++ b/include/dem/particle_point_line_broad_search.h
@@ -17,13 +17,12 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/data_containers.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/particles/particle_iterator.h>
-
-#include <unordered_map>
-#include <vector>
 
 using namespace dealii;
 
@@ -60,8 +59,8 @@ public:
    * (particle located near boundaries with vertices and the vertex location)
    */
 
-  std::unordered_map<types::particle_index,
-                     std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_candidates
   find_particle_point_contact_pairs(
     const Particles::ParticleHandler<dim> &particle_handler,
     const std::unordered_map<
@@ -83,9 +82,8 @@ public:
    * and the locations of beginning and ending vertices of the boundary lines
    */
 
-  std::unordered_map<
-    types::particle_index,
-    std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_line_candidates
   find_particle_line_contact_pairs(
     const Particles::ParticleHandler<dim> &particle_handler,
     const std::unordered_map<

--- a/include/dem/particle_point_line_contact_force.h
+++ b/include/dem/particle_point_line_contact_force.h
@@ -17,6 +17,8 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/data_containers.h>
+
 #include <dem/dem_properties.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/particle_point_line_contact_info_struct.h>
@@ -59,9 +61,8 @@ public:
    */
   void
   calculate_particle_point_contact_force(
-    const std::unordered_map<types::particle_index,
-                             particle_point_line_contact_info_struct<dim>>
-      *particle_point_line_pairs_in_contact,
+    const typename dem_data_containers::dem_data_structures<dim>::
+      particle_point_line_contact_info *particle_point_line_pairs_in_contact,
     const Parameters::Lagrangian::LagrangianPhysicalProperties
       &                        lagrangian_physical_properties,
     std::vector<Tensor<1, 3>> &force);
@@ -78,9 +79,8 @@ public:
    */
   void
   calculate_particle_line_contact_force(
-    const std::unordered_map<types::particle_index,
-                             particle_point_line_contact_info_struct<dim>>
-      *particle_line_pairs_in_contact,
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_point_line_contact_info *particle_line_pairs_in_contact,
     const Parameters::Lagrangian::LagrangianPhysicalProperties
       &                        lagrangian_physical_properties,
     std::vector<Tensor<1, 3>> &force);

--- a/include/dem/particle_point_line_fine_search.h
+++ b/include/dem/particle_point_line_fine_search.h
@@ -68,7 +68,7 @@ public:
   particle_point_fine_search(
     const typename dem_data_containers::dem_data_structures<
       dim>::particle_point_candidates &particle_point_contact_candidates,
-    const double &                     neighborhood_threshold);
+    const double                       neighborhood_threshold);
 
   /**
    * Iterates over a map of tuples (particle_line_contact_candidates) to see if
@@ -89,7 +89,7 @@ public:
   particle_line_fine_search(
     const typename dem_data_containers::dem_data_structures<
       dim>::particle_line_candidates &particle_line_contact_candidates,
-    const double &                    neighborhood_threshold);
+    const double                      neighborhood_threshold);
 
 private:
   /** This private function is used to find the projection of point_p on

--- a/include/dem/particle_point_line_fine_search.h
+++ b/include/dem/particle_point_line_fine_search.h
@@ -17,6 +17,8 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <core/data_containers.h>
+
 #include <dem/dem_properties.h>
 #include <dem/particle_point_line_contact_info_struct.h>
 
@@ -61,14 +63,12 @@ public:
    * particle-point contact force
    */
 
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info
   particle_point_fine_search(
-    const std::unordered_map<
-      types::particle_index,
-      std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
-      &           particle_point_contact_candidates,
-    const double &neighborhood_threshold);
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_point_candidates &particle_point_contact_candidates,
+    const double &                     neighborhood_threshold);
 
   /**
    * Iterates over a map of tuples (particle_line_contact_candidates) to see if
@@ -84,14 +84,12 @@ public:
    * particle-line contact force
    */
 
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info
   particle_line_fine_search(
-    const std::unordered_map<
-      types::particle_index,
-      std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
-      &           particle_line_contact_candidates,
-    const double &neighborhood_threshold);
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_line_candidates &particle_line_contact_candidates,
+    const double &                    neighborhood_threshold);
 
 private:
   /** This private function is used to find the projection of point_p on

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -76,15 +76,8 @@ public:
     const std::map<int, boundary_cells_info_struct<dim>>
       &                                    boundary_cells_information,
     const Particles::ParticleHandler<dim> &particle_handler,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::boundary_id,
-                         std::tuple<Particles::ParticleIterator<dim>,
-                                    Tensor<1, dim>,
-                                    Point<dim>,
-                                    types::boundary_id,
-                                    types::global_cell_index>>>
-      &particle_wall_contact_candidates);
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_candidates &particle_wall_contact_candidates);
 
   /**
    * Finds a two-layered unordered map of particle iterators which shows the
@@ -112,10 +105,8 @@ public:
     const Particles::ParticleHandler<dim> &particle_handler,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double &                                    simulation_time,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-      &pfw_contact_candidates);
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_floating_wall_candidates &pfw_contact_candidates);
 
   /**
    * Finds a two-layered unordered map
@@ -135,21 +126,14 @@ public:
 
   void
   particle_floating_mesh_contact_search(
-    const std::vector<std::vector<
-      std::pair<typename Triangulation<dim>::active_cell_iterator,
-                typename Triangulation<dim - 1, dim>::active_cell_iterator>>>
-      &                                    floating_mesh_information,
+    const typename dem_data_containers::dem_data_structures<
+      dim>::floating_mesh_information &    floating_mesh_information,
     const Particles::ParticleHandler<dim> &particle_handler,
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  Particles::ParticleIterator<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_floating_mesh_candidates
       &particle_floating_mesh_contact_candidates,
-    std::unordered_map<
-      types::global_cell_index,
-      std::vector<typename Triangulation<dim>::active_cell_iterator>>
-      &cells_total_neighbor_list);
+    typename dem_data_containers::dem_data_structures<
+      dim>::cells_total_neighbor_list &cells_total_neighbor_list);
 };
 
 #endif /* particle_wall_broad_search_h */

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -92,7 +92,7 @@ public:
    * @param floating_wall_properties Properties of the floating walls specified
    * in the parameter handler file
    * @param simulation_time Simulation time
-   * @param pfw_contact_candidates Output of particle-floating wall broad search
+   * @param particle_floating_wall_candidates Output of particle-floating wall broad search
    * which contains all the particle-floating wall collision candidates
    */
 
@@ -104,9 +104,9 @@ public:
       &                                    boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-    const double &                                    simulation_time,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_floating_wall_candidates &pfw_contact_candidates);
+    const double                                      simulation_time,
+    typename dem_data_containers::dem_data_structures<dim>::
+      particle_floating_wall_candidates &particle_floating_wall_candidates);
 
   /**
    * Finds a two-layered unordered map

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -130,14 +130,14 @@ public:
     Tensor<1, 3> &                          tangential_torque,
     Tensor<1, 3> &                          rolling_resistance_torque,
     IBParticle<dim> &                       particle,
-    const double &                          wall_youngs_modulus,
-    const double &                          wall_poisson_ratio,
-    const double &                          wall_restitution_coefficient,
-    const double &                          wall_friction_coefficient,
-    const double &                          wall_rolling_friction_coefficient,
+    const double                            wall_youngs_modulus,
+    const double                            wall_poisson_ratio,
+    const double                            wall_restitution_coefficient,
+    const double                            wall_friction_coefficient,
+    const double                            wall_rolling_friction_coefficient,
     const double                            dt,
-    const double &                          mass,
-    const double &                          radius) = 0;
+    const double                            mass,
+    const double                            radius) = 0;
 
   /** This function is used to find the projection of vector_a on
    * vector_b
@@ -190,7 +190,7 @@ protected:
     const double                            dt,
     const Tensor<1, 3> &                    cut_cell_translational_velocity,
     const Tensor<1, 3> &                    cut_cell_rotational_velocity,
-    const double &center_of_rotation_particle_distance);
+    const double center_of_rotation_particle_distance);
 
   /**
    * Carries out applying the calculated force and torque on the particle in

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -64,13 +64,11 @@ public:
    */
   virtual void
   calculate_particle_wall_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-      &                        particle_wall_pairs_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) = 0;
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+    const double                      dt,
+    std::vector<Tensor<1, 3>> &       torque,
+    std::vector<Tensor<1, 3>> &       force) = 0;
 
   /**
    * Carries out the calculation of particle-floating mesh contact force using
@@ -83,16 +81,13 @@ public:
    * @param force Force acting on particles
    * @param solids Floating solids
    */
-  virtual void calculate_particle_floating_wall_contact_force(
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  particle_wall_contact_info_struct<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
-      &                        particle_floating_mesh_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force,
+  virtual void
+  calculate_particle_floating_wall_contact_force(
+    typename dem_data_containers::dem_data_structures<dim>::
+      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+    const double                         dt,
+    std::vector<Tensor<1, 3>> &          torque,
+    std::vector<Tensor<1, 3>> &          force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids) = 0;
 
   std::map<types::boundary_id, Tensor<1, 3>>

--- a/include/dem/particle_wall_fine_search.h
+++ b/include/dem/particle_wall_fine_search.h
@@ -74,15 +74,15 @@ public:
 
   /**
    * Iterates over the contact candidates from particle-floating wall broad
-   * search (pfw_contact_candidates) to add new contact pairs to the
-   * pfw_pairs_in_contact container
+   * search (particle_floating_wall_candidates) to add new contact pairs to the
+   * particle_floating_wall_pairs_in_contact container
    *
-   * @param pfw_contact_pair_candidates The output of particle-floating wall
+   * @param particle_floating_wall_pair_candidates The output of particle-floating wall
    * broad search which shows contact pair candidates
    * @param floating_wall_properties Properties of floating walls defined in the
    * parameter handler
    * @param simulation_time Simulation time
-   * @param pfw_pairs_in_contact An unordered_map of maps which stores
+   * @param particle_floating_wall_pairs_in_contact An unordered_map of maps which stores
    * all the particle-floating wall pairs which are in contact, and
    * the contact information in a struct. Note that the size of this unordered
    * map is equal to the number of particles
@@ -90,11 +90,12 @@ public:
   void
   particle_floating_wall_fine_search(
     const typename dem_data_containers::dem_data_structures<
-      dim>::particle_floating_wall_candidates &       pfw_contact_candidates,
+      dim>::particle_floating_wall_candidates
+      &particle_floating_wall_contact_candidates,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-    const double &                                    simulation_time,
+    const double                                      simulation_time,
     typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact &pfw_pairs_in_contact);
+      dim>::particle_wall_in_contact &particle_floating_wall_in_contact);
 
 
   /**

--- a/include/dem/particle_wall_fine_search.h
+++ b/include/dem/particle_wall_fine_search.h
@@ -67,19 +67,10 @@ public:
 
   void
   particle_wall_fine_search(
-    const std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::boundary_id,
-                         std::tuple<Particles::ParticleIterator<dim>,
-                                    Tensor<1, dim>,
-                                    Point<dim>,
-                                    types::boundary_id,
-                                    types::global_cell_index>>>
-      &particle_wall_contact_pair_candidates,
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-      &particle_wall_pairs_in_contact);
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_candidates &particle_wall_contact_pair_candidates,
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact);
 
   /**
    * Iterates over the contact candidates from particle-floating wall broad
@@ -98,16 +89,12 @@ public:
    */
   void
   particle_floating_wall_fine_search(
-    const std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-      &                                               pfw_contact_candidates,
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_floating_wall_candidates &       pfw_contact_candidates,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double &                                    simulation_time,
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-      &pfw_pairs_in_contact);
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_in_contact &pfw_pairs_in_contact);
 
 
   /**
@@ -123,18 +110,11 @@ public:
 
   void
   particle_floating_mesh_fine_search(
-    const std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  Particles::ParticleIterator<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
+    const typename dem_data_containers::dem_data_structures<
+      dim>::particle_floating_mesh_candidates
       &particle_floating_mesh_contact_candidates,
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  particle_wall_contact_info_struct<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
-      &particle_floating_mesh_in_contact);
+    typename dem_data_containers::dem_data_structures<dim>::
+      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact);
 };
 
 #endif /* particle_wall_fine_search_h */

--- a/include/dem/particle_wall_linear_force.h
+++ b/include/dem/particle_wall_linear_force.h
@@ -78,13 +78,11 @@ public:
    */
   virtual void
   calculate_particle_wall_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-      &                        particle_wall_pairs_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) override;
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+    const double                      dt,
+    std::vector<Tensor<1, 3>> &       torque,
+    std::vector<Tensor<1, 3>> &       force) override;
 
   /**
    * Carries out the calculation of particle-floating mesh contact force using
@@ -97,16 +95,13 @@ public:
    * @param force Force acting on particles
    * @param solids Floating solids
    */
-  virtual void calculate_particle_floating_wall_contact_force(
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  particle_wall_contact_info_struct<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
-      &                        particle_floating_mesh_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force,
+  virtual void
+  calculate_particle_floating_wall_contact_force(
+    typename dem_data_containers::dem_data_structures<dim>::
+      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+    const double                         dt,
+    std::vector<Tensor<1, 3>> &          torque,
+    std::vector<Tensor<1, 3>> &          force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
     override;
 

--- a/include/dem/particle_wall_linear_force.h
+++ b/include/dem/particle_wall_linear_force.h
@@ -49,8 +49,8 @@ class ParticleWallLinearForce : public ParticleWallContactForce<dim>
 {
   using FuncPtrType = Tensor<1, 3> (ParticleWallLinearForce<dim>::*)(
     const ArrayView<const double> &,
-    const double &,
-    const double &,
+    const double,
+    const double,
     const Tensor<1, 3> &);
   FuncPtrType calculate_rolling_resistance_torque;
 
@@ -135,14 +135,14 @@ public:
     Tensor<1, 3> &                          tangential_torque,
     Tensor<1, 3> &                          rolling_resistance_torque,
     IBParticle<dim> &                       particle,
-    const double &                          wall_youngs_modulus,
-    const double &                          wall_poisson_ratio,
-    const double &                          wall_restitution_coefficient,
-    const double &                          wall_friction_coefficient,
-    const double &                          wall_rolling_friction_coefficient,
+    const double                            wall_youngs_modulus,
+    const double                            wall_poisson_ratio,
+    const double                            wall_restitution_coefficient,
+    const double                            wall_friction_coefficient,
+    const double                            wall_rolling_friction_coefficient,
     const double                            dt,
-    const double &                          mass,
-    const double &                          radius) override;
+    const double                            mass,
+    const double                            radius) override;
 
 private:
   /**
@@ -157,8 +157,8 @@ private:
    */
   inline Tensor<1, 3>
   no_resistance(const ArrayView<const double> & /*particle_properties*/,
-                const double & /*effective_rolling_friction_coefficient*/,
-                const double & /*normal_force_norm*/,
+                const double /*effective_rolling_friction_coefficient*/,
+                const double /*normal_force_norm*/,
                 const Tensor<1, 3> & /*normal_contact_vector*/)
   {
     Tensor<1, 3> rolling_resistance({0, 0, 0});
@@ -177,8 +177,8 @@ private:
    */
   inline Tensor<1, 3>
   constant_resistance(const ArrayView<const double> &particle_properties,
-                      const double &effective_rolling_friction_coefficient,
-                      const double &normal_force_norm,
+                      const double effective_rolling_friction_coefficient,
+                      const double normal_force_norm,
                       const Tensor<1, 3> & /*normal_contact_vector*/)
   {
     // Getting the angular velocity of particle in the vector format
@@ -220,8 +220,8 @@ private:
    */
   inline Tensor<1, 3>
   viscous_resistance(const ArrayView<const double> &particle_properties,
-                     const double &      effective_rolling_friction_coefficient,
-                     const double &      normal_force_norm,
+                     const double        effective_rolling_friction_coefficient,
+                     const double        normal_force_norm,
                      const Tensor<1, 3> &normal_contact_vector)
   {
     // Getting the angular velocity of particle in the vector format

--- a/include/dem/particle_wall_nonlinear_force.h
+++ b/include/dem/particle_wall_nonlinear_force.h
@@ -78,13 +78,11 @@ public:
    */
   virtual void
   calculate_particle_wall_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-      &                        particle_wall_pairs_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force) override;
+    typename dem_data_containers::dem_data_structures<
+      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+    const double                      dt,
+    std::vector<Tensor<1, 3>> &       torque,
+    std::vector<Tensor<1, 3>> &       force) override;
 
   /**
    * Carries out the calculation of particle-floating mesh contact force using
@@ -97,16 +95,13 @@ public:
    * @param force Force acting on particles
    * @param solids Floating solids
    */
-  virtual void calculate_particle_floating_wall_contact_force(
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  particle_wall_contact_info_struct<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
-      &                        particle_floating_mesh_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force,
+  virtual void
+  calculate_particle_floating_wall_contact_force(
+    typename dem_data_containers::dem_data_structures<dim>::
+      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+    const double                         dt,
+    std::vector<Tensor<1, 3>> &          torque,
+    std::vector<Tensor<1, 3>> &          force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
     override;
 

--- a/include/dem/particle_wall_nonlinear_force.h
+++ b/include/dem/particle_wall_nonlinear_force.h
@@ -49,8 +49,8 @@ class ParticleWallNonLinearForce : public ParticleWallContactForce<dim>
 {
   using FuncPtrType = Tensor<1, 3> (ParticleWallNonLinearForce<dim>::*)(
     const ArrayView<const double> &,
-    const double &,
-    const double &,
+    const double,
+    const double,
     const Tensor<1, 3> &);
   FuncPtrType calculate_rolling_resistance_torque;
 
@@ -131,14 +131,14 @@ public:
     Tensor<1, 3> &                          tangential_torque,
     Tensor<1, 3> &                          rolling_resistance_torque,
     IBParticle<dim> &                       particle,
-    const double &                          wall_youngs_modulus,
-    const double &                          wall_poisson_ratio,
-    const double &                          wall_restitution_coefficient,
-    const double &                          wall_friction_coefficient,
-    const double &                          wall_rolling_friction_coefficient,
+    const double                            wall_youngs_modulus,
+    const double                            wall_poisson_ratio,
+    const double                            wall_restitution_coefficient,
+    const double                            wall_friction_coefficient,
+    const double                            wall_rolling_friction_coefficient,
     const double                            dt,
-    const double &                          mass,
-    const double &                          radius) override;
+    const double                            mass,
+    const double                            radius) override;
 
 private:
   /**
@@ -153,8 +153,8 @@ private:
    */
   inline Tensor<1, 3>
   no_resistance(const ArrayView<const double> & /*particle_properties*/,
-                const double & /*effective_rolling_friction_coefficient*/,
-                const double & /*normal_force_norm*/,
+                const double /*effective_rolling_friction_coefficient*/,
+                const double /*normal_force_norm*/,
                 const Tensor<1, 3> & /*normal_contact_vector*/)
   {
     Tensor<1, 3> rolling_resistance({0, 0, 0});
@@ -173,8 +173,8 @@ private:
    */
   inline Tensor<1, 3>
   constant_resistance(const ArrayView<const double> &particle_properties,
-                      const double &effective_rolling_friction_coefficient,
-                      const double &normal_force_norm,
+                      const double effective_rolling_friction_coefficient,
+                      const double normal_force_norm,
                       const Tensor<1, 3> & /*normal_contact_vector*/)
   {
     // Getting the angular velocity of particle in the vector format
@@ -216,8 +216,8 @@ private:
    */
   inline Tensor<1, 3>
   viscous_resistance(const ArrayView<const double> &particle_properties,
-                     const double &      effective_rolling_friction_coefficient,
-                     const double &      normal_force_norm,
+                     const double        effective_rolling_friction_coefficient,
+                     const double        normal_force_norm,
                      const Tensor<1, 3> &normal_contact_vector)
   {
     // Getting the angular velocity of particle in the vector format

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -13,6 +13,7 @@
  *
  * ---------------------------------------------------------------------
  */
+#include <core/data_containers.h>
 
 #include <dem/boundary_cells_info_struct.h>
 #include <dem/dem_solver_parameters.h>
@@ -126,8 +127,8 @@ private:
 
   // Mapping of periodic boundaries information, cell index at outlet is the
   // map key
-  std::map<types::global_cell_index, periodic_boundaries_cells_info_struct<dim>>
-    periodic_boundaries_cells_information;
+  typename dem_data_containers::dem_data_structures<
+    dim>::periodic_boundaries_cells_info periodic_boundaries_cells_information;
 };
 
 #endif /* particle_wall_periodic_displacement_h */

--- a/include/dem/read_mesh.h
+++ b/include/dem/read_mesh.h
@@ -41,13 +41,12 @@ using namespace std;
  * @param pcout Printing in parallel
  * @param restart If in restart situation
  * @param triangulation Triangulation
- * @param triangulation_cell_diameter Triangulation cell diameter
  * @param bc_params Boundary conditions parameters for DEM
  */
 template <int dim, int spacedim = dim>
 void
 read_mesh(const Parameters::Mesh &             mesh_params,
-          const bool &                         restart,
+          const bool                           restart,
           const ConditionalOStream &           pcout,
           Triangulation<dim, spacedim> &       triangulation,
           double &                             triangulation_cell_diameter,

--- a/include/dem/rolling_resistance_torque_models.h
+++ b/include/dem/rolling_resistance_torque_models.h
@@ -35,11 +35,11 @@ enum class RollingResistanceTorqueModel
  */
 inline Tensor<1, 3>
 no_rolling_resistance_torque(
-  const double & /*effective_r*/,
+  const double /*effective_r*/,
   const ArrayView<const double> & /*particle_one_properties*/,
   const ArrayView<const double> & /*particle_two_properties*/,
-  const double & /*effective_rolling_friction_coefficient*/,
-  const double & /*normal_force_norm*/,
+  const double /*effective_rolling_friction_coefficient*/,
+  const double /*normal_force_norm*/,
   const Tensor<1, 3> & /*normal_contact_vector*/)
 
 {
@@ -58,11 +58,11 @@ no_rolling_resistance_torque(
 // omega_hat = (omega_i - omega_j) / (|oemaga_i - omega_j|)
 inline Tensor<1, 3>
 constant_rolling_resistance_torque(
-  const double &                 effective_r,
+  const double                   effective_r,
   const ArrayView<const double> &particle_one_properties,
   const ArrayView<const double> &particle_two_properties,
-  const double &                 effective_rolling_friction_coefficient,
-  const double &                 normal_force_norm,
+  const double                   effective_rolling_friction_coefficient,
+  const double                   normal_force_norm,
   const Tensor<1, 3> & /*normal_contact_vector*/)
 
 {
@@ -95,11 +95,11 @@ constant_rolling_resistance_torque(
 // V_omega = omega_i × (R_i * n_ij) - omega_j × (R_j * n_ji)
 inline Tensor<1, 3>
 viscous_rolling_resistance_torque(
-  const double &                 effective_r,
+  const double                   effective_r,
   const ArrayView<const double> &particle_one_properties,
   const ArrayView<const double> &particle_two_properties,
-  const double &                 effective_rolling_friction_coefficient,
-  const double &                 normal_force_norm,
+  const double                   effective_rolling_friction_coefficient,
+  const double                   normal_force_norm,
   const Tensor<1, 3> &           normal_contact_vector)
 
 {

--- a/include/dem/set_particle_wall_contact_force_model.h
+++ b/include/dem/set_particle_wall_contact_force_model.h
@@ -42,6 +42,6 @@ std::shared_ptr<ParticleWallContactForce<dim>>
 set_particle_wall_contact_force_model(
   const DEMSolverParameters<dim> &                 dem_parameters,
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const double &                                   triangulation_cell_diameter);
+  const double                                     triangulation_cell_diameter);
 
 #endif /* set_particle_wall_contact_force_model_h */

--- a/include/dem/uniform_insertion.h
+++ b/include/dem/uniform_insertion.h
@@ -41,7 +41,7 @@ class UniformInsertion : public Insertion<dim>
 {
 public:
   UniformInsertion<dim>(const DEMSolverParameters<dim> &dem_parameters,
-                        const double &maximum_particle_diameter);
+                        const double maximum_particle_diameter);
 
   /**
    * Carries out the insertion of particles by discretizing and looping over the

--- a/include/dem/update_ghost_particle_particle_contact_container.h
+++ b/include/dem/update_ghost_particle_particle_contact_container.h
@@ -16,9 +16,9 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
-#include <dem/particle_particle_contact_info_struct.h>
+#include <core/data_containers.h>
 
-#include <unordered_map>
+#include <dem/particle_particle_contact_info_struct.h>
 
 using namespace dealii;
 
@@ -36,12 +36,9 @@ using namespace dealii;
 template <int dim>
 void
 update_ghost_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container);
 
 #endif /* update_ghost_particle_particle_contact_container_h */

--- a/include/dem/update_local_particle_particle_contact_container.h
+++ b/include/dem/update_local_particle_particle_contact_container.h
@@ -16,9 +16,9 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
-#include <dem/particle_particle_contact_info_struct.h>
+#include <core/data_containers.h>
 
-#include <unordered_map>
+#include <dem/particle_particle_contact_info_struct.h>
 
 using namespace dealii;
 
@@ -36,12 +36,9 @@ using namespace dealii;
 template <int dim>
 void
 update_local_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container);
 
 #endif /* update_local_particle_particle_contact_container_h */

--- a/include/dem/update_particle_container.h
+++ b/include/dem/update_particle_container.h
@@ -16,9 +16,9 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
-#include <deal.II/particles/particle_handler.h>
+#include <core/data_containers.h>
 
-#include <unordered_map>
+#include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
 
@@ -39,8 +39,8 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &                                    particle_container,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<dim> *particle_handler);
 
 #endif /* update_particle_container_h */

--- a/include/dem/update_particle_point_line_contact_container.h
+++ b/include/dem/update_particle_point_line_contact_container.h
@@ -16,9 +16,9 @@
  *
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
-#include <dem/particle_point_line_contact_info_struct.h>
+#include <core/data_containers.h>
 
-#include <unordered_map>
+#include <dem/particle_point_line_contact_info_struct.h>
 
 using namespace dealii;
 
@@ -37,13 +37,11 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_point_line_contact_container_iterators(
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_lines_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container);
 
 #endif /* update_particle_point_line_contact_container_h */

--- a/include/dem/update_particle_wall_contact_container.h
+++ b/include/dem/update_particle_wall_contact_container.h
@@ -20,8 +20,6 @@
 
 #include <dem/particle_wall_contact_info_struct.h>
 
-#include <unordered_map>
-
 using namespace dealii;
 
 #ifndef update_particle_wall_contact_container_h
@@ -38,31 +36,26 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_wall_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container);
 
 /**
  * Updates the iterators to particles in
- * particle_floating_wall_contact_container
+ * particle floating mesh contact container
  *
- * @param particle_floating_wall_pairs_in_contact Output of particle-floating wall fine search
+ * @param particle_floating_mesh_in_contact Output of particle-floating mesh fine search
  * @param particle_container Output of update_particle_container function
  */
 
 template <int dim>
-void update_particle_floating_wall_contact_container_iterators(
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container);
+void
+update_particle_floating_mesh_contact_container_iterators(
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container);
 
 
 #endif /* update_particle_wall_contact_container_h */

--- a/include/dem/update_particle_wall_contact_container.h
+++ b/include/dem/update_particle_wall_contact_container.h
@@ -18,8 +18,6 @@
  */
 #include <core/data_containers.h>
 
-#include <dem/particle_wall_contact_info_struct.h>
-
 using namespace dealii;
 
 #ifndef update_particle_wall_contact_container_h

--- a/include/fem-dem/cfd_dem_coupling.h
+++ b/include/fem-dem/cfd_dem_coupling.h
@@ -18,6 +18,8 @@
 #ifndef lethe_dem_cfd_coupling_h
 #define lethe_dem_cfd_coupling_h
 
+#include <core/data_containers.h>
+
 #include <solvers/navier_stokes_scratch_data.h>
 
 #include <dem/dem.h>
@@ -208,7 +210,6 @@ private:
   void
   post_processing() override;
 
-
   unsigned int              coupling_frequency;
   bool                      contact_detection_step;
   bool                      checkpoint_step;
@@ -223,78 +224,44 @@ private:
   double                    smallest_contact_search_criterion;
   double                    triangulation_cell_diameter;
 
-  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    cells_local_neighbor_list;
-  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+  typename dem_data_structures<dim>::cells_neighbor_list
     cells_ghost_neighbor_list;
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    local_contact_pair_candidates;
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
+  typename dem_data_structures<dim>::cells_neighbor_list
+    cells_local_neighbor_list;
+  typename dem_data_structures<dim>::particle_particle_candidates
     ghost_contact_pair_candidates;
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
+  typename dem_data_structures<dim>::particle_particle_candidates
+    local_contact_pair_candidates;
+  typename dem_data_structures<dim>::adjacent_particle_pairs
     local_adjacent_particles;
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
+  typename dem_data_structures<dim>::adjacent_particle_pairs
     ghost_adjacent_particles;
-  std::unordered_map<
-    types::particle_index,
-    std::map<unsigned int, particle_wall_contact_info_struct<dim>>>
-    particle_wall_pairs_in_contact;
-  std::unordered_map<
-    types::particle_index,
-    std::map<unsigned int, particle_wall_contact_info_struct<dim>>>
-    pfw_pairs_in_contact;
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<unsigned int,
-                       std::tuple<Particles::ParticleIterator<dim>,
-                                  Tensor<1, dim>,
-                                  Point<dim>,
-                                  unsigned int,
-                                  unsigned int>>>
-    particle_wall_contact_candidates;
-  std::unordered_map<types::particle_index,
-                     std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
-    particle_point_contact_candidates;
-  std::unordered_map<
-    types::particle_index,
-    std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
-    particle_line_contact_candidates;
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    particle_points_in_contact, particle_lines_in_contact;
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<unsigned int, Particles::ParticleIterator<dim>>>
-    pfw_contact_candidates;
-
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
+  typename dem_data_structures<dim>::particle_wall_candidates
+    particle_wall_candidates;
+  typename dem_data_structures<dim>::particle_wall_in_contact
+    particle_wall_in_contact;
+  typename dem_data_structures<dim>::particle_wall_in_contact
+    particle_floating_wall_in_contact;
+  typename dem_data_structures<dim>::particle_point_candidates
+    particle_point_candidates;
+  typename dem_data_structures<dim>::particle_line_candidates
+    particle_line_candidates;
+  typename dem_data_structures<dim>::particle_point_line_contact_info
+    particle_points_in_contact;
+  typename dem_data_structures<dim>::particle_point_line_contact_info
+    particle_lines_in_contact;
+  typename dem_data_structures<dim>::particle_floating_wall_candidates
+    particle_floating_wall_candidates;
+  typename dem_data_structures<dim>::particle_floating_mesh_candidates
+    particle_floating_mesh_candidates;
+  typename dem_data_structures<dim>::particle_floating_mesh_in_contact
     particle_floating_mesh_in_contact;
-
-  std::vector<std::map<
-    typename Triangulation<dim - 1, dim>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>,
-    dem_data_containers::cut_cell_comparison<dim>>>
-    particle_floating_mesh_contact_candidates;
-
-
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
+  typename dem_data_structures<dim>::particle_index_iterator_map
     particle_container;
-
-  std::map<unsigned int, std::map<unsigned int, Tensor<1, 3>>>
+  typename dem_data_structures<dim>::vector_on_boundary
     forces_boundary_information;
-  std::map<unsigned int, std::map<unsigned int, Tensor<1, 3>>>
+  typename dem_data_structures<dim>::vector_on_boundary
     torques_boundary_information;
-
 
   ParticleParticleBroadSearch<dim>  particle_particle_broad_search_object;
   ParticleParticleFineSearch<dim>   particle_particle_fine_search_object;

--- a/source/core/data_containers.cc
+++ b/source/core/data_containers.cc
@@ -1,0 +1,22 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 - 2022 by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+
+ *
+ */
+
+#include <core/data_containers.h>
+
+template struct dem_data_containers::dem_data_structures<2>;
+template struct dem_data_containers::dem_data_structures<3>;

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -11,8 +11,6 @@
 #include <deal.II/grid/manifold_lib.h>
 
 #include <cmath>
-#include <unordered_map>
-
 
 template <int dim>
 void

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -966,8 +966,8 @@ DEMSolver<dim>::solve()
           particle_particle_broad_search_object
             .find_particle_particle_contact_pairs(
               particle_handler,
-              &cells_local_neighbor_list,
-              &cells_ghost_neighbor_list,
+              cells_local_neighbor_list,
+              cells_ghost_neighbor_list,
               local_contact_pair_candidates,
               ghost_contact_pair_candidates);
 

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -652,7 +652,7 @@ void
 BoundaryCellsInformation<dim>::find_boundary_cells_for_floating_walls(
   const parallel::distributed::Triangulation<dim> & triangulation,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-  const double &                                    maximum_cell_diameter)
+  const double                                      maximum_cell_diameter)
 {
   // Reading floating wall properties
   std::vector<Point<dim>> point_on_wall =

--- a/source/dem/find_cell_neighbors.cc
+++ b/source/dem/find_cell_neighbors.cc
@@ -1,7 +1,5 @@
 #include <dem/find_cell_neighbors.h>
 
-#include <unordered_map>
-
 using namespace dealii;
 
 // The constructor of this class is empty
@@ -15,9 +13,9 @@ template <int dim>
 void
 FindCellNeighbors<dim>::find_cell_neighbors(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+  typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
     &cells_local_neighbor_list,
-  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+  typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
     &cells_ghost_neighbor_list)
 {
   // The output vectors of the function are cells_local_neighbor_list and
@@ -122,10 +120,8 @@ template <int dim>
 void
 FindCellNeighbors<dim>::find_full_cell_neighbors(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  std::unordered_map<
-    types::global_cell_index,
-    std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    &cells_total_neighbor_list)
+  typename dem_data_containers::dem_data_structures<
+    dim>::cells_total_neighbor_list &cells_total_neighbor_list)
 {
   auto v_to_c = GridTools::vertex_to_cell_map(triangulation);
 

--- a/source/dem/find_contact_detection_step.cc
+++ b/source/dem/find_contact_detection_step.cc
@@ -5,10 +5,10 @@ using namespace dealii;
 template <int dim>
 bool
 find_contact_detection_step(Particles::ParticleHandler<dim> &particle_handler,
-                            const double &                   dt,
-                            const double &smallest_contact_search_criterion,
-                            MPI_Comm &    mpi_communicator,
-                            bool &        sorting_in_subdomains_step,
+                            const double                     dt,
+                            const double smallest_contact_search_criterion,
+                            MPI_Comm &   mpi_communicator,
+                            bool         sorting_in_subdomains_step,
                             std::vector<double> &displacement)
 {
   if (sorting_in_subdomains_step)
@@ -59,16 +59,16 @@ find_contact_detection_step(Particles::ParticleHandler<dim> &particle_handler,
 
 template bool
   find_contact_detection_step(Particles::ParticleHandler<2> &particle_handler,
-                              const double &                 dt,
-                              const double &smallest_contact_search_criterion,
-                              MPI_Comm &    mpi_communicator,
-                              bool &        sorting_in_subdomains_step,
+                              const double                   dt,
+                              const double smallest_contact_search_criterion,
+                              MPI_Comm &   mpi_communicator,
+                              bool         sorting_in_subdomains_step,
                               std::vector<double> &displacement);
 
 template bool
   find_contact_detection_step(Particles::ParticleHandler<3> &particle_handler,
-                              const double &                 dt,
-                              const double &smallest_contact_search_criterion,
-                              MPI_Comm &    mpi_communicator,
-                              bool &        sorting_in_subdomains_step,
+                              const double                   dt,
+                              const double smallest_contact_search_criterion,
+                              MPI_Comm &   mpi_communicator,
+                              bool         sorting_in_subdomains_step,
                               std::vector<double> &displacement);

--- a/source/dem/find_maximum_particle_size.cc
+++ b/source/dem/find_maximum_particle_size.cc
@@ -3,8 +3,8 @@
 double
 find_maximum_particle_size(
   const Parameters::Lagrangian::LagrangianPhysicalProperties
-    &           physical_properties,
-  const double &standard_deviation_multiplier)
+    &          physical_properties,
+  const double standard_deviation_multiplier)
 {
   double maximum_particle_size = 0;
 

--- a/source/dem/grid_motion.cc
+++ b/source/dem/grid_motion.cc
@@ -10,7 +10,7 @@ using namespace dealii;
 template <int dim, int spacedim>
 GridMotion<dim, spacedim>::GridMotion(
   const Parameters::Lagrangian::GridMotion<spacedim> &grid_motion_parameters,
-  const double &                                      dem_time_step)
+  const double                                        dem_time_step)
 {
   // Setting grid motion type
   if (grid_motion_parameters.motion_type ==

--- a/source/dem/input_parameter_inspection.cc
+++ b/source/dem/input_parameter_inspection.cc
@@ -7,7 +7,7 @@ template <int dim>
 void
 input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
                            const ConditionalOStream &      pcout,
-                           const double &standard_deviation_multiplier)
+                           const double standard_deviation_multiplier)
 {
   // Getting the input parameters as local variable
   auto   parameters          = dem_parameters;
@@ -101,9 +101,9 @@ input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
 template void
 input_parameter_inspection(const DEMSolverParameters<2> &dem_parameters,
                            const ConditionalOStream &    pcout,
-                           const double &standard_deviation_multiplier);
+                           const double standard_deviation_multiplier);
 
 template void
 input_parameter_inspection(const DEMSolverParameters<3> &dem_parameters,
                            const ConditionalOStream &    pcout,
-                           const double &standard_deviation_multiplier);
+                           const double standard_deviation_multiplier);

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -110,9 +110,9 @@ Insertion<dim>::assign_particle_properties(
 template <int dim>
 void
 Insertion<dim>::particle_size_sampling(std::vector<double> &particle_sizes,
-                                       const double &       average,
-                                       const double &       standard_deviation,
-                                       const double &       particle_number)
+                                       const double         average,
+                                       const double         standard_deviation,
+                                       const double         particle_number)
 {
   particle_sizes.clear();
   particle_sizes.reserve(particle_number);

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -177,8 +177,8 @@ LagrangianPostProcessing<dim>::write_average_particles_velocity(
   const parallel::distributed::Triangulation<dim> &triangulation,
   PVDHandler &                                     grid_pvdhandler,
   const DEMSolverParameters<dim> &                 dem_parameters,
-  const double &                                   time,
-  const unsigned int &                             step_number,
+  const double                                     time,
+  const unsigned int                               step_number,
   const MPI_Comm &                                 mpi_communicator)
 {
   const std::string folder = dem_parameters.simulation_control.output_folder;
@@ -232,8 +232,8 @@ LagrangianPostProcessing<dim>::write_granular_temperature(
   const parallel::distributed::Triangulation<dim> &triangulation,
   PVDHandler &                                     grid_pvdhandler,
   const DEMSolverParameters<dim> &                 dem_parameters,
-  const double &                                   time,
-  const unsigned int &                             step_number,
+  const double                                     time,
+  const unsigned int                               step_number,
   const MPI_Comm &                                 mpi_communicator)
 {
   const std::string folder = dem_parameters.simulation_control.output_folder;

--- a/source/dem/localize_contacts.cc
+++ b/source/dem/localize_contacts.cc
@@ -12,7 +12,7 @@ localize_contacts(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
+    dim>::particle_wall_in_contact &particle_floating_wall_in_contact,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
   typename dem_data_containers::dem_data_structures<
@@ -22,7 +22,8 @@ localize_contacts(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_wall_candidates &particle_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates &pfw_contact_candidates,
+    dim>::particle_floating_wall_candidates
+    &particle_floating_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates)
@@ -152,32 +153,41 @@ localize_contacts(
     }
 
   // Particle-floating wall contacts
-  for (auto pfw_pairs_in_contact_iterator = pfw_pairs_in_contact.begin();
-       pfw_pairs_in_contact_iterator != pfw_pairs_in_contact.end();
-       ++pfw_pairs_in_contact_iterator)
+  for (auto particle_floating_wall_pairs_iterator =
+         particle_floating_wall_in_contact.begin();
+       particle_floating_wall_pairs_iterator !=
+       particle_floating_wall_in_contact.end();
+       ++particle_floating_wall_pairs_iterator)
     {
-      auto particle_id = pfw_pairs_in_contact_iterator->first;
+      auto particle_id = particle_floating_wall_pairs_iterator->first;
 
-      auto pairs_in_contant_content = &pfw_pairs_in_contact_iterator->second;
+      auto pairs_in_contant_content =
+        &particle_floating_wall_pairs_iterator->second;
 
-      for (auto pfw_map_iterator = pairs_in_contant_content->begin();
-           pfw_map_iterator != pairs_in_contant_content->end();)
+      for (auto particle_floating_wall_map_iterator =
+             pairs_in_contant_content->begin();
+           particle_floating_wall_map_iterator !=
+           pairs_in_contant_content->end();)
         {
-          auto floating_wall_id = pfw_map_iterator->first;
-          auto pfw_contact_candidate_element =
-            &pfw_contact_candidates[particle_id];
+          auto floating_wall_id = particle_floating_wall_map_iterator->first;
+          auto particle_floating_wall_contact_candidate_element =
+            &particle_floating_wall_contact_candidates[particle_id];
 
           auto search_iterator =
-            pfw_contact_candidate_element->find(floating_wall_id);
+            particle_floating_wall_contact_candidate_element->find(
+              floating_wall_id);
 
-          if (search_iterator != pfw_contact_candidate_element->end())
+          if (search_iterator !=
+              particle_floating_wall_contact_candidate_element->end())
             {
-              pfw_contact_candidate_element->erase(search_iterator);
-              ++pfw_map_iterator;
+              particle_floating_wall_contact_candidate_element->erase(
+                search_iterator);
+              ++particle_floating_wall_map_iterator;
             }
           else
             {
-              pairs_in_contant_content->erase(pfw_map_iterator++);
+              pairs_in_contant_content->erase(
+                particle_floating_wall_map_iterator++);
             }
         }
     }
@@ -190,37 +200,43 @@ localize_contacts(
       auto &particle_floating_mesh_contact_pair =
         particle_floating_mesh_in_contact[solid_counter];
 
-      for (auto pfm_pairs_in_contact_iterator =
+      for (auto particle_floating_mesh_pairs_in_contact_iterator =
              particle_floating_mesh_contact_pair.begin();
-           pfm_pairs_in_contact_iterator !=
+           particle_floating_mesh_pairs_in_contact_iterator !=
            particle_floating_mesh_contact_pair.end();
-           ++pfm_pairs_in_contact_iterator)
+           ++particle_floating_mesh_pairs_in_contact_iterator)
         {
-          auto triangle = pfm_pairs_in_contact_iterator->first;
+          auto triangle =
+            particle_floating_mesh_pairs_in_contact_iterator->first;
 
           auto pairs_in_contant_content =
-            &pfm_pairs_in_contact_iterator->second;
+            &particle_floating_mesh_pairs_in_contact_iterator->second;
 
-          for (auto pfm_map_iterator = pairs_in_contant_content->begin();
-               pfm_map_iterator != pairs_in_contant_content->end();)
+          for (auto particle_floating_mesh_map_iterator =
+                 pairs_in_contant_content->begin();
+               particle_floating_mesh_map_iterator !=
+               pairs_in_contant_content->end();)
             {
-              auto particle_id = pfm_map_iterator->first;
+              auto particle_id = particle_floating_mesh_map_iterator->first;
 
-              auto pfm_contact_candidate_element =
+              auto particle_floating_mesh_candidate_element =
                 &particle_floating_mesh_contact_candidates[solid_counter]
                                                           [triangle];
 
               auto search_iterator =
-                pfm_contact_candidate_element->find(particle_id);
+                particle_floating_mesh_candidate_element->find(particle_id);
 
-              if (search_iterator != pfm_contact_candidate_element->end())
+              if (search_iterator !=
+                  particle_floating_mesh_candidate_element->end())
                 {
-                  pfm_contact_candidate_element->erase(search_iterator);
-                  ++pfm_map_iterator;
+                  particle_floating_mesh_candidate_element->erase(
+                    search_iterator);
+                  ++particle_floating_mesh_map_iterator;
                 }
               else
                 {
-                  pairs_in_contant_content->erase(pfm_map_iterator++);
+                  pairs_in_contant_content->erase(
+                    particle_floating_mesh_map_iterator++);
                 }
             }
         }
@@ -235,7 +251,7 @@ template void localize_contacts<2>(
   typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
-    &pfw_pairs_in_contact,
+    &particle_floating_wall_in_contact,
   typename dem_data_containers::dem_data_structures<
     2>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
   typename dem_data_containers::dem_data_structures<
@@ -245,7 +261,8 @@ template void localize_contacts<2>(
   typename dem_data_containers::dem_data_structures<2>::particle_wall_candidates
     &particle_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_wall_candidates &pfw_contact_candidates,
+    2>::particle_floating_wall_candidates
+    &particle_floating_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
     2>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);
@@ -258,7 +275,7 @@ template void localize_contacts<3>(
   typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
-    &pfw_pairs_in_contact,
+    &particle_floating_wall_in_contact,
   typename dem_data_containers::dem_data_structures<
     3>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
   typename dem_data_containers::dem_data_structures<
@@ -268,7 +285,8 @@ template void localize_contacts<3>(
   typename dem_data_containers::dem_data_structures<3>::particle_wall_candidates
     &particle_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_wall_candidates &pfw_contact_candidates,
+    3>::particle_floating_wall_candidates
+    &particle_floating_wall_contact_candidates,
   typename dem_data_containers::dem_data_structures<
     3>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);

--- a/source/dem/localize_contacts.cc
+++ b/source/dem/localize_contacts.cc
@@ -1,58 +1,30 @@
 #include <dem/localize_contacts.h>
 
-#include <unordered_map>
-
-
 using namespace dealii;
 
 template <int dim>
 void
 localize_contacts(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &pfw_pairs_in_contact,
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &particle_floating_mesh_in_contact,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &local_contact_pair_candidates,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &ghost_contact_pair_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<dim>,
-                                  Tensor<1, dim>,
-                                  Point<dim>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
-    &particle_wall_contact_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-    &pfw_contact_candidates,
-  std::vector<std::map<
-    typename Triangulation<dim - 1, dim>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>,
-    dem_data_containers::cut_cell_comparison<dim>>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &local_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &ghost_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_candidates &particle_wall_contact_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_wall_candidates &pfw_contact_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates)
 
 {
@@ -255,96 +227,48 @@ localize_contacts(
     }
 }
 
-template void localize_contacts(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<2>>>
+template void localize_contacts<2>(
+  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
     &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &pfw_pairs_in_contact,
-  std::vector<std::map<typename Triangulation<1, 2>::active_cell_iterator,
-                       std::unordered_map<types::particle_index,
-                                          particle_wall_contact_info_struct<2>>,
-                       dem_data_containers::cut_cell_comparison<2>>>
-    &particle_floating_mesh_in_contact,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &local_contact_pair_candidates,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &ghost_contact_pair_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<2>,
-                                  Tensor<1, 2>,
-                                  Point<2>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_particle_candidates &local_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_particle_candidates &ghost_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<2>::particle_wall_candidates
     &particle_wall_contact_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<2>>>
-    &pfw_contact_candidates,
-  std::vector<std::map<
-    typename Triangulation<1, 2>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>,
-    dem_data_containers::cut_cell_comparison<2>>>
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_floating_wall_candidates &pfw_contact_candidates,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);
 
-template void localize_contacts(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<3>>>
+template void localize_contacts<3>(
+  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
     &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &pfw_pairs_in_contact,
-  std::vector<std::map<typename Triangulation<2, 3>::active_cell_iterator,
-                       std::unordered_map<types::particle_index,
-                                          particle_wall_contact_info_struct<3>>,
-                       dem_data_containers::cut_cell_comparison<3>>>
-    &particle_floating_mesh_in_contact,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &local_contact_pair_candidates,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &ghost_contact_pair_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<3>,
-                                  Tensor<1, 3>,
-                                  Point<3>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_particle_candidates &local_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_particle_candidates &ghost_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<3>::particle_wall_candidates
     &particle_wall_contact_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<3>>>
-    &pfw_contact_candidates,
-  std::vector<std::map<
-    typename Triangulation<2, 3>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>,
-    dem_data_containers::cut_cell_comparison<3>>>
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_floating_wall_candidates &pfw_contact_candidates,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);

--- a/source/dem/locate_local_particles.cc
+++ b/source/dem/locate_local_particles.cc
@@ -6,38 +6,22 @@ template <int dim>
 void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<dim> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &pfw_pairs_in_contact,
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &pfm_pairs_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_lines_in_contact)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_lines_in_contact)
 {
   update_particle_container<dim>(particle_container, &particle_handler);
 
@@ -55,7 +39,7 @@ locate_local_particles_in_cells(
                                                         particle_container);
 
   // Calling the same function for floating mesh
-  update_particle_floating_wall_contact_container_iterators<dim>(
+  update_particle_floating_mesh_contact_container_iterators<dim>(
     pfm_pairs_in_contact, particle_container);
 
   update_particle_point_line_contact_container_iterators<dim>(
@@ -65,69 +49,39 @@ locate_local_particles_in_cells(
 template void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<2> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &particle_container,
+  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
     &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<2>>>
+  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &pfw_pairs_in_contact,
-  std::vector<std::map<typename Triangulation<1, 2>::active_cell_iterator,
-                       std::unordered_map<types::particle_index,
-                                          particle_wall_contact_info_struct<2>>,
-                       dem_data_containers::cut_cell_comparison<2>>>
-    &pfm_pairs_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<2>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<2>>
-    &particle_lines_in_contact);
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_point_line_contact_info &particle_lines_in_contact);
 
 template void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<3> &particle_handler,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &particle_container,
+  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
     &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<3>>>
+  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &pfw_pairs_in_contact,
-  std::vector<std::map<typename Triangulation<2, 3>::active_cell_iterator,
-                       std::unordered_map<types::particle_index,
-                                          particle_wall_contact_info_struct<3>>,
-                       dem_data_containers::cut_cell_comparison<3>>>
-    &pfm_pairs_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<3>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<3>>
-    &particle_lines_in_contact);
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_point_line_contact_info &particle_lines_in_contact);

--- a/source/dem/locate_local_particles.cc
+++ b/source/dem/locate_local_particles.cc
@@ -15,9 +15,9 @@ locate_local_particles_in_cells(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &pfw_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+    dim>::particle_wall_in_contact &particle_floating_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<dim>::
+    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_point_line_contact_info &particle_points_in_contact,
   typename dem_data_containers::dem_data_structures<
@@ -35,12 +35,12 @@ locate_local_particles_in_cells(
     particle_wall_pairs_in_contact, particle_container);
 
   // Calling the same function for floating walls
-  update_particle_wall_contact_container_iterators<dim>(pfw_pairs_in_contact,
-                                                        particle_container);
+  update_particle_wall_contact_container_iterators<dim>(
+    particle_floating_wall_pairs_in_contact, particle_container);
 
   // Calling the same function for floating mesh
   update_particle_floating_mesh_contact_container_iterators<dim>(
-    pfm_pairs_in_contact, particle_container);
+    particle_floating_mesh_pairs_in_contact, particle_container);
 
   update_particle_point_line_contact_container_iterators<dim>(
     particle_points_in_contact, particle_lines_in_contact, particle_container);
@@ -58,9 +58,9 @@ locate_local_particles_in_cells(
   typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
-    &pfw_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+    &particle_floating_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<2>::
+    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
     2>::particle_point_line_contact_info &particle_points_in_contact,
   typename dem_data_containers::dem_data_structures<
@@ -78,9 +78,9 @@ locate_local_particles_in_cells(
   typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
-    &pfw_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_mesh_in_contact &pfm_pairs_in_contact,
+    &particle_floating_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<3>::
+    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
   typename dem_data_containers::dem_data_structures<
     3>::particle_point_line_contact_info &particle_points_in_contact,
   typename dem_data_containers::dem_data_structures<

--- a/source/dem/non_uniform_insertion.cc
+++ b/source/dem/non_uniform_insertion.cc
@@ -10,7 +10,7 @@ using namespace DEM;
 template <int dim>
 NonUniformInsertion<dim>::NonUniformInsertion(
   const DEMSolverParameters<dim> &dem_parameters,
-  const double &                  maximum_particle_diameter)
+  const double                    maximum_particle_diameter)
   : remained_particles_of_each_type(
       dem_parameters.lagrangian_physical_properties.number.at(0))
 {
@@ -145,8 +145,8 @@ template <int dim>
 void
 NonUniformInsertion<dim>::create_random_number_container(
   std::vector<double> &random_container,
-  const double &       random_number_range,
-  const int &          random_number_seed)
+  const double         random_number_range,
+  const int            random_number_seed)
 {
   for (unsigned int i = 0; i < this->inserted_this_step; ++i)
     {
@@ -160,9 +160,9 @@ NonUniformInsertion<dim>::create_random_number_container(
 template <>
 void NonUniformInsertion<2>::find_insertion_location_nonuniform(
   Point<2> &                                   insertion_location,
-  const unsigned int &                         id,
-  const double &                               random_number1,
-  const double &                               random_number2,
+  const unsigned int                           id,
+  const double                                 random_number1,
+  const double                                 random_number2,
   const Parameters::Lagrangian::InsertionInfo &insertion_information)
 {
   std::vector<int> insertion_index;
@@ -186,9 +186,9 @@ void NonUniformInsertion<2>::find_insertion_location_nonuniform(
 template <>
 void NonUniformInsertion<3>::find_insertion_location_nonuniform(
   Point<3> &                                   insertion_location,
-  const unsigned int &                         id,
-  const double &                               random_number1,
-  const double &                               random_number2,
+  const unsigned int                           id,
+  const double                                 random_number1,
+  const double                                 random_number2,
   const Parameters::Lagrangian::InsertionInfo &insertion_information)
 {
   std::vector<int> insertion_index;

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -11,9 +11,9 @@ void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
   const typename dem_data_containers::dem_data_structures<
-    dim>::cells_neighbor_list *cells_local_neighbor_list,
+    dim>::cells_neighbor_list &cells_local_neighbor_list,
   const typename dem_data_containers::dem_data_structures<
-    dim>::cells_neighbor_list *cells_ghost_neighbor_list,
+    dim>::cells_neighbor_list &cells_ghost_neighbor_list,
   typename dem_data_containers::dem_data_structures<
     dim>::particle_particle_candidates &local_contact_pair_candidates,
   typename dem_data_containers::dem_data_structures<
@@ -24,8 +24,8 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   local_contact_pair_candidates.clear();
 
   // Looping over cells_local_neighbor_list
-  for (auto cell_neighbor_list_iterator = cells_local_neighbor_list->begin();
-       cell_neighbor_list_iterator != cells_local_neighbor_list->end();
+  for (auto cell_neighbor_list_iterator = cells_local_neighbor_list.begin();
+       cell_neighbor_list_iterator != cells_local_neighbor_list.end();
        ++cell_neighbor_list_iterator)
     {
       // The main cell
@@ -129,8 +129,8 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   ghost_contact_pair_candidates.clear();
 
   // Looping over cells_ghost_neighbor_list
-  for (auto cell_neighbor_list_iterator = cells_ghost_neighbor_list->begin();
-       cell_neighbor_list_iterator != cells_ghost_neighbor_list->end();
+  for (auto cell_neighbor_list_iterator = cells_ghost_neighbor_list.begin();
+       cell_neighbor_list_iterator != cells_ghost_neighbor_list.end();
        ++cell_neighbor_list_iterator)
     {
       // The main cell

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -10,16 +10,14 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  const std::vector<
-    std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    *cells_local_neighbor_list,
-  const std::vector<
-    std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    *cells_ghost_neighbor_list,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &local_contact_pair_candidates,
-  std::unordered_map<types::particle_index, std::vector<types::particle_index>>
-    &ghost_contact_pair_candidates)
+  const typename dem_data_containers::dem_data_structures<
+    dim>::cells_neighbor_list *cells_local_neighbor_list,
+  const typename dem_data_containers::dem_data_structures<
+    dim>::cells_neighbor_list *cells_ghost_neighbor_list,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &local_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &ghost_contact_pair_candidates)
 {
   // First we will handle the local-lcoal candidate pairs
   // Clearing local_contact_pair_candidates

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -9,25 +9,17 @@ ParticleParticleFineSearch<dim>::ParticleParticleFineSearch()
 template <int dim>
 void
 ParticleParticleFineSearch<dim>::particle_particle_fine_search(
-  const std::unordered_map<types::particle_index,
-                           std::vector<types::particle_index>>
-    &local_contact_pair_candidates,
-  const std::unordered_map<types::particle_index,
-                           std::vector<types::particle_index>>
-    &ghost_contact_pair_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &          particle_container,
-  const double neighborhood_threshold)
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &local_contact_pair_candidates,
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_particle_candidates &ghost_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container,
+  const double                         neighborhood_threshold)
 {
   // First iterating over local adjacent_particles
   for (auto &&adjacent_particles_list :

--- a/source/dem/particle_particle_linear_force.cc
+++ b/source/dem/particle_particle_linear_force.cc
@@ -329,7 +329,7 @@ ParticleParticleLinearForce<dim>::calculate_particle_particle_contact_force(
 template <int dim>
 void
 ParticleParticleLinearForce<dim>::calculate_IB_particle_particle_contact_force(
-  const double &                              normal_overlap,
+  const double                                normal_overlap,
   particle_particle_contact_info_struct<dim> &contact_info,
   Tensor<1, 3> &                              normal_force,
   Tensor<1, 3> &                              tangential_force,
@@ -341,10 +341,10 @@ ParticleParticleLinearForce<dim>::calculate_IB_particle_particle_contact_force(
   const Point<dim> &                          particle_one_location,
   const Point<dim> &                          particle_two_location,
   const double                                dt,
-  const double &                              particle_one_radius,
-  const double &                              particle_two_radius,
-  const double &                              particle_one_mass,
-  const double &                              particle_two_mass)
+  const double                                particle_one_radius,
+  const double                                particle_two_radius,
+  const double                                particle_one_mass,
+  const double                                particle_two_mass)
 {
   Point<3> particle_one_location_3d;
   Point<3> particle_two_location_3d;
@@ -441,9 +441,9 @@ template <int dim>
 void
 ParticleParticleLinearForce<dim>::calculate_linear_contact_force_and_torque(
   particle_particle_contact_info_struct<dim> &contact_info,
-  const double &                              normal_relative_velocity_value,
+  const double                                normal_relative_velocity_value,
   const Tensor<1, 3> &                        normal_unit_vector,
-  const double &                              normal_overlap,
+  const double                                normal_overlap,
   const ArrayView<const double> &             particle_one_properties,
   const ArrayView<const double> &             particle_two_properties,
   Tensor<1, 3> &                              normal_force,

--- a/source/dem/particle_particle_linear_force.cc
+++ b/source/dem/particle_particle_linear_force.cc
@@ -94,19 +94,13 @@ ParticleParticleLinearForce<dim>::ParticleParticleLinearForce(
 template <int dim>
 void
 ParticleParticleLinearForce<dim>::calculate_particle_particle_contact_force(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &                        ghost_adjacent_particles,
-  const double               dt,
-  std::vector<Tensor<1, 3>> &torque,
-  std::vector<Tensor<1, 3>> &force)
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  const double                     dt,
+  std::vector<Tensor<1, 3>> &      torque,
+  std::vector<Tensor<1, 3>> &      force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops

--- a/source/dem/particle_particle_nonlinear_force.cc
+++ b/source/dem/particle_particle_nonlinear_force.cc
@@ -110,19 +110,13 @@ template <int dim>
 void
 ParticleParticleHertzMindlinLimitOverlap<dim>::
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &local_adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force)
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &local_adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops
@@ -710,19 +704,13 @@ template <int dim>
 void
 ParticleParticleHertzMindlinLimitForce<dim>::
   calculate_particle_particle_contact_force(
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &local_adjacent_particles,
-    std::unordered_map<
-      types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info_struct<dim>>>
-      &                        ghost_adjacent_particles,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force)
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &local_adjacent_particles,
+    typename dem_data_containers::dem_data_structures<
+      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+    const double                     dt,
+    std::vector<Tensor<1, 3>> &      torque,
+    std::vector<Tensor<1, 3>> &      force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops
@@ -1297,19 +1285,13 @@ ParticleParticleHertz<dim>::ParticleParticleHertz(
 template <int dim>
 void
 ParticleParticleHertz<dim>::calculate_particle_particle_contact_force(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &                        ghost_adjacent_particles,
-  const double               dt,
-  std::vector<Tensor<1, 3>> &torque,
-  std::vector<Tensor<1, 3>> &force)
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  const double                     dt,
+  std::vector<Tensor<1, 3>> &      torque,
+  std::vector<Tensor<1, 3>> &      force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops

--- a/source/dem/particle_particle_nonlinear_force.cc
+++ b/source/dem/particle_particle_nonlinear_force.cc
@@ -348,7 +348,7 @@ template <int dim>
 void
 ParticleParticleHertzMindlinLimitOverlap<dim>::
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -360,10 +360,10 @@ ParticleParticleHertzMindlinLimitOverlap<dim>::
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass)
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass)
 {
   Point<3> particle_one_location_3d;
   Point<3> particle_two_location_3d;
@@ -472,9 +472,9 @@ void
 ParticleParticleHertzMindlinLimitOverlap<dim>::
   calculate_hertz_mindlin_limit_overlap_contact(
     particle_particle_contact_info_struct<dim> &contact_info,
-    const double &                              normal_relative_velocity_value,
+    const double                                normal_relative_velocity_value,
     const Tensor<1, 3> &                        normal_unit_vector,
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     const ArrayView<const double> &             particle_one_properties,
     const ArrayView<const double> &             particle_two_properties,
     Tensor<1, 3> &                              normal_force,
@@ -939,7 +939,7 @@ template <int dim>
 void
 ParticleParticleHertzMindlinLimitForce<dim>::
   calculate_IB_particle_particle_contact_force(
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     particle_particle_contact_info_struct<dim> &contact_info,
     Tensor<1, 3> &                              normal_force,
     Tensor<1, 3> &                              tangential_force,
@@ -951,10 +951,10 @@ ParticleParticleHertzMindlinLimitForce<dim>::
     const Point<dim> &                          particle_one_location,
     const Point<dim> &                          particle_two_location,
     const double                                dt,
-    const double &                              particle_one_radius,
-    const double &                              particle_two_radius,
-    const double &                              particle_one_mass,
-    const double &                              particle_two_mass)
+    const double                                particle_one_radius,
+    const double                                particle_two_radius,
+    const double                                particle_one_mass,
+    const double                                particle_two_mass)
 {
   Point<3> particle_one_location_3d;
   Point<3> particle_two_location_3d;
@@ -1062,9 +1062,9 @@ void
 ParticleParticleHertzMindlinLimitForce<dim>::
   calculate_hertz_mindlin_limit_force_contact(
     particle_particle_contact_info_struct<dim> &contact_info,
-    const double &                              normal_relative_velocity_value,
+    const double                                normal_relative_velocity_value,
     const Tensor<1, 3> &                        normal_unit_vector,
-    const double &                              normal_overlap,
+    const double                                normal_overlap,
     const ArrayView<const double> &             particle_one_properties,
     const ArrayView<const double> &             particle_two_properties,
     Tensor<1, 3> &                              normal_force,
@@ -1517,7 +1517,7 @@ ParticleParticleHertz<dim>::calculate_particle_particle_contact_force(
 template <int dim>
 void
 ParticleParticleHertz<dim>::calculate_IB_particle_particle_contact_force(
-  const double &                              normal_overlap,
+  const double                                normal_overlap,
   particle_particle_contact_info_struct<dim> &contact_info,
   Tensor<1, 3> &                              normal_force,
   Tensor<1, 3> &                              tangential_force,
@@ -1529,10 +1529,10 @@ ParticleParticleHertz<dim>::calculate_IB_particle_particle_contact_force(
   const Point<dim> &                          particle_one_location,
   const Point<dim> &                          particle_two_location,
   const double                                dt,
-  const double &                              particle_one_radius,
-  const double &                              particle_two_radius,
-  const double &                              particle_one_mass,
-  const double &                              particle_two_mass)
+  const double                                particle_one_radius,
+  const double                                particle_two_radius,
+  const double                                particle_one_mass,
+  const double                                particle_two_mass)
 {
   Point<3> particle_one_location_3d;
   Point<3> particle_two_location_3d;
@@ -1639,9 +1639,9 @@ template <int dim>
 void
 ParticleParticleHertz<dim>::calculate_hertz_contact(
   particle_particle_contact_info_struct<dim> &contact_info,
-  const double &                              normal_relative_velocity_value,
+  const double                                normal_relative_velocity_value,
   const Tensor<1, 3> &                        normal_unit_vector,
-  const double &                              normal_overlap,
+  const double                                normal_overlap,
   const ArrayView<const double> &             particle_one_properties,
   const ArrayView<const double> &             particle_two_properties,
   Tensor<1, 3> &                              normal_force,

--- a/source/dem/particle_point_line_broad_search.cc
+++ b/source/dem/particle_point_line_broad_search.cc
@@ -9,8 +9,8 @@ ParticlePointLineBroadSearch<dim>::ParticlePointLineBroadSearch()
 
 // This function finds all the particle-point contact candidates
 template <int dim>
-std::unordered_map<types::particle_index,
-                   std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
+typename dem_data_containers::dem_data_structures<
+  dim>::particle_point_candidates
 ParticlePointLineBroadSearch<dim>::find_particle_point_contact_pairs(
   const Particles::ParticleHandler<dim> &particle_handler,
   const std::unordered_map<
@@ -67,9 +67,7 @@ ParticlePointLineBroadSearch<dim>::find_particle_point_contact_pairs(
 
 // This function finds all the particle-line contact candidates
 template <int dim>
-std::unordered_map<
-  types::particle_index,
-  std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
+typename dem_data_containers::dem_data_structures<dim>::particle_line_candidates
 ParticlePointLineBroadSearch<dim>::find_particle_line_contact_pairs(
   const Particles::ParticleHandler<dim> &particle_handler,
   const std::unordered_map<

--- a/source/dem/particle_point_line_contact_force.cc
+++ b/source/dem/particle_point_line_contact_force.cc
@@ -14,9 +14,8 @@ ParticlePointLineForce<dim>::ParticlePointLineForce()
 template <int dim>
 void
 ParticlePointLineForce<dim>::calculate_particle_point_contact_force(
-  const std::unordered_map<types::particle_index,
-                           particle_point_line_contact_info_struct<dim>>
-    *particle_point_pairs_in_contact,
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info *particle_point_pairs_in_contact,
   const Parameters::Lagrangian::LagrangianPhysicalProperties
     &                        physical_properties,
   std::vector<Tensor<1, 3>> &force)
@@ -139,9 +138,8 @@ ParticlePointLineForce<dim>::calculate_particle_point_contact_force(
 template <int dim>
 void
 ParticlePointLineForce<dim>::calculate_particle_line_contact_force(
-  const std::unordered_map<types::particle_index,
-                           particle_point_line_contact_info_struct<dim>>
-    *particle_line_pairs_in_contact,
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info *particle_line_pairs_in_contact,
   const Parameters::Lagrangian::LagrangianPhysicalProperties
     &                        physical_properties,
   std::vector<Tensor<1, 3>> &force)

--- a/source/dem/particle_point_line_fine_search.cc
+++ b/source/dem/particle_point_line_fine_search.cc
@@ -19,7 +19,7 @@ typename dem_data_containers::dem_data_structures<
 ParticlePointLineFineSearch<dim>::particle_point_fine_search(
   const typename dem_data_containers::dem_data_structures<
     dim>::particle_point_candidates &particle_point_contact_candidates,
-  const double &                     neighborhood_threshold)
+  const double                       neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>
@@ -91,7 +91,7 @@ typename dem_data_containers::dem_data_structures<
 ParticlePointLineFineSearch<dim>::particle_line_fine_search(
   const typename dem_data_containers::dem_data_structures<
     dim>::particle_line_candidates &particle_line_contact_candidates,
-  const double &                    neighborhood_threshold)
+  const double                      neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>

--- a/source/dem/particle_point_line_fine_search.cc
+++ b/source/dem/particle_point_line_fine_search.cc
@@ -14,14 +14,12 @@ ParticlePointLineFineSearch<dim>::ParticlePointLineFineSearch()
 // calculated. The output of this function is used for calculation of the
 // contact force
 template <int dim>
-std::unordered_map<types::particle_index,
-                   particle_point_line_contact_info_struct<dim>>
+typename dem_data_containers::dem_data_structures<
+  dim>::particle_point_line_contact_info
 ParticlePointLineFineSearch<dim>::particle_point_fine_search(
-  const std::unordered_map<
-    types::particle_index,
-    std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
-    &           particle_point_contact_candidates,
-  const double &neighborhood_threshold)
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_candidates &particle_point_contact_candidates,
+  const double &                     neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>
@@ -88,14 +86,12 @@ ParticlePointLineFineSearch<dim>::particle_point_fine_search(
 // calculated. The output of this function is used for calculation of the
 // contact force
 template <int dim>
-std::unordered_map<types::particle_index,
-                   particle_point_line_contact_info_struct<dim>>
+typename dem_data_containers::dem_data_structures<
+  dim>::particle_point_line_contact_info
 ParticlePointLineFineSearch<dim>::particle_line_fine_search(
-  const std::unordered_map<
-    types::particle_index,
-    std::tuple<Particles::ParticleIterator<dim>, Point<dim>, Point<dim>>>
-    &           particle_line_contact_candidates,
-  const double &neighborhood_threshold)
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_line_candidates &particle_line_contact_candidates,
+  const double &                    neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -13,15 +13,8 @@ ParticleWallBroadSearch<dim>::find_particle_wall_contact_pairs(
   const std::map<int, boundary_cells_info_struct<dim>>
     &                                    boundary_cells_information,
   const Particles::ParticleHandler<dim> &particle_handler,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<dim>,
-                                  Tensor<1, dim>,
-                                  Point<dim>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
-    &particle_wall_contact_candidates)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_candidates &particle_wall_contact_candidates)
 {
   // Clearing particle_wall_contact_candidates (output of this function)
   particle_wall_contact_candidates.clear();
@@ -84,10 +77,8 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const Particles::ParticleHandler<dim> &particle_handler,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double &                                    simulation_time,
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-    &pfw_contact_candidates)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_wall_candidates &pfw_contact_candidates)
 {
   // Clearing pfw_contact_candidates(output of this function)
   pfw_contact_candidates.clear();
@@ -148,20 +139,14 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
 template <int dim>
 void
 ParticleWallBroadSearch<dim>::particle_floating_mesh_contact_search(
-  const std::vector<std::vector<
-    std::pair<typename Triangulation<dim>::active_cell_iterator,
-              typename Triangulation<dim - 1, dim>::active_cell_iterator>>>
-    &                                    floating_mesh_information,
+  const typename dem_data_containers::dem_data_structures<
+    dim>::floating_mesh_information &    floating_mesh_information,
   const Particles::ParticleHandler<dim> &particle_handler,
-  std::vector<std::map<
-    typename Triangulation<dim - 1, dim>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>,
-    dem_data_containers::cut_cell_comparison<dim>>>
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates,
-  std::unordered_map<
-    types::global_cell_index,
-    std::vector<typename Triangulation<dim>::active_cell_iterator>>
-    &cells_total_neighbor_list)
+  typename dem_data_containers::dem_data_structures<
+    dim>::cells_total_neighbor_list &cells_total_neighbor_list)
 {
   // Clear the candidate container
   particle_floating_mesh_contact_candidates.clear();

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -76,12 +76,12 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
     &                                    boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-  const double &                                    simulation_time,
+  const double                                      simulation_time,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates &pfw_contact_candidates)
+    dim>::particle_floating_wall_candidates &particle_floating_wall_candidates)
 {
-  // Clearing pfw_contact_candidates(output of this function)
-  pfw_contact_candidates.clear();
+  // Clearing particle_floating_wall_candidates(output of this function)
+  particle_floating_wall_candidates.clear();
 
   // Iterating over the boundary_cells_for_floating_walls, which is the output
   // of the find_boundary_cells_for_floating_walls function in
@@ -126,9 +126,10 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
                        particles_in_cell_iterator != particles_in_cell.end();
                        ++particles_in_cell_iterator)
                     {
-                      pfw_contact_candidates[particles_in_cell_iterator
-                                               ->get_id()]
-                        .insert({floating_wall_id, particles_in_cell_iterator});
+                      particle_floating_wall_candidates
+                        [particles_in_cell_iterator->get_id()]
+                          .insert(
+                            {floating_wall_id, particles_in_cell_iterator});
                     }
                 }
             }

--- a/source/dem/particle_wall_contact_force.cc
+++ b/source/dem/particle_wall_contact_force.cc
@@ -93,7 +93,7 @@ ParticleWallContactForce<dim>::
     const double                            dt,
     const Tensor<1, 3> &                    cut_cell_translational_velocity,
     const Tensor<1, 3> &                    cut_cell_rotational_velocity,
-    const double &center_of_rotation_particle_distance)
+    const double center_of_rotation_particle_distance)
 {
   const Tensor<1, 3> normal_vector = contact_info.normal_vector;
 

--- a/source/dem/particle_wall_fine_search.cc
+++ b/source/dem/particle_wall_fine_search.cc
@@ -81,11 +81,11 @@ template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
   const typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates &       pfw_contact_candidates,
+    dim>::particle_floating_wall_candidates &particle_floating_wall_candidates,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-  const double &                                    simulation_time,
+  const double                                      simulation_time,
   typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &pfw_pairs_in_contact)
+    dim>::particle_wall_in_contact &particle_floating_wall_pairs_in_contact)
 {
   // Reading floating wall properties
   std::vector<Point<dim>> point_on_wall =
@@ -94,9 +94,9 @@ ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
     floating_wall_properties.floating_walls_normal_vectors;
 
   // Iterating over contact candidates from broad search and adding the pairs to
-  // the pfw_pairs_in_contact
+  // the particle_floating_wall_pairs_in_contact
   for (auto const &[particle_id, particle_pair_candidates] :
-       pfw_contact_candidates)
+       particle_floating_wall_candidates)
     {
       if (!particle_pair_candidates.empty())
         {
@@ -177,7 +177,7 @@ ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
                   contact_info.tangential_relative_velocity = .0;
 
 
-                  pfw_pairs_in_contact[particle_id].insert(
+                  particle_floating_wall_pairs_in_contact[particle_id].insert(
                     {floating_wall_id, contact_info});
                 }
             }

--- a/source/dem/particle_wall_fine_search.cc
+++ b/source/dem/particle_wall_fine_search.cc
@@ -14,19 +14,10 @@ ParticleWallFineSearch<dim>::ParticleWallFineSearch()
 template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_wall_fine_search(
-  const std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id,
-                       std::tuple<Particles::ParticleIterator<dim>,
-                                  Tensor<1, dim>,
-                                  Point<dim>,
-                                  types::boundary_id,
-                                  types::global_cell_index>>>
-    &particle_wall_contact_pair_candidates,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact)
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_candidates &particle_wall_contact_pair_candidates,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact)
 {
   // Iterating over contact candidates from broad search and adding the pairs to
   // the particle_wall_pairs_in_contact
@@ -89,16 +80,12 @@ ParticleWallFineSearch<dim>::particle_wall_fine_search(
 template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
-  const std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
-    &                                               pfw_contact_candidates,
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_wall_candidates &       pfw_contact_candidates,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double &                                    simulation_time,
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &pfw_pairs_in_contact)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &pfw_pairs_in_contact)
 {
   // Reading floating wall properties
   std::vector<Point<dim>> point_on_wall =
@@ -202,17 +189,11 @@ ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
 template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_floating_mesh_fine_search(
-  const std::vector<std::map<
-    typename Triangulation<dim - 1, dim>::active_cell_iterator,
-    std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>,
-    dem_data_containers::cut_cell_comparison<dim>>>
+  const typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates,
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &particle_floating_mesh_in_contact)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact)
 {
   for (unsigned int solid_counter = 0;
        solid_counter < particle_floating_mesh_contact_candidates.size();

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -470,14 +470,14 @@ ParticleWallLinearForce<dim>::calculate_IB_particle_wall_contact_force(
   Tensor<1, 3> & /*tangential_torque*/,
   Tensor<1, 3> & /*rolling_resistance_torque*/,
   IBParticle<dim> & /*particle*/,
-  const double & /*wall_youngs_modulus*/,
-  const double & /*wall_poisson_ratio*/,
-  const double & /*wall_restitution_coefficient*/,
-  const double & /*wall_friction_coefficient*/,
-  const double & /*wall_rolling_friction_coefficient*/,
+  const double /*wall_youngs_modulus*/,
+  const double /*wall_poisson_ratio*/,
+  const double /*wall_restitution_coefficient*/,
+  const double /*wall_friction_coefficient*/,
+  const double /*wall_rolling_friction_coefficient*/,
   const double /*dt*/,
-  const double &,
-  const double &)
+  const double,
+  const double)
 {}
 
 template class ParticleWallLinearForce<2>;

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -114,13 +114,11 @@ ParticleWallLinearForce<dim>::ParticleWallLinearForce(
 template <int dim>
 void
 ParticleWallLinearForce<dim>::calculate_particle_wall_contact_force(
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &                        particle_wall_pairs_in_contact,
-  const double               dt,
-  std::vector<Tensor<1, 3>> &torque,
-  std::vector<Tensor<1, 3>> &force)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  const double                      dt,
+  std::vector<Tensor<1, 3>> &       torque,
+  std::vector<Tensor<1, 3>> &       force)
 {
   ParticleWallContactForce<dim>::force_on_walls =
     ParticleWallContactForce<dim>::initialize();
@@ -214,17 +212,13 @@ ParticleWallLinearForce<dim>::calculate_particle_wall_contact_force(
 
 template <int dim>
 void
-  ParticleWallLinearForce<dim>::calculate_particle_floating_wall_contact_force(
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  particle_wall_contact_info_struct<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
-      &                        particle_floating_mesh_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force,
-    const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
+ParticleWallLinearForce<dim>::calculate_particle_floating_wall_contact_force(
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  const double                               dt,
+  std::vector<Tensor<1, 3>> &                torque,
+  std::vector<Tensor<1, 3>> &                force,
+  const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
 {
   std::vector<Particles::ParticleIterator<dim>> particle_locations;
   std::vector<Point<dim>> triangle(this->vertices_per_triangle);

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -122,13 +122,11 @@ ParticleWallNonLinearForce<dim>::ParticleWallNonLinearForce(
 template <int dim>
 void
 ParticleWallNonLinearForce<dim>::calculate_particle_wall_contact_force(
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &                        particle_wall_pairs_in_contact,
-  const double               dt,
-  std::vector<Tensor<1, 3>> &torque,
-  std::vector<Tensor<1, 3>> &force)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  const double                      dt,
+  std::vector<Tensor<1, 3>> &       torque,
+  std::vector<Tensor<1, 3>> &       force)
 {
   ParticleWallContactForce<dim>::force_on_walls =
     ParticleWallContactForce<dim>::initialize();
@@ -226,18 +224,14 @@ ParticleWallNonLinearForce<dim>::calculate_particle_wall_contact_force(
 
 
 template <int dim>
-void ParticleWallNonLinearForce<dim>::
-  calculate_particle_floating_wall_contact_force(
-    std::vector<
-      std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-               std::unordered_map<types::particle_index,
-                                  particle_wall_contact_info_struct<dim>>,
-               dem_data_containers::cut_cell_comparison<dim>>>
-      &                        particle_floating_mesh_in_contact,
-    const double               dt,
-    std::vector<Tensor<1, 3>> &torque,
-    std::vector<Tensor<1, 3>> &force,
-    const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
+void
+ParticleWallNonLinearForce<dim>::calculate_particle_floating_wall_contact_force(
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  const double                               dt,
+  std::vector<Tensor<1, 3>> &                torque,
+  std::vector<Tensor<1, 3>> &                force,
+  const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
 {
   std::vector<Particles::ParticleIterator<dim>> particle_locations;
   std::vector<Point<dim>> triangle(this->vertices_per_triangle);

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -484,14 +484,14 @@ ParticleWallNonLinearForce<dim>::calculate_IB_particle_wall_contact_force(
   Tensor<1, 3> &                          tangential_torque,
   Tensor<1, 3> &                          rolling_resistance_torque,
   IBParticle<dim> &                       particle,
-  const double &                          wall_youngs_modulus,
-  const double &                          wall_poisson_ratio,
-  const double &                          wall_restitution_coefficient,
-  const double &                          wall_friction_coefficient,
-  const double &                          wall_rolling_friction_coefficient,
+  const double                            wall_youngs_modulus,
+  const double                            wall_poisson_ratio,
+  const double                            wall_restitution_coefficient,
+  const double                            wall_friction_coefficient,
+  const double                            wall_rolling_friction_coefficient,
   const double                            dt,
-  const double &                          mass,
-  const double &                          radius)
+  const double                            mass,
+  const double                            radius)
 {
   auto particle_properties                        = particle.get_properties();
   particle_properties[DEM::PropertiesIndex::mass] = mass;

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -4,7 +4,7 @@
 template <int dim, int spacedim>
 void
 read_mesh(const Parameters::Mesh &             mesh_params,
-          const bool &                         restart,
+          const bool                           restart,
           const ConditionalOStream &           pcout,
           Triangulation<dim, spacedim> &       triangulation,
           double &                             triangulation_cell_diameter,
@@ -86,7 +86,7 @@ match_periodic_boundaries(Triangulation<dim, spacedim> &       triangulation,
 
 template void
 read_mesh<1, 2>(const Parameters::Mesh &  mesh_params,
-                const bool &              restart,
+                const bool                restart,
                 const ConditionalOStream &pcout,
                 Triangulation<1, 2> &     triangulation,
                 double &                  triangulation_cell_diameter,
@@ -94,7 +94,7 @@ read_mesh<1, 2>(const Parameters::Mesh &  mesh_params,
 
 template void
 read_mesh<2, 2>(const Parameters::Mesh &  mesh_params,
-                const bool &              restart,
+                const bool                restart,
                 const ConditionalOStream &pcout,
                 Triangulation<2, 2> &     triangulation,
                 double &                  triangulation_cell_diameter,
@@ -102,7 +102,7 @@ read_mesh<2, 2>(const Parameters::Mesh &  mesh_params,
 
 template void
 read_mesh<2, 3>(const Parameters::Mesh &  mesh_params,
-                const bool &              restart,
+                const bool                restart,
                 const ConditionalOStream &pcout,
                 Triangulation<2, 3> &     triangulation,
                 double &                  triangulation_cell_diameter,
@@ -110,7 +110,7 @@ read_mesh<2, 3>(const Parameters::Mesh &  mesh_params,
 
 template void
 read_mesh<3, 3>(const Parameters::Mesh &  mesh_params,
-                const bool &              restart,
+                const bool                restart,
                 const ConditionalOStream &pcout,
                 Triangulation<3, 3> &     triangulation,
                 double &                  triangulation_cell_diameter,

--- a/source/dem/set_particle_wall_contact_force_model.cc
+++ b/source/dem/set_particle_wall_contact_force_model.cc
@@ -7,7 +7,7 @@ std::shared_ptr<ParticleWallContactForce<dim>>
 set_particle_wall_contact_force_model(
   const DEMSolverParameters<dim> &                 dem_parameters,
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const double &                                   triangulation_cell_diameter)
+  const double                                     triangulation_cell_diameter)
 {
   std::shared_ptr<ParticleWallContactForce<dim>>
     particle_wall_contact_force_object;
@@ -51,10 +51,10 @@ template std::shared_ptr<ParticleWallContactForce<2>>
 set_particle_wall_contact_force_model(
   const DEMSolverParameters<2> &                 dem_parameters,
   const parallel::distributed::Triangulation<2> &triangulation,
-  const double &                                 triangulation_cell_diameter);
+  const double                                   triangulation_cell_diameter);
 
 template std::shared_ptr<ParticleWallContactForce<3>>
 set_particle_wall_contact_force_model(
   const DEMSolverParameters<3> &                 dem_parameters,
   const parallel::distributed::Triangulation<3> &triangulation,
-  const double &                                 triangulation_cell_diameter);
+  const double                                   triangulation_cell_diameter);

--- a/source/dem/uniform_insertion.cc
+++ b/source/dem/uniform_insertion.cc
@@ -10,7 +10,7 @@ using namespace DEM;
 template <int dim>
 UniformInsertion<dim>::UniformInsertion(
   const DEMSolverParameters<dim> &dem_parameters,
-  const double &                  maximum_particle_diameter)
+  const double                    maximum_particle_diameter)
   : remained_particles_of_each_type(
       dem_parameters.lagrangian_physical_properties.number.at(0))
 {

--- a/source/dem/update_ghost_particle_particle_contact_container.cc
+++ b/source/dem/update_ghost_particle_particle_contact_container.cc
@@ -5,13 +5,10 @@ using namespace dealii;
 template <int dim>
 void
 update_ghost_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container)
 {
   for (auto adjacent_particles_iterator = ghost_adjacent_particles.begin();
        adjacent_particles_iterator != ghost_adjacent_particles.end();
@@ -32,20 +29,14 @@ update_ghost_particle_particle_contact_container_iterators(
         }
     }
 }
-template void update_ghost_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<2>>>
+template void update_ghost_particle_particle_contact_container_iterators<2>(
+  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &particle_container);
 
-template void update_ghost_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<3>>>
+template void update_ghost_particle_particle_contact_container_iterators<3>(
+  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &particle_container);

--- a/source/dem/update_local_particle_particle_contact_container.cc
+++ b/source/dem/update_local_particle_particle_contact_container.cc
@@ -5,13 +5,10 @@ using namespace dealii;
 template <int dim>
 void
 update_local_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<dim>>>
-    &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+  typename dem_data_containers::dem_data_structures<
+    dim>::adjacent_particle_pairs &local_adjacent_particles,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container)
 {
   for (auto adjacent_particles_iterator = local_adjacent_particles.begin();
        adjacent_particles_iterator != local_adjacent_particles.end();
@@ -34,20 +31,14 @@ update_local_particle_particle_contact_container_iterators(
     }
 }
 
-template void update_local_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<2>>>
+template void update_local_particle_particle_contact_container_iterators<2>(
+  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
     &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &particle_container);
 
-template void update_local_particle_particle_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::unordered_map<types::particle_index,
-                       particle_particle_contact_info_struct<3>>>
+template void update_local_particle_particle_contact_container_iterators<3>(
+  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
     &local_adjacent_particles,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &particle_container);

--- a/source/dem/update_particle_container.cc
+++ b/source/dem/update_particle_container.cc
@@ -5,8 +5,8 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &                                    particle_container,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<dim> *particle_handler)
 {
   particle_container.clear();
@@ -27,11 +27,11 @@ update_particle_container(
 }
 
 template void update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &                                  particle_container,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<2> *particle_handler);
 
 template void update_particle_container(
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &                                  particle_container,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<3> *particle_handler);

--- a/source/dem/update_particle_point_line_contact_container.cc
+++ b/source/dem/update_particle_point_line_contact_container.cc
@@ -5,14 +5,12 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_point_line_contact_container_iterators(
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<dim>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_point_line_contact_info &particle_lines_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container)
 {
   for (auto particle_point_pairs_in_contact_iterator =
          particle_points_in_contact.begin();
@@ -40,22 +38,18 @@ update_particle_point_line_contact_container_iterators(
     }
 }
 
-template void update_particle_point_line_contact_container_iterators(
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<2>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<2>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+template void update_particle_point_line_contact_container_iterators<2>(
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_point_line_contact_info &particle_lines_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &particle_container);
 
-template void update_particle_point_line_contact_container_iterators(
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<3>>
-    &particle_points_in_contact,
-  std::unordered_map<types::particle_index,
-                     particle_point_line_contact_info_struct<3>>
-    &particle_lines_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+template void update_particle_point_line_contact_container_iterators<3>(
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_point_line_contact_info &particle_points_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_point_line_contact_info &particle_lines_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &particle_container);

--- a/source/dem/update_particle_wall_contact_container.cc
+++ b/source/dem/update_particle_wall_contact_container.cc
@@ -5,12 +5,10 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_wall_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container)
 {
   for (auto particle_wall_pairs_in_contact_iterator =
          particle_wall_pairs_in_contact.begin();
@@ -34,22 +32,19 @@ update_particle_wall_contact_container_iterators(
 }
 
 template <int dim>
-void update_particle_floating_wall_contact_container_iterators(
-  std::vector<
-    std::map<typename Triangulation<dim - 1, dim>::active_cell_iterator,
-             std::unordered_map<types::particle_index,
-                                particle_wall_contact_info_struct<dim>>,
-             dem_data_containers::cut_cell_comparison<dim>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<dim>>
-    &particle_container)
+void
+update_particle_floating_mesh_contact_container_iterators(
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    dim>::particle_index_iterator_map &particle_container)
 {
   for (unsigned int solid_counter = 0;
-       solid_counter < particle_wall_pairs_in_contact.size();
+       solid_counter < particle_floating_mesh_in_contact.size();
        ++solid_counter)
     {
       auto &particle_floating_wall_contact_pair =
-        particle_wall_pairs_in_contact[solid_counter];
+        particle_floating_mesh_in_contact[solid_counter];
       for (auto particle_floating_wall_iterator =
              particle_floating_wall_contact_pair.begin();
            particle_floating_wall_iterator !=
@@ -73,36 +68,26 @@ void update_particle_floating_wall_contact_container_iterators(
     }
 }
 
-template void update_particle_wall_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<2>>>
+template void update_particle_wall_contact_container_iterators<2>(
+  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &particle_container);
 
-template void update_particle_wall_contact_container_iterators(
-  std::unordered_map<
-    types::particle_index,
-    std::map<types::boundary_id, particle_wall_contact_info_struct<3>>>
+template void update_particle_wall_contact_container_iterators<3>(
+  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &particle_container);
 
-template void update_particle_floating_wall_contact_container_iterators(
-  std::vector<std::map<typename Triangulation<1, 2>::active_cell_iterator,
-                       std::unordered_map<types::particle_index,
-                                          particle_wall_contact_info_struct<2>>,
-                       dem_data_containers::cut_cell_comparison<2>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<2>>
-    &particle_container);
+template void update_particle_floating_mesh_contact_container_iterators<2>(
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    2>::particle_index_iterator_map &particle_container);
 
-template void update_particle_floating_wall_contact_container_iterators(
-  std::vector<std::map<typename Triangulation<2, 3>::active_cell_iterator,
-                       std::unordered_map<types::particle_index,
-                                          particle_wall_contact_info_struct<3>>,
-                       dem_data_containers::cut_cell_comparison<3>>>
-    &particle_wall_pairs_in_contact,
-  std::unordered_map<types::particle_index, Particles::ParticleIterator<3>>
-    &particle_container);
+template void update_particle_floating_mesh_contact_container_iterators<3>(
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
+  typename dem_data_containers::dem_data_structures<
+    3>::particle_index_iterator_map &particle_container);

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -967,8 +967,8 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
     {
       particle_particle_broad_search_object
         .find_particle_particle_contact_pairs(this->particle_handler,
-                                              &cells_local_neighbor_list,
-                                              &cells_ghost_neighbor_list,
+                                              cells_local_neighbor_list,
+                                              cells_ghost_neighbor_list,
                                               local_contact_pair_candidates,
                                               ghost_contact_pair_candidates);
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -978,22 +978,22 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
 
       localize_contacts<dim>(local_adjacent_particles,
                              ghost_adjacent_particles,
-                             particle_wall_pairs_in_contact,
-                             pfw_pairs_in_contact,
+                             particle_wall_in_contact,
+                             particle_floating_wall_in_contact,
                              particle_floating_mesh_in_contact,
                              local_contact_pair_candidates,
                              ghost_contact_pair_candidates,
-                             particle_wall_contact_candidates,
-                             pfw_contact_candidates,
-                             particle_floating_mesh_contact_candidates);
+                             particle_wall_candidates,
+                             particle_floating_wall_candidates,
+                             particle_floating_mesh_candidates);
 
 
       locate_local_particles_in_cells<dim>(this->particle_handler,
                                            particle_container,
                                            ghost_adjacent_particles,
                                            local_adjacent_particles,
-                                           particle_wall_pairs_in_contact,
-                                           pfw_pairs_in_contact,
+                                           particle_wall_in_contact,
+                                           particle_floating_wall_in_contact,
                                            particle_floating_mesh_in_contact,
                                            particle_points_in_contact,
                                            particle_lines_in_contact);
@@ -1059,7 +1059,7 @@ CFDDEMSolver<dim>::particle_wall_broad_search()
   particle_wall_broad_search_object.find_particle_wall_contact_pairs(
     boundary_cell_object.get_boundary_cells_information(),
     this->particle_handler,
-    particle_wall_contact_candidates);
+    particle_wall_candidates);
 
   // Particle - floating wall contact pairs
   if (dem_parameters.floating_walls.floating_walls_number > 0)
@@ -1070,17 +1070,17 @@ CFDDEMSolver<dim>::particle_wall_broad_search()
           this->particle_handler,
           dem_parameters.floating_walls,
           this->simulation_control->get_current_time(),
-          pfw_contact_candidates);
+          particle_floating_wall_candidates);
     }
 
-  particle_point_contact_candidates =
+  particle_point_candidates =
     particle_point_line_broad_search_object.find_particle_point_contact_pairs(
       this->particle_handler,
       boundary_cell_object.get_boundary_cells_with_points());
 
   if (dim == 3)
     {
-      particle_line_contact_candidates =
+      particle_line_candidates =
         particle_point_line_broad_search_object
           .find_particle_line_contact_pairs(
             this->particle_handler,
@@ -1094,27 +1094,27 @@ CFDDEMSolver<dim>::particle_wall_fine_search()
 {
   // Particle - wall fine search
   particle_wall_fine_search_object.particle_wall_fine_search(
-    particle_wall_contact_candidates, particle_wall_pairs_in_contact);
+    particle_wall_candidates, particle_wall_in_contact);
 
   // Particle - floating wall fine search
   if (dem_parameters.floating_walls.floating_walls_number > 0)
     {
       particle_wall_fine_search_object.particle_floating_wall_fine_search(
-        pfw_contact_candidates,
+        particle_floating_wall_candidates,
         dem_parameters.floating_walls,
         this->simulation_control->get_current_time(),
-        pfw_pairs_in_contact);
+        particle_floating_wall_in_contact);
     }
 
   particle_points_in_contact =
     particle_point_line_fine_search_object.particle_point_fine_search(
-      particle_point_contact_candidates, neighborhood_threshold_squared);
+      particle_point_candidates, neighborhood_threshold_squared);
 
   if (dim == 3)
     {
       particle_lines_in_contact =
         particle_point_line_fine_search_object.particle_line_fine_search(
-          particle_line_contact_candidates, neighborhood_threshold_squared);
+          particle_line_candidates, neighborhood_threshold_squared);
     }
 }
 
@@ -1124,7 +1124,7 @@ CFDDEMSolver<dim>::particle_wall_contact_force()
 {
   // Particle-wall contact force
   particle_wall_contact_force_object->calculate_particle_wall_contact_force(
-    particle_wall_pairs_in_contact, dem_time_step, torque, force);
+    particle_wall_in_contact, dem_time_step, torque, force);
 
   if (this->cfd_dem_simulation_parameters.dem_parameters.forces_torques
         .calculate_force_torque)
@@ -1140,7 +1140,7 @@ CFDDEMSolver<dim>::particle_wall_contact_force()
   if (dem_parameters.floating_walls.floating_walls_number > 0)
     {
       particle_wall_contact_force_object->calculate_particle_wall_contact_force(
-        pfw_pairs_in_contact, dem_time_step, torque, force);
+        particle_floating_wall_in_contact, dem_time_step, torque, force);
     }
 
   particle_point_line_contact_force_object

--- a/tests/dem/find_contact_pairs.cc
+++ b/tests/dem/find_contact_pairs.cc
@@ -115,8 +115,8 @@ test()
 
   broad_search_object.find_particle_particle_contact_pairs(
     particle_handler,
-    &local_neighbor_list,
-    &local_neighbor_list,
+    local_neighbor_list,
+    local_neighbor_list,
     local_contact_pair_candidates,
     ghost_contact_pair_candidates);
 

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -177,8 +177,9 @@ test()
     dem_parameters);
   VelocityVerletIntegrator<dim> integrator_object;
   double                        distance;
+  double                        time = 0.0;
 
-  for (double time = 0; time < 0.00115; time += dt)
+  while (time < 0.00115)
     {
       auto particle = particle_handler.begin();
       force[0][0]   = 0;
@@ -242,6 +243,8 @@ test()
             << particle_wall_contact_information_iterator->second.normal_overlap
             << " " << step_force << std::endl;
         }
+
+      time += dt;
     }
 }
 

--- a/tests/dem/particle_particle_contact_force_linear.cc
+++ b/tests/dem/particle_particle_contact_force_linear.cc
@@ -178,8 +178,8 @@ test()
 
   broad_search_object.find_particle_particle_contact_pairs(
     particle_handler,
-    &local_neighbor_list,
-    &local_neighbor_list,
+    local_neighbor_list,
+    local_neighbor_list,
     local_contact_pair_candidates,
     ghost_contact_pair_candidates);
 

--- a/tests/dem/particle_particle_contact_force_nonlinear.cc
+++ b/tests/dem/particle_particle_contact_force_nonlinear.cc
@@ -177,8 +177,8 @@ test()
 
   broad_search_object.find_particle_particle_contact_pairs(
     particle_handler,
-    &local_neighbor_list,
-    &local_neighbor_list,
+    local_neighbor_list,
+    local_neighbor_list,
     local_contact_pair_candidates,
     ghost_contact_pair_candidates);
 

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -391,8 +391,8 @@ test()
       // Calling broad search
       broad_search_object.find_particle_particle_contact_pairs(
         particle_handler,
-        &local_neighbor_list,
-        &ghost_neighbor_list,
+        local_neighbor_list,
+        ghost_neighbor_list,
         local_contact_pair_candidates,
         ghost_contact_pair_candidates);
 

--- a/tests/dem/particle_particle_fine_search.cc
+++ b/tests/dem/particle_particle_fine_search.cc
@@ -139,8 +139,8 @@ test()
 
   broad_search_object.find_particle_particle_contact_pairs(
     particle_handler,
-    &local_neighbor_list,
-    &local_neighbor_list,
+    local_neighbor_list,
+    local_neighbor_list,
     local_contact_pair_candidates,
     ghost_contact_pair_candidates);
 

--- a/tests/dem/particle_point_contact.cc
+++ b/tests/dem/particle_point_contact.cc
@@ -153,7 +153,9 @@ test()
   for (unsigned i = 0; i < MOI.size(); ++i)
     MOI[i] = 1;
 
-  for (double time = 0; time < 0.2; time += dt)
+  double time = 0.0;
+
+  while (time < 0.2)
     {
       auto particle                = particle_handler.begin();
       force[particle->get_id()][0] = 0;
@@ -181,6 +183,8 @@ test()
           deallog << particle->get_location() << std::endl;
         }
       ++step;
+
+      time += dt;
     }
 }
 

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -365,8 +365,8 @@ test()
       // Calling broad search
       broad_search_object.find_particle_particle_contact_pairs(
         particle_handler,
-        &local_neighbor_list,
-        &ghost_neighbor_list,
+        local_neighbor_list,
+        ghost_neighbor_list,
         local_contact_pair_candidates,
         ghost_contact_pair_candidates);
 


### PR DESCRIPTION
# Description of the problem

- Data structures used in the dem solver were complicated and difficult to read.

# Description of the solution

- Store complex dem data structures in data_containers.h and use them in dem and unresolved cfd-dem solvers.

