### PR TITLE
Fix doc and exponent calculation in stabilization

### DIFF
--- a/include/solvers/stabilization.h
+++ b/include/solvers/stabilization.h
@@ -33,8 +33,8 @@ using namespace dealii;
  */
 inline double
 calculate_navier_stokes_gls_tau_steady(const double u_mag,
-                                   const double viscosity,
-                                   const double h)
+                                       const double viscosity,
+                                       const double h)
 {
   return 1. / std::sqrt(Utilities::fixed_power<2>(2. * u_mag / h) +
                         9 * Utilities::fixed_power<2>(4 * viscosity / (h * h)));
@@ -55,9 +55,9 @@ calculate_navier_stokes_gls_tau_steady(const double u_mag,
 
 inline double
 calculate_navier_stokes_gls_tau_transient(const double u_mag,
-                                      const double viscosity,
-                                      const double h,
-                                      const double sdt)
+                                          const double viscosity,
+                                          const double h,
+                                          const double sdt)
 {
   return 1. / std::sqrt(Utilities::fixed_power<2>(sdt) +
                         Utilities::fixed_power<2>(2. * u_mag / h) +

--- a/include/solvers/stabilization.h
+++ b/include/solvers/stabilization.h
@@ -15,7 +15,11 @@
  *
  */
 
+#include <deal.II/base/utilities.h>
+
 #include <cmath>
+
+using namespace dealii;
 
 /**
  * @brief Calculate the stabilization parameter for the Navier-Stokes equations in steady-state
@@ -28,16 +32,16 @@
  * @param h Cell size. Should be calculated using the diameter of a sphere of equal volume to that of the cell
  */
 inline double
-calculate_navier_stokes_tau_steady(const double u_mag,
+calculate_navier_stokes_gls_tau_steady(const double u_mag,
                                    const double viscosity,
                                    const double h)
 {
-  return 1. / std::sqrt(std::pow(2. * u_mag / h, 2) +
-                        9 * std::pow(4 * viscosity / (h * h), 2));
+  return 1. / std::sqrt(Utilities::fixed_power<2>(2. * u_mag / h) +
+                        9 * Utilities::fixed_power<2>(4 * viscosity / (h * h)));
 }
 
 /**
- * @brief Calculate the stabilization parameter for the Navier-Stokes equations in steady-state
+ * @brief Calculate the stabilization parameter for the transient Navier-Stokes equations
  * @return Value of the stabilization parameter - tau
  *
  * @param u_mag Magnitude of the velocity
@@ -50,11 +54,12 @@ calculate_navier_stokes_tau_steady(const double u_mag,
  */
 
 inline double
-calculate_navier_stokes_tau_transient(const double u_mag,
+calculate_navier_stokes_gls_tau_transient(const double u_mag,
                                       const double viscosity,
                                       const double h,
                                       const double sdt)
 {
-  return 1. / std::sqrt(std::pow(sdt, 2) + std::pow(2. * u_mag / h, 2) +
-                        9 * std::pow(4 * viscosity / (h * h), 2));
+  return 1. / std::sqrt(Utilities::fixed_power<2>(sdt) +
+                        Utilities::fixed_power<2>(2. * u_mag / h) +
+                        9 * Utilities::fixed_power<2>(4 * viscosity / (h * h)));
 }

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -66,8 +66,8 @@ PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_matrix(
       const double tau =
         this->simulation_control->get_assembly_method() ==
             Parameters::SimulationControl::TimeSteppingMethod::steady ?
-          calculate_navier_stokes_tau_steady(u_mag, viscosity, h) :
-          calculate_navier_stokes_tau_transient(u_mag, viscosity, h, sdt);
+          calculate_navier_stokes_gls_tau_steady(u_mag, viscosity, h) :
+          calculate_navier_stokes_gls_tau_transient(u_mag, viscosity, h, sdt);
 
       // Calculate the strong residual for GLS stabilization
       auto strong_residual = velocity_gradient * velocity + pressure_gradient -
@@ -211,8 +211,8 @@ PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_rhs(
       const double tau =
         this->simulation_control->get_assembly_method() ==
             Parameters::SimulationControl::TimeSteppingMethod::steady ?
-          calculate_navier_stokes_tau_steady(u_mag, viscosity, h) :
-          calculate_navier_stokes_tau_transient(u_mag, viscosity, h, sdt);
+          calculate_navier_stokes_gls_tau_steady(u_mag, viscosity, h) :
+          calculate_navier_stokes_gls_tau_transient(u_mag, viscosity, h, sdt);
 
 
       // Calculate the strong residual for GLS stabilization
@@ -318,8 +318,8 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
       const double tau =
         this->simulation_control->get_assembly_method() ==
             Parameters::SimulationControl::TimeSteppingMethod::steady ?
-          calculate_navier_stokes_tau_steady(u_mag, viscosity, h) :
-          calculate_navier_stokes_tau_transient(u_mag, viscosity, h, sdt);
+          calculate_navier_stokes_gls_tau_steady(u_mag, viscosity, h) :
+          calculate_navier_stokes_gls_tau_transient(u_mag, viscosity, h, sdt);
 
       // Calculate the strong residual for GLS stabilization
       auto strong_residual = velocity_gradient * velocity + pressure_gradient -
@@ -465,8 +465,8 @@ GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
       const double tau =
         this->simulation_control->get_assembly_method() ==
             Parameters::SimulationControl::TimeSteppingMethod::steady ?
-          calculate_navier_stokes_tau_steady(u_mag, viscosity, h) :
-          calculate_navier_stokes_tau_transient(u_mag, viscosity, h, sdt);
+          calculate_navier_stokes_gls_tau_steady(u_mag, viscosity, h) :
+          calculate_navier_stokes_gls_tau_transient(u_mag, viscosity, h, sdt);
 
 
       // Calculate the strong residual for GLS stabilization
@@ -596,8 +596,8 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
       const double tau =
         this->simulation_control->get_assembly_method() ==
             Parameters::SimulationControl::TimeSteppingMethod::steady ?
-          calculate_navier_stokes_tau_steady(u_mag, viscosity, h) :
-          calculate_navier_stokes_tau_transient(u_mag, viscosity, h, sdt);
+          calculate_navier_stokes_gls_tau_steady(u_mag, viscosity, h) :
+          calculate_navier_stokes_gls_tau_transient(u_mag, viscosity, h, sdt);
 
       // Calculate the strong residual for GLS stabilization
       auto strong_residual = velocity_gradient * velocity + pressure_gradient -
@@ -776,8 +776,8 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
       const double tau =
         this->simulation_control->get_assembly_method() ==
             Parameters::SimulationControl::TimeSteppingMethod::steady ?
-          calculate_navier_stokes_tau_steady(u_mag, viscosity, h) :
-          calculate_navier_stokes_tau_transient(u_mag, viscosity, h, sdt);
+          calculate_navier_stokes_gls_tau_steady(u_mag, viscosity, h) :
+          calculate_navier_stokes_gls_tau_transient(u_mag, viscosity, h, sdt);
 
 
       // Calculate the strong residual for GLS stabilization


### PR DESCRIPTION


Fixed also the wording of some parts.

# Description of the problem

- Stabilization used std::pow(X,2).

# Description of the solution

-  These are fixed exponent for which there is a templated exponent calculation routine in deal.II. Use this
instead.

# How Has This Been Tested?
If tests pass, this works

# Comments

We should be careful to try and use these routines for fixed powers.

