### PR TITLE
Add copybutton to documentation

### DIFF
--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup Sphinx
         run: |
           pip install sphinx==${{ env.SPHINX_VERSION }}
+          pip install sphinx-copybutton
           pip install -r doc/requirements.txt
 
       - name: Build HTML

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,8 +33,13 @@ author = 'Lethe-CFD'
 extensions = [
     'sphinx.ext.duration',
     'sphinx.ext.githubpages',
-    'sphinx.ext.todo'
+    'sphinx.ext.todo',
+    'sphinx_copybutton'
 ]
+
+# Create a copybitton selector to be able to turn on a copybutton in a code
+# block
+copybutton_selector = "div.copy-button pre"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -55,6 +55,12 @@ To install Sphinx globally:
 
     pip install 'sphinx==4.*'
 
+To install additional packages:
+
+.. code-block:: shell
+
+    pip install sphinx-copybutton
+
 Then, install the Sphinx requirements:
 
 .. code-block:: shell

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -46,26 +46,30 @@ To build the doc on your personal machine, you'll need the following requirement
 To install required system packages:
 
 .. code-block:: shell
+  :class: copy-button
 
-    sudo apt-get install python3 build-essential
+  sudo apt-get install python3 build-essential
 
 To install Sphinx globally:
 
 .. code-block:: shell
+  :class: copy-button
 
-    pip install 'sphinx==4.*'
+  pip install 'sphinx==4.*'
 
 To install additional packages:
 
 .. code-block:: shell
+  :class: copy-button
 
-    pip install sphinx-copybutton
+  pip install sphinx-copybutton
 
 Then, install the Sphinx requirements:
 
 .. code-block:: shell
+  :class: copy-button
 
-    pip install -r doc/requirements.txt
+  pip install -r doc/requirements.txt
 
 Build HTML
 ^^^^^^^^^^
@@ -73,9 +77,10 @@ Build HTML
 To build standalone HTML files like the CI would, enter the following commands:
 
 .. code-block:: shell
+  :class: copy-button
 
-    cd doc
-    make html
+  cd doc
+  make html
 
 The generated files should be in the ``build/html`` directory. Open ``index.html`` in a browser to view the rendered documents.
 

--- a/doc/source/installation/apple_arm.rst
+++ b/doc/source/installation/apple_arm.rst
@@ -24,6 +24,7 @@ Clone the candi git repository in a folder of your choice  (e.g. ``$HOME/sofware
 From the candi folder, the installation of candi can be launched using:
 
 .. code-block:: text
+  :class: copy-button
 
   ./candi.sh -j $num_proc --prefix=$path --packages="parmetis p4est trilinos dealii"
 
@@ -32,8 +33,9 @@ After installation, you should have a ``deal.ii-candi`` folder in the installati
 After installation, add an environment variable to your ``~/.zshrc`` either manually or through the following command:
 
 .. code-block:: text
+  :class: copy-button
 
-   echo "export DEAL_II_DIR=/home/username/deal.ii-candi/deal.II-<version>" >> ~/.zshrc
+  echo "export DEAL_II_DIR=/home/username/deal.ii-candi/deal.II-<version>" >> ~/.zshrc
 
 Setting the Library and Include paths
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,6 +43,7 @@ Setting the Library and Include paths
 The deal.II installation procedure might not set the correct path for the libraries agaisnt which it needs to link. These include parmetis, p4est and trilinos. To fix this issue, the include and library path must be manually added by appending the following lines to the ``~/.zshrc`` file.
 
 .. code-block::
+  :class: copy-button
 
   export PATH=/opt/homebrew/bin:$PATH
   export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:path/to/candi/install/trilinos-release-12-18-1/lib/
@@ -63,6 +66,7 @@ Lethe compiles using the C++ 17 standard. There is a header file in the Trilinos
 The following file needs to be modified in the include dir of your Trilinos installation:
 
 .. code-block::
+  :class: copy-button
 
   path/to/candi/install/trilinos-release-12-18-1/include/Tpetra_Import_def.hpp
 
@@ -77,7 +81,8 @@ At line 1169, the following line:
 Should be replaced by:
 
 .. code-block:: cpp
-  
+  :class: copy-button
+
   const size_type numInvalidRemote = 0;
 
 .. warning::
@@ -89,6 +94,7 @@ numdiff
 numdiff is used within the automatic testing procedure of Lethe to compare files obtained through floating point arithmetic. Without numdiff, Lethe automatic tests may fail when they should not. Numdiff can be installed directly from your package manager.
 
 .. code-block:: text
+  :class: copy-button
 
   brew install numdiff
 
@@ -101,12 +107,14 @@ Installation of lethe (Step #2)
 Clone lethe from the `official repository <https://github.com/lethe-cfd/lethe>`
 
 .. code-block:: text
+  :class: copy-button
 
   git clone https://github.com/lethe-cfd/lethe 
 
 Create a build folder at the same level as the lethe folder
 
 .. code-block:: text
+  :class: copy-button
 
   mkdir build
   cd build
@@ -114,17 +122,20 @@ Create a build folder at the same level as the lethe folder
 Compile Lethe choosing the compilation option (Debug or Release). You can also optionally specify a path to an installation directory of your choice. We recommend that you do so, since this makes using Lethe much more comfortable.
 
 .. code-block:: text
+  :class: copy-button
 
   cmake ../lethe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/username/path/to/installation
 
 or
 
 .. code-block:: text
+  :class: copy-button
 
   cmake ../lethe -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/home/username/path/to/installation
 
 Then you can compile:
 
 .. code-block:: text
+  :class: copy-button
 
   make -j<numprocs>

--- a/doc/source/installation/digital_alliance.rst
+++ b/doc/source/installation/digital_alliance.rst
@@ -11,8 +11,9 @@ Setting-up the folder structure
 In your ``$HOME``, create a "dealii" folder and a "lethe" folder, each containing "build" and "inst" folders:
 
 .. code-block:: text
+  :class: copy-button
 
- mkdir -p {dealii,lethe}/{build,inst}
+  mkdir -p {dealii,lethe}/{build,inst}
 
 The deal.II and Lethe projects can then be cloned in their corresponding folders, as indicated later in this tutorial.
 
@@ -41,33 +42,37 @@ All operations can be performed on login nodes.
 Load ``Trilinos``, ``Parmetis`` and ``P4est``, and their prerequisite modules:
 
 .. code-block:: text
+  :class: copy-button
 
- module load StdEnv/2020
- module load gcc/9.3.0
- module load openmpi/4.0.3
- module load trilinos/13.0.1
- module load parmetis/4.0.3
- module load p4est/2.2
+  module load StdEnv/2020
+  module load gcc/9.3.0
+  module load openmpi/4.0.3
+  module load trilinos/13.0.1
+  module load parmetis/4.0.3
+  module load p4est/2.2
 
 Then, we can clone and compile ``dealii``. Although Lethe always supports the master branch of deal.II, we maintain an identical deal.II fork on the lethe repository. This fork is always tested to make sure it works with lethe. To clone the deal.II fork github repository, execute in ``$HOME/dealii`` directory:
 
 .. code-block:: text
+  :class: copy-button
 
- git clone https://github.com/lethe-cfd/dealii.git
+  git clone https://github.com/lethe-cfd/dealii.git
 
 We can compile ``dealii`` in the ``$HOME/dealii/build`` folder, by defining the paths to installation folders of ``Trilinos``, ``Parmetis`` and ``P4est``. To increase the speed of this step, we skip ``dealii`` tests and compile in release mode only.
 
 .. code-block:: text
+  :class: copy-button
 
- cmake ../dealii -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release  -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=$EBROOTTRILINOS -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=$EBROOTP4EST -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=$EBROOTPARMETIS -DCMAKE_INSTALL_PREFIX=../inst -DTrilinos_FIND_COMPONENTS="Pike;PikeImplicit;PikeBlackBox;TrilinosCouplings;Panzer;PanzerMiniEM;PanzerAdaptersSTK;PanzerDiscFE;PanzerDofMgr;PanzerCore;Piro;ROL;Stokhos;Tempus;Rythmos;ShyLU;ShyLU_DD;ShyLU_DDCommon;ShyLU_DDFROSch;ShyLU_DDBDDC;Zoltan2;Zoltan2Sphynx;MueLu;Moertel;NOX;Phalanx;Percept;STK;STKExprEval;STKDoc_tests;STKUnit_tests;STKBalance;STKTools;STKTransfer;STKSearchUtil;STKSearch;STKUnit_test_utils;STKNGP_TEST;STKIO;STKMesh;STKTopology;STKSimd;STKUtil;STKMath;Compadre;Intrepid2;Intrepid;Teko;FEI;Stratimikos;Ifpack2;Anasazi;Komplex;SEACAS;SEACASEx2ex1v2;SEACASTxtexo;SEACASNumbers;SEACASNemspread;SEACASNemslice;SEACASMat2exo;SEACASMapvar-kd;SEACASMapvar;SEACASMapvarlib;SEACASExplore;SEACASGrepos;SEACASGenshell;SEACASGen3D;SEACASGjoin;SEACASFastq;SEACASEx1ex2v2;SEACASExo_format;SEACASExotxt;SEACASExomatlab;SEACASExodiff;SEACASExo2mat;SEACASEpu;SEACASEjoin;SEACASConjoin;SEACASBlot;SEACASAprepro;SEACASAlgebra;SEACASPLT;SEACASSVDI;SEACASSuplibCpp;SEACASSuplibC;SEACASSuplib;SEACASSupes;SEACASAprepro_lib;SEACASChaco;SEACASIoss;SEACASNemesis;SEACASExoIIv2for32;SEACASExodus_for;SEACASExodus;Amesos2;ShyLU_Node;ShyLU_NodeTacho;ShyLU_NodeHTS;Belos;ML;Ifpack;Zoltan2Core;Pamgen;Amesos;Galeri;AztecOO;Pliris;Isorropia;Xpetra;Thyra;ThyraTpetraAdapters;ThyraEpetraExtAdapters;ThyraEpetraAdapters;ThyraCore;Domi;TrilinosSS;Tpetra;TpetraCore;TpetraTSQR;TpetraClassic;EpetraExt;Triutils;Shards;Zoltan;Epetra;MiniTensor;Sacado;RTOp;KokkosKernels;Teuchos;TeuchosKokkosComm;TeuchosKokkosCompat;TeuchosRemainder;TeuchosNumerics;TeuchosComm;TeuchosParameterList;TeuchosParser;TeuchosCore;Kokkos;KokkosAlgorithms;KokkosContainers;KokkosCore;Gtest;TrilinosATDMConfigTests;TrilinosFrameworkTests"
+  cmake ../dealii -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release  -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=$EBROOTTRILINOS -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=$EBROOTP4EST -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=$EBROOTPARMETIS -DCMAKE_INSTALL_PREFIX=../inst -DTrilinos_FIND_COMPONENTS="Pike;PikeImplicit;PikeBlackBox;TrilinosCouplings;Panzer;PanzerMiniEM;PanzerAdaptersSTK;PanzerDiscFE;PanzerDofMgr;PanzerCore;Piro;ROL;Stokhos;Tempus;Rythmos;ShyLU;ShyLU_DD;ShyLU_DDCommon;ShyLU_DDFROSch;ShyLU_DDBDDC;Zoltan2;Zoltan2Sphynx;MueLu;Moertel;NOX;Phalanx;Percept;STK;STKExprEval;STKDoc_tests;STKUnit_tests;STKBalance;STKTools;STKTransfer;STKSearchUtil;STKSearch;STKUnit_test_utils;STKNGP_TEST;STKIO;STKMesh;STKTopology;STKSimd;STKUtil;STKMath;Compadre;Intrepid2;Intrepid;Teko;FEI;Stratimikos;Ifpack2;Anasazi;Komplex;SEACAS;SEACASEx2ex1v2;SEACASTxtexo;SEACASNumbers;SEACASNemspread;SEACASNemslice;SEACASMat2exo;SEACASMapvar-kd;SEACASMapvar;SEACASMapvarlib;SEACASExplore;SEACASGrepos;SEACASGenshell;SEACASGen3D;SEACASGjoin;SEACASFastq;SEACASEx1ex2v2;SEACASExo_format;SEACASExotxt;SEACASExomatlab;SEACASExodiff;SEACASExo2mat;SEACASEpu;SEACASEjoin;SEACASConjoin;SEACASBlot;SEACASAprepro;SEACASAlgebra;SEACASPLT;SEACASSVDI;SEACASSuplibCpp;SEACASSuplibC;SEACASSuplib;SEACASSupes;SEACASAprepro_lib;SEACASChaco;SEACASIoss;SEACASNemesis;SEACASExoIIv2for32;SEACASExodus_for;SEACASExodus;Amesos2;ShyLU_Node;ShyLU_NodeTacho;ShyLU_NodeHTS;Belos;ML;Ifpack;Zoltan2Core;Pamgen;Amesos;Galeri;AztecOO;Pliris;Isorropia;Xpetra;Thyra;ThyraTpetraAdapters;ThyraEpetraExtAdapters;ThyraEpetraAdapters;ThyraCore;Domi;TrilinosSS;Tpetra;TpetraCore;TpetraTSQR;TpetraClassic;EpetraExt;Triutils;Shards;Zoltan;Epetra;MiniTensor;Sacado;RTOp;KokkosKernels;Teuchos;TeuchosKokkosComm;TeuchosKokkosCompat;TeuchosRemainder;TeuchosNumerics;TeuchosComm;TeuchosParameterList;TeuchosParser;TeuchosCore;Kokkos;KokkosAlgorithms;KokkosContainers;KokkosCore;Gtest;TrilinosATDMConfigTests;TrilinosFrameworkTests"
 
 This command is absolutely barbaric, but it is required to prevent the usage of the Zadelus library within Trilinos 13.0.1.
 
 and:
 
 .. code-block:: text
+  :class: copy-button
 
- make -j8 install
+  make -j8 install
 
 The argument ``-jX`` specifies the number of processors used for the compilation. On login nodes, a maximum of 8 cores should be used in order to ensure that other users can continue using the cluster without slowdowns. In addition, the ``nice`` command can be used at the beginning of the call to give a lower priority to this task.
 
@@ -83,15 +88,17 @@ After installing deal.II, compiling Lethe is relatively straightforward, especia
 In the ``$HOME/lethe`` directory, download Lethe:
 
 .. code-block:: text
+  :class: copy-button
 
- git clone https://github.com/lethe-cfd/lethe.git
+  git clone https://github.com/lethe-cfd/lethe.git
 
 To install Lethe in the ``$HOME/lethe/inst`` directory (applications will be in ``inst/bin``), run in the ``$HOME/lethe/build`` directory:
 
 .. code-block:: text
+  :class: copy-button
 
- cmake ../lethe  -DDEAL_II_DIR=../../dealii/inst -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst -DBUILD_TESTING=OFF
- make install -j8
+  cmake ../lethe  -DDEAL_II_DIR=../../dealii/inst -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst -DBUILD_TESTING=OFF
+  make install -j8
 
 
 Installing numdiff to enable tests
@@ -105,13 +112,15 @@ You will need to have numdiff installed to enable the test suite, otherwise you 
 4. In the numdiff folder on the cluster, execute:
 
    .. code-block:: text
+     :class: copy-button
 
-    ./configure
-    make
+     ./configure
+     make
 
 5. Add it to your path environment:
 
    .. code-block:: text
+     :class: copy-button
 
      PATH=$PATH:$HOME/path/to/numdiff/folder
 
@@ -125,17 +134,19 @@ Copying local files
 On Linux, use ``scp`` (for secure copy) to copy needed files for the simulation (``prm``, ``msh``):
 
 .. code-block:: text
+  :class: copy-button
 
-	scp /home/path/in/your/computer/*.prm username@clustername.calculcanada.ca:/scratch/path/in/cluster
+  scp /home/path/in/your/computer/*.prm username@clustername.calculcanada.ca:/scratch/path/in/cluster
 
 If you need to copy a folder, use ``scp -r``.
 
 Simulation files must be in scratch. To get the address of your scratch folder, in your cluster account run:
 
 .. code-block:: text
+  :class: copy-button
 
- cd $SCRATCH
- pwd
+  cd $SCRATCH
+  pwd
 
 On Windows, use third-party, such as ``PuTTY`` (see the `wiki page on Transferring data <https://docs.computecanada.ca/wiki/Transferring_data>`_))
 
@@ -147,31 +158,34 @@ Creating a .dealii
 In order to call your deal.II local installation, it is convenient to create a ``.dealii`` file in your ``$HOME`` directory:
 
 .. code-block:: text
+  :class: copy-button
 
- nano .dealii
+  nano .dealii
 
 In the nano terminal, copy-paste (with ``Ctrl+Shift+V``):
 
 .. code-block:: text
+  :class: copy-button
 
- module load CCEnv #if on Niagara
- module load nixpkgs/16.09
- module load gcc/7.3.0
- module load openmpi/3.1.2
- module load p4est/2.0
- module load trilinos/12.12.1
- module load parmetis/4.0.3
+  module load CCEnv #if on Niagara
+  module load nixpkgs/16.09
+  module load gcc/7.3.0
+  module load openmpi/3.1.2
+  module load p4est/2.0
+  module load trilinos/12.12.1
+  module load parmetis/4.0.3
 
- export DEAL_II_DIR=$HOME/dealii/inst/
- export PATH=$PATH:$HOME/lethe/inst/bin/
+  export DEAL_II_DIR=$HOME/dealii/inst/
+  export PATH=$PATH:$HOME/lethe/inst/bin/
 
 Exit the nano mode with ``Ctrl+x`` and save the document by hitting ``y`` on the prompt "Save modify buffer?" (in the bottom). The prompt "File Name to Write: .dealii" should then appear, hit ``Enter``.
 
 You can then source it on the terminal with:
 
 .. code-block:: text
+  :class: copy-button
 
- source $HOME/.dealii
+  source $HOME/.dealii
 
 and use it in your ``.sh`` script (see Launching simulations below).
 
@@ -182,34 +196,37 @@ Launching simulations
 Simulations are sent to the scheduler via batch scripts. Visit the Digital Research Alliance of Canada (Alliance) wiki page for more information about the `scheduler <https://docs.alliancecan.ca/wiki/What_is_a_scheduler%3F>`_ and `running jobs <https://docs.alliancecan.ca/wiki/Running_jobs>`_. For your convenience, an example of ``job.sh`` used on Beluga is given below:
 
 .. code-block:: text
+  :class: copy-button
 
- #!/bin/bash
- #SBATCH --account=$yourgroupaccount
- #SBATCH --ntasks-per-node=$X #number of parallel tasks (as in mpirun -np X)
- #SBATCH --nodes=1 #number of whole nodes used (each with up to 40 tasks-per-node)
- #SBATCH --time=1:00:00 #maximum time for the simulation (hh:mm:ss)
- #SBATCH --mem=120G #memory usage per node. See cluster specification for maximal amount.
- #SBATCH --job-name=$yourjobname
- #SBATCH --mail-type=END #email preferences
- #SBATCH --mail-type=FAIL
- #SBATCH --mail-user=$your.email.adress@email.provider
+  #!/bin/bash
+  #SBATCH --account=$yourgroupaccount
+  #SBATCH --ntasks-per-node=$X #number of parallel tasks (as in mpirun -np X)
+  #SBATCH --nodes=1 #number of whole nodes used (each with up to 40 tasks-per-node)
+  #SBATCH --time=1:00:00 #maximum time for the simulation (hh:mm:ss)
+  #SBATCH --mem=120G #memory usage per node. See cluster specification for maximal amount.
+  #SBATCH --job-name=$yourjobname
+  #SBATCH --mail-type=END #email preferences
+  #SBATCH --mail-type=FAIL
+  #SBATCH --mail-user=$your.email.adress@email.provider
 
- source $HOME/.dealii
- srun $HOME/lethe/inst/bin/$lethe_application_name_wanted $parameter_file_name.prm
+  source $HOME/.dealii
+  srun $HOME/lethe/inst/bin/$lethe_application_name_wanted $parameter_file_name.prm
 
 The job is sent using:
 
 .. code-block:: text
+  :class: copy-button
 
- sbatch job.sh
+  sbatch job.sh
 
 Status can be followed with the ``sq`` command: under ``ST``, ``PD`` indicates a pending job, and ``R`` a running job.
 
 Console outputs are written in ``slurm-$jobID.out``. For instance, to display the 20 last lines from this file, use:
 
 .. code-block:: text
+  :class: copy-button
 
- tail -n 20 slurm-$jobID.out
+  tail -n 20 slurm-$jobID.out
 
 .. note::
  If you need to launch multiple simulations, such as with varying parameter, feel free to adapt one of the scripts provided on `lethe-utils <https://github.com/lethe-cfd/lethe-utils/tree/master/python/cluster>`_.
@@ -222,14 +239,16 @@ Saving a SSH key (linux)
 To save your key on the cluster, so that it is not asked for each log or ``scp``, generate your ssh-key with:
 
 .. code-block:: text
+  :class: copy-button
 
- ssh-keygen
+  ssh-keygen
 
 which defaults to an RSA key. If you want to specify the key type you want to generate (i.e. ED25519 key), type
 
 .. code-block:: text
+  :class: copy-button
 
- ssh-keygen -t ed25519
+  ssh-keygen -t ed25519
 
 .. note::
   ED25519 keys are preferred to RSA keys since they are more secure and performant. Seek more information in the `Gitlab Documentation<https://docs.gitlab.com/ee/user/ssh.html>`.
@@ -237,13 +256,15 @@ which defaults to an RSA key. If you want to specify the key type you want to ge
 To upload this local key to your Compute Canada Database account (CCDB) use:
 
 .. code-block:: text
+  :class: copy-button
 
- ssh-copy-id username@clustername.computecanada.ca
+  ssh-copy-id username@clustername.computecanada.ca
 
 .. warning::
  This command does not work on Niagara anymore. You may use the following:
 
  .. code-block:: text
+  :class: copy-button
 
   cat ~/.ssh/$KEY_ID.pub
 

--- a/doc/source/installation/digital_alliance.rst
+++ b/doc/source/installation/digital_alliance.rst
@@ -169,11 +169,11 @@ In the nano terminal, copy-paste (with ``Ctrl+Shift+V``):
 
   module load CCEnv #if on Niagara
   module load nixpkgs/16.09
-  module load gcc/7.3.0
-  module load openmpi/3.1.2
-  module load p4est/2.0
-  module load trilinos/12.12.1
+  module load gcc/9.3.0
+  module load openmpi/4.0.3
+  module load trilinos/13.0.1
   module load parmetis/4.0.3
+  module load p4est/2.2
 
   export DEAL_II_DIR=$HOME/dealii/inst/
   export PATH=$PATH:$HOME/lethe/inst/bin/

--- a/doc/source/installation/docker.rst
+++ b/doc/source/installation/docker.rst
@@ -30,6 +30,7 @@ Sometimes it's easier to effectively set up a completely new OS than compile mil
 In some directory run:
 
 .. code-block:: bash
+  :class: copy-button
 
     local:~$ mkdir lethe-simulations && cd lethe-simulations
     local:~/lethe-simulations$ docker run -it --name lethe-container -v $(pwd):/home/docker-host dealii/dealii:master-focal
@@ -45,8 +46,9 @@ This starts a new docker container with an interactive terminal (:code:`-it`) na
 Exit the docker container with :code:`ctrl-d`; run :code:`docker ps -a` to see the current containers on your machine - you'll see the :code:`lethe-container`. Restart your container and attach to its terminal with:
 
 .. code-block:: bash
+  :class: copy-button
 
-    docker start lethe-container && docker attach lethe-container
+  docker start lethe-container && docker attach lethe-container
 
 Have fun.
 
@@ -68,25 +70,28 @@ Some Docker basics:
 In your terminal, you can then run:
 
 .. code-block:: bash
+  :class: copy-button
 
-    docker run -it --name lethe-container dealii/dealii:master-focal
+  docker run -it --name lethe-container dealii/dealii:master-focal
 
 This starts a new container with an interactive terminal (:code:`-it`) running the :code:`dealii/dealii:master-focal` image (`see here <https://hub.docker.com/r/dealii/dealii/tags>`_ for all the deal.II images) named :code:`lethe-container`. Press :code:`ctrl-d` to exit the container.
 
 To see your current docker containers, run:
 
 .. code-block:: bash
+  :class: copy-button
 
-    docker ps -a
+  docker ps -a
 
-    CONTAINER ID   IMAGE                        COMMAND   CREATED          STATUS                      PORTS     NAMES
-    e3a7f71639f6   dealii/dealii:master-focal   "bash"    14 minutes ago   Exited (0) 35 seconds ago             lethe-container
+  CONTAINER ID   IMAGE                        COMMAND   CREATED          STATUS                      PORTS     NAMES
+  e3a7f71639f6   dealii/dealii:master-focal   "bash"    14 minutes ago   Exited (0) 35 seconds ago             lethe-container
 
 This container saved your changes. You can restart and attach to the container's terminal by running:
 
 .. code-block:: bash
+  :class: copy-button
 
-    docker start lethe-container && docker attach lethe-container
+  docker start lethe-container && docker attach lethe-container
 
 If you want to, you can remove the container with :code:`docker rm lethe-container`; you'll start a new fresh container by running the :code:`docker run...` command above.
 
@@ -95,21 +100,22 @@ However, any files saved in the container are only accessible inside it, and are
 For example, on your local machine:
 
 .. code-block:: bash
+  :class: copy-button
 
-    local:~$ mkdir ~/lethe-simulations
-    local:~$ cd ~/lethe-simulations
-    local:~/lethe-simulations$ ls
+  local:~$ mkdir ~/lethe-simulations
+  local:~$ cd ~/lethe-simulations
+  local:~/lethe-simulations$ ls
 
-    local$ docker run -it --name lethe-container -v $(pwd):/home/docker-host dealii/dealii:master-focal
-    To run a command as administrator (user "root"), use "sudo <command>".
-    See "man sudo_root" for details.
+  local$ docker run -it --name lethe-container -v $(pwd):/home/docker-host dealii/dealii:master-focal
+  To run a command as administrator (user "root"), use "sudo <command>".
+  See "man sudo_root" for details.
 
-    dealii@2e92a38a6223:~$ cd /home/docker-host/
-    dealii@2e92a38a6223:/home/docker-host$ echo "Hello lethe!" > somefile.txt
-    dealii@2e92a38a6223:/home/docker-host$ exit
+  dealii@2e92a38a6223:~$ cd /home/docker-host/
+  dealii@2e92a38a6223:/home/docker-host$ echo "Hello lethe!" > somefile.txt
+  dealii@2e92a38a6223:/home/docker-host$ exit
 
-    local:~/lethe-simulations$ ls
-    somefile.txt
+  local:~/lethe-simulations$ ls
+  somefile.txt
 
 That's all the Docker-specific tutorial! Launch your container running a deal.II image, go to :code:`/home/docker-host` to save your changes locally too, download lethe, compile it, and run your simulations there.
 
@@ -122,45 +128,47 @@ That's all the Docker-specific tutorial! Launch your container running a deal.II
 We can add all the commands above, plus some comments and helpful messages to a single shell script named `docker_lethe.sh`:
 
 .. code-block:: bash
+  :class: copy-button
 
-    #!/bin/sh
+  #!/bin/sh
 
-    # Launch a persistent docker container from a given image, automatically re-attaching to it on
-    # future runs.
-    #
-    # The current local directory is mounted in /home/docker-host within the container; run any
-    # simulations there to save results on the local machine's current directory.
+  # Launch a persistent docker container from a given image, automatically re-attaching to it on
+  # future runs.
+  #
+  # The current local directory is mounted in /home/docker-host within the container; run any
+  # simulations there to save results on the local machine's current directory.
 
-    DOCKER_IMAGE='dealii/dealii:master-focal'
-    DOCKER_CONTAINER="$USER-${DOCKER_IMAGE##*/}"        # Remove repository prefix
-    DOCKER_CONTAINER=${DOCKER_CONTAINER/:/-}            # Replace : with -
+  DOCKER_IMAGE='dealii/dealii:master-focal'
+  DOCKER_CONTAINER="$USER-${DOCKER_IMAGE##*/}"        # Remove repository prefix
+  DOCKER_CONTAINER=${DOCKER_CONTAINER/:/-}            # Replace : with -
 
-    HOST_DIR=$(pwd)
-    REMOTE_DIR="/home/docker-host"
-
-
-    printf "Image:     ${DOCKER_IMAGE}\nContainer: ${DOCKER_CONTAINER}\n\n"
+  HOST_DIR=$(pwd)
+  REMOTE_DIR="/home/docker-host"
 
 
-    # If a container with this name already exists, re-attach to it
-    if [ "$(docker ps -q -af name=${DOCKER_CONTAINER})" ]
-    then
-        printf "Found previous container with same name; starting and attaching...\n\n"
-        docker start ${DOCKER_CONTAINER}
-        docker attach ${DOCKER_CONTAINER}
-    else
-        printf "Launching new container...\n\n"
-        docker run -it \
-            --name $DOCKER_CONTAINER \
-            -v $HOST_DIR:$REMOTE_DIR \
-            $DOCKER_IMAGE
-    fi
+  printf "Image:     ${DOCKER_IMAGE}\nContainer: ${DOCKER_CONTAINER}\n\n"
+
+
+  # If a container with this name already exists, re-attach to it
+  if [ "$(docker ps -q -af name=${DOCKER_CONTAINER})" ]
+  then
+      printf "Found previous container with same name; starting and attaching...\n\n"
+      docker start ${DOCKER_CONTAINER}
+      docker attach ${DOCKER_CONTAINER}
+  else
+      printf "Launching new container...\n\n"
+      docker run -it \
+          --name $DOCKER_CONTAINER \
+          -v $HOST_DIR:$REMOTE_DIR \
+          $DOCKER_IMAGE
+  fi
 
 Then just execute the shell script:
 
 .. code-block:: bash
+  :class: copy-button
 
-    local:~/lethe-simulations$ sh docker_lethe.sh
+  local:~/lethe-simulations$ sh docker_lethe.sh
 
 
 Final Notes
@@ -179,11 +187,12 @@ If you don't want to build Lethe and its dependencies, you can use the provided 
 For example, to launch the 2D Lid-Driven Cavity Flow simulation, run the following lines inside the root Lethe folder:
 
 .. code-block:: shell
+  :class: copy-button
 
-    docker run --rm \
-        -v $(pwd):/home/dealii \
-        ghcr.io/lethe-cfd/lethe:master \
-        gls_navier_stokes_2d examples/incompressible_flow/2d_lid_driven_cavity/cavity.prm
+  docker run --rm \
+    -v $(pwd):/home/dealii \
+    ghcr.io/lethe-cfd/lethe:master \
+    gls_navier_stokes_2d examples/incompressible_flow/2d_lid_driven_cavity/cavity.prm
 
 Usage
 -----

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -40,6 +40,7 @@ Clone the candi git repository in a folder of your choice  (e.g. ``/home/usernam
 From the candi folder, the installation of candi can be launched using:
 
 .. code-block:: text
+  :class: copy-button
 
   ./candi.sh -j $num_proc --prefix=$path
 
@@ -55,8 +56,9 @@ After installation, you should have a ``deal.II-candi`` folder in the installati
 After installation, add an environment variable to your ``.bashrc`` either manually or through the following command:
 
 .. code-block:: text
+  :class: copy-button
 
-   echo "export DEAL_II_DIR=/home/username/deal.ii-candi/deal.II-<version>" >> ~/.bashrc
+  echo "export DEAL_II_DIR=/home/username/deal.ii-candi/deal.II-<version>" >> ~/.bashrc
 
 Installing deal.II manually (Step #1)
 --------------------------------------
@@ -74,13 +76,15 @@ MPI, for Message Passing Interface, is required for the installation of all comp
 As an example, in Ubuntu:
 
 .. code-block:: text
+  :class: copy-button
 
   sudo apt-get install libopenmpi-dev openmpi-bin openmpi-common
 
 In Manjaro or other arch based linux distribution:
 
 .. code-block:: text
-  
+  :class: copy-button
+
   sudo pacman -Sy openmpi
 
 
@@ -90,6 +94,7 @@ numdiff
 numdiff is used within the automatic testing procedure of Lethe to compare files obtained through floating point arithmetic. Without numdiff, Lethe automatic tests may fail when they should not. numdiff can be installed directly from your package manager.
 
 .. code-block:: text
+  :class: copy-button
 
   sudo apt-get install numdiff
 
@@ -122,12 +127,14 @@ Installation of deal.II
 Clone deal.II from the `deal.ii official repository <https://github.com/dealii/dealii>`_
 
 .. code-block:: text
+  :class: copy-button
 
   git clone https://github.com/dealii/dealii 
 
 Configure deal.II in a build folder at the same level as the source code
 
 .. code-block:: text
+  :class: copy-button
 
   mkdir build
   cd build
@@ -135,26 +142,30 @@ Configure deal.II in a build folder at the same level as the source code
 Depending on how you have installed p4est, Trilinos and METIS, you may need to specify the installation folder of the three libraries
 
 .. code-block:: text
+  :class: copy-button
 
   cmake ../dealii -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=path/to/your/trilinos/installation -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=path/to/your/p4est/installation  -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=path/to/your/metis/installation -DCMAKE_INSTALL_PREFIX=/path/to/desired/installation`
 
 Compile deal.II
 
 .. code-block:: text
+  :class: copy-button
 
   make -j<nprocessor> install
 
 Create an environment variable for the deal.II directory
 
 .. code-block:: text
- 
+  :class: copy-button
+
   export DEAL_II_DIR=/path/to/dealii/installation
 
 It is generally recommended to add the variable to your bashrc so it is always loaded:
 
 .. code-block:: text
+  :class: copy-button
 
- echo "export DEAL_II_DIR=/path/to/dealii/installation" >> ~/.bashrc
+  echo "export DEAL_II_DIR=/path/to/dealii/installation" >> ~/.bashrc
 
 .. _install-lethe:
 
@@ -164,12 +175,14 @@ Installing lethe (Step #2)
 Clone lethe from the `Lethe official repository <https://github.com/lethe-cfd/lethe>`_.
 
 .. code-block:: text
+  :class: copy-button
 
   git clone https://github.com/lethe-cfd/lethe 
 
 Create a build folder at the same level as the lethe folder
 
 .. code-block:: text
+  :class: copy-button
 
   mkdir build
   cd build
@@ -177,18 +190,21 @@ Create a build folder at the same level as the lethe folder
 Build Lethe choosing the compilation option (Debug or Release). You can also optionally specify a path to an installation directory of your choice. We recommend that you do so, since this makes using Lethe much more comfortable.
 
 .. code-block:: text
+  :class: copy-button
 
   cmake ../lethe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/username/path/to/installation
 
 or
 
 .. code-block:: text
+  :class: copy-button
 
   cmake ../lethe -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/home/username/path/to/installation
 
 Then you can compile:
 
 .. code-block:: text
+  :class: copy-button
 
   make -j<numprocs>
 
@@ -198,6 +214,7 @@ Testing your installation (Step #3)
 Lethe comes pre-packaged with an extensive test suit for all of its modules. It can be used to test the validity of your installation. Within the build folder, the test suite can be launched with the following command:
 
 .. code-block:: text
+  :class: copy-button
 
   ctest -j $numprocs
 
@@ -217,6 +234,7 @@ With candi
 In the candi folder (for instance, ``/home/username/software/candi``), modify the ``candi.cfg`` to get the latest dealii version, by changing the ``DEAL_II_VERSION`` variable in the case of an official release, or by changing the ``STABLE_BUILD`` in the case of a development release. The ``candi.cfg`` should contain:
 
 .. code-block:: text
+  :class: copy-button
 
   # Install the following deal.II version:
   DEAL_II_VERSION=v9.3.0

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -35,17 +35,19 @@ Installing WSL and Ubuntu (Step #0)
 	In the windows command prompt (Start menu > ``cmd``):
 
 	.. code-block:: text
+  	  :class: copy-button
 
-		wsl -l -v
+  	  wsl -l -v
 
 	should indicate ``version 2``. If not, follow this to update WSL: https://docs.microsoft.com/fr-fr/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2
 
 2. |win_shell| Launch Ubuntu (from the start menu) and |linux_shell| update Ubuntu: 
 
 .. code-block:: text
+  :class: copy-button
 
-	sudo apt update
-	sudo apt upgrade
+  sudo apt update
+  sudo apt upgrade
 
 .. tip::
 	The ``sudo`` command will ask you to type your user password, as defined during Ubuntu installation. Note that Linux does not show any symbol while typing a password, contrary to Windows with ``*``: simply type your password and press ``Enter``.
@@ -82,12 +84,13 @@ Installing deal.II using candi (Step #1)
 1. |linux_shell| Install candi required packages:
 
 .. code-block:: text
+  :class: copy-button
 
-	sudo apt-get install lsb-release git subversion wget \
-	bc libgmp-dev build-essential autoconf automake cmake \
-	libtool gfortran libboost-all-dev zlib1g-dev openmpi-bin \
-	openmpi-common libopenmpi-dev libblas3 libblas-dev \
-	liblapack3 liblapack-dev libsuitesparse-dev
+  sudo apt-get install lsb-release git subversion wget \
+  bc libgmp-dev build-essential autoconf automake cmake \
+  libtool gfortran libboost-all-dev zlib1g-dev openmpi-bin \
+  openmpi-common libopenmpi-dev libblas3 libblas-dev \
+  liblapack3 liblapack-dev libsuitesparse-dev
 
 .. tip::
 	The symbols ``\`` indicate that this a single command written on multiple lines.
@@ -95,23 +98,26 @@ Installing deal.II using candi (Step #1)
 2. |linux_shell| Install compilers:
 
 .. code-block:: text
+  :class: copy-button
 
-	sudo apt-get install gcc-10 g++-10 gfortran-10
+  sudo apt-get install gcc-10 g++-10 gfortran-10
 
 3. |linux_shell| Create folders (suggested structure):
 
 .. code-block:: text
+  :class: copy-button
 
-	mkdir Softwares; cd Softwares
-	mkdir candi; cd candi
+  mkdir Softwares; cd Softwares
+  mkdir candi; cd candi
 
 Note the use of ``;`` which enable to serialize operations on a single execution line.
 
 4. |linux_shell| Download candi:
 
 .. code-block:: text
+  :class: copy-button
 
-	git clone https://github.com/dealii/candi.git .
+  git clone https://github.com/dealii/candi.git .
 
 Do not forget the ``.`` at the end of the command, which means "here".
 
@@ -154,8 +160,9 @@ Do not forget the ``.`` at the end of the command, which means "here".
 6. |linux_shell| Still in the candi subfolder, run candi installation script:
 
 .. code-block:: text
+  :class: copy-button
 
-	./candi.sh -j$numprocs
+  ./candi.sh -j$numprocs
 
 Where ``$numprocs`` corresponds to the number of processors used for the compilation:
 	* if you have less than 8Gb of RAM, use 1 to 2 procs: ``./candi.sh -j1`` or ``./candi.sh -j2``
@@ -178,8 +185,9 @@ Where ``$numprocs`` corresponds to the number of processors used for the compila
 8. |linux_shell| Add a deal.II environment variable in Ubuntu through the following command:
 
 .. code-block:: text
+  :class: copy-button
 
-	echo "export DEAL_II_DIR=$HOME/deal.ii-candi/deal.II-master" >> ~/.bashrc
+  echo "export DEAL_II_DIR=$HOME/deal.ii-candi/deal.II-master" >> ~/.bashrc
 
 
 Installing Lethe (Step #2)
@@ -188,8 +196,9 @@ Installing Lethe (Step #2)
 1. |linux_shell| Set-up the folder structure: in the ``Softwares`` folder created at the beginning of Step #1 (if you are in the candi folder, type ``cd ..``), type:
 
 .. code-block:: text
+  :class: copy-button
 
-	mkdir -p lethe/{git,build,inst}
+  mkdir -p lethe/{git,build,inst}
 
 After installation is complete, the folder structure will be:
 
@@ -200,22 +209,25 @@ After installation is complete, the folder structure will be:
 2. |linux_shell| Download lethe:
 
 .. code-block:: text
+  :class: copy-button
 
-	cd lethe
-	git clone https://github.com/lethe-cfd/lethe git
+  cd lethe
+  git clone https://github.com/lethe-cfd/lethe git
 
 3. |linux_shell| Build lethe:
 
 .. code-block:: text
+  :class: copy-button
 
-	cd build
-	cmake ../git -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../inst/
+  cd build
+  cmake ../git -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../inst/
 
 4. |linux_shell| Compile lethe:
 
 .. code-block:: text
+  :class: copy-button
 
-	make -j$numprocs
+  make -j$numprocs
 
 Where ``$numprocs`` corresponds to the number of processors used for the compilation:
 	* if you have less than 8Gb of RAM, use 1 to 2 procs: ``make -j1`` or ``make -j2``
@@ -224,8 +236,9 @@ Where ``$numprocs`` corresponds to the number of processors used for the compila
 5. |linux_shell| (optional) Test your installation, still in the build folder:
 
 .. code-block:: text
+  :class: copy-button
 
-	ctest -j$numprocs
+  ctest -j$numprocs
 
 This will take from a few minutes to an hour, depending on your hardware. At the end, you should have this message on the console:
 
@@ -243,18 +256,20 @@ If you have already installed deal.II and lethe, you can update them without doi
 1. |linux_shell| Update deal.ii by typing, from your home directory:
 
 .. code-block:: text
+  :class: copy-button
 
-	cd Softwares/candi
-	./candi.sh -j$numprocs
+  cd Softwares/candi
+  ./candi.sh -j$numprocs
 
 2. |linux_shell| Then, update lethe:
 
 .. code-block:: text
+  :class: copy-button
 
-	cd ../lethe/git
-	git pull
-	cd ../build
-	cmake ../git -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../inst/
-	make -j$numprocs
+  cd ../lethe/git
+  git pull
+  cd ../build
+  cmake ../git -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../inst/
+  make -j$numprocs
 	
 


### PR DESCRIPTION
# Description of the problem

In the installation instructions in the documentation there are many commands that should be copied into the terminal. This PR adds a copy button to those blocks of code. It requires the sphinx-copybutton package; therefore, the CI is updated as well as the instructions for contributing to the documentation. 

# Description of the solution

All the files in the installation section of the documentation were updated accordingly. 

# Comments

This change will affect all the people working in the documentation. Therefore, everybody should run the following lines in their local machines to ensure compilation:
`pip install sphinx-copybutton`
`pip install -r doc/requirements.txt`
