### PR TITLE
Fix a bug in the definition of stabilization constant for VOF simulations

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/gls_vof_hydrostat_mesh-adapt.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_hydrostat_mesh-adapt.output
@@ -7,21 +7,21 @@ Running on 1 MPI rank(s)...
 *****************************************************************
 Transient iteration : 1        Time : 0.02     Time step : 0.02     CFL : 0       
 *****************************************************************
-L2 error velocity : 3.07121e-05
+L2 error velocity : 3.0712e-05
 L2 error phase : 0.0104167
 
 *****************************************************************
-Transient iteration : 2        Time : 0.04     Time step : 0.02     CFL : 8.8806e-05
+Transient iteration : 2        Time : 0.04     Time step : 0.02     CFL : 8.88062e-05
 *****************************************************************
    Number of active cells:       448
    Number of degrees of freedom: 1596
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 532
-L2 error velocity : 4.14391e-06
+L2 error velocity : 4.14394e-06
 L2 error phase : 0.00425552
 
 *****************************************************************
-Transient iteration : 3        Time : 0.06     Time step : 0.02     CFL : 2.1861e-05
+Transient iteration : 3        Time : 0.06     Time step : 0.02     CFL : 2.18611e-05
 *****************************************************************
    Number of active cells:       472
    Number of degrees of freedom: 1659
@@ -33,31 +33,31 @@ L2 error phase : 0.00425561
 *****************************************************************
 Transient iteration : 4        Time : 0.08     Time step : 0.02     CFL : 1.96295e-05
 *****************************************************************
+   Number of active cells:       400
+   Number of degrees of freedom: 1437
+   Volume of triangulation:      1
+   Number of VOF degrees of freedom: 479
+L2 error velocity : 3.73655e-06
+L2 error phase : 0.00425569
+
+*****************************************************************
+Transient iteration : 5        Time : 0.1      Time step : 0.02     CFL : 2.18368e-05
+*****************************************************************
    Number of active cells:       568
    Number of degrees of freedom: 1950
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 650
-L2 error velocity : 2.7637e-06
-L2 error phase : 0.0042557
-
-*****************************************************************
-Transient iteration : 5        Time : 0.1      Time step : 0.02     CFL : 1.89363e-05
-*****************************************************************
-   Number of active cells:       784
-   Number of degrees of freedom: 2787
-   Volume of triangulation:      1
-   Number of VOF degrees of freedom: 929
-L2 error velocity : 3.56824e-06
-L2 error phase : 0.00425576
+L2 error velocity : 2.76371e-06
+L2 error phase : 0.00425577
  time  error_velocity error_pressure 
-0.0200 3.071207e-05   0.0682         
-0.0400 4.143914e-06   0.0668         
-0.0600 3.312462e-06   0.0669         
-0.0800 2.763695e-06   0.0669         
-0.1000 3.568241e-06   0.0669         
+0.0200 3.071204e-05   0.0682         
+0.0400 4.143936e-06   0.0668         
+0.0600 3.312457e-06   0.0669         
+0.0800 3.736546e-06   0.0669         
+0.1000 2.763707e-06   0.0669         
  time  error_phase  
-0.0200 1.041667e-02 
+0.0200 1.041668e-02 
 0.0400 4.255519e-03 
 0.0600 4.255607e-03 
-0.0800 4.255695e-03 
-0.1000 4.255762e-03 
+0.0800 4.255687e-03 
+0.1000 4.255774e-03 

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_wetting-inverted.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_wetting-inverted.output
@@ -12,7 +12,7 @@ Peeling/wetting correction at step 1
   -number of peeled cells: 0
 
 *****************************************************************
-Transient iteration : 2        Time : 0.01     Time step : 0.005    CFL : 0.000293369
+Transient iteration : 2        Time : 0.01     Time step : 0.005    CFL : 0.00030248
 *****************************************************************
 Peeling/wetting correction at step 2
   -number of wet cells: 32

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_wetting_mesh-adapt.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_wetting_mesh-adapt.output
@@ -12,45 +12,45 @@ Peeling/wetting correction at step 1
   -number of peeled cells: 0
 
 *****************************************************************
-Transient iteration : 2        Time : 0.04     Time step : 0.02     CFL : 1.10334 
+Transient iteration : 2        Time : 0.04     Time step : 0.02     CFL : 1.10333 
 *****************************************************************
-   Number of active cells:       1210
-   Number of degrees of freedom: 4029
+   Number of active cells:       1216
+   Number of degrees of freedom: 4047
    Volume of triangulation:      0.04
-   Number of VOF degrees of freedom: 1343
+   Number of VOF degrees of freedom: 1349
 Peeling/wetting correction at step 2
   -number of wet cells: 28
   -number of peeled cells: 0
 
 *****************************************************************
-Transient iteration : 3        Time : 0.06     Time step : 0.02     CFL : 1.19539 
+Transient iteration : 3        Time : 0.06     Time step : 0.02     CFL : 1.17981 
 *****************************************************************
-   Number of active cells:       3040
-   Number of degrees of freedom: 9930
+   Number of active cells:       3052
+   Number of degrees of freedom: 9972
    Volume of triangulation:      0.04
-   Number of VOF degrees of freedom: 3310
+   Number of VOF degrees of freedom: 3324
 Peeling/wetting correction at step 3
   -number of wet cells: 66
   -number of peeled cells: 0
 
 *****************************************************************
-Transient iteration : 4        Time : 0.08     Time step : 0.02     CFL : 2.68869 
+Transient iteration : 4        Time : 0.08     Time step : 0.02     CFL : 2.73094 
 *****************************************************************
-   Number of active cells:       5344
-   Number of degrees of freedom: 16827
+   Number of active cells:       5350
+   Number of degrees of freedom: 16845
    Volume of triangulation:      0.04
-   Number of VOF degrees of freedom: 5609
+   Number of VOF degrees of freedom: 5615
 Peeling/wetting correction at step 4
   -number of wet cells: 69
   -number of peeled cells: 0
 
 *****************************************************************
-Transient iteration : 5        Time : 0.1      Time step : 0.02     CFL : 2.83106 
+Transient iteration : 5        Time : 0.1      Time step : 0.02     CFL : 2.85992 
 *****************************************************************
-   Number of active cells:       5665
-   Number of degrees of freedom: 17727
+   Number of active cells:       5662
+   Number of degrees of freedom: 17718
    Volume of triangulation:      0.04
-   Number of VOF degrees of freedom: 5909
+   Number of VOF degrees of freedom: 5906
 Peeling/wetting correction at step 5
   -number of wet cells: 60
   -number of peeled cells: 0

--- a/examples/multiphysics/dam-break/dam-break-Martin-and-Moyce.prm
+++ b/examples/multiphysics/dam-break/dam-break-Martin-and-Moyce.prm
@@ -161,10 +161,10 @@ end
 subsection linear solver
   set verbosity                             = verbose
   set method                                = gmres
-  set max iters                             = 8000
+  set max iters                             = 1000
   set relative residual                     = 1e-3
   set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 1
+  set ilu preconditioner fill               = 0
   set ilu preconditioner absolute tolerance = 1e-12
   set ilu preconditioner relative tolerance = 1.00
   set max krylov vectors                    = 200

--- a/include/solvers/stabilization.h
+++ b/include/solvers/stabilization.h
@@ -30,14 +30,19 @@ using namespace dealii;
  * @param viscosity Kinematic viscosity
  *
  * @param h Cell size. Should be calculated using the diameter of a sphere of equal volume to that of the cell
+ *
+ * @param density Density of the fluid, assumed to be 1 by default.
+ *
  */
 inline double
 calculate_navier_stokes_gls_tau_steady(const double u_mag,
                                        const double viscosity,
-                                       const double h)
+                                       const double h,
+                                       const double density = 1)
 {
-  return 1. / std::sqrt(Utilities::fixed_power<2>(2. * u_mag / h) +
-                        9 * Utilities::fixed_power<2>(4 * viscosity / (h * h)));
+  return 1. / std::sqrt(Utilities::fixed_power<2>(2. * density * u_mag / h) +
+                        9 * Utilities::fixed_power<2>(4 * density * viscosity /
+                                                      (h * h)));
 }
 
 /**
@@ -50,16 +55,20 @@ calculate_navier_stokes_gls_tau_steady(const double u_mag,
  *
  * @param h Cell size. Should be calculated using the diameter of a sphere of equal volume to that of the cell
  *
- * \param sdt Inverse of the time-step (1/dt)
+ * @param sdt Inverse of the time-step (1/dt)
+ *
+ * @param density Density of the fluid, assumed to be 1 by default.
  */
 
 inline double
 calculate_navier_stokes_gls_tau_transient(const double u_mag,
                                           const double viscosity,
                                           const double h,
-                                          const double sdt)
+                                          const double sdt,
+                                          const double density = 1)
 {
-  return 1. / std::sqrt(Utilities::fixed_power<2>(sdt) +
-                        Utilities::fixed_power<2>(2. * u_mag / h) +
-                        9 * Utilities::fixed_power<2>(4 * viscosity / (h * h)));
+  return 1. / std::sqrt(Utilities::fixed_power<2>(density * sdt) +
+                        Utilities::fixed_power<2>(2. * density * u_mag / h) +
+                        9 * Utilities::fixed_power<2>(4 * density * viscosity /
+                                                      (h * h)));
 }

--- a/include/solvers/stabilization.h
+++ b/include/solvers/stabilization.h
@@ -32,6 +32,8 @@ using namespace dealii;
  * @param h Cell size. Should be calculated using the diameter of a sphere of equal volume to that of the cell
  *
  * @param density Density of the fluid, assumed to be 1 by default.
+ * This is because most of Lethe simulations (except the VOF ones) assume a
+ * density of 1 and use the kinetic viscosity to set the Reynolds number
  *
  */
 inline double
@@ -58,6 +60,8 @@ calculate_navier_stokes_gls_tau_steady(const double u_mag,
  * @param sdt Inverse of the time-step (1/dt)
  *
  * @param density Density of the fluid, assumed to be 1 by default.
+ * This is because most of Lethe simulations (except the VOF ones) assume a
+ * density of 1 and use the kinetic viscosity to set the Reynolds number
  */
 
 inline double

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -382,10 +382,10 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
 
       densities[0] = scratch_data.density[q];
 
-      for (unsigned int p = 1; p < number_of_previous_solutions(method) + 1;
+      for (unsigned int p = 0; p < number_of_previous_solutions(method) + 1;
            ++p)
         {
-          densities[p] = scratch_data.previous_density[p - 1][q];
+          densities[p + 1] = scratch_data.previous_density[p][q];
         }
 
       for (unsigned int p = 0; p < number_of_previous_solutions(method) + 1;


### PR DESCRIPTION
# Description of the problem

- The stabilization constant was not defined correctly for VOF simulations. There was a density term missing on the transient term
- The Dam-Break example was using a high fill level for the ILU preconditioner for no reason

# Description of the solution

- I decided to use the small inlined stabilization functions we have in the stabilization.h file. This way all the calculations are the same for everyone
- Reduce fill level of the dam-break example to 0.

# How Has This Been Tested?

- I reran the examples (nothing changed, but they are slightly more stable from a linear solver perspective)
- The outputs of some tests have changed very very slightly, they have been updated.

# Comments

- High-order time integration is still sketchy at best for the VOF solvers. This will be fixed in another PR where we change the order of the solvers.
