### PR TITLE
core: remove dependency on solvers from tests

### DIFF
--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -29,8 +29,6 @@
 #include <core/solid_base.h>
 #include <core/solid_objects_parameters.h>
 
-#include <solvers/simulation_parameters.h>
-
 // Tests (with common definitions)
 #include <../tests/tests.h>
 
@@ -49,7 +47,6 @@ test()
 {
   MPI_Comm mpi_communicator(MPI_COMM_WORLD);
 
-  SimulationParameters<3> NSparam;
   auto             param = std::make_shared<Parameters::NitscheObject<3>>();
   ParameterHandler prm;
   std::shared_ptr<parallel::DistributedTriangulationBase<3>> fluid_tria =

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -32,9 +32,6 @@
 #include <core/solid_objects_parameters.h>
 #include <core/solutions_output.h>
 
-#include <solvers/simulation_parameters.h>
-
-
 // Tests (with common definitions)
 #include <../tests/tests.h>
 
@@ -45,7 +42,6 @@ test()
 {
   MPI_Comm mpi_communicator(MPI_COMM_WORLD);
 
-  SimulationParameters<3> NSparam;
   auto             param = std::make_shared<Parameters::NitscheObject<3>>();
   ParameterHandler prm;
   std::shared_ptr<parallel::DistributedTriangulationBase<3>> fluid_tria =


### PR DESCRIPTION
* tests/core/solid_base_33_moving_particles.cc: Don't include
solvers/simulation_parameters.h.
(test): Remove unused variable NSparam.
* tests/core/solid_base_33_moving_triangulation.cc: Same.