### PR TITLE
Fix void fraction calculation mode in examples

### DIFF
--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
@@ -8,11 +8,9 @@ subsection simulation control
   set number mesh adapt       = 0
   set output name              = result_
   set output frequency	  	= 1
-  set startup time scaling         = 0.6
   set time end                     = 0.5
-  set time step                    = 0.002
+  set time step                    = 0.01
   set subdivision             = 1 
-  set log precision     = 10 
   set output path                  	 = ./output/
 end
 
@@ -50,7 +48,7 @@ end
 # Void Fraction
 #---------------------------------------------------
 subsection void fraction
-   set mode = dem
+   set mode = pcm
    set read dem = true
    set dem file name = dem
    set l2 smoothing factor = 0.000005
@@ -144,5 +142,4 @@ subsection linear solver
   set ilu preconditioner absolute tolerance  = 1e-14
   set ilu preconditioner relative tolerance  = 1.00
   set verbosity               = verbose
-  set max krylov vectors = 200
 end

--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/output_dem/dummy
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/output_dem/dummy
@@ -1,0 +1,1 @@
+dummy file

--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/packing-in-cylinder.prm
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/packing-in-cylinder.prm
@@ -8,6 +8,7 @@ subsection simulation control
   set time end       					 = 0.6
   set log frequency				         = 1000
   set output frequency            			 = 1000
+  set output path                                        = ./output_dem/
 end
 
 #---------------------------------------------------
@@ -33,7 +34,7 @@ end
 subsection model parameters
   set contact detection method 		   		 = dynamic
   set contact detection frequency                 	 = 10
-  set neighborhood threshold				 = 1.8
+  set neighborhood threshold				 = 1.3
   set particle particle contact force method             = hertz_mindlin_limit_overlap
   set particle wall contact force method                 = nonlinear
   set integration method				 = velocity_verlet

--- a/examples/unresolved-cfd-dem/square-fluidized-bed/fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/square-fluidized-bed/fluidized-bed.prm
@@ -8,7 +8,6 @@ subsection simulation control
   set number mesh adapt       = 0
   set output name              = cfd_dem
   set output frequency	  	= 10
-  set startup time scaling         = 0.6
   set time end                     = 1.
   set time step                    = 0.001
   set output path                  	 = ./output/
@@ -49,7 +48,7 @@ end
 # Void Fraction
 #---------------------------------------------------
 subsection void fraction
-   set mode = dem
+   set mode = pcm
    set read dem = true
    set dem file name = dem
    set l2 smoothing factor = 0.000005
@@ -221,7 +220,7 @@ subsection linear solver
   set ilu preconditioner fill                = 1
   set ilu preconditioner absolute tolerance  = 1e-14
   set ilu preconditioner relative tolerance  = 1.00
-  set verbosity               = quiet
+  set verbosity               = verbose
   set max krylov vectors = 1000
 
 end


### PR DESCRIPTION
# Description of the problem

-  The CFD-DEM examples were not running anymore because of the void fraction calculation mode

# Description of the solution

- Fixed them. Improved the outputs at the same time

# How Has This Been Tested?

- Ran them on my machine, all is well


