### PR TITLE
Correct last term of the GLS stabilization in the documentation

### DIFF
--- a/doc/source/theory/fluid_dynamics/stabilization.rst
+++ b/doc/source/theory/fluid_dynamics/stabilization.rst
@@ -67,7 +67,7 @@ The GLS formulation is built as a generalization of the stabilization procedure 
   \\
   & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{SUPG} u_k \partial_l v_k \right) \mathrm{d}\Omega_k 
   \\
-  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu \partial_l \partial_l u_k \right) \mathrm{d}\Omega_k  =0
+  & + \sum_{k} \int_{\Omega_k} \left( \partial_t u_k + u_l \partial_l u_k + \partial_k p - \nu \partial_l \partial_l u_k - f_k \right) \cdot \left(\tau_{GLS} \nu \partial_l \partial_l v_k \right) \mathrm{d}\Omega_k  =0
 
 This is the version of the GLS stabilization if the finite element method is only used for the spatial discretization and no time-space finite element formulation is used as is the case in Lethe. The stabilization parameters are taken to be the same in all cases and given by the same :math:`\tau` expressions presented in the SUPG/PSPG section. The non-linear problem is solved in the same fashion and the structure of the Jacobian is the same one as that of the SUPG/PSPG formulation.
 


### PR DESCRIPTION
# Description of the problem

- An error was found in the last term of the GLS stabilization formulation

# Description of the solution

- The term was corrected.

# Documentation

- Only the `doc/source/theory/fluid_dynamics_stabilization.rst` file was modified.

