### PR TITLE
Multiphysics interface previous solutions

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction.output
@@ -1,0 +1,55 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      4
+   Number of thermal degrees of freedom: 4225
+
+*****************************************************************
+Transient iteration : 1        Time : 0.4      Time step : 0.4      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 4.65604e-07
+
+*****************************************************************
+Transient iteration : 2        Time : 1        Time step : 0.6      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 1.23705e-06
+
+*****************************************************************
+Transient iteration : 3        Time : 2        Time step : 1        CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 6.87696e-07
+
+*****************************************************************
+Transient iteration : 4        Time : 3        Time step : 1        CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 5.91022e-06
+
+*****************************************************************
+Transient iteration : 5        Time : 4        Time step : 1        CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 1.5608e-05
+
+*****************************************************************
+Transient iteration : 6        Time : 5        Time step : 1        CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 3.48882e-06
+ time  error_velocity 
+0.4000 0.000000e+00   
+1.0000 0.000000e+00   
+2.0000 0.000000e+00   
+3.0000 0.000000e+00   
+4.0000 0.000000e+00   
+5.0000 0.000000e+00   
+cells error_temperature 
+1024  4.656042e-07      
+1024  1.237050e-06      
+1024  6.876965e-07      
+1024  5.910219e-06      
+1024  1.560796e-05      
+1024  3.488818e-06      

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction.prm
@@ -1,0 +1,129 @@
+# Listing of Parameters
+# ---------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  		= bdf2
+  set time end                		= 5
+  set time step               		= 1
+  set number mesh adapt       		= 0
+  set output name             		= conduction
+  set output frequency        		= 1
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+	set heat transfer  = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection uvwp
+        set Function expression 	= 0; 0; 0
+    end
+    subsection temperature
+    	set Function expression 	= 0
+    end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+subsection source term
+    set enable = false
+    subsection xyz
+        set Function expression = 0; 0; 0
+    end
+
+    subsection heat transfer
+        set Function expression = +(2*(2*pi)^2*sin(t) + cos(t))*sin(2*pi*x)*sin(2*pi*y)
+    end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+  set number of fluids     = 1
+    subsection fluid 0
+    set thermal conductivity model 	= constant
+    set thermal conductivity 		= 1
+    set specific heat model 		= constant
+    set specific heat 			= 1
+    
+    set density              		= 1
+    set kinematic viscosity  		= 0.01
+    end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+        set type = dealii
+        set grid type = subdivided_hyper_rectangle
+        set grid arguments = 1, 1: -1, -1 : 1, 1 : false
+        set initial refinement = 5
+end
+
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions heat transfer
+  set number                  = 1
+    subsection bc 0
+    	set id = 0
+	  set type	      = temperature
+        set value	      = 0
+    end
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable                 = true
+  set verbosity = verbose
+    subsection uvwp
+            set Function expression =  0 ; 0 ; 0
+    end
+    subsection temperature
+            set Function expression =  sin(2*pi*x)*sin(2*pi*y)*sin(t)
+    end
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+subsection FEM
+    set velocity order            = 1
+    set pressure order            = 1
+    set temperature order         = 2
+end
+
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set tolerance               = 1e-8
+  set max iterations          = 100
+  set verbosity               = quiet
+end
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               		           = quiet
+  set method                                 = gmres
+  set relative residual                      = 1e-3
+  set minimum residual                       = 1e-8
+  set ilu preconditioner fill                = 0
+  set ilu preconditioner absolute tolerance  = 1e-12
+  set ilu preconditioner relative tolerance  = 1.00
+  set max krylov vectors                     = 200
+end

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction_bdf3.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction_bdf3.output
@@ -1,0 +1,55 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       4096
+   Number of degrees of freedom: 12675
+   Volume of triangulation:      4
+   Number of thermal degrees of freedom: 16641
+
+*****************************************************************
+Transient iteration : 1        Time : 0.2      Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 0.00338715
+
+*****************************************************************
+Transient iteration : 2        Time : 0.4      Time step : 0.2      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 0.000500893
+
+*****************************************************************
+Transient iteration : 3        Time : 0.5      Time step : 0.1      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 8.66319e-07
+
+*****************************************************************
+Transient iteration : 4        Time : 1        Time step : 0.5      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 0.000178774
+
+*****************************************************************
+Transient iteration : 5        Time : 1.5      Time step : 0.5      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 3.0248e-06
+
+*****************************************************************
+Transient iteration : 6        Time : 2        Time step : 0.5      CFL : 0       
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 4.80627e-06
+ time  error_velocity 
+0.2000 0.000000e+00   
+0.4000 0.000000e+00   
+0.5000 0.000000e+00   
+1.0000 0.000000e+00   
+1.5000 0.000000e+00   
+2.0000 0.000000e+00   
+cells error_temperature 
+4096  3.387150e-03      
+4096  5.008934e-04      
+4096  8.663189e-07      
+4096  1.787739e-04      
+4096  3.024804e-06      
+4096  4.806270e-06      

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction_bdf3.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction_bdf3.prm
@@ -1,0 +1,129 @@
+# Listing of Parameters
+# ---------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  		= bdf3
+  set time end                		= 2
+  set time step               		= 0.5
+  set number mesh adapt       		= 0
+  set output name             		= conduction
+  set output frequency        		= 1
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+	set heat transfer  = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection uvwp
+        set Function expression 	= 0; 0; 0
+    end
+    subsection temperature
+    	set Function expression 	= 0
+    end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+subsection source term
+    set enable = false
+    subsection xyz
+        set Function expression = 0; 0; 0
+    end
+
+    subsection heat transfer
+        set Function expression =(2*(2*pi)^2 + 1)*exp(t)*sin(2*pi*x)*sin(2*pi*y)
+    end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+  set number of fluids     = 1
+    subsection fluid 0
+    set thermal conductivity model 	= constant
+    set thermal conductivity 		= 1
+    set specific heat model 		= constant
+    set specific heat 			= 1
+    
+    set density              		= 1
+    set kinematic viscosity  		= 0.01
+    end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+        set type = dealii
+        set grid type = subdivided_hyper_rectangle
+        set grid arguments = 1, 1: -1, -1 : 1, 1 : false
+        set initial refinement = 6
+end
+
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions heat transfer
+  set number                  = 1
+    subsection bc 0
+    	set id = 0
+	  set type	      = temperature
+        set value	      = 0
+    end
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable                 = true
+  set verbosity = verbose
+    subsection uvwp
+            set Function expression =  0 ; 0 ; 0
+    end
+    subsection temperature
+            set Function expression =  sin(2*pi*x)*sin(2*pi*y)*exp(t)
+    end
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+subsection FEM
+    set velocity order            = 1
+    set pressure order            = 1
+    set temperature order         = 2
+end
+
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set tolerance               = 1e-8
+  set max iterations          = 100
+  set verbosity               = quiet
+end
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               		           = quiet
+  set method                                 = gmres
+  set relative residual                      = 1e-3
+  set minimum residual                       = 1e-8
+  set ilu preconditioner fill                = 0
+  set ilu preconditioner absolute tolerance  = 1e-12
+  set ilu preconditioner relative tolerance  = 1.00
+  set max krylov vectors                     = 200
+end

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -59,7 +59,7 @@ public:
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,
-    ConditionalOStream                &p_pcout);
+    ConditionalOStream &               p_pcout);
 
   std::vector<PhysicsID>
   get_active_physics()
@@ -470,7 +470,7 @@ public:
    * @param physics_id The physics of the DOF handler being requested
    */
   DoFHandler<dim> *
-  get_dof_handler(PhysicsID physics_id)
+  get_dof_handler(const PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -486,7 +486,7 @@ public:
    * @param physics_id The physics of the solution being requested
    */
   TrilinosWrappers::MPI::Vector *
-  get_solution(PhysicsID physics_id)
+  get_solution(const PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -496,12 +496,28 @@ public:
   }
 
   /**
+   * @brief Request the present block solution of a given physics
+   *
+   * @param physics_id The physics of the solution being requested
+   */
+  TrilinosWrappers::MPI::BlockVector *
+  get_block_solution(const PhysicsID physics_id)
+  {
+    AssertThrow((std::find(active_physics.begin(),
+                           active_physics.end(),
+                           physics_id) != active_physics.end()),
+                ExcInternalError());
+    return block_physics_solutions[physics_id];
+  }
+
+
+  /**
    * @brief Request the time-average solution of a given physics
    *
    * @param physics_id The physics of the solution being requested
    */
   TrilinosWrappers::MPI::Vector *
-  get_time_average_solution(PhysicsID physics_id)
+  get_time_average_solution(const PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -516,7 +532,7 @@ public:
    * @param physics_id The physics of the solution being requested
    */
   TrilinosWrappers::MPI::BlockVector *
-  get_block_time_average_solution(PhysicsID physics_id)
+  get_block_time_average_solution(const PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -532,7 +548,7 @@ public:
    * @param physics_id The physics of the solution being requested
    */
   TrilinosWrappers::MPI::Vector *
-  get_reynolds_stress_solution(PhysicsID physics_id)
+  get_reynolds_stress_solution(const PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -584,20 +600,6 @@ public:
   DoFHandler<dim> *
   get_filtered_phase_fraction_gradient_dof_handler();
 
-  /**
-   * @brief Request the present block solution of a given physics
-   *
-   * @param physics_id The physics of the solution being requested
-   */
-  TrilinosWrappers::MPI::BlockVector *
-  get_block_solution(PhysicsID physics_id)
-  {
-    AssertThrow((std::find(active_physics.begin(),
-                           active_physics.end(),
-                           physics_id) != active_physics.end()),
-                ExcInternalError());
-    return block_physics_solutions[physics_id];
-  }
 
   /**
    * @brief Request the previous solutions of a given physics
@@ -616,36 +618,19 @@ public:
 
 
   /**
-   * @brief Request the past (minus 1) solution of a given physics
+   * @brief Request the previous solutions of a given block physics
    *
    * @param physics_id The physics of the solution being requested
    */
-  TrilinosWrappers::MPI::Vector *
-  get_solution_m1(PhysicsID physics_id)
+  std::vector<TrilinosWrappers::MPI::BlockVector> *
+  get_block_previous_solutions(const PhysicsID physics_id)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
                            physics_id) != active_physics.end()),
                 ExcInternalError());
-    return physics_solutions_m1[physics_id];
+    return block_physics_previous_solutions[physics_id];
   }
-
-
-  /**
-   * @brief Request the past (minus 1) block solution of a given physics
-   *
-   * @param physics_id The physics of the solution being requested
-   */
-  TrilinosWrappers::MPI::BlockVector *
-  get_block_solution_m1(PhysicsID physics_id)
-  {
-    AssertThrow((std::find(active_physics.begin(),
-                           active_physics.end(),
-                           physics_id) != active_physics.end()),
-                ExcInternalError());
-    return block_physics_solutions_m1[physics_id];
-  }
-
 
   /**
    * @brief Sets the reference to the DOFHandler of the physics in the multiphysics interface
@@ -655,7 +640,7 @@ public:
    * @param dof_handler The dof handler for which the reference is stored
    */
   void
-  set_dof_handler(PhysicsID physics_id, DoFHandler<dim> *dof_handler)
+  set_dof_handler(const PhysicsID physics_id, DoFHandler<dim> *dof_handler)
   {
     AssertThrow((std::find(active_physics.begin(),
                            active_physics.end(),
@@ -683,7 +668,7 @@ public:
    * @param solution_vector The reference to the solution vector of the physics
    */
   void
-  set_solution(PhysicsID                      physics_id,
+  set_solution(const PhysicsID                physics_id,
                TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
@@ -701,7 +686,7 @@ public:
    * @param solution_vector The reference to the solution vector of the physics
    */
   void
-  set_time_average_solution(PhysicsID                      physics_id,
+  set_time_average_solution(const PhysicsID                physics_id,
                             TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
@@ -721,7 +706,7 @@ public:
    * @param solution_vector The reference to the solution vector of the physics
    */
   void
-  set_reynolds_stress_solutions(PhysicsID                      physics_id,
+  set_reynolds_stress_solutions(const PhysicsID                physics_id,
                                 TrilinosWrappers::MPI::Vector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
@@ -740,7 +725,7 @@ public:
    * @param solution_vector The reference to the solution vector of the physics
    */
   void
-  set_block_solution(PhysicsID                           physics_id,
+  set_block_solution(const PhysicsID                     physics_id,
                      TrilinosWrappers::MPI::BlockVector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
@@ -759,7 +744,7 @@ public:
    */
   void
   set_block_time_average_solution(
-    PhysicsID                           physics_id,
+    const PhysicsID                     physics_id,
     TrilinosWrappers::MPI::BlockVector *solution_vector)
   {
     AssertThrow((std::find(active_physics.begin(),
@@ -768,43 +753,6 @@ public:
                 ExcInternalError());
     block_physics_time_average_solutions[physics_id] = solution_vector;
   }
-
-  /**
-   * @brief Sets the reference to the solution of the physics in the multiphysics interface
-   *
-   * @param physics_id The physics of the DOF handler being requested
-   *
-   * @param solution_vector The reference to the solution vector of the physics
-   */
-  void
-  set_solution_m1(PhysicsID                      physics_id,
-                  TrilinosWrappers::MPI::Vector *solution_vector)
-  {
-    AssertThrow((std::find(active_physics.begin(),
-                           active_physics.end(),
-                           physics_id) != active_physics.end()),
-                ExcInternalError());
-    physics_solutions_m1[physics_id] = solution_vector;
-  }
-
-  /**
-   * @brief Sets the reference to the solution of the physics in the multiphysics interface
-   *
-   * @param physics_id The physics of the DOF handler being requested
-   *
-   * @param solution_vector The reference to the solution vector of the physics
-   */
-  void
-  set_block_solution_m1(PhysicsID                           physics_id,
-                        TrilinosWrappers::MPI::BlockVector *solution_vector)
-  {
-    AssertThrow((std::find(active_physics.begin(),
-                           active_physics.end(),
-                           physics_id) != active_physics.end()),
-                ExcInternalError());
-    block_physics_solutions_m1[physics_id] = solution_vector;
-  }
-
 
   /**
    * @brief Sets the pointer to the vector of previous solutions of the physics in the multiphysics interface

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -500,7 +500,7 @@ private:
    * @param mass_matrix
    */
   void
-  assemble_mass_matrix_diagonal(TrilinosWrappers::SparseMatrix &mass_matrix);
+  assemble_mass_matrix(TrilinosWrappers::SparseMatrix &mass_matrix);
 
 
   /**

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -2975,13 +2975,10 @@ GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
+                              *this->multiphysics->get_previous_solutions(
+                                PhysicsID::VOF),
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
@@ -3068,14 +3065,10 @@ GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
+                              *this->multiphysics->get_previous_solutions(
+                                PhysicsID::VOF),
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -230,13 +230,10 @@ GDNavierStokesSolver<dim>::assemble_local_system_matrix(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
+                              *this->multiphysics->get_previous_solutions(
+                                PhysicsID::VOF),
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 
@@ -358,14 +355,10 @@ GDNavierStokesSolver<dim>::assemble_local_system_rhs(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
+                              *this->multiphysics->get_previous_solutions(
+                                PhysicsID::VOF),
                               std::vector<TrilinosWrappers::MPI::Vector>());
     }
 

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -625,13 +625,10 @@ GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
+                              *this->multiphysics->get_previous_solutions(
+                                PhysicsID::VOF),
                               std::vector<TrilinosWrappers::MPI::Vector>());
 
       if (this->simulation_parameters.multiphysics.vof_parameters
@@ -808,14 +805,10 @@ GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
         cell->index(),
         dof_handler_vof);
 
-      std::vector<TrilinosWrappers::MPI::Vector> previous_solutions;
-      previous_solutions.push_back(
-        *this->multiphysics->get_solution_m1(PhysicsID::VOF));
-
-
       scratch_data.reinit_vof(phase_cell,
                               *this->multiphysics->get_solution(PhysicsID::VOF),
-                              previous_solutions,
+                              *this->multiphysics->get_previous_solutions(
+                                PhysicsID::VOF),
                               std::vector<TrilinosWrappers::MPI::Vector>());
 
       if (this->simulation_parameters.multiphysics.vof_parameters

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -892,6 +892,8 @@ HeatTransfer<dim>::setup_dofs()
   // multiphysics interface
   multiphysics->set_dof_handler(PhysicsID::heat_transfer, &this->dof_handler);
   multiphysics->set_solution(PhysicsID::heat_transfer, &this->present_solution);
+  multiphysics->set_previous_solutions(PhysicsID::heat_transfer,
+                                       &this->previous_solutions);
 }
 
 template <int dim>

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -662,6 +662,8 @@ Tracer<dim>::setup_dofs()
   // multiphysics interface
   multiphysics->set_dof_handler(PhysicsID::tracer, &this->dof_handler);
   multiphysics->set_solution(PhysicsID::tracer, &this->present_solution);
+  multiphysics->set_previous_solutions(PhysicsID::tracer,
+                                       &this->previous_solutions);
 }
 
 template <int dim>

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -99,8 +99,8 @@ template <int dim>
 void
 VolumeOfFluid<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  VOFScratchData<dim> &                                 scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  VOFScratchData<dim>                                  &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -190,8 +190,8 @@ template <int dim>
 void
 VolumeOfFluid<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  VOFScratchData<dim> &                                 scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  VOFScratchData<dim>                                  &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -379,16 +379,14 @@ VolumeOfFluid<dim>::calculate_volume_and_mass(
             {
               switch (monitored_fluid)
                 {
-                  case Parameters::FluidIndicator::fluid0:
-                    {
+                    case Parameters::FluidIndicator::fluid0: {
                       this->volume_monitored +=
                         fe_values_vof.JxW(q) * (1 - phase_values[q]);
                       this->mass_monitored +=
                         this->volume_monitored * density_0[q];
                       break;
                     }
-                  case Parameters::FluidIndicator::fluid1:
-                    {
+                    case Parameters::FluidIndicator::fluid1: {
                       this->volume_monitored +=
                         fe_values_vof.JxW(q) * phase_values[q];
                       this->mass_monitored +=
@@ -414,7 +412,7 @@ template <typename VectorType>
 double
 VolumeOfFluid<dim>::find_monitored_fluid_avg_pressure(
   const TrilinosWrappers::MPI::Vector &solution,
-  const VectorType &                   current_solution_fd,
+  const VectorType                    &current_solution_fd,
   const Parameters::FluidIndicator     monitored_fluid)
 {
   QGauss<dim>    quadrature_formula(this->cell_quadrature->size());
@@ -499,14 +497,14 @@ VolumeOfFluid<3>::find_monitored_fluid_avg_pressure<
 template double
 VolumeOfFluid<2>::find_monitored_fluid_avg_pressure<
   TrilinosWrappers::MPI::BlockVector>(
-  const TrilinosWrappers::MPI::Vector &     solution,
+  const TrilinosWrappers::MPI::Vector      &solution,
   const TrilinosWrappers::MPI::BlockVector &current_solution_fd,
   const Parameters::FluidIndicator          monitored_fluid);
 
 template double
 VolumeOfFluid<3>::find_monitored_fluid_avg_pressure<
   TrilinosWrappers::MPI::BlockVector>(
-  const TrilinosWrappers::MPI::Vector &     solution,
+  const TrilinosWrappers::MPI::Vector      &solution,
   const TrilinosWrappers::MPI::BlockVector &current_solution_fd,
   const Parameters::FluidIndicator          monitored_fluid);
 
@@ -788,9 +786,8 @@ VolumeOfFluid<dim>::find_sharpening_threshold()
           st_min             = st_avg;
           mass_deviation_min = mass_deviation_avg;
         }
-    }
-  while (std::abs(mass_deviation_avg) > mass_deviation_tol &&
-         nb_search_ite < max_iterations);
+  } while (std::abs(mass_deviation_avg) > mass_deviation_tol &&
+           nb_search_ite < max_iterations);
 
   // Take minimum deviation in between the two endpoints of the last
   // interval searched, if out of the do-while loop because max_iterations is
@@ -1643,6 +1640,9 @@ VolumeOfFluid<dim>::setup_dofs()
   // NB: for now, inertia in fluid dynamics is considered with a constant
   // density (see if needed / to be debugged)
   multiphysics->set_solution_m1(PhysicsID::VOF, &this->previous_solutions[0]);
+  multiphysics->set_previous_solutions(PhysicsID::VOF,
+                                       &this->previous_solutions);
+
 
   mass_matrix_phase_fraction.reinit(this->locally_owned_dofs,
                                     this->locally_owned_dofs,
@@ -2308,9 +2308,9 @@ VolumeOfFluid<3>::apply_peeling_wetting<TrilinosWrappers::MPI::BlockVector>(
 template <int dim>
 void
 VolumeOfFluid<dim>::change_cell_phase(
-  const PhaseChange &                         type,
-  const double &                              new_phase,
-  TrilinosWrappers::MPI::Vector &             solution_pw,
+  const PhaseChange                          &type,
+  const double                               &new_phase,
+  TrilinosWrappers::MPI::Vector              &solution_pw,
   const std::vector<types::global_dof_index> &dof_indices_vof)
 {
   if (type == PhaseChange::wetting)


### PR DESCRIPTION
# Description of the problem

- The code use to only be able to gather one previous solution from the auxiliary physics instead of the entire list of vector. This lead to breakdown of BDF schemes when physics A needed the previous values of physics B

# Description of the solution

- Fixed this by allowing the passing of the entire previous solutions vector
- Also cleaned the multiphysics interface at the same time.

# How Has This Been Tested?

- All previous tests pass so this means this is correct.


