### PR TITLE
Refactor the particle-particle broad search code in DEM

### DIFF
--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -43,9 +43,6 @@ using namespace dealii;
 template <int dim>
 class ParticleParticleBroadSearch
 {
-private:
-  // std::vector<int> particle_candidate_container;
-
 public:
   ParticleParticleBroadSearch<dim>();
 
@@ -58,10 +55,10 @@ public:
    * search
    * @param cells_local_neighbor_list This vector is the output of
    * find_cell_neighbors class and shows the local neighbor cells of all local
-   * celsl in the triangulation
+   * cells in the triangulation
    * @param cells_ghost_neighbor_list This vector is the output of
    * find_cell_neighbors class and shows the ghost neighbor cells of all local
-   * celsl in the triangulation
+   * cells in the triangulation
    * @param local_contact_pair_candidates A map of vectors which contains all
    * the local-local particle pairs in adjacent cells which are collision
    * candidates
@@ -81,6 +78,24 @@ public:
       dim>::particle_particle_candidates &local_contact_pair_candidates,
     typename dem_data_containers::dem_data_structures<
       dim>::particle_particle_candidates &ghost_contact_pair_candidates);
+
+  /**
+   * Stores the candidate particle-particle collision pairs with a given
+   * particle iterator.
+   *
+   * @param particle_begin The particle iterator to start storing particle id
+   * @param particles_to_evaluate The particle range to evaluate with the
+   * particle iterator prior storing ids
+   * @param contact_pair_candidates_container A vector which will contain all
+   * the particle pairs which are collision candidates
+   */
+  void
+  store_candidates(
+    typename Particles::ParticleHandler<dim>::particle_iterator_range::iterator
+      particle_begin,
+    typename Particles::ParticleHandler<dim>::particle_iterator_range
+      &                                 particles_to_evaluate,
+    std::vector<types::particle_index> &contact_pair_candidates_container);
 };
 
 #endif /* particle_particle_broad_search_h */

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -81,7 +81,11 @@ public:
 
   /**
    * Stores the candidate particle-particle collision pairs with a given
-   * particle iterator.
+   * particle iterator. particle_begin iterator is useful to skip storage of the
+   * first particle in main cell (particle_begin will be the iterator after the
+   * particles_to_evaluate.begin() in that case). When particle_begin is
+   * particles_to_evaluate.begin(), it stores all the particle id in
+   * contact_pair_candidates_container.
    *
    * @param particle_begin The particle iterator to start storing particle id
    * @param particles_to_evaluate The particle range to evaluate with the
@@ -89,13 +93,29 @@ public:
    * @param contact_pair_candidates_container A vector which will contain all
    * the particle pairs which are collision candidates
    */
-  void
+  inline void
   store_candidates(
-    typename Particles::ParticleHandler<dim>::particle_iterator_range::iterator
-      particle_begin,
-    typename Particles::ParticleHandler<dim>::particle_iterator_range
+    const typename Particles::ParticleHandler<
+      dim>::particle_iterator_range::iterator &particle_begin,
+    const typename Particles::ParticleHandler<dim>::particle_iterator_range
       &                                 particles_to_evaluate,
-    std::vector<types::particle_index> &contact_pair_candidates_container);
+    std::vector<types::particle_index> &contact_pair_candidates_container)
+  {
+    // Create a arbitrary temporary empty container
+    if (contact_pair_candidates_container.empty())
+      {
+        contact_pair_candidates_container.reserve(40);
+      }
+
+    // Store particle ids from the selected particle iterator
+    for (auto particle_iterator = particle_begin;
+         particle_iterator != particles_to_evaluate.end();
+         ++particle_iterator)
+      {
+        contact_pair_candidates_container.emplace_back(
+          particle_iterator->get_id());
+      }
+  }
 };
 
 #endif /* particle_particle_broad_search_h */

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -963,6 +963,7 @@ DEMSolver<dim>::solve()
           // Reset checkpoint step
           checkpoint_step = false;
 
+          // Fill containers of particle-particle contact pair candidates
           particle_particle_broad_search_object
             .find_particle_particle_contact_pairs(
               particle_handler,

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -963,7 +963,9 @@ DEMSolver<dim>::solve()
           // Reset checkpoint step
           checkpoint_step = false;
 
-          // Fill containers of particle-particle contact pair candidates
+          // Fill containers of particle-particle
+          // (local_contact_pair_candidates) and particle-ghost contact pair
+          // candidates (ghost_contact_pair_candidates) by using broad search
           particle_particle_broad_search_object
             .find_particle_particle_contact_pairs(
               particle_handler,

--- a/source/dem/find_cell_neighbors.cc
+++ b/source/dem/find_cell_neighbors.cc
@@ -39,8 +39,6 @@ FindCellNeighbors<dim>::find_cell_neighbors(
   // The reason is to find the cells located on the corners of the main cell.
   auto v_to_c = GridTools::vertex_to_cell_map(triangulation);
 
-  unsigned int cell_number_iterator = 0;
-
   // Looping over cells
   for (const auto &cell : triangulation.active_cell_iterators())
     {
@@ -106,7 +104,6 @@ FindCellNeighbors<dim>::find_cell_neighbors(
 
       local_neighbor_vector.clear();
       ghost_neighbor_vector.clear();
-      ++cell_number_iterator;
     }
 }
 

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -19,11 +19,13 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   typename dem_data_containers::dem_data_structures<
     dim>::particle_particle_candidates &ghost_contact_pair_candidates)
 {
-  // First we will handle the local-local candidate pairs
+  // First we handle the local-local candidate pairs
   // Clearing local_contact_pair_candidates
   local_contact_pair_candidates.clear();
 
-  // Looping over the list of cells with neighbors
+  // Looping over the potential cells which may contain particles.
+  // This includes the cell itself as well as the neighbouring cells that
+  // were identified.
   // cell_neighbor_list_iterator is [cell_it, neighbor_0_it, neighbor_1_it, ...]
   for (auto cell_neighbor_list_iterator = cells_local_neighbor_list.begin();
        cell_neighbor_list_iterator != cells_local_neighbor_list.end();
@@ -128,31 +130,6 @@ ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
                 }
             }
         }
-    }
-}
-
-template <int dim>
-void
-ParticleParticleBroadSearch<dim>::store_candidates(
-  typename Particles::ParticleHandler<dim>::particle_iterator_range::iterator
-    particle_begin,
-  typename Particles::ParticleHandler<dim>::particle_iterator_range
-    &                                 particles_to_evaluate,
-  std::vector<types::particle_index> &contact_pair_candidates_container)
-{
-  // Create a temporary empty container
-  if (contact_pair_candidates_container.empty())
-    {
-      contact_pair_candidates_container.reserve(40);
-    }
-
-  // Store particle ids from the selected particle iterator
-  for (auto particle_iterator = particle_begin;
-       particle_iterator != particles_to_evaluate.end();
-       ++particle_iterator)
-    {
-      contact_pair_candidates_container.emplace_back(
-        particle_iterator->get_id());
     }
 }
 


### PR DESCRIPTION
# Description of the problem

- PR n°1 of a series of refactoring PRs for the DEM code.
- Enhancement of the particle-particle broad search code.

# Description of the solution

- Addition of the private method `particle-particle broad search code` that allows to fill containers of contact pair candidates with a range of particles and the first iterator of this range (prior skipping the first particle when used for particles in main cell).
