### PR TITLE
Fix Saffman Lift 3d particle_number update

### DIFF
--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1448,8 +1448,8 @@ GLSVansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
               undisturbed_flow_force[d] +=
                 lift_force[d] / scratch_data.cell_volume;
             }
+          particle_number += 1;
         }
-      particle_number += 1;
     }
 }
 


### PR DESCRIPTION
# Description of the problem

- Particle's number was not being updated within the loop;

# Description of the solution

- Moved "particle_number += 1;" inside the loop.
