### PR TITLE
Parameters for multivariable mesh adaptation

### DIFF
--- a/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes_2d/cylinder_carreau_gd.prm
@@ -135,3 +135,4 @@ subsection linear solver
   set ilu preconditioner absolute tolerance = 1e-10
   set ilu preconditioner relative tolerance = 1.00
 end
+

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -31,11 +31,12 @@
 #ifndef lethe_parameters_h
 #define lethe_parameters_h
 
+#include <core/ib_particle.h>
+#include <core/multiphysics.h>
+
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/parsed_function.h>
-
-#include <core/ib_particle.h>
 
 
 using namespace dealii;
@@ -831,6 +832,18 @@ namespace Parameters
   };
 
   /**
+   * @brief Mesh Adaptation Parameters that can differ for each refinement variable
+   */
+  struct MultipleAdaptationParameters
+  {
+    // Coarsening fraction
+    double coarsening_fraction;
+
+    // Refinement fraction
+    double refinement_fraction;
+  };
+
+  /**
    * @brief MeshAdaption - Parameters that control dynamic mesh adaptation.
    * Dynamic mesh adaptation in Lethe is very flexible and can be both local
    * and global.
@@ -853,9 +866,14 @@ namespace Parameters
       velocity,
       pressure,
       phase,
-      temperature,
-      velocity_temperature,
+      temperature
     } variable;
+
+    // Map containing the refinement variables
+    std::map<Variable, MultipleAdaptationParameters> variables;
+    // declaration for parsing variables
+    Variable                     vars;
+    MultipleAdaptationParameters var_adaptation_param;
 
     // Decision factor for Kelly refinement (number or fraction)
     enum class FractionType
@@ -875,12 +893,6 @@ namespace Parameters
 
     // Refinement after frequency iter
     unsigned int frequency;
-
-    // Refinement fraction
-    double refinement_fraction;
-
-    // Coarsening fraction
-    double coarsening_fraction;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -31,11 +31,11 @@
 #ifndef lethe_parameters_h
 #define lethe_parameters_h
 
-#include <core/ib_particle.h>
-
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/parsed_function.h>
+
+#include <core/ib_particle.h>
 
 
 using namespace dealii;
@@ -853,7 +853,8 @@ namespace Parameters
       velocity,
       pressure,
       phase,
-      temperature
+      temperature,
+      velocity_temperature,
     } variable;
 
     // Decision factor for Kelly refinement (number or fraction)

--- a/include/solvers/auxiliary_physics.h
+++ b/include/solvers/auxiliary_physics.h
@@ -161,7 +161,7 @@ public:
    * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   virtual void
-  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+  compute_kelly(const std::pair<const Parameters::MeshAdaptation::Variable,
                                 Parameters::MultipleAdaptationParameters> &ivar,
                 dealii::Vector<float> &estimated_error_per_cell) = 0;
 

--- a/include/solvers/auxiliary_physics.h
+++ b/include/solvers/auxiliary_physics.h
@@ -155,9 +155,15 @@ public:
 
   /**
    * @brief Compute the Kelly error estimator used to refine mesh on a auxiliary physic parameter.
+   *
+   * @param ivar The current element of the map simulation_parameters.mesh_adaptation.variables
+   *
+   * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   virtual void
-  compute_kelly(dealii::Vector<float> &estimated_error_per_cell) = 0;
+  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+                                Parameters::MultipleAdaptationParameters> &ivar,
+                dealii::Vector<float> &estimated_error_per_cell) = 0;
 
   /**
    * @brief Sets-up the DofHandler and the degree of freedom associated with the physics.

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -193,9 +193,15 @@ public:
 
   /**
    * @brief Compute the Kelly error estimator for mesh refinement.
+   *
+   * @param ivar The current element of the map simulation_parameters.mesh_adaptation.variables
+   *
+   * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   void
-  compute_kelly(dealii::Vector<float> &estimated_error_per_cell);
+  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+                                Parameters::MultipleAdaptationParameters> &ivar,
+                dealii::Vector<float> &estimated_error_per_cell);
 
   /**
    * @brief Prepares Heat Transfer to write checkpoint

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -52,7 +52,7 @@ template <int dim>
 class HeatTransfer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  HeatTransfer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
+  HeatTransfer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
                     const SimulationParameters<dim> &p_simulation_parameters,
                     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                        p_triangulation,
@@ -199,7 +199,7 @@ public:
    * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   void
-  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+  compute_kelly(const std::pair<const Parameters::MeshAdaptation::Variable,
                                 Parameters::MultipleAdaptationParameters> &ivar,
                 dealii::Vector<float> &estimated_error_per_cell);
 
@@ -318,8 +318,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    HeatTransferScratchData<dim> &                        scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    HeatTransferScratchData<dim>                         &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -337,8 +337,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    HeatTransferScratchData<dim> &                        scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    HeatTransferScratchData<dim>                         &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -362,7 +362,7 @@ private:
   virtual void
   copy_local_rhs_to_global_rhs(const StabilizedMethodsCopyData &copy_data);
 
-  MultiphysicsInterface<dim> *     multiphysics;
+  MultiphysicsInterface<dim>      *multiphysics;
   const SimulationParameters<dim> &simulation_parameters;
 
 

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -52,7 +52,7 @@ template <int dim>
 class HeatTransfer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  HeatTransfer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
+  HeatTransfer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
                     const SimulationParameters<dim> &p_simulation_parameters,
                     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                        p_triangulation,
@@ -318,8 +318,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    HeatTransferScratchData<dim>                         &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    HeatTransferScratchData<dim> &                        scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -337,8 +337,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    HeatTransferScratchData<dim>                         &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    HeatTransferScratchData<dim> &                        scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -362,7 +362,7 @@ private:
   virtual void
   copy_local_rhs_to_global_rhs(const StabilizedMethodsCopyData &copy_data);
 
-  MultiphysicsInterface<dim>      *multiphysics;
+  MultiphysicsInterface<dim> *     multiphysics;
   const SimulationParameters<dim> &simulation_parameters;
 
 

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -22,6 +22,15 @@
 #ifndef lethe_multiphysics_interface_h
 #define lethe_multiphysics_interface_h
 
+#include <core/exceptions.h>
+#include <core/multiphysics.h>
+#include <core/parameters_multiphysics.h>
+#include <core/simulation_control.h>
+#include <core/solid_base.h>
+
+#include <solvers/auxiliary_physics.h>
+#include <solvers/simulation_parameters.h>
+
 #include <deal.II/base/exceptions.h>
 
 #include <deal.II/distributed/tria_base.h>
@@ -30,13 +39,6 @@
 
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
-
-#include <core/exceptions.h>
-#include <core/multiphysics.h>
-#include <core/parameters_multiphysics.h>
-#include <core/simulation_control.h>
-#include <solvers/auxiliary_physics.h>
-#include <solvers/simulation_parameters.h>
 
 #include <map>
 #include <memory>
@@ -57,7 +59,7 @@ public:
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,
-    ConditionalOStream &               p_pcout);
+    ConditionalOStream                &p_pcout);
 
   std::vector<PhysicsID>
   get_active_physics()
@@ -795,7 +797,7 @@ public:
    * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   virtual void
-  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+  compute_kelly(const std::pair<const Parameters::MeshAdaptation::Variable,
                                 Parameters::MultipleAdaptationParameters> &ivar,
                 dealii::Vector<float> &estimated_error_per_cell)
   {

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -789,30 +789,24 @@ public:
 
   /**
    * @brief Mesh refinement according to an auxiliary physic parameter
-   * NB : only implemented for VOF for now
+   *
+   * @param ivar The current element of the map simulation_parameters.mesh_adaptation.variables
+   *
+   * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   virtual void
-  compute_kelly( // Parameters::MeshAdaptation::Variable
-                 // mesh_adaptation_variable,
-    dealii::Vector<float> &estimated_error_per_cell)
+  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+                                Parameters::MultipleAdaptationParameters> &ivar,
+                dealii::Vector<float> &estimated_error_per_cell)
   {
-    //    if (mesh_adaptation_variable ==
-    //        Parameters::MeshAdaptation::Variable::velocity_temperature)
-    //      {
-    //        physics[PhysicsID::heat_transfer]->compute_kelly(
-    //          estimated_error_per_cell);
-    //      }
-    //    else
-    //      {
     for (auto &iphys : physics)
       {
-        iphys.second->compute_kelly(estimated_error_per_cell);
+        iphys.second->compute_kelly(ivar, estimated_error_per_cell);
       }
     for (auto &iphys : block_physics)
       {
-        iphys.second->compute_kelly(estimated_error_per_cell);
+        iphys.second->compute_kelly(ivar, estimated_error_per_cell);
       }
-    //      }
   };
 
   /**

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -22,15 +22,6 @@
 #ifndef lethe_multiphysics_interface_h
 #define lethe_multiphysics_interface_h
 
-#include <core/exceptions.h>
-#include <core/multiphysics.h>
-#include <core/parameters_multiphysics.h>
-#include <core/simulation_control.h>
-#include <core/solid_base.h>
-
-#include <solvers/auxiliary_physics.h>
-#include <solvers/simulation_parameters.h>
-
 #include <deal.II/base/exceptions.h>
 
 #include <deal.II/distributed/tria_base.h>
@@ -39,6 +30,13 @@
 
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
+
+#include <core/exceptions.h>
+#include <core/multiphysics.h>
+#include <core/parameters_multiphysics.h>
+#include <core/simulation_control.h>
+#include <solvers/auxiliary_physics.h>
+#include <solvers/simulation_parameters.h>
 
 #include <map>
 #include <memory>
@@ -794,8 +792,18 @@ public:
    * NB : only implemented for VOF for now
    */
   virtual void
-  compute_kelly(dealii::Vector<float> &estimated_error_per_cell)
+  compute_kelly( // Parameters::MeshAdaptation::Variable
+                 // mesh_adaptation_variable,
+    dealii::Vector<float> &estimated_error_per_cell)
   {
+    //    if (mesh_adaptation_variable ==
+    //        Parameters::MeshAdaptation::Variable::velocity_temperature)
+    //      {
+    //        physics[PhysicsID::heat_transfer]->compute_kelly(
+    //          estimated_error_per_cell);
+    //      }
+    //    else
+    //      {
     for (auto &iphys : physics)
       {
         iphys.second->compute_kelly(estimated_error_per_cell);
@@ -804,6 +812,7 @@ public:
       {
         iphys.second->compute_kelly(estimated_error_per_cell);
       }
+    //      }
   };
 
   /**

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -59,7 +59,7 @@ public:
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,
-    ConditionalOStream                &p_pcout);
+    ConditionalOStream &               p_pcout);
 
   std::vector<PhysicsID>
   get_active_physics()

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -164,9 +164,16 @@ public:
   /**
    * @brief Compute the Kelly error estimator for mesh refinement.
    * NB : not implemented for the tracer parameter for now.
+   *
+   * @param ivar The current element of the map simulation_parameters.mesh_adaptation.variables
+   *
+   * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   void
-  compute_kelly(dealii::Vector<float> & /*estimated_error_per_cell*/)
+  compute_kelly(
+    const std::pair<Parameters::MeshAdaptation::Variable,
+                    Parameters::MultipleAdaptationParameters> & /*ivar*/,
+    dealii::Vector<float> & /*estimated_error_per_cell*/)
   {
     return;
   }

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -52,7 +52,7 @@ template <int dim>
 class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  Tracer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
+  Tracer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
               const SimulationParameters<dim> &p_simulation_parameters,
               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                  p_triangulation,
@@ -171,7 +171,7 @@ public:
    */
   void
   compute_kelly(
-    const std::pair<Parameters::MeshAdaptation::Variable,
+    const std::pair<const Parameters::MeshAdaptation::Variable,
                     Parameters::MultipleAdaptationParameters> & /*ivar*/,
     dealii::Vector<float> & /*estimated_error_per_cell*/)
   {
@@ -297,8 +297,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim> &                              scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    TracerScratchData<dim>                               &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -316,8 +316,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim> &                              scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    TracerScratchData<dim>                               &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -353,7 +353,7 @@ private:
   void
   write_tracer_statistics();
 
-  MultiphysicsInterface<dim> *     multiphysics;
+  MultiphysicsInterface<dim>      *multiphysics;
   const SimulationParameters<dim> &simulation_parameters;
 
 

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -52,7 +52,7 @@ template <int dim>
 class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  Tracer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
+  Tracer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
               const SimulationParameters<dim> &p_simulation_parameters,
               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                  p_triangulation,
@@ -297,8 +297,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim>                               &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    TracerScratchData<dim> &                              scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -316,8 +316,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim>                               &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    TracerScratchData<dim> &                              scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -353,7 +353,7 @@ private:
   void
   write_tracer_statistics();
 
-  MultiphysicsInterface<dim>      *multiphysics;
+  MultiphysicsInterface<dim> *     multiphysics;
   const SimulationParameters<dim> &simulation_parameters;
 
 

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -53,7 +53,7 @@ public:
    * @brief VOF - Base constructor.
    */
   VolumeOfFluid<dim>(
-    MultiphysicsInterface<dim> *     multiphysics_interface,
+    MultiphysicsInterface<dim>      *multiphysics_interface,
     const SimulationParameters<dim> &p_simulation_parameters,
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
@@ -197,7 +197,7 @@ public:
   double
   find_monitored_fluid_avg_pressure(
     const TrilinosWrappers::MPI::Vector &solution,
-    const VectorType &                   current_solution_fd,
+    const VectorType                    &current_solution_fd,
     const Parameters::FluidIndicator     monitored_fluid);
 
   /**
@@ -261,7 +261,7 @@ public:
    * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   void
-  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+  compute_kelly(const std::pair<const Parameters::MeshAdaptation::Variable,
                                 Parameters::MultipleAdaptationParameters> &ivar,
                 dealii::Vector<float> &estimated_error_per_cell);
 
@@ -407,8 +407,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    VOFScratchData<dim> &                                 scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    VOFScratchData<dim>                                  &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -426,8 +426,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    VOFScratchData<dim> &                                 scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    VOFScratchData<dim>                                  &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -523,7 +523,7 @@ private:
   template <typename VectorType>
   void
   apply_peeling_wetting(const unsigned int i_bc,
-                        const VectorType & current_solution_fd);
+                        const VectorType  &current_solution_fd);
 
   /**
    * @brief Change cell phase, small method called to avoid code repetition and reduce sloppy
@@ -539,9 +539,9 @@ private:
    */
   void
   change_cell_phase(
-    const PhaseChange &                         type,
-    const double &                              new_phase,
-    TrilinosWrappers::MPI::Vector &             solution_pw,
+    const PhaseChange                          &type,
+    const double                               &new_phase,
+    TrilinosWrappers::MPI::Vector              &solution_pw,
     const std::vector<types::global_dof_index> &dof_indices_vof);
 
   /**
@@ -650,7 +650,7 @@ private:
 
   TrilinosWrappers::MPI::Vector nodal_phase_fraction_owned;
 
-  MultiphysicsInterface<dim> *     multiphysics;
+  MultiphysicsInterface<dim>      *multiphysics;
   const SimulationParameters<dim> &simulation_parameters;
 
   // Core elements for the VOF simulation

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -53,7 +53,7 @@ public:
    * @brief VOF - Base constructor.
    */
   VolumeOfFluid<dim>(
-    MultiphysicsInterface<dim>      *multiphysics_interface,
+    MultiphysicsInterface<dim> *     multiphysics_interface,
     const SimulationParameters<dim> &p_simulation_parameters,
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
@@ -197,7 +197,7 @@ public:
   double
   find_monitored_fluid_avg_pressure(
     const TrilinosWrappers::MPI::Vector &solution,
-    const VectorType                    &current_solution_fd,
+    const VectorType &                   current_solution_fd,
     const Parameters::FluidIndicator     monitored_fluid);
 
   /**
@@ -407,8 +407,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    VOFScratchData<dim>                                  &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    VOFScratchData<dim> &                                 scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -426,8 +426,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    VOFScratchData<dim>                                  &scratch_data,
-    StabilizedMethodsCopyData                            &copy_data);
+    VOFScratchData<dim> &                                 scratch_data,
+    StabilizedMethodsCopyData &                           copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -523,7 +523,7 @@ private:
   template <typename VectorType>
   void
   apply_peeling_wetting(const unsigned int i_bc,
-                        const VectorType  &current_solution_fd);
+                        const VectorType & current_solution_fd);
 
   /**
    * @brief Change cell phase, small method called to avoid code repetition and reduce sloppy
@@ -539,9 +539,9 @@ private:
    */
   void
   change_cell_phase(
-    const PhaseChange                          &type,
-    const double                               &new_phase,
-    TrilinosWrappers::MPI::Vector              &solution_pw,
+    const PhaseChange &                         type,
+    const double &                              new_phase,
+    TrilinosWrappers::MPI::Vector &             solution_pw,
     const std::vector<types::global_dof_index> &dof_indices_vof);
 
   /**
@@ -650,7 +650,7 @@ private:
 
   TrilinosWrappers::MPI::Vector nodal_phase_fraction_owned;
 
-  MultiphysicsInterface<dim>      *multiphysics;
+  MultiphysicsInterface<dim> *     multiphysics;
   const SimulationParameters<dim> &simulation_parameters;
 
   // Core elements for the VOF simulation

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -255,9 +255,15 @@ public:
    * See :
    * https://www.dealii.org/current/doxygen/deal.II/classKellyErrorEstimator.html
    * for more information on the Kelly error estimator.
+   *
+   * @param ivar The current element of the map simulation_parameters.mesh_adaptation.variables
+   *
+   * @param estimated_error_per_cell The deal.II vector of estimated_error_per_cell
    */
   void
-  compute_kelly(dealii::Vector<float> &estimated_error_per_cell);
+  compute_kelly(const std::pair<Parameters::MeshAdaptation::Variable,
+                                Parameters::MultipleAdaptationParameters> &ivar,
+                dealii::Vector<float> &estimated_error_per_cell);
 
   /**
    * @brief Prepares auxiliary physics to write checkpoint

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1,6 +1,6 @@
-#include <core/parameters.h>
-
 #include <deal.II/base/exceptions.h>
+
+#include <core/parameters.h>
 
 DeclException2(
   PhaseChangeIntervalError,
@@ -1542,12 +1542,39 @@ namespace Parameters
                         "Type of mesh adaptation"
                         "Choices are <none|uniform|kelly>.");
 
-      prm.declare_entry("variable",
-                        "velocity",
-                        Patterns::Selection(
-                          "velocity|pressure|phase|temperature"),
-                        "Variable for kelly estimation"
-                        "Choices are <velocity|pressure|phase|temperature>.");
+      prm.declare_entry(
+        "variable",
+        "velocity",
+        Patterns::Selection(
+          "velocity|pressure|phase|temperature|velocity and temperature"),
+        "Variable for kelly estimation"
+        "Choices are <velocity|pressure|phase|temperature|velocity and temperature>.");
+
+      prm.declare_entry("refine on velocity",
+                        "true",
+                        Patterns::Bool(),
+                        "Enable refinement on velocity with kelly estimation"
+                        "Choices are <true|false>.");
+      prm.declare_entry("refine on temperature",
+                        "false",
+                        Patterns::Bool(),
+                        "Enable refinement on velocity with kelly estimation"
+                        "Choices are <true|false>.");
+      prm.declare_entry("refine on pressure",
+                        "false",
+                        Patterns::Bool(),
+                        "Enable refinement on velocity with kelly estimation"
+                        "Choices are <true|false>.");
+      prm.declare_entry("refine on phase",
+                        "false",
+                        Patterns::Bool(),
+                        "Enable refinement on velocity with kelly estimation"
+                        "Choices are <true|false>.");
+      prm.declare_entry("refine on tracer",
+                        "false",
+                        Patterns::Bool(),
+                        "Enable refinement on velocity with kelly estimation"
+                        "Choices are <true|false>.");
 
       prm.declare_entry(
         "fraction type",
@@ -1607,6 +1634,14 @@ namespace Parameters
         variable = Variable::phase;
       if (vop == "temperature")
         variable = Variable::temperature;
+      if (vop == "velocity and temperature")
+        variable = Variable::velocity_temperature;
+
+      //      refine_on_velocity    = prm.get_bool("refine on velocity");
+      //      refine_on_temperature = prm.get_bool("refine on temperature");
+      //      refine_on_pressure    = prm.get_bool("refine on pressure");
+      //      refine_on_phase       = prm.get_bool("refine on phase");
+      //      refine_on_tracer      = prm.get_bool("refine on tracer");
 
       const std::string fop = prm.get("fraction type");
       if (fop == "number")

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -3658,12 +3658,18 @@ GLSSharpNavierStokesSolver<dim>::solve()
   if (this->simulation_parameters.restart_parameters.restart == false)
     {
       // To change once refinement is split into two function
+      // Warning: variables.begin() only takes the first values given (not
+      // generalized for multivariables mesh adaptation)
       double temp_refine =
-        this->simulation_parameters.mesh_adaptation.refinement_fraction;
+        this->simulation_parameters.mesh_adaptation.variables.begin()
+          ->second.refinement_fraction;
       double temp_coarse =
-        this->simulation_parameters.mesh_adaptation.coarsening_fraction;
-      this->simulation_parameters.mesh_adaptation.refinement_fraction = 0;
-      this->simulation_parameters.mesh_adaptation.coarsening_fraction = 0;
+        this->simulation_parameters.mesh_adaptation.variables.begin()
+          ->second.coarsening_fraction;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.refinement_fraction = 0;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.coarsening_fraction = 0;
 
       for (unsigned int i = 0;
            i <
@@ -3680,10 +3686,10 @@ GLSSharpNavierStokesSolver<dim>::solve()
           NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
             refine_mesh();
         }
-      this->simulation_parameters.mesh_adaptation.refinement_fraction =
-        temp_refine;
-      this->simulation_parameters.mesh_adaptation.coarsening_fraction =
-        temp_coarse;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.refinement_fraction = temp_refine;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.coarsening_fraction = temp_coarse;
 
       vertices_cell_mapping();
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1,13 +1,3 @@
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-
-#include <solvers/heat_transfer.h>
-#include <solvers/heat_transfer_assemblers.h>
-#include <solvers/heat_transfer_scratch_data.h>
-#include <solvers/postprocessing_cfd.h>
-
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -25,6 +15,15 @@
 
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
+
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+#include <solvers/heat_transfer.h>
+#include <solvers/heat_transfer_assemblers.h>
+#include <solvers/heat_transfer_scratch_data.h>
+#include <solvers/postprocessing_cfd.h>
 
 template <int dim>
 void
@@ -723,7 +722,9 @@ HeatTransfer<dim>::compute_kelly(
   dealii::Vector<float> &estimated_error_per_cell)
 {
   if (this->simulation_parameters.mesh_adaptation.variable ==
-      Parameters::MeshAdaptation::Variable::temperature)
+        Parameters::MeshAdaptation::Variable::temperature ||
+      this->simulation_parameters.mesh_adaptation.variable ==
+        Parameters::MeshAdaptation::Variable::velocity_temperature)
     {
       const FEValuesExtractors::Scalar temperature(0);
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -276,8 +276,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim>                         &scratch_data,
-  StabilizedMethodsCopyData                            &copy_data)
+  HeatTransferScratchData<dim> &                        scratch_data,
+  StabilizedMethodsCopyData &                           copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -422,8 +422,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim>                         &scratch_data,
-  StabilizedMethodsCopyData                            &copy_data)
+  HeatTransferScratchData<dim> &                        scratch_data,
+  StabilizedMethodsCopyData &                           copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -276,8 +276,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  HeatTransferScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -422,8 +422,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  HeatTransferScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -720,7 +720,7 @@ HeatTransfer<dim>::post_mesh_adaptation()
 template <int dim>
 void
 HeatTransfer<dim>::compute_kelly(
-  const std::pair<Parameters::MeshAdaptation::Variable,
+  const std::pair<const Parameters::MeshAdaptation::Variable,
                   Parameters::MultipleAdaptationParameters> &ivar,
   dealii::Vector<float> &estimated_error_per_cell)
 {

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1,3 +1,13 @@
+#include <core/bdf.h>
+#include <core/sdirk.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+
+#include <solvers/heat_transfer.h>
+#include <solvers/heat_transfer_assemblers.h>
+#include <solvers/heat_transfer_scratch_data.h>
+#include <solvers/postprocessing_cfd.h>
+
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
@@ -15,15 +25,6 @@
 
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
-
-#include <core/bdf.h>
-#include <core/sdirk.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-#include <solvers/heat_transfer.h>
-#include <solvers/heat_transfer_assemblers.h>
-#include <solvers/heat_transfer_scratch_data.h>
-#include <solvers/postprocessing_cfd.h>
 
 template <int dim>
 void
@@ -719,12 +720,11 @@ HeatTransfer<dim>::post_mesh_adaptation()
 template <int dim>
 void
 HeatTransfer<dim>::compute_kelly(
+  const std::pair<Parameters::MeshAdaptation::Variable,
+                  Parameters::MultipleAdaptationParameters> &ivar,
   dealii::Vector<float> &estimated_error_per_cell)
 {
-  if (this->simulation_parameters.mesh_adaptation.variable ==
-        Parameters::MeshAdaptation::Variable::temperature ||
-      this->simulation_parameters.mesh_adaptation.variable ==
-        Parameters::MeshAdaptation::Variable::velocity_temperature)
+  if (ivar.first == Parameters::MeshAdaptation::Variable::temperature)
     {
       const FEValuesExtractors::Scalar temperature(0);
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -17,20 +17,6 @@
  * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
-#include <core/bdf.h>
-#include <core/grids.h>
-#include <core/lethe_grid_tools.h>
-#include <core/sdirk.h>
-#include <core/solutions_output.h>
-#include <core/time_integration_utilities.h>
-#include <core/utilities.h>
-
-#include <solvers/flow_control.h>
-#include <solvers/navier_stokes_base.h>
-#include <solvers/post_processors.h>
-#include <solvers/postprocessing_cfd.h>
-#include <solvers/postprocessing_velocities.h>
-
 #include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/grid_refinement.h>
 
@@ -51,6 +37,18 @@
 #include <deal.II/opencascade/manifold_lib.h>
 #include <deal.II/opencascade/utilities.h>
 
+#include <core/bdf.h>
+#include <core/grids.h>
+#include <core/lethe_grid_tools.h>
+#include <core/sdirk.h>
+#include <core/solutions_output.h>
+#include <core/time_integration_utilities.h>
+#include <core/utilities.h>
+#include <solvers/flow_control.h>
+#include <solvers/navier_stokes_base.h>
+#include <solvers/post_processors.h>
+#include <solvers/postprocessing_cfd.h>
+#include <solvers/postprocessing_velocities.h>
 #include <sys/stat.h>
 
 
@@ -889,10 +887,49 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
         estimated_error_per_cell,
         this->fe->component_mask(velocity));
     }
+  else if (this->simulation_parameters.mesh_adaptation.variable ==
+           Parameters::MeshAdaptation::Variable::velocity_temperature)
+    {
+      Vector<float> multiphysics_estimated_error_per_cell(
+        tria.n_active_cells());
+
+      KellyErrorEstimator<dim>::estimate(
+        *this->mapping,
+        this->dof_handler,
+        *this->face_quadrature,
+        typename std::map<types::boundary_id, const Function<dim, double> *>(),
+        present_solution,
+        estimated_error_per_cell,
+        this->fe->component_mask(velocity));
+
+      multiphysics->compute_kelly(
+        // this->simulation_parameters.mesh_adaptation.variable,
+        multiphysics_estimated_error_per_cell);
+
+      if (this->simulation_parameters.mesh_adaptation.fractionType ==
+          Parameters::MeshAdaptation::FractionType::number)
+        parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
+          tria,
+          multiphysics_estimated_error_per_cell,
+          this->simulation_parameters.mesh_adaptation.refinement_fraction,
+          this->simulation_parameters.mesh_adaptation.coarsening_fraction,
+          this->simulation_parameters.mesh_adaptation.maximum_number_elements);
+
+      else if (this->simulation_parameters.mesh_adaptation.fractionType ==
+               Parameters::MeshAdaptation::FractionType::fraction)
+        parallel::distributed::GridRefinement::
+          refine_and_coarsen_fixed_fraction(
+            tria,
+            multiphysics_estimated_error_per_cell,
+            this->simulation_parameters.mesh_adaptation.refinement_fraction,
+            this->simulation_parameters.mesh_adaptation.coarsening_fraction);
+    }
   else
     {
       // refine_mesh on an auxiliary physic parameter
-      multiphysics->compute_kelly(estimated_error_per_cell);
+      multiphysics->compute_kelly(
+        // this->simulation_parameters.mesh_adaptation.variable,
+        estimated_error_per_cell);
     }
 
   if (this->simulation_parameters.mesh_adaptation.fractionType ==

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -863,9 +863,9 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto &                           present_solution = this->present_solution;
+  auto                            &present_solution = this->present_solution;
 
-  for (const std::pair<Parameters::MeshAdaptation::Variable,
+  for (const std::pair<const Parameters::MeshAdaptation::Variable,
                        Parameters::MultipleAdaptationParameters> &ivar :
        this->simulation_parameters.mesh_adaptation.variables)
     {

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -863,7 +863,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto                            &present_solution = this->present_solution;
+  auto &                           present_solution = this->present_solution;
 
   for (const std::pair<const Parameters::MeshAdaptation::Variable,
                        Parameters::MultipleAdaptationParameters> &ivar :

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1343,9 +1343,7 @@ VolumeOfFluid<dim>::post_mesh_adaptation()
 
 template <int dim>
 void
-VolumeOfFluid<dim>::compute_kelly(
-  const std::pair<Parameters::MeshAdaptation::Variable,
-                  Parameters::MultipleAdaptationParameters> &ivar,
+VolumeOfFluid<dim>::compute_kelly(const std::pair<const Parameters::MeshAdaptation::Variable, Parameters::MultipleAdaptationParameters> &ivar,
   dealii::Vector<float> &estimated_error_per_cell)
 {
   if (ivar.first == Parameters::MeshAdaptation::Variable::phase)

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1343,7 +1343,9 @@ VolumeOfFluid<dim>::post_mesh_adaptation()
 
 template <int dim>
 void
-VolumeOfFluid<dim>::compute_kelly(const std::pair<const Parameters::MeshAdaptation::Variable, Parameters::MultipleAdaptationParameters> &ivar,
+VolumeOfFluid<dim>::compute_kelly(
+  const std::pair<const Parameters::MeshAdaptation::Variable,
+                  Parameters::MultipleAdaptationParameters> &ivar,
   dealii::Vector<float> &estimated_error_per_cell)
 {
   if (ivar.first == Parameters::MeshAdaptation::Variable::phase)

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1344,10 +1344,11 @@ VolumeOfFluid<dim>::post_mesh_adaptation()
 template <int dim>
 void
 VolumeOfFluid<dim>::compute_kelly(
+  const std::pair<Parameters::MeshAdaptation::Variable,
+                  Parameters::MultipleAdaptationParameters> &ivar,
   dealii::Vector<float> &estimated_error_per_cell)
 {
-  if (this->simulation_parameters.mesh_adaptation.variable ==
-      Parameters::MeshAdaptation::Variable::phase)
+  if (ivar.first == Parameters::MeshAdaptation::Variable::phase)
     {
       const FEValuesExtractors::Scalar phase(0);
 

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -27,9 +27,7 @@ VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim> &      scratch_data,
   const double sdt = 1. / dt;
 
   // Add a small diffusivity, used in the context of the wetting mechanism
-  double diffusivity = 0.;
-  if (this->vof_parameters.peeling_wetting.enable)
-    diffusivity = this->vof_parameters.diffusivity;
+  const double diffusivity = this->vof_parameters.diffusivity;
 
   // Copy data elements
   auto &strong_jacobian_vec = copy_data.strong_jacobian;
@@ -168,9 +166,7 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim> &      scratch_data,
   const auto method = this->simulation_control->get_assembly_method();
 
   // Add a small diffusivity, used in the context of the wetting mechanism
-  double diffusivity = 0.;
-  if (this->vof_parameters.peeling_wetting.enable)
-    diffusivity = this->vof_parameters.diffusivity;
+  const double diffusivity = this->vof_parameters.diffusivity;
 
   // Loop and quadrature informations
   const auto &       JxW_vec    = scratch_data.JxW;


### PR DESCRIPTION
# Description of the problem

For now, only one parameter can be parsed for mesh adaptation

# Description of the solution

Create parameters to be used for mesh adaptation with multiple variables. Multiple parameters can be parsed separated by a comma, for instance:

<pre><code>
   set types = kelly,kelly
   set variables = velocity,temperature
   set fractions coarsening = 0.2,0.5
   set fractions refinement = 0.3,0.4
</code></pre>

This created a map `mesh_adaptation.variables`, with :
- `first` being the adaptation variable (like `Variable::velocity`), and 
- `second` a structure `MultipleAdaptationParameters`, with its element `type`, `coarsening_fraction` and `refinement_fraction`

For now the parameters name has been put in plural (`variables etc`) to prevent any modification of the existing code (with `variable`) but this can be renamed when the mechanism is implemented.

# How Has This Been Tested?

Locally on a prm file. All configurations and assertions work as expected.

# Documentation

None for now, will be updated when implemented.

# Future changes

For now, the mono-variable mesh adaptation is the only implemented, so these parameters are not used. This will be implemented in the next PR about this issue.
