### PR TITLE
Fix containers and rename namespace

### DIFF
--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -42,7 +42,7 @@
  * are here, but eventually all the data containers of the DEM solver will be
  * moved here
  */
-namespace dem_data_containers
+namespace DEM
 {
   /**
    * Operator overloading to enable using triangulation cells as map keys.
@@ -203,18 +203,20 @@ namespace dem_data_containers
       cells_total_neighbor_list;
 
     // <boundary id, (tensor, point)>
-    typedef std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
+    typedef std::unordered_map<types::boundary_id,
+                               std::pair<Tensor<1, 3>, Point<3>>>
       boundary_points_and_normal_vectors;
 
     // <int, <boundary id, tensor>>
-    typedef std::map<unsigned int, std::map<types::boundary_id, Tensor<1, 3>>>
+    typedef std::unordered_map<unsigned int,
+                               std::map<types::boundary_id, Tensor<1, 3>>>
       vector_on_boundary;
 
     // <cell id, periodic cells info>
-    typedef std::map<types::global_cell_index,
-                     periodic_boundaries_cells_info_struct<dim>>
+    typedef std::unordered_map<types::global_cell_index,
+                               periodic_boundaries_cells_info_struct<dim>>
       periodic_boundaries_cells_info;
   };
 
-} // namespace dem_data_containers
+} // namespace DEM
 #endif

--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -45,6 +45,13 @@
 namespace DEM
 {
   /**
+   * Defined global face id as a type to ensure that we know what the
+   * structures use as index. This is more verbose than unsigned int
+   */
+  typedef unsigned int global_face_id;
+
+
+  /**
    * Operator overloading to enable using triangulation cells as map keys.
    */
   using namespace dealii;
@@ -127,28 +134,28 @@ namespace DEM
       std::pair<Particles::ParticleIterator<dim>, Point<dim>>>
       particle_point_candidates;
 
-    // <particle id, <boundary id, particle iterator>>
+    // <particle id, <global face id, particle iterator>>
     typedef std::unordered_map<
       types::particle_index,
-      std::unordered_map<types::boundary_id, Particles::ParticleIterator<dim>>>
+      std::unordered_map<global_face_id, Particles::ParticleIterator<dim>>>
       particle_floating_wall_candidates;
 
-    // <particle id, <boundary id, (particle iterator, tensor, point, boundary
-    // id, cell id)>>
+    // <particle id, <global_face_id, (particle iterator, tensor, point,
+    // boundary id, cell id)>>
     typedef std::unordered_map<
       types::particle_index,
-      std::unordered_map<types::boundary_id,
+      std::unordered_map<global_face_id,
                          std::tuple<Particles::ParticleIterator<dim>,
                                     Tensor<1, dim>,
                                     Point<dim>,
-                                    types::boundary_id,
+                                    global_face_id,
                                     types::global_cell_index>>>
       particle_wall_candidates;
 
-    // <particle id, <boundary id, particle-wall info>>
+    // <particle id, <global_face_id, particle-wall info>>
     typedef std::unordered_map<
       types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info_struct<dim>>>
+      std::map<global_face_id, particle_wall_contact_info_struct<dim>>>
       particle_wall_in_contact;
 
     // <particle id, <particle id, particle-particle info>>
@@ -202,14 +209,14 @@ namespace DEM
       std::vector<typename Triangulation<dim>::active_cell_iterator>>
       cells_total_neighbor_list;
 
-    // <boundary id, (tensor, point)>
-    typedef std::unordered_map<types::boundary_id,
+    // <global_face_id, (tensor, point)>
+    typedef std::unordered_map<global_face_id,
                                std::pair<Tensor<1, 3>, Point<3>>>
       boundary_points_and_normal_vectors;
 
-    // <int, <boundary id, tensor>>
+    // <unsigned int, <global_face_id, tensor>>
     typedef std::unordered_map<unsigned int,
-                               std::map<types::boundary_id, Tensor<1, 3>>>
+                               std::unordered_map<global_face_id, Tensor<1, 3>>>
       vector_on_boundary;
 
     // <cell id, periodic cells info>

--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -216,7 +216,7 @@ namespace DEM
 
     // <unsigned int, <global_face_id, tensor>>
     typedef std::unordered_map<unsigned int,
-                               std::unordered_map<global_face_id, Tensor<1, 3>>>
+                               std::map<types::boundary_id, Tensor<1, 3>>>
       vector_on_boundary;
 
     // <cell id, periodic cells info>

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -55,10 +55,10 @@
 #include <iostream>
 #include <unordered_set>
 
-#ifndef Lethe_DEM_h
-#  define Lethe_DEM_h
+#ifndef lethe_dem_h
+#  define lethe_dem_h
 
-using namespace dem_data_containers;
+using namespace DEM;
 
 /**
  * The DEM class which initializes all the required parameters and iterates over

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -18,6 +18,7 @@
  */
 
 #include <dem/boundary_cells_info_struct.h>
+#include <dem/data_containers.h>
 #include <dem/dem_solver_parameters.h>
 
 #include <deal.II/base/quadrature_lib.h>
@@ -126,8 +127,9 @@ public:
    * @param updated_boundary_points_and_normal_vectors Normal vector and a point
    * on the boundary faces which are updated after motion of the grid
    */
-  void update_boundary_info_after_grid_motion(
-    std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
+  void
+  update_boundary_info_after_grid_motion(
+    typename DEM::dem_data_structures<dim>::boundary_points_and_normal_vectors
       &updated_boundary_points_and_normal_vectors);
 
 private:

--- a/include/dem/find_cell_neighbors.h
+++ b/include/dem/find_cell_neighbors.h
@@ -64,9 +64,9 @@ public:
   void
   find_cell_neighbors(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
+    typename DEM::dem_data_structures<dim>::cells_neighbor_list
       &cells_local_neighbor_list,
-    typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
+    typename DEM::dem_data_structures<dim>::cells_neighbor_list
       &cells_ghost_neighbor_list);
 
   /**
@@ -84,8 +84,8 @@ public:
   void
   find_full_cell_neighbors(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    typename dem_data_containers::dem_data_structures<
-      dim>::cells_total_neighbor_list &cells_total_neighbor_list);
+    typename DEM::dem_data_structures<dim>::cells_total_neighbor_list
+      &cells_total_neighbor_list);
 };
 
 #endif /* find_cell_neighbors_h */

--- a/include/dem/grid_motion.h
+++ b/include/dem/grid_motion.h
@@ -17,6 +17,7 @@
  * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
 
+#include <dem/data_containers.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/particle_wall_contact_info_struct.h>
 
@@ -88,7 +89,8 @@ public:
       types::particle_index,
       std::map<types::boundary_id, particle_wall_contact_info_struct<spacedim>>>
       &particle_wall_pairs_in_contact,
-    const std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
+    const typename DEM::dem_data_structures<
+      spacedim>::boundary_points_and_normal_vectors
       &updated_boundary_points_and_normal_vectors);
 
 private:

--- a/include/dem/localize_contacts.h
+++ b/include/dem/localize_contacts.h
@@ -51,27 +51,25 @@ using namespace std;
 template <int dim>
 void
 localize_contacts(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_floating_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &local_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &ghost_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_candidates &particle_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_floating_wall_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &local_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &ghost_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::particle_wall_candidates
+    &particle_wall_contact_candidates,
+  typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates
     &particle_floating_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_candidates
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);
 
 /**

--- a/include/dem/locate_local_particles.h
+++ b/include/dem/locate_local_particles.h
@@ -91,8 +91,8 @@ locate_local_particles_in_cells(
 template <int dim>
 void
 update_particle_container(
-  typename DEM::dem_data_structures<
-    dim>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &                                    particle_container,
   const Particles::ParticleHandler<dim> *particle_handler);
 
 /**
@@ -110,8 +110,8 @@ template <int dim, typename pairs_structure, ContactType contact_type>
 void
 update_contact_container_iterators(
   pairs_structure &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container);
 
 
 #endif /* locate_local_particles_h */

--- a/include/dem/locate_local_particles.h
+++ b/include/dem/locate_local_particles.h
@@ -60,21 +60,21 @@ template <int dim>
 void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<dim> &particle_handler,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_floating_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<dim>::
-    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_lines_in_contact);
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_floating_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_lines_in_contact);
 
 #endif /* locate_local_particles_h */

--- a/include/dem/locate_local_particles.h
+++ b/include/dem/locate_local_particles.h
@@ -91,7 +91,7 @@ locate_local_particles_in_cells(
 template <int dim>
 void
 update_particle_container(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     dim>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<dim> *particle_handler);
 
@@ -110,7 +110,7 @@ template <int dim, typename pairs_structure, ContactType contact_type>
 void
 update_contact_container_iterators(
   pairs_structure &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     dim>::particle_index_iterator_map &particle_container);
 
 

--- a/include/dem/output_force_torque_calculation.h
+++ b/include/dem/output_force_torque_calculation.h
@@ -17,6 +17,7 @@
  * Author: Lethe's community, 2021
  */
 
+#include <dem/data_containers.h>
 #include <dem/dem_solver_parameters.h>
 
 #include <deal.II/base/mpi.h>
@@ -43,14 +44,12 @@ write_forces_torques_output_locally(
 template <int dim>
 void
 write_forces_torques_output_results(
-  const std::string               filename,
-  const unsigned int              output_frequency,
-  const std::vector<unsigned int> boundary_index,
-  const double                    time_step,
-  std::map<unsigned int, std::map<unsigned int, dealii::Tensor<1, 3>>>
-    &forces_boundary_information,
-  std::map<unsigned int, std::map<unsigned int, dealii::Tensor<1, 3>>>
-    &torques_boundary_information)
+  const std::string                                filename,
+  const unsigned int                               output_frequency,
+  const std::vector<unsigned int>                  boundary_index,
+  const double                                     time_step,
+  DEM::dem_data_structures<3>::vector_on_boundary &forces_boundary_information,
+  DEM::dem_data_structures<3>::vector_on_boundary &torques_boundary_information)
 {
   unsigned int this_mpi_process =
     Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);

--- a/include/dem/output_force_torque_calculation.h
+++ b/include/dem/output_force_torque_calculation.h
@@ -33,8 +33,8 @@
  */
 void
 write_forces_torques_output_locally(
-  std::map<unsigned int, Tensor<1, 3>> force_on_walls,
-  std::map<unsigned int, Tensor<1, 3>> torque_on_walls);
+  std::unordered_map<unsigned int, Tensor<1, 3>> force_on_walls,
+  std::unordered_map<unsigned int, Tensor<1, 3>> torque_on_walls);
 
 /**
  * @brief write_forces_torques_output_results

--- a/include/dem/output_force_torque_calculation.h
+++ b/include/dem/output_force_torque_calculation.h
@@ -33,8 +33,8 @@
  */
 void
 write_forces_torques_output_locally(
-  std::unordered_map<unsigned int, Tensor<1, 3>> force_on_walls,
-  std::unordered_map<unsigned int, Tensor<1, 3>> torque_on_walls);
+  std::map<unsigned int, Tensor<1, 3>> force_on_walls,
+  std::map<unsigned int, Tensor<1, 3>> torque_on_walls);
 
 /**
  * @brief write_forces_torques_output_results

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -70,14 +70,14 @@ public:
   void
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    const typename dem_data_containers::dem_data_structures<
-      dim>::cells_neighbor_list &cells_local_neighbor_list,
-    const typename dem_data_containers::dem_data_structures<
-      dim>::cells_neighbor_list &cells_ghost_neighbor_list,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_particle_candidates &local_contact_pair_candidates,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_particle_candidates &ghost_contact_pair_candidates);
+    const typename DEM::dem_data_structures<dim>::cells_neighbor_list
+      &cells_local_neighbor_list,
+    const typename DEM::dem_data_structures<dim>::cells_neighbor_list
+      &cells_ghost_neighbor_list,
+    typename DEM::dem_data_structures<dim>::particle_particle_candidates
+      &local_contact_pair_candidates,
+    typename DEM::dem_data_structures<dim>::particle_particle_candidates
+      &ghost_contact_pair_candidates);
 
   /**
    * Stores the candidate particle-particle collision pairs with a given

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -66,13 +66,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &local_adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force) = 0;
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &local_adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) = 0;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This

--- a/include/dem/particle_particle_fine_search.h
+++ b/include/dem/particle_particle_fine_search.h
@@ -81,17 +81,17 @@ public:
 
   void
   particle_particle_fine_search(
-    const typename dem_data_containers::dem_data_structures<
-      dim>::particle_particle_candidates &local_contact_pair_candidates,
-    const typename dem_data_containers::dem_data_structures<
-      dim>::particle_particle_candidates &ghost_contact_pair_candidates,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &local_adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_index_iterator_map &particle_container,
-    const double                         neighborhood_threshold);
+    const typename DEM::dem_data_structures<dim>::particle_particle_candidates
+      &local_contact_pair_candidates,
+    const typename DEM::dem_data_structures<dim>::particle_particle_candidates
+      &ghost_contact_pair_candidates,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &local_adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &ghost_adjacent_particles,
+    typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+      &          particle_container,
+    const double neighborhood_threshold);
 };
 
 #endif /* particle_particle_fine_search_h */

--- a/include/dem/particle_particle_linear_force.h
+++ b/include/dem/particle_particle_linear_force.h
@@ -61,13 +61,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &local_adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force) override;
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &local_adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This

--- a/include/dem/particle_particle_nonlinear_force.h
+++ b/include/dem/particle_particle_nonlinear_force.h
@@ -64,13 +64,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force) override;
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This
@@ -197,13 +197,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force) override;
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This
@@ -331,13 +331,13 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force) override;
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) override;
 
   /**
    * Carries out the calculation of the contact force for IB particles. This

--- a/include/dem/particle_point_line_broad_search.h
+++ b/include/dem/particle_point_line_broad_search.h
@@ -59,8 +59,7 @@ public:
    * (particle located near boundaries with vertices and the vertex location)
    */
 
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_candidates
+  typename DEM::dem_data_structures<dim>::particle_point_candidates
   find_particle_point_contact_pairs(
     const Particles::ParticleHandler<dim> &particle_handler,
     const std::unordered_map<
@@ -82,8 +81,7 @@ public:
    * and the locations of beginning and ending vertices of the boundary lines
    */
 
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_line_candidates
+  typename DEM::dem_data_structures<dim>::particle_line_candidates
   find_particle_line_contact_pairs(
     const Particles::ParticleHandler<dim> &particle_handler,
     const std::unordered_map<

--- a/include/dem/particle_point_line_contact_force.h
+++ b/include/dem/particle_point_line_contact_force.h
@@ -61,7 +61,7 @@ public:
    */
   void
   calculate_particle_point_contact_force(
-    const typename dem_data_containers::dem_data_structures<dim>::
+    const typename DEM::dem_data_structures<dim>::
       particle_point_line_contact_info *particle_point_line_pairs_in_contact,
     const Parameters::Lagrangian::LagrangianPhysicalProperties
       &                        lagrangian_physical_properties,
@@ -79,7 +79,7 @@ public:
    */
   void
   calculate_particle_line_contact_force(
-    const typename dem_data_containers::dem_data_structures<
+    const typename DEM::dem_data_structures<
       dim>::particle_point_line_contact_info *particle_line_pairs_in_contact,
     const Parameters::Lagrangian::LagrangianPhysicalProperties
       &                        lagrangian_physical_properties,

--- a/include/dem/particle_point_line_fine_search.h
+++ b/include/dem/particle_point_line_fine_search.h
@@ -63,12 +63,11 @@ public:
    * particle-point contact force
    */
 
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
   particle_point_fine_search(
-    const typename dem_data_containers::dem_data_structures<
-      dim>::particle_point_candidates &particle_point_contact_candidates,
-    const double                       neighborhood_threshold);
+    const typename DEM::dem_data_structures<dim>::particle_point_candidates
+      &          particle_point_contact_candidates,
+    const double neighborhood_threshold);
 
   /**
    * Iterates over a map of tuples (particle_line_contact_candidates) to see if
@@ -84,12 +83,11 @@ public:
    * particle-line contact force
    */
 
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
   particle_line_fine_search(
-    const typename dem_data_containers::dem_data_structures<
-      dim>::particle_line_candidates &particle_line_contact_candidates,
-    const double                      neighborhood_threshold);
+    const typename DEM::dem_data_structures<dim>::particle_line_candidates
+      &          particle_line_contact_candidates,
+    const double neighborhood_threshold);
 
 private:
   /** This private function is used to find the projection of point_p on

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -75,8 +75,8 @@ public:
     const std::map<int, boundary_cells_info_struct<dim>>
       &                                    boundary_cells_information,
     const Particles::ParticleHandler<dim> &particle_handler,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_candidates &particle_wall_contact_candidates);
+    typename DEM::dem_data_structures<dim>::particle_wall_candidates
+      &particle_wall_contact_candidates);
 
   /**
    * Finds a two-layered unordered map of particle iterators which shows the
@@ -104,8 +104,8 @@ public:
     const Particles::ParticleHandler<dim> &particle_handler,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double                                      simulation_time,
-    typename dem_data_containers::dem_data_structures<dim>::
-      particle_floating_wall_candidates &particle_floating_wall_candidates);
+    typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates
+      &particle_floating_wall_candidates);
 
   /**
    * Finds a two-layered unordered map
@@ -125,14 +125,13 @@ public:
 
   void
   particle_floating_mesh_contact_search(
-    const typename dem_data_containers::dem_data_structures<
-      dim>::floating_mesh_information &    floating_mesh_information,
+    const typename DEM::dem_data_structures<dim>::floating_mesh_information
+      &                                    floating_mesh_information,
     const Particles::ParticleHandler<dim> &particle_handler,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_floating_mesh_candidates
+    typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
       &particle_floating_mesh_contact_candidates,
-    typename dem_data_containers::dem_data_structures<
-      dim>::cells_total_neighbor_list &cells_total_neighbor_list);
+    typename DEM::dem_data_structures<dim>::cells_total_neighbor_list
+      &cells_total_neighbor_list);
 };
 
 #endif /* particle_wall_broad_search_h */

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -89,13 +89,13 @@ public:
     std::vector<Tensor<1, 3>> &force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids) = 0;
 
-  std::unordered_map<types::boundary_id, Tensor<1, 3>>
+  std::map<types::boundary_id, Tensor<1, 3>>
   get_force()
   {
     return force_on_walls;
   }
 
-  std::unordered_map<types::boundary_id, Tensor<1, 3>>
+  std::map<types::boundary_id, Tensor<1, 3>>
   get_torque()
   {
     return torque_on_walls;
@@ -246,7 +246,7 @@ protected:
   /** This function is used to initialize a map of vectors to zero
    * with the member class boundary index which has the keys as information
    */
-  std::unordered_map<unsigned int, Tensor<1, 3>>
+  std::map<unsigned int, Tensor<1, 3>>
   initialize();
 
   /** This function sums all the forces and torques from all the
@@ -269,8 +269,8 @@ protected:
   std::map<types::particle_index, double>
     effective_coefficient_of_rolling_friction;
 
-  std::unordered_map<unsigned int, Tensor<1, 3>> force_on_walls;
-  std::unordered_map<unsigned int, Tensor<1, 3>> torque_on_walls;
+  std::map<unsigned int, Tensor<1, 3>> force_on_walls;
+  std::map<unsigned int, Tensor<1, 3>> torque_on_walls;
 
   bool                            calculate_force_torque_on_boundary;
   Point<3>                        center_mass_container;

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -89,13 +89,13 @@ public:
     std::vector<Tensor<1, 3>> &force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids) = 0;
 
-  std::map<types::boundary_id, Tensor<1, 3>>
+  std::unordered_map<types::boundary_id, Tensor<1, 3>>
   get_force()
   {
     return force_on_walls;
   }
 
-  std::map<types::boundary_id, Tensor<1, 3>>
+  std::unordered_map<types::boundary_id, Tensor<1, 3>>
   get_torque()
   {
     return torque_on_walls;
@@ -246,7 +246,7 @@ protected:
   /** This function is used to initialize a map of vectors to zero
    * with the member class boundary index which has the keys as information
    */
-  std::map<unsigned int, Tensor<1, 3>>
+  std::unordered_map<unsigned int, Tensor<1, 3>>
   initialize();
 
   /** This function sums all the forces and torques from all the
@@ -267,9 +267,10 @@ protected:
   std::map<types::particle_index, double> effective_coefficient_of_restitution;
   std::map<types::particle_index, double> effective_coefficient_of_friction;
   std::map<types::particle_index, double>
-                                       effective_coefficient_of_rolling_friction;
-  std::map<unsigned int, Tensor<1, 3>> force_on_walls;
-  std::map<unsigned int, Tensor<1, 3>> torque_on_walls;
+    effective_coefficient_of_rolling_friction;
+
+  std::unordered_map<unsigned int, Tensor<1, 3>> force_on_walls;
+  std::unordered_map<unsigned int, Tensor<1, 3>> torque_on_walls;
 
   bool                            calculate_force_torque_on_boundary;
   Point<3>                        center_mass_container;

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -63,11 +63,11 @@ public:
    */
   virtual void
   calculate_particle_wall_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-    const double                      dt,
-    std::vector<Tensor<1, 3>> &       torque,
-    std::vector<Tensor<1, 3>> &       force) = 0;
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+      &                        particle_wall_pairs_in_contact,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) = 0;
 
   /**
    * Carries out the calculation of particle-floating mesh contact force using
@@ -82,11 +82,11 @@ public:
    */
   virtual void
   calculate_particle_floating_wall_contact_force(
-    typename dem_data_containers::dem_data_structures<dim>::
-      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-    const double                         dt,
-    std::vector<Tensor<1, 3>> &          torque,
-    std::vector<Tensor<1, 3>> &          force,
+    typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+      &                        particle_floating_mesh_in_contact,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids) = 0;
 
   std::map<types::boundary_id, Tensor<1, 3>>

--- a/include/dem/particle_wall_fine_search.h
+++ b/include/dem/particle_wall_fine_search.h
@@ -67,10 +67,10 @@ public:
 
   void
   particle_wall_fine_search(
-    const typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_candidates &particle_wall_contact_pair_candidates,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact);
+    const typename DEM::dem_data_structures<dim>::particle_wall_candidates
+      &particle_wall_contact_pair_candidates,
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+      &particle_wall_pairs_in_contact);
 
   /**
    * Iterates over the contact candidates from particle-floating wall broad
@@ -89,13 +89,13 @@ public:
    */
   void
   particle_floating_wall_fine_search(
-    const typename dem_data_containers::dem_data_structures<
+    const typename DEM::dem_data_structures<
       dim>::particle_floating_wall_candidates
       &particle_floating_wall_contact_candidates,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double                                      simulation_time,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact &particle_floating_wall_in_contact);
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+      &particle_floating_wall_in_contact);
 
 
   /**
@@ -111,11 +111,11 @@ public:
 
   void
   particle_floating_mesh_fine_search(
-    const typename dem_data_containers::dem_data_structures<
+    const typename DEM::dem_data_structures<
       dim>::particle_floating_mesh_candidates
       &particle_floating_mesh_contact_candidates,
-    typename dem_data_containers::dem_data_structures<dim>::
-      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact);
+    typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+      &particle_floating_mesh_in_contact);
 };
 
 #endif /* particle_wall_fine_search_h */

--- a/include/dem/particle_wall_linear_force.h
+++ b/include/dem/particle_wall_linear_force.h
@@ -78,11 +78,11 @@ public:
    */
   virtual void
   calculate_particle_wall_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-    const double                      dt,
-    std::vector<Tensor<1, 3>> &       torque,
-    std::vector<Tensor<1, 3>> &       force) override;
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+      &                        particle_wall_pairs_in_contact,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) override;
 
   /**
    * Carries out the calculation of particle-floating mesh contact force using
@@ -97,11 +97,11 @@ public:
    */
   virtual void
   calculate_particle_floating_wall_contact_force(
-    typename dem_data_containers::dem_data_structures<dim>::
-      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-    const double                         dt,
-    std::vector<Tensor<1, 3>> &          torque,
-    std::vector<Tensor<1, 3>> &          force,
+    typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+      &                        particle_floating_mesh_in_contact,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
     override;
 

--- a/include/dem/particle_wall_nonlinear_force.h
+++ b/include/dem/particle_wall_nonlinear_force.h
@@ -78,11 +78,11 @@ public:
    */
   virtual void
   calculate_particle_wall_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-    const double                      dt,
-    std::vector<Tensor<1, 3>> &       torque,
-    std::vector<Tensor<1, 3>> &       force) override;
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+      &                        particle_wall_pairs_in_contact,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force) override;
 
   /**
    * Carries out the calculation of particle-floating mesh contact force using
@@ -97,11 +97,11 @@ public:
    */
   virtual void
   calculate_particle_floating_wall_contact_force(
-    typename dem_data_containers::dem_data_structures<dim>::
-      particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-    const double                         dt,
-    std::vector<Tensor<1, 3>> &          torque,
-    std::vector<Tensor<1, 3>> &          force,
+    typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+      &                        particle_floating_mesh_in_contact,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force,
     const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
     override;
 

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -126,8 +126,8 @@ private:
 
   // Mapping of periodic boundaries information, cell index at outlet is the
   // map key
-  typename dem_data_containers::dem_data_structures<
-    dim>::periodic_boundaries_cells_info periodic_boundaries_cells_information;
+  typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
+    periodic_boundaries_cells_information;
 };
 
 #endif /* particle_wall_periodic_displacement_h */

--- a/include/dem/update_ghost_particle_particle_contact_container.h
+++ b/include/dem/update_ghost_particle_particle_contact_container.h
@@ -35,9 +35,9 @@ using namespace dealii;
 template <int dim>
 void
 update_ghost_particle_particle_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container);
 
 #endif /* update_ghost_particle_particle_contact_container_h */

--- a/include/dem/update_local_particle_particle_contact_container.h
+++ b/include/dem/update_local_particle_particle_contact_container.h
@@ -35,9 +35,9 @@ using namespace dealii;
 template <int dim>
 void
 update_local_particle_particle_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container);
 
 #endif /* update_local_particle_particle_contact_container_h */

--- a/include/dem/update_particle_container.h
+++ b/include/dem/update_particle_container.h
@@ -39,8 +39,8 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_container(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &                                    particle_container,
   const Particles::ParticleHandler<dim> *particle_handler);
 
 #endif /* update_particle_container_h */

--- a/include/dem/update_particle_point_line_contact_container.h
+++ b/include/dem/update_particle_point_line_contact_container.h
@@ -36,11 +36,11 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_point_line_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_lines_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_lines_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container);
 
 #endif /* update_particle_point_line_contact_container_h */

--- a/include/dem/update_particle_wall_contact_container.h
+++ b/include/dem/update_particle_wall_contact_container.h
@@ -34,10 +34,10 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_wall_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container);
 
 /**
  * Updates the iterators to particles in
@@ -50,10 +50,10 @@ update_particle_wall_contact_container_iterators(
 template <int dim>
 void
 update_particle_floating_mesh_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container);
 
 
 #endif /* update_particle_wall_contact_container_h */

--- a/source/dem/data_containers.cc
+++ b/source/dem/data_containers.cc
@@ -18,5 +18,5 @@
 
 #include <dem/data_containers.h>
 
-template struct dem_data_containers::dem_data_structures<2>;
-template struct dem_data_containers::dem_data_structures<3>;
+template struct DEM::dem_data_structures<2>;
+template struct DEM::dem_data_structures<3>;

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -18,6 +18,7 @@
 #include <core/solutions_output.h>
 #include <core/utilities.h>
 
+#include <dem/data_containers.h>
 #include <dem/dem.h>
 #include <dem/explicit_euler_integrator.h>
 #include <dem/find_contact_detection_step.h>

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -1,5 +1,6 @@
 #include <core/tensors_and_points_dimension_manipulation.h>
 
+#include <dem/data_containers.h>
 #include <dem/find_boundary_cells_information.h>
 
 #include <deal.II/distributed/tria.h>
@@ -223,8 +224,9 @@ BoundaryCellsInformation<dim>::find_boundary_cells_information(
 // Updated points and normal vectors are then used to update the particle-wall
 // contact list.
 template <int dim>
-void BoundaryCellsInformation<dim>::update_boundary_info_after_grid_motion(
-  std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
+void
+BoundaryCellsInformation<dim>::update_boundary_info_after_grid_motion(
+  typename DEM::dem_data_structures<dim>::boundary_points_and_normal_vectors
     &updated_boundary_points_and_normal_vectors)
 {
   // Initialize a simple quadrature for on the system. This will be used to

--- a/source/dem/find_cell_neighbors.cc
+++ b/source/dem/find_cell_neighbors.cc
@@ -13,9 +13,9 @@ template <int dim>
 void
 FindCellNeighbors<dim>::find_cell_neighbors(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
+  typename DEM::dem_data_structures<dim>::cells_neighbor_list
     &cells_local_neighbor_list,
-  typename dem_data_containers::dem_data_structures<dim>::cells_neighbor_list
+  typename DEM::dem_data_structures<dim>::cells_neighbor_list
     &cells_ghost_neighbor_list)
 {
   // The output vectors of the function are cells_local_neighbor_list and
@@ -116,8 +116,8 @@ template <int dim>
 void
 FindCellNeighbors<dim>::find_full_cell_neighbors(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  typename dem_data_containers::dem_data_structures<
-    dim>::cells_total_neighbor_list &cells_total_neighbor_list)
+  typename DEM::dem_data_structures<dim>::cells_total_neighbor_list
+    &cells_total_neighbor_list)
 {
   auto v_to_c = GridTools::vertex_to_cell_map(triangulation);
 

--- a/source/dem/grid_motion.cc
+++ b/source/dem/grid_motion.cc
@@ -77,7 +77,8 @@ GridMotion<dim, spacedim>::
       types::particle_index,
       std::map<types::boundary_id, particle_wall_contact_info_struct<spacedim>>>
       &particle_wall_pairs_in_contact,
-    const std::map<types::boundary_id, std::pair<Tensor<1, 3>, Point<3>>>
+    const typename DEM::dem_data_structures<
+      spacedim>::boundary_points_and_normal_vectors
       &updated_boundary_points_and_normal_vectors)
 {
   for (auto &[particle_id, pairs_in_contact_content] :

--- a/source/dem/localize_contacts.cc
+++ b/source/dem/localize_contacts.cc
@@ -6,37 +6,33 @@ using namespace dealii;
 template <int dim>
 void
 localize_contacts(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_floating_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &local_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &ghost_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_candidates &particle_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_floating_wall_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &local_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &ghost_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::particle_wall_candidates
+    &particle_wall_contact_candidates,
+  typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates
     &particle_floating_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_candidates
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates)
 {
   // Update particle-particle contacts in local_adjacent_particles of fine
   // search step with local_contact_pair_candidates
   update_fine_search_candidates<
     dim,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_particle_candidates,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs,
+    typename DEM::dem_data_structures<dim>::particle_particle_candidates,
     ContactType::local_particle_particle>(local_adjacent_particles,
                                           local_contact_pair_candidates);
 
@@ -44,10 +40,8 @@ localize_contacts(
   // search step with global_contact_pair_candidates
   update_fine_search_candidates<
     dim,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_particle_candidates,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs,
+    typename DEM::dem_data_structures<dim>::particle_particle_candidates,
     ContactType::ghost_particle_particle>(ghost_adjacent_particles,
                                           ghost_contact_pair_candidates);
 
@@ -55,10 +49,8 @@ localize_contacts(
   // search step with particle_wall_contact_candidates
   update_fine_search_candidates<
     dim,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_candidates,
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact,
+    typename DEM::dem_data_structures<dim>::particle_wall_candidates,
     ContactType::particle_wall>(particle_wall_pairs_in_contact,
                                 particle_wall_contact_candidates);
 
@@ -66,10 +58,8 @@ localize_contacts(
   // of fine search step with particle_floating_wall_contact_candidates
   update_fine_search_candidates<
     dim,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_wall_in_contact,
-    typename dem_data_containers::dem_data_structures<
-      dim>::particle_floating_wall_candidates,
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact,
+    typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates,
     ContactType::particle_floating_wall>(
     particle_floating_wall_in_contact,
     particle_floating_wall_contact_candidates);
@@ -82,9 +72,9 @@ localize_contacts(
     {
       update_fine_search_candidates<
         dim,
-        typename dem_data_containers::dem_data_structures<
+        typename DEM::dem_data_structures<
           dim>::particle_floating_wall_from_mesh_in_contact,
-        typename dem_data_containers::dem_data_structures<
+        typename DEM::dem_data_structures<
           dim>::particle_floating_wall_from_mesh_candidates,
         ContactType::particle_floating_mesh>(
         particle_floating_mesh_in_contact[solid_counter],
@@ -229,171 +219,155 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
 }
 
 template void localize_contacts<2>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &particle_floating_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_particle_candidates &local_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_particle_candidates &ghost_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_candidates
+  typename DEM::dem_data_structures<2>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<2>::particle_particle_candidates
+    &local_contact_pair_candidates,
+  typename DEM::dem_data_structures<2>::particle_particle_candidates
+    &ghost_contact_pair_candidates,
+  typename DEM::dem_data_structures<2>::particle_wall_candidates
     &particle_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_wall_candidates
+  typename DEM::dem_data_structures<2>::particle_floating_wall_candidates
     &particle_floating_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_mesh_candidates
+  typename DEM::dem_data_structures<2>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);
 
 template void localize_contacts<3>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &particle_floating_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_particle_candidates &local_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_particle_candidates &ghost_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_candidates
+  typename DEM::dem_data_structures<3>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<3>::particle_particle_candidates
+    &local_contact_pair_candidates,
+  typename DEM::dem_data_structures<3>::particle_particle_candidates
+    &ghost_contact_pair_candidates,
+  typename DEM::dem_data_structures<3>::particle_wall_candidates
     &particle_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_wall_candidates
+  typename DEM::dem_data_structures<3>::particle_floating_wall_candidates
     &particle_floating_wall_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_mesh_candidates
+  typename DEM::dem_data_structures<3>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates);
 
 
 // Local particle-particle contacts
 template void update_fine_search_candidates<
   2,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_particle_candidates,
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<2>::particle_particle_candidates,
   ContactType::local_particle_particle>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_particle_candidates &contact_pair_candidates);
-
-template void update_fine_search_candidates<
-  3,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_particle_candidates,
-  ContactType::local_particle_particle>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
-    &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_particle_candidates &contact_candidates);
-
-// Ghost particle-particle contacts
-template void update_fine_search_candidates<
-  2,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_particle_candidates,
-  ContactType::ghost_particle_particle>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
-    &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_particle_candidates &contact_pair_candidates);
-
-template void update_fine_search_candidates<
-  3,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_particle_candidates,
-  ContactType::ghost_particle_particle>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
-    &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_particle_candidates &contact_candidates);
-
-// Particle-wall contacts
-template void update_fine_search_candidates<
-  2,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_wall_candidates,
-  ContactType::particle_wall>(
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
-    &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_candidates
+  typename DEM::dem_data_structures<2>::particle_particle_candidates
     &contact_pair_candidates);
 
 template void update_fine_search_candidates<
   3,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_wall_candidates,
-  ContactType::particle_wall>(
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<3>::particle_particle_candidates,
+  ContactType::local_particle_particle>(
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
+    &pairs_in_contact,
+  typename DEM::dem_data_structures<3>::particle_particle_candidates
+    &contact_candidates);
+
+// Ghost particle-particle contacts
+template void update_fine_search_candidates<
+  2,
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<2>::particle_particle_candidates,
+  ContactType::ghost_particle_particle>(
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_candidates
+  typename DEM::dem_data_structures<2>::particle_particle_candidates
+    &contact_pair_candidates);
+
+template void update_fine_search_candidates<
+  3,
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<3>::particle_particle_candidates,
+  ContactType::ghost_particle_particle>(
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
+    &pairs_in_contact,
+  typename DEM::dem_data_structures<3>::particle_particle_candidates
+    &contact_candidates);
+
+// Particle-wall contacts
+template void update_fine_search_candidates<
+  2,
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<2>::particle_wall_candidates,
+  ContactType::particle_wall>(
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
+    &adjacent_particles,
+  typename DEM::dem_data_structures<2>::particle_wall_candidates
+    &contact_pair_candidates);
+
+template void update_fine_search_candidates<
+  3,
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<3>::particle_wall_candidates,
+  ContactType::particle_wall>(
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
+    &adjacent_particles,
+  typename DEM::dem_data_structures<3>::particle_wall_candidates
     &contact_pair_candidates);
 
 // Particle-floating wall contacts
 template void update_fine_search_candidates<
   2,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_wall_candidates,
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<2>::particle_floating_wall_candidates,
   ContactType::particle_floating_wall>(
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_wall_candidates &contact_pair_candidates);
+  typename DEM::dem_data_structures<2>::particle_floating_wall_candidates
+    &contact_pair_candidates);
 
 template void update_fine_search_candidates<
   3,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_wall_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_wall_candidates,
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<3>::particle_floating_wall_candidates,
   ContactType::particle_floating_wall>(
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_wall_candidates &contact_pair_candidates);
+  typename DEM::dem_data_structures<3>::particle_floating_wall_candidates
+    &contact_pair_candidates);
 
 // Particle-floating mesh contacts
 template void update_fine_search_candidates<
   2,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_candidates,
   ContactType::particle_floating_mesh>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_in_contact &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_candidates &contact_pair_candidates);
 
 template void update_fine_search_candidates<
   3,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_candidates,
   ContactType::particle_floating_mesh>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_in_contact &adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_candidates &contact_pair_candidates);

--- a/source/dem/locate_local_particles.cc
+++ b/source/dem/locate_local_particles.cc
@@ -1,4 +1,5 @@
 #include <dem/locate_local_particles.h>
+#include <dem/data_containers.h>
 
 using namespace dealii;
 
@@ -29,7 +30,7 @@ locate_local_particles_in_cells(
   // Update contact containers for local particle-particle pairs in contact
   update_contact_container_iterators<
     dim,
-    typename dem_data_containers::dem_data_structures<
+    typename DEM::dem_data_structures<
       dim>::adjacent_particle_pairs,
     ContactType::local_particle_particle>(local_adjacent_particles,
                                           particle_container);
@@ -37,7 +38,7 @@ locate_local_particles_in_cells(
   // Update contact containers for local particle-particle pairs in contact
   update_contact_container_iterators<
     dim,
-    typename dem_data_containers::dem_data_structures<
+    typename DEM::dem_data_structures<
       dim>::adjacent_particle_pairs,
     ContactType::ghost_particle_particle>(ghost_adjacent_particles,
                                           particle_container);
@@ -45,7 +46,7 @@ locate_local_particles_in_cells(
   // Update contact containers for particle-wall pairs in contact
   update_contact_container_iterators<
     dim,
-    typename dem_data_containers::dem_data_structures<
+    typename DEM::dem_data_structures<
       dim>::particle_wall_in_contact,
     ContactType::particle_wall>(particle_wall_pairs_in_contact,
                                 particle_container);
@@ -53,7 +54,7 @@ locate_local_particles_in_cells(
   // Update contact containers for particle-floating wall pairs in contact
   update_contact_container_iterators<
     dim,
-    typename dem_data_containers::dem_data_structures<
+    typename DEM::dem_data_structures<
       dim>::particle_wall_in_contact,
     ContactType::particle_floating_wall>(
     particle_floating_wall_pairs_in_contact, particle_container);
@@ -66,7 +67,7 @@ locate_local_particles_in_cells(
     {
       update_contact_container_iterators<
         dim,
-        typename dem_data_containers::dem_data_structures<
+        typename DEM::dem_data_structures<
           dim>::particle_floating_wall_from_mesh_in_contact,
         ContactType::particle_floating_mesh>(
         particle_floating_mesh_pairs_in_contact[solid_counter],
@@ -76,14 +77,14 @@ locate_local_particles_in_cells(
   // Update contact containers for particle-line pairs in contact
   update_contact_container_iterators<
     dim,
-    typename dem_data_containers::dem_data_structures<
+    typename DEM::dem_data_structures<
       dim>::particle_point_line_contact_info,
     ContactType::particle_point>(particle_lines_in_contact, particle_container);
 
   // Update contact containers for particle-point pairs in contact
   update_contact_container_iterators<
     dim,
-    typename dem_data_containers::dem_data_structures<
+    typename DEM::dem_data_structures<
       dim>::particle_point_line_contact_info,
     ContactType::particle_point>(particle_points_in_contact,
                                  particle_container);
@@ -92,7 +93,7 @@ locate_local_particles_in_cells(
 template <int dim>
 void
 update_particle_container(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     dim>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<dim> *particle_handler)
 {
@@ -118,10 +119,8 @@ update_particle_container(
 
 template <int dim, typename pairs_structure, ContactType contact_type>
 void
-update_contact_container_iterators(
-  pairs_structure &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container)
+update_contact_container_iterators(pairs_structure &pairs_in_contact,
+                                   typename DEM::dem_data_structures<dim>::particle_index_iterator_map &particle_container)
 {
   // Loop over particle-object (particle/wall/line/point) pairs in contact
   for (auto pairs_in_contact_iterator = pairs_in_contact.begin();
@@ -243,154 +242,154 @@ locate_local_particles_in_cells(
 
 // Particle container
 template void update_particle_container(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<2> *particle_handler);
 
 template void update_particle_container(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &  particle_container,
   const Particles::ParticleHandler<3> *particle_handler);
 
 // Local particle-particle contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs,
   ContactType::local_particle_particle>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs,
   ContactType::local_particle_particle>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);
 
 // Ghost particle-particle contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs,
   ContactType::ghost_particle_particle>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs,
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs,
   ContactType::ghost_particle_particle>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);
 
 // Particle-wall contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_wall_in_contact,
   ContactType::particle_wall>(
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_wall_in_contact,
   ContactType::particle_wall>(
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);
 
 // Particle-floating wall contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_wall_in_contact,
   ContactType::particle_floating_wall>(
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_wall_in_contact,
   ContactType::particle_floating_wall>(
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);
 
 // Particle-floating mesh contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_in_contact,
   ContactType::particle_floating_mesh>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_in_contact &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_in_contact,
   ContactType::particle_floating_mesh>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_in_contact &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);
 
 // Particle-point contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_point_line_contact_info,
   ContactType::particle_point>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_point_line_contact_info &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_point_line_contact_info,
   ContactType::particle_point>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_point_line_contact_info &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);
 
 // Particle-line contact container
 template void update_contact_container_iterators<
   2,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_point_line_contact_info,
   ContactType::particle_line>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_point_line_contact_info &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     2>::particle_index_iterator_map &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_point_line_contact_info,
   ContactType::particle_line>(
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_point_line_contact_info &pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
+  typename DEM::dem_data_structures<
     3>::particle_index_iterator_map &particle_container);

--- a/source/dem/locate_local_particles.cc
+++ b/source/dem/locate_local_particles.cc
@@ -1,5 +1,5 @@
-#include <dem/locate_local_particles.h>
 #include <dem/data_containers.h>
+#include <dem/locate_local_particles.h>
 
 using namespace dealii;
 
@@ -30,32 +30,28 @@ locate_local_particles_in_cells(
   // Update contact containers for local particle-particle pairs in contact
   update_contact_container_iterators<
     dim,
-    typename DEM::dem_data_structures<
-      dim>::adjacent_particle_pairs,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs,
     ContactType::local_particle_particle>(local_adjacent_particles,
                                           particle_container);
 
   // Update contact containers for local particle-particle pairs in contact
   update_contact_container_iterators<
     dim,
-    typename DEM::dem_data_structures<
-      dim>::adjacent_particle_pairs,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs,
     ContactType::ghost_particle_particle>(ghost_adjacent_particles,
                                           particle_container);
 
   // Update contact containers for particle-wall pairs in contact
   update_contact_container_iterators<
     dim,
-    typename DEM::dem_data_structures<
-      dim>::particle_wall_in_contact,
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact,
     ContactType::particle_wall>(particle_wall_pairs_in_contact,
                                 particle_container);
 
   // Update contact containers for particle-floating wall pairs in contact
   update_contact_container_iterators<
     dim,
-    typename DEM::dem_data_structures<
-      dim>::particle_wall_in_contact,
+    typename DEM::dem_data_structures<dim>::particle_wall_in_contact,
     ContactType::particle_floating_wall>(
     particle_floating_wall_pairs_in_contact, particle_container);
 
@@ -77,15 +73,13 @@ locate_local_particles_in_cells(
   // Update contact containers for particle-line pairs in contact
   update_contact_container_iterators<
     dim,
-    typename DEM::dem_data_structures<
-      dim>::particle_point_line_contact_info,
+    typename DEM::dem_data_structures<dim>::particle_point_line_contact_info,
     ContactType::particle_point>(particle_lines_in_contact, particle_container);
 
   // Update contact containers for particle-point pairs in contact
   update_contact_container_iterators<
     dim,
-    typename DEM::dem_data_structures<
-      dim>::particle_point_line_contact_info,
+    typename DEM::dem_data_structures<dim>::particle_point_line_contact_info,
     ContactType::particle_point>(particle_points_in_contact,
                                  particle_container);
 }
@@ -93,8 +87,8 @@ locate_local_particles_in_cells(
 template <int dim>
 void
 update_particle_container(
-  typename DEM::dem_data_structures<
-    dim>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &                                    particle_container,
   const Particles::ParticleHandler<dim> *particle_handler)
 {
   // Clear the current particle container
@@ -119,8 +113,10 @@ update_particle_container(
 
 template <int dim, typename pairs_structure, ContactType contact_type>
 void
-update_contact_container_iterators(pairs_structure &pairs_in_contact,
-                                   typename DEM::dem_data_structures<dim>::particle_index_iterator_map &particle_container)
+update_contact_container_iterators(
+  pairs_structure &pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container)
 {
   // Loop over particle-object (particle/wall/line/point) pairs in contact
   for (auto pairs_in_contact_iterator = pairs_in_contact.begin();
@@ -242,13 +238,13 @@ locate_local_particles_in_cells(
 
 // Particle container
 template void update_particle_container(
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &                                  particle_container,
   const Particles::ParticleHandler<2> *particle_handler);
 
 template void update_particle_container(
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &                                  particle_container,
   const Particles::ParticleHandler<3> *particle_handler);
 
 // Local particle-particle contact container
@@ -258,8 +254,8 @@ template void update_contact_container_iterators<
   ContactType::local_particle_particle>(
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
@@ -267,8 +263,8 @@ template void update_contact_container_iterators<
   ContactType::local_particle_particle>(
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 // Ghost particle-particle contact container
 template void update_contact_container_iterators<
@@ -277,8 +273,8 @@ template void update_contact_container_iterators<
   ContactType::ghost_particle_particle>(
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
@@ -286,50 +282,46 @@ template void update_contact_container_iterators<
   ContactType::ghost_particle_particle>(
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 // Particle-wall contact container
 template void update_contact_container_iterators<
   2,
-  typename DEM::dem_data_structures<
-    2>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact,
   ContactType::particle_wall>(
   typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename DEM::dem_data_structures<
-    3>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact,
   ContactType::particle_wall>(
   typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 // Particle-floating wall contact container
 template void update_contact_container_iterators<
   2,
-  typename DEM::dem_data_structures<
-    2>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact,
   ContactType::particle_floating_wall>(
   typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename DEM::dem_data_structures<
-    3>::particle_wall_in_contact,
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact,
   ContactType::particle_floating_wall>(
   typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 // Particle-floating mesh contact container
 template void update_contact_container_iterators<
@@ -339,8 +331,8 @@ template void update_contact_container_iterators<
   ContactType::particle_floating_mesh>(
   typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_in_contact &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
@@ -349,47 +341,43 @@ template void update_contact_container_iterators<
   ContactType::particle_floating_mesh>(
   typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_in_contact &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 // Particle-point contact container
 template void update_contact_container_iterators<
   2,
-  typename DEM::dem_data_structures<
-    2>::particle_point_line_contact_info,
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info,
   ContactType::particle_point>(
-  typename DEM::dem_data_structures<
-    2>::particle_point_line_contact_info &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info
+    &pairs_in_contact,
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename DEM::dem_data_structures<
-    3>::particle_point_line_contact_info,
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info,
   ContactType::particle_point>(
-  typename DEM::dem_data_structures<
-    3>::particle_point_line_contact_info &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info
+    &pairs_in_contact,
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 // Particle-line contact container
 template void update_contact_container_iterators<
   2,
-  typename DEM::dem_data_structures<
-    2>::particle_point_line_contact_info,
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info,
   ContactType::particle_line>(
-  typename DEM::dem_data_structures<
-    2>::particle_point_line_contact_info &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info
+    &pairs_in_contact,
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_contact_container_iterators<
   3,
-  typename DEM::dem_data_structures<
-    3>::particle_point_line_contact_info,
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info,
   ContactType::particle_line>(
-  typename DEM::dem_data_structures<
-    3>::particle_point_line_contact_info &pairs_in_contact,
-  typename DEM::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info
+    &pairs_in_contact,
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);

--- a/source/dem/locate_local_particles.cc
+++ b/source/dem/locate_local_particles.cc
@@ -6,22 +6,22 @@ template <int dim>
 void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<dim> &particle_handler,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_floating_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<dim>::
-    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_lines_in_contact)
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_floating_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_lines_in_contact)
 {
   update_particle_container<dim>(particle_container, &particle_handler);
 
@@ -49,39 +49,39 @@ locate_local_particles_in_cells(
 template void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<2> &particle_handler,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container,
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &particle_floating_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<2>::
-    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_point_line_contact_info &particle_lines_in_contact);
+  typename DEM::dem_data_structures<2>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_pairs_in_contact,
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info
+    &particle_lines_in_contact);
 
 template void
 locate_local_particles_in_cells(
   const Particles::ParticleHandler<3> &particle_handler,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container,
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &particle_floating_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<3>::
-    particle_floating_mesh_in_contact &particle_floating_mesh_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_point_line_contact_info &particle_lines_in_contact);
+  typename DEM::dem_data_structures<3>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_pairs_in_contact,
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info
+    &particle_lines_in_contact);

--- a/source/dem/output_force_torque_calculation.cc
+++ b/source/dem/output_force_torque_calculation.cc
@@ -2,8 +2,8 @@
 
 void
 write_forces_torques_output_locally(
-  std::unordered_map<unsigned int, Tensor<1, 3>> force_on_walls,
-  std::unordered_map<unsigned int, Tensor<1, 3>> torque_on_walls)
+  std::map<unsigned int, Tensor<1, 3>> force_on_walls,
+  std::map<unsigned int, Tensor<1, 3>> torque_on_walls)
 {
   TableHandler table;
 

--- a/source/dem/output_force_torque_calculation.cc
+++ b/source/dem/output_force_torque_calculation.cc
@@ -2,8 +2,8 @@
 
 void
 write_forces_torques_output_locally(
-  std::map<unsigned int, Tensor<1, 3>> force_on_walls,
-  std::map<unsigned int, Tensor<1, 3>> torque_on_walls)
+  std::unordered_map<unsigned int, Tensor<1, 3>> force_on_walls,
+  std::unordered_map<unsigned int, Tensor<1, 3>> torque_on_walls)
 {
   TableHandler table;
 

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -10,14 +10,14 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  const typename dem_data_containers::dem_data_structures<
-    dim>::cells_neighbor_list &cells_local_neighbor_list,
-  const typename dem_data_containers::dem_data_structures<
-    dim>::cells_neighbor_list &cells_ghost_neighbor_list,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &local_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &ghost_contact_pair_candidates)
+  const typename DEM::dem_data_structures<dim>::cells_neighbor_list
+    &cells_local_neighbor_list,
+  const typename DEM::dem_data_structures<dim>::cells_neighbor_list
+    &cells_ghost_neighbor_list,
+  typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &local_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &ghost_contact_pair_candidates)
 {
   // First we handle the local-local candidate pairs
   // Clearing local_contact_pair_candidates

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -9,17 +9,17 @@ ParticleParticleFineSearch<dim>::ParticleParticleFineSearch()
 template <int dim>
 void
 ParticleParticleFineSearch<dim>::particle_particle_fine_search(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &local_contact_pair_candidates,
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_particle_candidates &ghost_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container,
-  const double                         neighborhood_threshold)
+  const typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &local_contact_pair_candidates,
+  const typename DEM::dem_data_structures<dim>::particle_particle_candidates
+    &ghost_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &          particle_container,
+  const double neighborhood_threshold)
 {
   // First iterating over local adjacent_particles
   for (auto &&adjacent_particles_list :

--- a/source/dem/particle_particle_linear_force.cc
+++ b/source/dem/particle_particle_linear_force.cc
@@ -94,13 +94,13 @@ ParticleParticleLinearForce<dim>::ParticleParticleLinearForce(
 template <int dim>
 void
 ParticleParticleLinearForce<dim>::calculate_particle_particle_contact_force(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  const double                     dt,
-  std::vector<Tensor<1, 3>> &      torque,
-  std::vector<Tensor<1, 3>> &      force)
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &                        ghost_adjacent_particles,
+  const double               dt,
+  std::vector<Tensor<1, 3>> &torque,
+  std::vector<Tensor<1, 3>> &force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops

--- a/source/dem/particle_particle_nonlinear_force.cc
+++ b/source/dem/particle_particle_nonlinear_force.cc
@@ -110,13 +110,13 @@ template <int dim>
 void
 ParticleParticleHertzMindlinLimitOverlap<dim>::
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &local_adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force)
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &local_adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops
@@ -704,13 +704,13 @@ template <int dim>
 void
 ParticleParticleHertzMindlinLimitForce<dim>::
   calculate_particle_particle_contact_force(
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &local_adjacent_particles,
-    typename dem_data_containers::dem_data_structures<
-      dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-    const double                     dt,
-    std::vector<Tensor<1, 3>> &      torque,
-    std::vector<Tensor<1, 3>> &      force)
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &local_adjacent_particles,
+    typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+      &                        ghost_adjacent_particles,
+    const double               dt,
+    std::vector<Tensor<1, 3>> &torque,
+    std::vector<Tensor<1, 3>> &force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops
@@ -1285,13 +1285,13 @@ ParticleParticleHertz<dim>::ParticleParticleHertz(
 template <int dim>
 void
 ParticleParticleHertz<dim>::calculate_particle_particle_contact_force(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  const double                     dt,
-  std::vector<Tensor<1, 3>> &      torque,
-  std::vector<Tensor<1, 3>> &      force)
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &                        ghost_adjacent_particles,
+  const double               dt,
+  std::vector<Tensor<1, 3>> &torque,
+  std::vector<Tensor<1, 3>> &force)
 {
   // Contact forces calculations of local-local and local-ghost particle
   // pairs are performed in separate loops

--- a/source/dem/particle_point_line_broad_search.cc
+++ b/source/dem/particle_point_line_broad_search.cc
@@ -9,8 +9,7 @@ ParticlePointLineBroadSearch<dim>::ParticlePointLineBroadSearch()
 
 // This function finds all the particle-point contact candidates
 template <int dim>
-typename dem_data_containers::dem_data_structures<
-  dim>::particle_point_candidates
+typename DEM::dem_data_structures<dim>::particle_point_candidates
 ParticlePointLineBroadSearch<dim>::find_particle_point_contact_pairs(
   const Particles::ParticleHandler<dim> &particle_handler,
   const std::unordered_map<
@@ -67,7 +66,7 @@ ParticlePointLineBroadSearch<dim>::find_particle_point_contact_pairs(
 
 // This function finds all the particle-line contact candidates
 template <int dim>
-typename dem_data_containers::dem_data_structures<dim>::particle_line_candidates
+typename DEM::dem_data_structures<dim>::particle_line_candidates
 ParticlePointLineBroadSearch<dim>::find_particle_line_contact_pairs(
   const Particles::ParticleHandler<dim> &particle_handler,
   const std::unordered_map<

--- a/source/dem/particle_point_line_contact_force.cc
+++ b/source/dem/particle_point_line_contact_force.cc
@@ -14,8 +14,8 @@ ParticlePointLineForce<dim>::ParticlePointLineForce()
 template <int dim>
 void
 ParticlePointLineForce<dim>::calculate_particle_point_contact_force(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info *particle_point_pairs_in_contact,
+  const typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    *particle_point_pairs_in_contact,
   const Parameters::Lagrangian::LagrangianPhysicalProperties
     &                        physical_properties,
   std::vector<Tensor<1, 3>> &force)
@@ -138,8 +138,8 @@ ParticlePointLineForce<dim>::calculate_particle_point_contact_force(
 template <int dim>
 void
 ParticlePointLineForce<dim>::calculate_particle_line_contact_force(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info *particle_line_pairs_in_contact,
+  const typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    *particle_line_pairs_in_contact,
   const Parameters::Lagrangian::LagrangianPhysicalProperties
     &                        physical_properties,
   std::vector<Tensor<1, 3>> &force)

--- a/source/dem/particle_point_line_fine_search.cc
+++ b/source/dem/particle_point_line_fine_search.cc
@@ -14,12 +14,11 @@ ParticlePointLineFineSearch<dim>::ParticlePointLineFineSearch()
 // calculated. The output of this function is used for calculation of the
 // contact force
 template <int dim>
-typename dem_data_containers::dem_data_structures<
-  dim>::particle_point_line_contact_info
+typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
 ParticlePointLineFineSearch<dim>::particle_point_fine_search(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_candidates &particle_point_contact_candidates,
-  const double                       neighborhood_threshold)
+  const typename DEM::dem_data_structures<dim>::particle_point_candidates
+    &          particle_point_contact_candidates,
+  const double neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>
@@ -86,12 +85,11 @@ ParticlePointLineFineSearch<dim>::particle_point_fine_search(
 // calculated. The output of this function is used for calculation of the
 // contact force
 template <int dim>
-typename dem_data_containers::dem_data_structures<
-  dim>::particle_point_line_contact_info
+typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
 ParticlePointLineFineSearch<dim>::particle_line_fine_search(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_line_candidates &particle_line_contact_candidates,
-  const double                      neighborhood_threshold)
+  const typename DEM::dem_data_structures<dim>::particle_line_candidates
+    &          particle_line_contact_candidates,
+  const double neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
                      particle_point_line_contact_info_struct<dim>>

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -13,8 +13,8 @@ ParticleWallBroadSearch<dim>::find_particle_wall_contact_pairs(
   const std::map<int, boundary_cells_info_struct<dim>>
     &                                    boundary_cells_information,
   const Particles::ParticleHandler<dim> &particle_handler,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_candidates &particle_wall_contact_candidates)
+  typename DEM::dem_data_structures<dim>::particle_wall_candidates
+    &particle_wall_contact_candidates)
 {
   // Clearing particle_wall_contact_candidates (output of this function)
   particle_wall_contact_candidates.clear();
@@ -77,8 +77,8 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const Particles::ParticleHandler<dim> &particle_handler,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double                                      simulation_time,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_wall_candidates &particle_floating_wall_candidates)
+  typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates
+    &particle_floating_wall_candidates)
 {
   // Clearing particle_floating_wall_candidates(output of this function)
   particle_floating_wall_candidates.clear();
@@ -140,14 +140,13 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
 template <int dim>
 void
 ParticleWallBroadSearch<dim>::particle_floating_mesh_contact_search(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::floating_mesh_information &    floating_mesh_information,
+  const typename DEM::dem_data_structures<dim>::floating_mesh_information
+    &                                    floating_mesh_information,
   const Particles::ParticleHandler<dim> &particle_handler,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_candidates
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::cells_total_neighbor_list &cells_total_neighbor_list)
+  typename DEM::dem_data_structures<dim>::cells_total_neighbor_list
+    &cells_total_neighbor_list)
 {
   // Clear the candidate container
   particle_floating_mesh_contact_candidates.clear();

--- a/source/dem/particle_wall_contact_force.cc
+++ b/source/dem/particle_wall_contact_force.cc
@@ -161,10 +161,10 @@ ParticleWallContactForce<dim>::calculate_force_and_torque_on_boundary(
 }
 
 template <int dim>
-std::map<unsigned int, Tensor<1, 3>>
+std::unordered_map<unsigned int, Tensor<1, 3>>
 ParticleWallContactForce<dim>::initialize()
 {
-  std::map<unsigned int, Tensor<1, 3>> map;
+  std::unordered_map<unsigned int, Tensor<1, 3>> map;
   for (const auto &it : boundary_index)
     {
       map[it] = 0;

--- a/source/dem/particle_wall_contact_force.cc
+++ b/source/dem/particle_wall_contact_force.cc
@@ -161,10 +161,10 @@ ParticleWallContactForce<dim>::calculate_force_and_torque_on_boundary(
 }
 
 template <int dim>
-std::unordered_map<unsigned int, Tensor<1, 3>>
+std::map<unsigned int, Tensor<1, 3>>
 ParticleWallContactForce<dim>::initialize()
 {
-  std::unordered_map<unsigned int, Tensor<1, 3>> map;
+  std::map<unsigned int, Tensor<1, 3>> map;
   for (const auto &it : boundary_index)
     {
       map[it] = 0;

--- a/source/dem/particle_wall_fine_search.cc
+++ b/source/dem/particle_wall_fine_search.cc
@@ -14,10 +14,10 @@ ParticleWallFineSearch<dim>::ParticleWallFineSearch()
 template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_wall_fine_search(
-  const typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_candidates &particle_wall_contact_pair_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact)
+  const typename DEM::dem_data_structures<dim>::particle_wall_candidates
+    &particle_wall_contact_pair_candidates,
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact)
 {
   // Iterating over contact candidates from broad search and adding the pairs to
   // the particle_wall_pairs_in_contact
@@ -80,12 +80,12 @@ ParticleWallFineSearch<dim>::particle_wall_fine_search(
 template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
-  const typename dem_data_containers::dem_data_structures<
+  const typename DEM::dem_data_structures<
     dim>::particle_floating_wall_candidates &particle_floating_wall_candidates,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double                                      simulation_time,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_floating_wall_pairs_in_contact)
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_floating_wall_pairs_in_contact)
 {
   // Reading floating wall properties
   std::vector<Point<dim>> point_on_wall =
@@ -189,11 +189,11 @@ ParticleWallFineSearch<dim>::particle_floating_wall_fine_search(
 template <int dim>
 void
 ParticleWallFineSearch<dim>::particle_floating_mesh_fine_search(
-  const typename dem_data_containers::dem_data_structures<
+  const typename DEM::dem_data_structures<
     dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact)
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact)
 {
   for (unsigned int solid_counter = 0;
        solid_counter < particle_floating_mesh_contact_candidates.size();

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -114,11 +114,11 @@ ParticleWallLinearForce<dim>::ParticleWallLinearForce(
 template <int dim>
 void
 ParticleWallLinearForce<dim>::calculate_particle_wall_contact_force(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  const double                      dt,
-  std::vector<Tensor<1, 3>> &       torque,
-  std::vector<Tensor<1, 3>> &       force)
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &                        particle_wall_pairs_in_contact,
+  const double               dt,
+  std::vector<Tensor<1, 3>> &torque,
+  std::vector<Tensor<1, 3>> &force)
 {
   ParticleWallContactForce<dim>::force_on_walls =
     ParticleWallContactForce<dim>::initialize();
@@ -213,11 +213,11 @@ ParticleWallLinearForce<dim>::calculate_particle_wall_contact_force(
 template <int dim>
 void
 ParticleWallLinearForce<dim>::calculate_particle_floating_wall_contact_force(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  const double                               dt,
-  std::vector<Tensor<1, 3>> &                torque,
-  std::vector<Tensor<1, 3>> &                force,
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &                        particle_floating_mesh_in_contact,
+  const double               dt,
+  std::vector<Tensor<1, 3>> &torque,
+  std::vector<Tensor<1, 3>> &force,
   const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
 {
   std::vector<Particles::ParticleIterator<dim>> particle_locations;

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -122,11 +122,11 @@ ParticleWallNonLinearForce<dim>::ParticleWallNonLinearForce(
 template <int dim>
 void
 ParticleWallNonLinearForce<dim>::calculate_particle_wall_contact_force(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  const double                      dt,
-  std::vector<Tensor<1, 3>> &       torque,
-  std::vector<Tensor<1, 3>> &       force)
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &                        particle_wall_pairs_in_contact,
+  const double               dt,
+  std::vector<Tensor<1, 3>> &torque,
+  std::vector<Tensor<1, 3>> &force)
 {
   ParticleWallContactForce<dim>::force_on_walls =
     ParticleWallContactForce<dim>::initialize();
@@ -226,11 +226,11 @@ ParticleWallNonLinearForce<dim>::calculate_particle_wall_contact_force(
 template <int dim>
 void
 ParticleWallNonLinearForce<dim>::calculate_particle_floating_wall_contact_force(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  const double                               dt,
-  std::vector<Tensor<1, 3>> &                torque,
-  std::vector<Tensor<1, 3>> &                force,
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &                        particle_floating_mesh_in_contact,
+  const double               dt,
+  std::vector<Tensor<1, 3>> &torque,
+  std::vector<Tensor<1, 3>> &force,
   const std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solids)
 {
   std::vector<Particles::ParticleIterator<dim>> particle_locations;

--- a/source/dem/update_ghost_particle_particle_contact_container.cc
+++ b/source/dem/update_ghost_particle_particle_contact_container.cc
@@ -5,10 +5,10 @@ using namespace dealii;
 template <int dim>
 void
 update_ghost_particle_particle_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container)
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &ghost_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container)
 {
   for (auto adjacent_particles_iterator = ghost_adjacent_particles.begin();
        adjacent_particles_iterator != ghost_adjacent_particles.end();
@@ -30,13 +30,13 @@ update_ghost_particle_particle_contact_container_iterators(
     }
 }
 template void update_ghost_particle_particle_contact_container_iterators<2>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_ghost_particle_particle_contact_container_iterators<3>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &ghost_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);

--- a/source/dem/update_local_particle_particle_contact_container.cc
+++ b/source/dem/update_local_particle_particle_contact_container.cc
@@ -5,10 +5,10 @@ using namespace dealii;
 template <int dim>
 void
 update_local_particle_particle_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::adjacent_particle_pairs &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container)
+  typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
+    &local_adjacent_particles,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container)
 {
   for (auto adjacent_particles_iterator = local_adjacent_particles.begin();
        adjacent_particles_iterator != local_adjacent_particles.end();
@@ -32,13 +32,13 @@ update_local_particle_particle_contact_container_iterators(
 }
 
 template void update_local_particle_particle_contact_container_iterators<2>(
-  typename dem_data_containers::dem_data_structures<2>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_local_particle_particle_contact_container_iterators<3>(
-  typename dem_data_containers::dem_data_structures<3>::adjacent_particle_pairs
+  typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &local_adjacent_particles,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);

--- a/source/dem/update_particle_container.cc
+++ b/source/dem/update_particle_container.cc
@@ -5,8 +5,8 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_container(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &                                    particle_container,
   const Particles::ParticleHandler<dim> *particle_handler)
 {
   particle_container.clear();
@@ -27,11 +27,11 @@ update_particle_container(
 }
 
 template void update_particle_container(
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &                                  particle_container,
   const Particles::ParticleHandler<2> *particle_handler);
 
 template void update_particle_container(
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &  particle_container,
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &                                  particle_container,
   const Particles::ParticleHandler<3> *particle_handler);

--- a/source/dem/update_particle_point_line_contact_container.cc
+++ b/source/dem/update_particle_point_line_contact_container.cc
@@ -5,12 +5,12 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_point_line_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_point_line_contact_info &particle_lines_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container)
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
+    &particle_lines_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container)
 {
   for (auto particle_point_pairs_in_contact_iterator =
          particle_points_in_contact.begin();
@@ -39,17 +39,17 @@ update_particle_point_line_contact_container_iterators(
 }
 
 template void update_particle_point_line_contact_container_iterators<2>(
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_point_line_contact_info &particle_lines_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<2>::particle_point_line_contact_info
+    &particle_lines_in_contact,
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_particle_point_line_contact_container_iterators<3>(
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_point_line_contact_info &particle_points_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_point_line_contact_info &particle_lines_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info
+    &particle_points_in_contact,
+  typename DEM::dem_data_structures<3>::particle_point_line_contact_info
+    &particle_lines_in_contact,
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);

--- a/source/dem/update_particle_wall_contact_container.cc
+++ b/source/dem/update_particle_wall_contact_container.cc
@@ -5,10 +5,10 @@ using namespace dealii;
 template <int dim>
 void
 update_particle_wall_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_wall_in_contact &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container)
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
+    &particle_wall_pairs_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container)
 {
   for (auto particle_wall_pairs_in_contact_iterator =
          particle_wall_pairs_in_contact.begin();
@@ -34,10 +34,10 @@ update_particle_wall_contact_container_iterators(
 template <int dim>
 void
 update_particle_floating_mesh_contact_container_iterators(
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    dim>::particle_index_iterator_map &particle_container)
+  typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<dim>::particle_index_iterator_map
+    &particle_container)
 {
   for (unsigned int solid_counter = 0;
        solid_counter < particle_floating_mesh_in_contact.size();
@@ -69,25 +69,25 @@ update_particle_floating_mesh_contact_container_iterators(
 }
 
 template void update_particle_wall_contact_container_iterators<2>(
-  typename dem_data_containers::dem_data_structures<2>::particle_wall_in_contact
+  typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_particle_wall_contact_container_iterators<3>(
-  typename dem_data_containers::dem_data_structures<3>::particle_wall_in_contact
+  typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &particle_wall_pairs_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);
 
 template void update_particle_floating_mesh_contact_container_iterators<2>(
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    2>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<2>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<2>::particle_index_iterator_map
+    &particle_container);
 
 template void update_particle_floating_mesh_contact_container_iterators<3>(
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_floating_mesh_in_contact &particle_floating_mesh_in_contact,
-  typename dem_data_containers::dem_data_structures<
-    3>::particle_index_iterator_map &particle_container);
+  typename DEM::dem_data_structures<3>::particle_floating_mesh_in_contact
+    &particle_floating_mesh_in_contact,
+  typename DEM::dem_data_structures<3>::particle_index_iterator_map
+    &particle_container);


### PR DESCRIPTION
# Description of the problem

- Some containers defined in the data containers of the DEM where not used everywhere
- Some maps were remaining that needed to be refactored
- I don't think it is a good idea to have a seperate namespace for the container, moved them to the DEM namespace

# Description of the solution

- Fixed the container usage
- Renamed the namespace to DEM

# How Has This Been Tested?

- All tests pass so this is good to go.
