### PR TITLE
Add initial adaptive refinement

### DIFF
--- a/doc/source/parameters/cfd/mesh_adaptation_control.rst
+++ b/doc/source/parameters/cfd/mesh_adaptation_control.rst
@@ -6,35 +6,39 @@ This subsection controls the mesh adaptation method, with default values given b
 .. code-block:: text
 
 	subsection mesh adaptation
+	  # Number of initial (pre-solve) refinement steps
+	  set initial refinement steps = 0
+
 	  # Type of mesh adaptation. Choices are  none, uniform or kelly.
-	  set type                 = none
+	  set type                     = none
 
 	  # Variable for kelly estimation. Choices are velocity, pressure, phase or temperature.
-	  set variable             = velocity
+	  set variable                 = velocity
 
 	  # Frequency of the mesh refinement
-	  set frequency            = 1
+	  set frequency                = 1
 
 	  # Minimum refinement level
-	  set min refinement level = 0
+	  set min refinement level     = 0
 
 	  # Maximum refinement level
-	  set max refinement level = 10
+	  set max refinement level     = 10
 
 	  # Fraction of coarsened elements
-	  set fraction coarsening  = 0.05
+	  set fraction coarsening      = 0.05
 
 	  # Fraction of refined elements
-	  set fraction refinement  = 0.1
+	  set fraction refinement      = 0.1
 
 	  # How the fraction of refinement/coarsening are interpreted
 	  # Choices are number or fraction 
-	  set fraction type        = number
+	  set fraction type            = number
 
 	  # Maximum number of elements
-	  set max number elements  = 100000000
+	  set max number elements      = 100000000
 	end
 
+* The number of initial (before solving) adaptive refinement steps is controlled by the ``initial refinement steps`` parameter. With an ``initial refinement steps`` larger than 0, the triangulation is refined adaptively before the solver starts solving the problem.
 * Two ``type`` of mesh adaptation are available. The ``uniform`` mesh adaptation refines the mesh at every cell, whereas the ``kelly`` uses a `kelly error estimator <https://www.dealii.org/current/doxygen/deal.II/classKellyErrorEstimator.html>`_ to decide which cell are refined, by estimating the error per cell for a given variable. 
 * The variable for kelly estimation should be specified with ``set variable``, and can be:
 	* velocity

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -837,6 +837,9 @@ namespace Parameters
    */
   struct MeshAdaptation
   {
+    // Initial adaptive refinement
+    unsigned int initial_refinement;
+
     // Type of mesh adaptation
     enum class Type
     {

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -201,13 +201,24 @@ protected:
   set_initial_condition(Parameters::InitialConditionType initial_condition_type,
                         bool                             restart = false)
   {
-    set_initial_condition_fd(initial_condition_type, restart);
-    if (!restart)
+    unsigned int ref_iter = 0;
+    do
       {
-        multiphysics->set_initial_conditions();
-        this->postprocess_fd(true);
-        multiphysics->postprocess(true);
-      }
+        set_initial_condition_fd(initial_condition_type, restart);
+        if (!restart)
+          {
+            multiphysics->set_initial_conditions();
+            this->postprocess_fd(true);
+            multiphysics->postprocess(true);
+          }
+
+        if (ref_iter > 0)
+          this->refine_mesh();
+        ref_iter++;
+    } while (
+      ref_iter <
+        (this->simulation_parameters.mesh_adaptation.initial_refinement + 1) &&
+      restart == false);
   }
 
   /**

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -215,7 +215,8 @@ protected:
         if (ref_iter > 0)
           this->refine_mesh();
         ref_iter++;
-    } while (
+      }
+    while (
       ref_iter <
         (this->simulation_parameters.mesh_adaptation.initial_refinement + 1) &&
       restart == false);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1531,6 +1531,11 @@ namespace Parameters
   {
     prm.enter_subsection("mesh adaptation");
     {
+      prm.declare_entry("initial refinement steps",
+                        "0",
+                        Patterns::Integer(),
+                        "Number of pre-solve adaptive mesh refinement steps");
+
       prm.declare_entry("type",
                         "none",
                         Patterns::Selection("none|uniform|kelly"),
@@ -1582,6 +1587,8 @@ namespace Parameters
   {
     prm.enter_subsection("mesh adaptation");
     {
+      initial_refinement = prm.get_integer("initial refinement steps");
+
       const std::string op = prm.get("type");
       if (op == "none")
         type = Type::none;

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -1215,7 +1215,16 @@ GDNavierStokesSolver<dim>::solve()
       this->dynamic_flow_control();
 
       if (this->simulation_control->is_at_start())
-        this->iterate();
+        {
+          for (unsigned int i = 0; i<this->simulation_parameters.mesh_adaptation
+                                       .initial_refinement> 0;
+               i++)
+            NavierStokesBase<dim,
+                             TrilinosWrappers::MPI::BlockVector,
+                             std::vector<IndexSet>>::refine_mesh();
+
+          this->iterate();
+        }
       else
         {
           NavierStokesBase<dim,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -1216,8 +1216,9 @@ GDNavierStokesSolver<dim>::solve()
 
       if (this->simulation_control->is_at_start())
         {
-          for (unsigned int i = 0; i<this->simulation_parameters.mesh_adaptation
-                                       .initial_refinement> 0;
+          for (unsigned int i = 0;
+               i <
+               this->simulation_parameters.mesh_adaptation.initial_refinement;
                i++)
             NavierStokesBase<dim,
                              TrilinosWrappers::MPI::BlockVector,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1598,6 +1598,12 @@ GLSNavierStokesSolver<dim>::solve()
 
       if (this->simulation_control->is_at_start())
         {
+          for (unsigned int i = 0; i<this->simulation_parameters.mesh_adaptation
+                                       .initial_refinement> 0;
+               i++)
+            NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
+              refine_mesh();
+
           this->iterate();
         }
       else

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -926,10 +926,21 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
     }
   else if (initial_condition_type == Parameters::InitialConditionType::nodal)
     {
-      this->set_nodal_values();
-      this->finish_time_step_fd();
-    }
+      // *** HERE
+      for (unsigned int i = 0;
+           i <
+           this->simulation_parameters.mesh_adaptation.initial_refinement + 1;
+           i++)
+        {
+          if (i != 0)
+            NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
+              refine_mesh();
+          // *** HERE
 
+          this->set_nodal_values();
+          this->finish_time_step_fd();
+        } // THIS LINE SHOULD ALSO BE REMOVED
+    }
   else if (initial_condition_type == Parameters::InitialConditionType::viscous)
     {
       this->set_nodal_values();
@@ -1595,16 +1606,8 @@ GLSNavierStokesSolver<dim>::solve()
       this->simulation_control->print_progression(this->pcout);
       this->dynamic_flow_control();
 
-
       if (this->simulation_control->is_at_start())
         {
-          for (unsigned int i = 0;
-               i <
-               this->simulation_parameters.mesh_adaptation.initial_refinement;
-               i++)
-            NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
-              refine_mesh();
-
           this->iterate();
         }
       else

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1598,8 +1598,9 @@ GLSNavierStokesSolver<dim>::solve()
 
       if (this->simulation_control->is_at_start())
         {
-          for (unsigned int i = 0; i<this->simulation_parameters.mesh_adaptation
-                                       .initial_refinement> 0;
+          for (unsigned int i = 0;
+               i <
+               this->simulation_parameters.mesh_adaptation.initial_refinement;
                i++)
             NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
               refine_mesh();

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -124,7 +124,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto &                 nonzero_constraints = this->get_nonzero_constraints();
+  auto                  &nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -601,8 +601,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -784,8 +784,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -926,20 +926,8 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
     }
   else if (initial_condition_type == Parameters::InitialConditionType::nodal)
     {
-      // *** HERE
-      for (unsigned int i = 0;
-           i <
-           this->simulation_parameters.mesh_adaptation.initial_refinement + 1;
-           i++)
-        {
-          if (i != 0)
-            NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
-              refine_mesh();
-          // *** HERE
-
-          this->set_nodal_values();
-          this->finish_time_step_fd();
-        } // THIS LINE SHOULD ALSO BE REMOVED
+      this->set_nodal_values();
+      this->finish_time_step_fd();
     }
   else if (initial_condition_type == Parameters::InitialConditionType::viscous)
     {
@@ -993,10 +981,10 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
       const int n_iter_viscosity =
         this->simulation_parameters.initial_condition->ramp.ramp_viscosity
           .n_iter;
-      double viscosity = n_iter_viscosity > 0 ?
-                           this->simulation_parameters.initial_condition->ramp
+      double       viscosity = n_iter_viscosity > 0 ?
+                                 this->simulation_parameters.initial_condition->ramp
                              .ramp_viscosity.viscosity_init :
-                           viscosity_end;
+                                 viscosity_end;
       const double alpha_viscosity =
         this->simulation_parameters.initial_condition->ramp.ramp_viscosity
           .alpha;
@@ -1228,8 +1216,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
   const unsigned int smoother_overlap =
     this->simulation_parameters.linear_solver.amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char *                                      smoother_type  = "ILU";
-  const char *                                      coarse_type    = "ILU";
+  const char                                       *smoother_type  = "ILU";
+  const char                                       *coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -124,7 +124,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto                  &nonzero_constraints = this->get_nonzero_constraints();
+  auto &                 nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -601,8 +601,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -784,8 +784,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim>                         &scratch_data,
-  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
+  NavierStokesScratchData<dim> &                        scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &                copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -981,10 +981,10 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
       const int n_iter_viscosity =
         this->simulation_parameters.initial_condition->ramp.ramp_viscosity
           .n_iter;
-      double       viscosity = n_iter_viscosity > 0 ?
-                                 this->simulation_parameters.initial_condition->ramp
+      double viscosity = n_iter_viscosity > 0 ?
+                           this->simulation_parameters.initial_condition->ramp
                              .ramp_viscosity.viscosity_init :
-                                 viscosity_end;
+                           viscosity_end;
       const double alpha_viscosity =
         this->simulation_parameters.initial_condition->ramp.ramp_viscosity
           .alpha;
@@ -1216,8 +1216,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
   const unsigned int smoother_overlap =
     this->simulation_parameters.linear_solver.amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char                                       *smoother_type  = "ILU";
-  const char                                       *coarse_type    = "ILU";
+  const char *                                      smoother_type  = "ILU";
+  const char *                                      coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,


### PR DESCRIPTION
# Description of the problem

- Choosing a large number of mesh initial refinement makes the code very slow in the first step (before adaptive refinement can make the grids larger in unnecessary regions).

# Description of the solution

- Adds initial (pre-solve) adaptive mesh refinement.

