### PR TITLE
Add post-processing capabilities when using log output with DEM

### DIFF
--- a/applications_tests/cfd_dem_coupling_3d/dynamic_contact_search.output
+++ b/applications_tests/cfd_dem_coupling_3d/dynamic_contact_search.output
@@ -26,7 +26,7 @@ Finished 100 DEM iterations
 Mass Source: 0 s^-1
 Max Local Mass Source: 0 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 3.088066198e-07
+Total particles kinetic energy: 9.106355178e-09
 
 *****************************************************************
 Transient iteration : 2        Time : 0.01     Time step : 0.005    CFL : 0       
@@ -41,7 +41,7 @@ Finished 100 DEM iterations
 Mass Source: -1.507798244e-18 s^-1
 Max Local Mass Source: 1.562921799e-11 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 6.068578828e-07
+Total particles kinetic energy: 3.516781428e-08
 
 *****************************************************************
 Transient iteration : 3        Time : 0.015    Time step : 0.005    CFL : 1.44013875e-07
@@ -56,7 +56,7 @@ Finished 100 DEM iterations
 Mass Source: -1.793820164e-18 s^-1
 Max Local Mass Source: 5.859416933e-11 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 8.851543287e-07
+Total particles kinetic energy: 7.481856548e-08
 
 *****************************************************************
 Transient iteration : 4        Time : 0.02     Time step : 0.005    CFL : 5.413028059e-07
@@ -72,7 +72,7 @@ Finished 100 DEM iterations
 Mass Source: -1.381287187e-18 s^-1
 Max Local Mass Source: 1.361804831e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.137988494e-06
+Total particles kinetic energy: 1.236650918e-07
 
 *****************************************************************
 Transient iteration : 5        Time : 0.025    Time step : 0.005    CFL : 1.266447763e-06
@@ -88,7 +88,7 @@ Finished 100 DEM iterations
 Mass Source: -7.071982244e-19 s^-1
 Max Local Mass Source: 2.522486406e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.362189665e-06
+Total particles kinetic energy: 1.77192993e-07
 
 *****************************************************************
 Transient iteration : 6        Time : 0.03     Time step : 0.005    CFL : 2.336167269e-06
@@ -104,7 +104,7 @@ Finished 100 DEM iterations
 Mass Source: -7.395227779e-19 s^-1
 Max Local Mass Source: 4.049715825e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.556784959e-06
+Total particles kinetic energy: 2.314347856e-07
 
 *****************************************************************
 Transient iteration : 7        Time : 0.035    Time step : 0.005    CFL : 3.799779026e-06
@@ -120,7 +120,7 @@ Finished 100 DEM iterations
 Mass Source: -1.25007915e-18 s^-1
 Max Local Mass Source: 5.933878764e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.72255284e-06
+Total particles kinetic energy: 2.833456098e-07
 
 *****************************************************************
 Transient iteration : 8        Time : 0.04     Time step : 0.005    CFL : 5.630592482e-06
@@ -136,7 +136,7 @@ Finished 100 DEM iterations
 Mass Source: 1.594978936e-15 s^-1
 Max Local Mass Source: 1.807514377e-08 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 1.861509651e-06
+Total particles kinetic energy: 3.309039613e-07
 
 *****************************************************************
 Transient iteration : 9        Time : 0.045    Time step : 0.005    CFL : 4.011156818e-05
@@ -152,7 +152,7 @@ Finished 100 DEM iterations
 Mass Source: 4.346973173e-15 s^-1
 Max Local Mass Source: 6.803894566e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 1.976015426e-06
+Total particles kinetic energy: 3.728653644e-07
 
 *****************************************************************
 Transient iteration : 10       Time : 0.05     Time step : 0.005    CFL : 1.088272012e-05
@@ -169,7 +169,7 @@ Finished 100 DEM iterations
 Mass Source: 4.078082613e-15 s^-1
 Max Local Mass Source: 3.302576013e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.069927926e-06
+Total particles kinetic energy: 4.091493159e-07
 
 *****************************************************************
 Transient iteration : 11       Time : 0.055    Time step : 0.005    CFL : 1.015100041e-05
@@ -185,7 +185,7 @@ Finished 100 DEM iterations
 Mass Source: 3.512961578e-15 s^-1
 Max Local Mass Source: 1.859831775e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.146062996e-06
+Total particles kinetic energy: 4.398011032e-07
 
 *****************************************************************
 Transient iteration : 12       Time : 0.06     Time step : 0.005    CFL : 1.248656786e-05
@@ -202,7 +202,7 @@ Finished 100 DEM iterations
 Mass Source: 2.988709701e-15 s^-1
 Max Local Mass Source: 1.569329418e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.207287464e-06
+Total particles kinetic energy: 4.652529931e-07
 
 *****************************************************************
 Transient iteration : 13       Time : 0.065    Time step : 0.005    CFL : 1.571691668e-05
@@ -218,7 +218,7 @@ Finished 100 DEM iterations
 Mass Source: 2.569247391e-15 s^-1
 Max Local Mass Source: 1.554991621e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.25621324e-06
+Total particles kinetic energy: 4.861067693e-07
 
 *****************************************************************
 Transient iteration : 14       Time : 0.07     Time step : 0.005    CFL : 1.95206646e-05
@@ -234,7 +234,7 @@ Finished 100 DEM iterations
 Mass Source: 2.245536837e-15 s^-1
 Max Local Mass Source: 1.616123558e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.29511932e-06
+Total particles kinetic energy: 5.030161393e-07
 
 *****************************************************************
 Transient iteration : 15       Time : 0.075    Time step : 0.005    CFL : 2.324506e-05
@@ -251,7 +251,7 @@ Finished 100 DEM iterations
 Mass Source: 2.001449992e-15 s^-1
 Max Local Mass Source: 1.973857172e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.325939573e-06
+Total particles kinetic energy: 5.166164578e-07
 
 *****************************************************************
 Transient iteration : 16       Time : 0.08     Time step : 0.005    CFL : 2.69511627e-05
@@ -268,7 +268,7 @@ Finished 100 DEM iterations
 Mass Source: 1.81927689e-15 s^-1
 Max Local Mass Source: 2.357644822e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.350281578e-06
+Total particles kinetic energy: 5.274862884e-07
 
 *****************************************************************
 Transient iteration : 17       Time : 0.085    Time step : 0.005    CFL : 3.066419123e-05
@@ -284,7 +284,7 @@ Finished 100 DEM iterations
 Mass Source: 1.684188125e-15 s^-1
 Max Local Mass Source: 2.727076685e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.369464614e-06
+Total particles kinetic energy: 5.36132132e-07
 
 *****************************************************************
 Transient iteration : 18       Time : 0.09     Time step : 0.005    CFL : 3.439045598e-05
@@ -301,7 +301,7 @@ Finished 100 DEM iterations
 Mass Source: 1.584553786e-15 s^-1
 Max Local Mass Source: 3.085994717e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.38455978e-06
+Total particles kinetic energy: 5.429849734e-07
 
 *****************************************************************
 Transient iteration : 19       Time : 0.095    Time step : 0.005    CFL : 3.812904813e-05
@@ -317,7 +317,7 @@ Finished 100 DEM iterations
 Mass Source: 1.511482221e-15 s^-1
 Max Local Mass Source: 3.436498732e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.396424584e-06
+Total particles kinetic energy: 5.484018543e-07
 
 *****************************************************************
 Transient iteration : 20       Time : 0.1      Time step : 0.005    CFL : 4.187660105e-05
@@ -334,7 +334,7 @@ Finished 100 DEM iterations
 Mass Source: 1.458287108e-15 s^-1
 Max Local Mass Source: 3.779738636e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.405746814e-06
+Total particles kinetic energy: 5.526767825e-07
 
 *****************************************************************
 Transient iteration : 21       Time : 0.105    Time step : 0.005    CFL : 4.562929676e-05
@@ -350,7 +350,7 @@ Finished 100 DEM iterations
 Mass Source: 1.419974312e-15 s^-1
 Max Local Mass Source: 4.116341847e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.413069185e-06
+Total particles kinetic energy: 5.56046267e-07
 
 *****************************************************************
 Transient iteration : 22       Time : 0.11     Time step : 0.005    CFL : 4.938370819e-05
@@ -367,7 +367,7 @@ Finished 100 DEM iterations
 Mass Source: 1.392829457e-15 s^-1
 Max Local Mass Source: 4.44663692e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.418824369e-06
+Total particles kinetic energy: 5.587017772e-07
 
 *****************************************************************
 Transient iteration : 23       Time : 0.115    Time step : 0.005    CFL : 5.313694687e-05
@@ -384,7 +384,7 @@ Finished 100 DEM iterations
 Mass Source: 1.374087598e-15 s^-1
 Max Local Mass Source: 4.770790563e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.423349901e-06
+Total particles kinetic energy: 5.607943539e-07
 
 *****************************************************************
 Transient iteration : 24       Time : 0.12     Time step : 0.005    CFL : 5.688665624e-05
@@ -400,7 +400,7 @@ Finished 100 DEM iterations
 Mass Source: 1.361700466e-15 s^-1
 Max Local Mass Source: 5.088872668e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.42691301e-06
+Total particles kinetic energy: 5.624446649e-07
 
 *****************************************************************
 Transient iteration : 25       Time : 0.125    Time step : 0.005    CFL : 6.063085529e-05
@@ -417,7 +417,7 @@ Finished 100 DEM iterations
 Mass Source: 1.354152061e-15 s^-1
 Max Local Mass Source: 5.400898527e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.429725317e-06
+Total particles kinetic energy: 5.637489422e-07
 
 *****************************************************************
 Transient iteration : 26       Time : 0.13     Time step : 0.005    CFL : 6.436783586e-05
@@ -433,7 +433,7 @@ Finished 100 DEM iterations
 Mass Source: 1.350316741e-15 s^-1
 Max Local Mass Source: 5.706857628e-09 s^-1
 Average Void Fraction in Bed: 0.9999925455
-Total particles kinetic energy: 2.431948994e-06
+Total particles kinetic energy: 5.647812967e-07
 
 *****************************************************************
 Transient iteration : 27       Time : 0.135    Time step : 0.005    CFL : 6.809612584e-05
@@ -450,7 +450,7 @@ Finished 100 DEM iterations
 Mass Source: 1.3711727e-14 s^-1
 Max Local Mass Source: 2.303197561e-08 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.433695564e-06
+Total particles kinetic energy: 5.65592814e-07
 
 *****************************************************************
 Transient iteration : 28       Time : 0.14     Time step : 0.005    CFL : 6.139020009e-05
@@ -467,7 +467,7 @@ Finished 100 DEM iterations
 Mass Source: 1.710484865e-14 s^-1
 Max Local Mass Source: 1.151430271e-08 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.434580176e-06
+Total particles kinetic energy: 5.660040579e-07
 
 *****************************************************************
 Transient iteration : 29       Time : 0.145    Time step : 0.005    CFL : 6.959578325e-05
@@ -483,7 +483,7 @@ Finished 100 DEM iterations
 Mass Source: 1.726993939e-14 s^-1
 Max Local Mass Source: 7.872332799e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.435619147e-06
+Total particles kinetic energy: 5.66487252e-07
 
 *****************************************************************
 Transient iteration : 30       Time : 0.15     Time step : 0.005    CFL : 7.042329902e-05
@@ -500,7 +500,7 @@ Finished 100 DEM iterations
 Mass Source: 1.700989512e-14 s^-1
 Max Local Mass Source: 6.350113591e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.43651076e-06
+Total particles kinetic energy: 5.669020786e-07
 
 *****************************************************************
 Transient iteration : 31       Time : 0.155    Time step : 0.005    CFL : 7.27418997e-05
@@ -516,7 +516,7 @@ Finished 100 DEM iterations
 Mass Source: 1.677145895e-14 s^-1
 Max Local Mass Source: 5.961017065e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.437221912e-06
+Total particles kinetic energy: 5.672330537e-07
 
 *****************************************************************
 Transient iteration : 32       Time : 0.16     Time step : 0.005    CFL : 7.65364088e-05
@@ -533,7 +533,7 @@ Finished 100 DEM iterations
 Mass Source: 1.661331115e-14 s^-1
 Max Local Mass Source: 6.023112013e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.437797102e-06
+Total particles kinetic energy: 5.675008217e-07
 
 *****************************************************************
 Transient iteration : 33       Time : 0.165    Time step : 0.005    CFL : 7.987648107e-05
@@ -550,7 +550,7 @@ Finished 100 DEM iterations
 Mass Source: 1.652911962e-14 s^-1
 Max Local Mass Source: 6.122572268e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.438241665e-06
+Total particles kinetic energy: 5.677078227e-07
 
 *****************************************************************
 Transient iteration : 34       Time : 0.17     Time step : 0.005    CFL : 8.299776702e-05
@@ -566,7 +566,7 @@ Finished 100 DEM iterations
 Mass Source: 1.650760565e-14 s^-1
 Max Local Mass Source: 6.233340229e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.438581933e-06
+Total particles kinetic energy: 5.678662863e-07
 
 *****************************************************************
 Transient iteration : 35       Time : 0.175    Time step : 0.005    CFL : 8.600045736e-05
@@ -583,7 +583,7 @@ Finished 100 DEM iterations
 Mass Source: 1.653641176e-14 s^-1
 Max Local Mass Source: 6.345884712e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.438860117e-06
+Total particles kinetic energy: 5.679958535e-07
 
 *****************************************************************
 Transient iteration : 36       Time : 0.18     Time step : 0.005    CFL : 8.893029031e-05
@@ -599,7 +599,7 @@ Finished 100 DEM iterations
 Mass Source: 1.660466275e-14 s^-1
 Max Local Mass Source: 6.455973601e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439069298e-06
+Total particles kinetic energy: 5.680932917e-07
 
 *****************************************************************
 Transient iteration : 37       Time : 0.185    Time step : 0.005    CFL : 9.181073796e-05
@@ -616,7 +616,7 @@ Finished 100 DEM iterations
 Mass Source: 1.670375982e-14 s^-1
 Max Local Mass Source: 6.561377828e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439244884e-06
+Total particles kinetic energy: 5.681750877e-07
 
 *****************************************************************
 Transient iteration : 38       Time : 0.19     Time step : 0.005    CFL : 9.465466353e-05
@@ -633,7 +633,7 @@ Finished 100 DEM iterations
 Mass Source: 1.682714089e-14 s^-1
 Max Local Mass Source: 6.660811338e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439374007e-06
+Total particles kinetic energy: 5.682352426e-07
 
 *****************************************************************
 Transient iteration : 39       Time : 0.195    Time step : 0.005    CFL : 9.746989816e-05
@@ -649,7 +649,7 @@ Finished 100 DEM iterations
 Mass Source: 1.696981856e-14 s^-1
 Max Local Mass Source: 6.753467754e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439467053e-06
+Total particles kinetic energy: 5.682785925e-07
 
 *****************************************************************
 Transient iteration : 40       Time : 0.2      Time step : 0.005    CFL : 0.0001002612643
@@ -666,7 +666,7 @@ Finished 100 DEM iterations
 Mass Source: 1.712799702e-14 s^-1
 Max Local Mass Source: 6.838821374e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439552402e-06
+Total particles kinetic energy: 5.683183573e-07
 
 *****************************************************************
 Transient iteration : 41       Time : 0.205    Time step : 0.005    CFL : 0.0001030318926
@@ -683,7 +683,7 @@ Finished 100 DEM iterations
 Mass Source: 1.729879234e-14 s^-1
 Max Local Mass Source: 6.916540576e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439611759e-06
+Total particles kinetic energy: 5.683460134e-07
 
 *****************************************************************
 Transient iteration : 42       Time : 0.21     Time step : 0.005    CFL : 0.0001057842162
@@ -699,7 +699,7 @@ Finished 100 DEM iterations
 Mass Source: 1.748002851e-14 s^-1
 Max Local Mass Source: 6.986399742e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439651169e-06
+Total particles kinetic energy: 5.683643761e-07
 
 *****************************************************************
 Transient iteration : 43       Time : 0.215    Time step : 0.005    CFL : 0.0001085199512
@@ -716,7 +716,7 @@ Finished 100 DEM iterations
 Mass Source: 1.767006842e-14 s^-1
 Max Local Mass Source: 7.048252803e-09 s^-1
 Average Void Fraction in Bed: 0.9999925708
-Total particles kinetic energy: 2.439695362e-06
+Total particles kinetic energy: 5.683849675e-07
 
 *****************************************************************
 Transient iteration : 44       Time : 0.22     Time step : 0.005    CFL : 0.0001112513009
@@ -732,7 +732,7 @@ Finished 100 DEM iterations
 Mass Source: 1.567522369e-14 s^-1
 Max Local Mass Source: 2.118752864e-08 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439725628e-06
+Total particles kinetic energy: 5.683990697e-07
 
 *****************************************************************
 Transient iteration : 45       Time : 0.225    Time step : 0.005    CFL : 0.0001132886328
@@ -749,7 +749,7 @@ Finished 100 DEM iterations
 Mass Source: 2.01726023e-14 s^-1
 Max Local Mass Source: 9.792331153e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439275428e-06
+Total particles kinetic energy: 5.681893171e-07
 
 *****************************************************************
 Transient iteration : 46       Time : 0.23     Time step : 0.005    CFL : 0.0001155355923
@@ -766,7 +766,7 @@ Finished 100 DEM iterations
 Mass Source: 2.044701935e-14 s^-1
 Max Local Mass Source: 7.180401326e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439283886e-06
+Total particles kinetic energy: 5.681932575e-07
 
 *****************************************************************
 Transient iteration : 47       Time : 0.235    Time step : 0.005    CFL : 0.0001129370768
@@ -782,7 +782,7 @@ Finished 100 DEM iterations
 Mass Source: 2.028816878e-14 s^-1
 Max Local Mass Source: 5.744396769e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439363316e-06
+Total particles kinetic energy: 5.682302617e-07
 
 *****************************************************************
 Transient iteration : 48       Time : 0.24     Time step : 0.005    CFL : 0.0001130057138
@@ -799,7 +799,7 @@ Finished 100 DEM iterations
 Mass Source: 2.014045321e-14 s^-1
 Max Local Mass Source: 5.043459445e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439463858e-06
+Total particles kinetic energy: 5.682771037e-07
 
 *****************************************************************
 Transient iteration : 49       Time : 0.245    Time step : 0.005    CFL : 0.0001130399814
@@ -815,7 +815,7 @@ Finished 100 DEM iterations
 Mass Source: 2.005161885e-14 s^-1
 Max Local Mass Source: 5.132790827e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439548161e-06
+Total particles kinetic energy: 5.683163816e-07
 
 *****************************************************************
 Transient iteration : 50       Time : 0.25     Time step : 0.005    CFL : 0.000113131987
@@ -832,7 +832,7 @@ Finished 100 DEM iterations
 Mass Source: 2.002961386e-14 s^-1
 Max Local Mass Source: 5.264530404e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439631773e-06
+Total particles kinetic energy: 5.683553387e-07
 
 *****************************************************************
 Transient iteration : 51       Time : 0.255    Time step : 0.005    CFL : 0.0001133006679
@@ -849,7 +849,7 @@ Finished 100 DEM iterations
 Mass Source: 2.006940919e-14 s^-1
 Max Local Mass Source: 5.416154737e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439692504e-06
+Total particles kinetic energy: 5.683836357e-07
 
 *****************************************************************
 Transient iteration : 52       Time : 0.26     Time step : 0.005    CFL : 0.0001135361947
@@ -865,7 +865,7 @@ Finished 100 DEM iterations
 Mass Source: 2.016157884e-14 s^-1
 Max Local Mass Source: 5.576612975e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439733345e-06
+Total particles kinetic energy: 5.684026653e-07
 
 *****************************************************************
 Transient iteration : 53       Time : 0.265    Time step : 0.005    CFL : 0.0001138251167
@@ -882,7 +882,7 @@ Finished 100 DEM iterations
 Mass Source: 2.02968324e-14 s^-1
 Max Local Mass Source: 5.739599194e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439777622e-06
+Total particles kinetic energy: 5.684232967e-07
 
 *****************************************************************
 Transient iteration : 54       Time : 0.27     Time step : 0.005    CFL : 0.0001141566019
@@ -899,7 +899,7 @@ Finished 100 DEM iterations
 Mass Source: 2.046724778e-14 s^-1
 Max Local Mass Source: 5.901281469e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439803622e-06
+Total particles kinetic energy: 5.684354118e-07
 
 *****************************************************************
 Transient iteration : 55       Time : 0.275    Time step : 0.005    CFL : 0.0001145231089
@@ -915,7 +915,7 @@ Finished 100 DEM iterations
 Mass Source: 2.066636816e-14 s^-1
 Max Local Mass Source: 6.05923027e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439814633e-06
+Total particles kinetic energy: 5.684405429e-07
 
 *****************************************************************
 Transient iteration : 56       Time : 0.28     Time step : 0.005    CFL : 0.0001149195017
@@ -932,7 +932,7 @@ Finished 100 DEM iterations
 Mass Source: 2.088903762e-14 s^-1
 Max Local Mass Source: 6.211862886e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.43983408e-06
+Total particles kinetic energy: 5.684496044e-07
 
 *****************************************************************
 Transient iteration : 57       Time : 0.285    Time step : 0.005    CFL : 0.0001153422768
@@ -948,7 +948,7 @@ Finished 100 DEM iterations
 Mass Source: 2.113117747e-14 s^-1
 Max Local Mass Source: 6.35814367e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.43983899e-06
+Total particles kinetic energy: 5.684518926e-07
 
 *****************************************************************
 Transient iteration : 58       Time : 0.29     Time step : 0.005    CFL : 0.0001175308243
@@ -965,7 +965,7 @@ Finished 100 DEM iterations
 Mass Source: 2.13895659e-14 s^-1
 Max Local Mass Source: 6.497354177e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439853076e-06
+Total particles kinetic energy: 5.684584561e-07
 
 *****************************************************************
 Transient iteration : 59       Time : 0.295    Time step : 0.005    CFL : 0.000120386547
@@ -982,7 +982,7 @@ Finished 100 DEM iterations
 Mass Source: 2.166164189e-14 s^-1
 Max Local Mass Source: 6.629009215e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439853069e-06
+Total particles kinetic energy: 5.684584529e-07
 
 *****************************************************************
 Transient iteration : 60       Time : 0.3      Time step : 0.005    CFL : 0.0001232237291
@@ -998,7 +998,7 @@ Finished 100 DEM iterations
 Mass Source: 2.194534715e-14 s^-1
 Max Local Mass Source: 6.7527642e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439841741e-06
+Total particles kinetic energy: 5.684531742e-07
 
 *****************************************************************
 Transient iteration : 61       Time : 0.305    Time step : 0.005    CFL : 0.0001260432611
@@ -1015,7 +1015,7 @@ Finished 100 DEM iterations
 Mass Source: 1.48760103e-14 s^-1
 Max Local Mass Source: 2.097590767e-08 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439868153e-06
+Total particles kinetic energy: 5.684654817e-07
 
 *****************************************************************
 Transient iteration : 62       Time : 0.31     Time step : 0.005    CFL : 0.000131793928
@@ -1031,7 +1031,7 @@ Finished 100 DEM iterations
 Mass Source: 2.428264633e-14 s^-1
 Max Local Mass Source: 8.905775616e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439231316e-06
+Total particles kinetic energy: 5.681687666e-07
 
 *****************************************************************
 Transient iteration : 63       Time : 0.315    Time step : 0.005    CFL : 0.0001320110182
@@ -1048,7 +1048,7 @@ Finished 100 DEM iterations
 Mass Source: 2.523845557e-14 s^-1
 Max Local Mass Source: 5.903718561e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439209039e-06
+Total particles kinetic energy: 5.681583889e-07
 
 *****************************************************************
 Transient iteration : 64       Time : 0.32     Time step : 0.005    CFL : 0.0001282612659
@@ -1065,7 +1065,7 @@ Finished 100 DEM iterations
 Mass Source: 2.53567076e-14 s^-1
 Max Local Mass Source: 4.676361512e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439280149e-06
+Total particles kinetic energy: 5.681915166e-07
 
 *****************************************************************
 Transient iteration : 65       Time : 0.325    Time step : 0.005    CFL : 0.00012589474
@@ -1081,7 +1081,7 @@ Finished 100 DEM iterations
 Mass Source: 2.561229678e-14 s^-1
 Max Local Mass Source: 4.538868473e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439340535e-06
+Total particles kinetic energy: 5.682196484e-07
 
 *****************************************************************
 Transient iteration : 66       Time : 0.33     Time step : 0.005    CFL : 0.0001244503397
@@ -1098,7 +1098,7 @@ Finished 100 DEM iterations
 Mass Source: 2.608840652e-14 s^-1
 Max Local Mass Source: 4.392403456e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439395166e-06
+Total particles kinetic energy: 5.682451003e-07
 
 *****************************************************************
 Transient iteration : 67       Time : 0.335    Time step : 0.005    CFL : 0.0001234473951
@@ -1114,7 +1114,7 @@ Finished 100 DEM iterations
 Mass Source: 2.677631142e-14 s^-1
 Max Local Mass Source: 4.263305781e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.43940471e-06
+Total particles kinetic energy: 5.682495471e-07
 
 *****************************************************************
 Transient iteration : 68       Time : 0.34     Time step : 0.005    CFL : 0.0001226734719
@@ -1131,7 +1131,7 @@ Finished 100 DEM iterations
 Mass Source: 2.763974805e-14 s^-1
 Max Local Mass Source: 4.247582695e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439403452e-06
+Total particles kinetic energy: 5.682489606e-07
 
 *****************************************************************
 Transient iteration : 69       Time : 0.345    Time step : 0.005    CFL : 0.0001220300951
@@ -1148,7 +1148,7 @@ Finished 100 DEM iterations
 Mass Source: 2.864298669e-14 s^-1
 Max Local Mass Source: 4.467107363e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439356146e-06
+Total particles kinetic energy: 5.682269217e-07
 
 *****************************************************************
 Transient iteration : 70       Time : 0.35     Time step : 0.005    CFL : 0.0001214697152
@@ -1164,7 +1164,7 @@ Finished 100 DEM iterations
 Mass Source: 2.975723438e-14 s^-1
 Max Local Mass Source: 4.683562694e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439267191e-06
+Total particles kinetic energy: 5.681854799e-07
 
 *****************************************************************
 Transient iteration : 71       Time : 0.355    Time step : 0.005    CFL : 0.0001209679138
@@ -1181,7 +1181,7 @@ Finished 100 DEM iterations
 Mass Source: 3.096062228e-14 s^-1
 Max Local Mass Source: 4.896629336e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439176787e-06
+Total particles kinetic energy: 5.681433643e-07
 
 *****************************************************************
 Transient iteration : 72       Time : 0.36     Time step : 0.005    CFL : 0.0001205115426
@@ -1198,7 +1198,7 @@ Finished 100 DEM iterations
 Mass Source: 3.223687134e-14 s^-1
 Max Local Mass Source: 5.106310666e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439044869e-06
+Total particles kinetic energy: 5.680819122e-07
 
 *****************************************************************
 Transient iteration : 73       Time : 0.365    Time step : 0.005    CFL : 0.000120093155
@@ -1214,7 +1214,7 @@ Finished 100 DEM iterations
 Mass Source: 3.357391384e-14 s^-1
 Max Local Mass Source: 5.31267929e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.438875467e-06
+Total particles kinetic energy: 5.680030036e-07
 
 *****************************************************************
 Transient iteration : 74       Time : 0.37     Time step : 0.005    CFL : 0.0001197082839
@@ -1231,7 +1231,7 @@ Finished 100 DEM iterations
 Mass Source: 3.496281878e-14 s^-1
 Max Local Mass Source: 5.515808191e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.43871197e-06
+Total particles kinetic energy: 5.679268507e-07
 
 *****************************************************************
 Transient iteration : 75       Time : 0.375    Time step : 0.005    CFL : 0.0001193540996
@@ -1247,7 +1247,7 @@ Finished 100 DEM iterations
 Mass Source: 3.639700248e-14 s^-1
 Max Local Mass Source: 5.715803497e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.438509177e-06
+Total particles kinetic energy: 5.678324018e-07
 
 *****************************************************************
 Transient iteration : 76       Time : 0.38     Time step : 0.005    CFL : 0.0001215332844
@@ -1263,7 +1263,7 @@ Finished 100 DEM iterations
 Mass Source: 3.787158289e-14 s^-1
 Max Local Mass Source: 5.91270506e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 4.799874444e-07
+Total particles kinetic energy: 2.200042834e-08
 
 *****************************************************************
 Transient iteration : 77       Time : 0.385    Time step : 0.005    CFL : 0.0001243162096
@@ -1279,7 +1279,7 @@ Finished 100 DEM iterations
 Mass Source: 3.918780016e-14 s^-1
 Max Local Mass Source: 5.808799941e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.500459394e-07
+Total particles kinetic energy: 2.149908002e-09
 
 *****************************************************************
 Transient iteration : 78       Time : 0.39     Time step : 0.005    CFL : 0.00012370851
@@ -1294,7 +1294,7 @@ Finished 100 DEM iterations
 Mass Source: 4.037556663e-14 s^-1
 Max Local Mass Source: 5.735486344e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.62545986e-07
+Total particles kinetic energy: 2.523038517e-09
 
 *****************************************************************
 Transient iteration : 79       Time : 0.395    Time step : 0.005    CFL : 0.0001232664204
@@ -1309,7 +1309,7 @@ Finished 100 DEM iterations
 Mass Source: 4.146831953e-14 s^-1
 Max Local Mass Source: 5.677584603e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 4.671466849e-07
+Total particles kinetic energy: 2.083905038e-08
 
 *****************************************************************
 Transient iteration : 80       Time : 0.4      Time step : 0.005    CFL : 0.0001229195851
@@ -1324,7 +1324,7 @@ Finished 100 DEM iterations
 Mass Source: 4.250010196e-14 s^-1
 Max Local Mass Source: 5.639607764e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 5.751215739e-08
+Total particles kinetic energy: 3.158571411e-10
 
 *****************************************************************
 Transient iteration : 81       Time : 0.405    Time step : 0.005    CFL : 0.0001227534938
@@ -1339,7 +1339,7 @@ Finished 100 DEM iterations
 Mass Source: 4.347672841e-14 s^-1
 Max Local Mass Source: 5.589497967e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.467415286e-09
+Total particles kinetic energy: 2.056257312e-13
 
 *****************************************************************
 Transient iteration : 82       Time : 0.41     Time step : 0.005    CFL : 0.0001224108082
@@ -1354,7 +1354,7 @@ Finished 100 DEM iterations
 Mass Source: 4.43927197e-14 s^-1
 Max Local Mass Source: 5.542601734e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.197817211e-09
+Total particles kinetic energy: 1.370100674e-13
 
 *****************************************************************
 Transient iteration : 83       Time : 0.415    Time step : 0.005    CFL : 0.0001220658736
@@ -1369,7 +1369,7 @@ Finished 100 DEM iterations
 Mass Source: 4.527729922e-14 s^-1
 Max Local Mass Source: 5.497488759e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.150200664e-09
+Total particles kinetic energy: 1.263335238e-13
 
 *****************************************************************
 Transient iteration : 84       Time : 0.42     Time step : 0.005    CFL : 0.0001217353674
@@ -1384,7 +1384,7 @@ Finished 100 DEM iterations
 Mass Source: 4.613516283e-14 s^-1
 Max Local Mass Source: 5.454032297e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.12412011e-09
+Total particles kinetic energy: 1.206693065e-13
 
 *****************************************************************
 Transient iteration : 85       Time : 0.425    Time step : 0.005    CFL : 0.0001214157393
@@ -1399,7 +1399,7 @@ Finished 100 DEM iterations
 Mass Source: 4.69729194e-14 s^-1
 Max Local Mass Source: 5.411835083e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.131566482e-09
+Total particles kinetic energy: 1.222732714e-13
 
 *****************************************************************
 Transient iteration : 86       Time : 0.43     Time step : 0.005    CFL : 0.0001211057728
@@ -1414,7 +1414,7 @@ Finished 100 DEM iterations
 Mass Source: 4.779449584e-14 s^-1
 Max Local Mass Source: 5.370637703e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.172162999e-09
+Total particles kinetic energy: 1.312040975e-13
 
 *****************************************************************
 Transient iteration : 87       Time : 0.435    Time step : 0.005    CFL : 0.0001208042898
@@ -1429,7 +1429,7 @@ Finished 100 DEM iterations
 Mass Source: 4.860256404e-14 s^-1
 Max Local Mass Source: 5.330323672e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.233301999e-09
+Total particles kinetic energy: 1.452480306e-13
 
 *****************************************************************
 Transient iteration : 88       Time : 0.44     Time step : 0.005    CFL : 0.0001205104473
@@ -1444,7 +1444,7 @@ Finished 100 DEM iterations
 Mass Source: 4.93988451e-14 s^-1
 Max Local Mass Source: 5.29091192e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.294773003e-09
+Total particles kinetic energy: 1.600879536e-13
 
 *****************************************************************
 Transient iteration : 89       Time : 0.445    Time step : 0.005    CFL : 0.0001202235315
@@ -1459,7 +1459,7 @@ Finished 100 DEM iterations
 Mass Source: 5.018450107e-14 s^-1
 Max Local Mass Source: 5.25203128e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.336177432e-09
+Total particles kinetic energy: 1.704902889e-13
 
 *****************************************************************
 Transient iteration : 90       Time : 0.45     Time step : 0.005    CFL : 0.0001199429556
@@ -1474,7 +1474,7 @@ Finished 100 DEM iterations
 Mass Source: 5.096032404e-14 s^-1
 Max Local Mass Source: 5.213608021e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.344411095e-09
+Total particles kinetic energy: 1.7259792e-13
 
 *****************************************************************
 Transient iteration : 91       Time : 0.455    Time step : 0.005    CFL : 0.0001197823574
@@ -1489,7 +1489,7 @@ Finished 100 DEM iterations
 Mass Source: 5.172687e-14 s^-1
 Max Local Mass Source: 5.175594582e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.318472534e-09
+Total particles kinetic energy: 1.660020901e-13
 
 *****************************************************************
 Transient iteration : 92       Time : 0.46     Time step : 0.005    CFL : 0.0001197765193
@@ -1504,7 +1504,7 @@ Finished 100 DEM iterations
 Mass Source: 5.248453929e-14 s^-1
 Max Local Mass Source: 5.137961886e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.269834676e-09
+Total particles kinetic energy: 1.539805077e-13
 
 *****************************************************************
 Transient iteration : 93       Time : 0.465    Time step : 0.005    CFL : 0.0001197685572
@@ -1519,7 +1519,7 @@ Finished 100 DEM iterations
 Mass Source: 5.323363431e-14 s^-1
 Max Local Mass Source: 5.100692771e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.218241237e-09
+Total particles kinetic energy: 1.41722229e-13
 
 *****************************************************************
 Transient iteration : 94       Time : 0.47     Time step : 0.005    CFL : 0.0001197585059
@@ -1534,7 +1534,7 @@ Finished 100 DEM iterations
 Mass Source: 5.397439969e-14 s^-1
 Max Local Mass Source: 5.063776685e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.184466843e-09
+Total particles kinetic energy: 1.339729739e-13
 
 *****************************************************************
 Transient iteration : 95       Time : 0.475    Time step : 0.005    CFL : 0.0001197463876
@@ -1549,7 +1549,7 @@ Finished 100 DEM iterations
 Mass Source: 5.470704789e-14 s^-1
 Max Local Mass Source: 5.034401066e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.182696706e-09
+Total particles kinetic energy: 1.335728389e-13
 
 *****************************************************************
 Transient iteration : 96       Time : 0.48     Time step : 0.005    CFL : 0.0001197322241
@@ -1564,7 +1564,7 @@ Finished 100 DEM iterations
 Mass Source: 5.543177271e-14 s^-1
 Max Local Mass Source: 5.010674045e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.21532357e-09
+Total particles kinetic energy: 1.410441973e-13
 
 *****************************************************************
 Transient iteration : 97       Time : 0.485    Time step : 0.005    CFL : 0.0001197160462
@@ -1579,7 +1579,7 @@ Finished 100 DEM iterations
 Mass Source: 5.614875395e-14 s^-1
 Max Local Mass Source: 4.987326027e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.272071755e-09
+Total particles kinetic energy: 1.545235232e-13
 
 *****************************************************************
 Transient iteration : 98       Time : 0.49     Time step : 0.005    CFL : 0.0001196979004
@@ -1594,7 +1594,7 @@ Finished 100 DEM iterations
 Mass Source: 5.685815613e-14 s^-1
 Max Local Mass Source: 4.964346835e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.33376831e-09
+Total particles kinetic energy: 1.698760565e-13
 
 *****************************************************************
 Transient iteration : 99       Time : 0.495    Time step : 0.005    CFL : 0.0001196778517
@@ -1609,7 +1609,7 @@ Finished 100 DEM iterations
 Mass Source: 5.756012558e-14 s^-1
 Max Local Mass Source: 4.941814546e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.379376034e-09
+Total particles kinetic energy: 1.816923885e-13
 
 *****************************************************************
 Transient iteration : 100      Time : 0.5      Time step : 0.005    CFL : 0.0001196559828
@@ -1624,4 +1624,4 @@ Finished 100 DEM iterations
 Mass Source: 5.825478742e-14 s^-1
 Max Local Mass Source: 4.919617753e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.393708765e-09
+Total particles kinetic energy: 1.854878402e-13

--- a/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.output
+++ b/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.output
@@ -22,7 +22,7 @@ Finished 10 DEM iterations
 Mass Source: -9.410572586e-13 s^-1
 Max Local Mass Source: 3.680942381e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.0002862965591
+Total particles kinetic energy: 3.689636582e-07
 
 *****************************************************************
 Transient iteration : 2        Time : 0.0002   Time step : 0.0001   CFL : 0.004908663353
@@ -33,7 +33,7 @@ Finished 10 DEM iterations
 Mass Source: -2.734704189e-11 s^-1
 Max Local Mass Source: 3.488154464e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.01469808337
+Total particles kinetic energy: 0.0006108898357
 
 *****************************************************************
 Transient iteration : 3        Time : 0.0003   Time step : 0.0001   CFL : 0.00446056468
@@ -44,7 +44,7 @@ Finished 10 DEM iterations
 Mass Source: 1.130247817e-11 s^-1
 Max Local Mass Source: 3.26894259e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.02357465846
+Total particles kinetic energy: 0.001582298798
 
 *****************************************************************
 Transient iteration : 4        Time : 0.0004   Time step : 0.0001   CFL : 0.004195189901
@@ -55,7 +55,7 @@ Finished 10 DEM iterations
 Mass Source: 4.748921487e-12 s^-1
 Max Local Mass Source: 3.134656066e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.02907948431
+Total particles kinetic energy: 0.002432373053
 
 *****************************************************************
 Transient iteration : 5        Time : 0.0005   Time step : 0.0001   CFL : 0.004015474146
@@ -66,4 +66,4 @@ Finished 10 DEM iterations
 Mass Source: 3.398615733e-13 s^-1
 Max Local Mass Source: 3.057397489e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.03255589633
+Total particles kinetic energy: 0.00308171238

--- a/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.output
+++ b/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.output
@@ -22,7 +22,7 @@ Finished 10 DEM iterations
 Mass Source: -9.410572586e-13 s^-1
 Max Local Mass Source: 3.680942381e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 3.689636582e-07
+Total particles kinetic energy: 1.844818291e-07
 
 *****************************************************************
 Transient iteration : 2        Time : 0.0002   Time step : 0.0001   CFL : 0.004908663353
@@ -33,7 +33,7 @@ Finished 10 DEM iterations
 Mass Source: -2.734704189e-11 s^-1
 Max Local Mass Source: 3.488154464e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.0006108898357
+Total particles kinetic energy: 0.0003054449179
 
 *****************************************************************
 Transient iteration : 3        Time : 0.0003   Time step : 0.0001   CFL : 0.00446056468
@@ -44,7 +44,7 @@ Finished 10 DEM iterations
 Mass Source: 1.130247817e-11 s^-1
 Max Local Mass Source: 3.26894259e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.001582298798
+Total particles kinetic energy: 0.0007911493991
 
 *****************************************************************
 Transient iteration : 4        Time : 0.0004   Time step : 0.0001   CFL : 0.004195189901
@@ -55,7 +55,7 @@ Finished 10 DEM iterations
 Mass Source: 4.748921487e-12 s^-1
 Max Local Mass Source: 3.134656066e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.002432373053
+Total particles kinetic energy: 0.001216186526
 
 *****************************************************************
 Transient iteration : 5        Time : 0.0005   Time step : 0.0001   CFL : 0.004015474146
@@ -66,4 +66,4 @@ Finished 10 DEM iterations
 Mass Source: 3.398615733e-13 s^-1
 Max Local Mass Source: 3.057397489e-07 s^-1
 Average Void Fraction in Bed: 0.7846025865
-Total particles kinetic energy: 0.00308171238
+Total particles kinetic energy: 0.00154085619

--- a/applications_tests/cfd_dem_coupling_3d/particle_sedimentation.output
+++ b/applications_tests/cfd_dem_coupling_3d/particle_sedimentation.output
@@ -35,7 +35,7 @@ Finished 100 DEM iterations
 Mass Source: 0 s^-1
 Max Local Mass Source: 0 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 3.088066198e-07
+Total particles kinetic energy: 9.106355178e-09
 
 *****************************************************************
 Transient iteration : 2        Time : 0.01     Time step : 0.005    CFL : 0       
@@ -57,13 +57,13 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.141394056e-18 s^-1
-Max Local Mass Source: 1.540015984e-11 s^-1
+Mass Source: -1.507798368e-18 s^-1
+Max Local Mass Source: 1.562921799e-11 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 6.068578828e-07
+Total particles kinetic energy: 3.516781428e-08
 
 *****************************************************************
-Transient iteration : 3        Time : 0.015    Time step : 0.005    CFL : 1.410413016e-07
+Transient iteration : 3        Time : 0.015    Time step : 0.005    CFL : 1.44013875e-07
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -82,17 +82,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.567346446e-18 s^-1
-Max Local Mass Source: 5.819844405e-11 s^-1
+Mass Source: -1.793820771e-18 s^-1
+Max Local Mass Source: 5.859416934e-11 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 8.851543174e-07
+Total particles kinetic energy: 7.481856548e-08
 
 *****************************************************************
-Transient iteration : 4        Time : 0.02     Time step : 0.005    CFL : 5.38451126e-07
+Transient iteration : 4        Time : 0.02     Time step : 0.005    CFL : 5.413028059e-07
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.01815062577,  y: 0.0004999999831,  z: -0.0004999999832,  v_x: -0.08452601101,  v_y: -6.682247143e-09,  vz: 6.66221098e-09
+id: 0,  x: -0.01815062578,  y: 0.000499999983,  z: -0.0004999999831,  v_x: -0.08452601208,  v_y: -6.743071674e-09,  vz: 6.687503992e-09
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 4
 DEM contact search at dem step 0
@@ -107,17 +107,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.813124547e-18 s^-1
-Max Local Mass Source: 1.353672423e-10 s^-1
+Mass Source: -1.381285092e-18 s^-1
+Max Local Mass Source: 1.361804828e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.137988474e-06
+Total particles kinetic energy: 1.236650918e-07
 
 *****************************************************************
-Transient iteration : 5        Time : 0.025    Time step : 0.005    CFL : 1.262559619e-06
+Transient iteration : 5        Time : 0.025    Time step : 0.005    CFL : 1.266447763e-06
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.01863421913,  y: 0.0004999998676,  z: -0.0004999998679,  v_x: -0.1086698945,  v_y: -3.921604785e-08,  vz: 3.914038993e-08
+id: 0,  x: -0.01863421914,  y: 0.0004999998676,  z: -0.0004999998678,  v_x: -0.1086698964,  v_y: -3.908564029e-08,  vz: 3.910453849e-08
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 5
 DEM contact search at dem step 0
@@ -132,17 +132,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.568305944e-18 s^-1
-Max Local Mass Source: 2.501550769e-10 s^-1
+Mass Source: -7.071751005e-19 s^-1
+Max Local Mass Source: 2.522486351e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.362189639e-06
+Total particles kinetic energy: 1.77192993e-07
 
 *****************************************************************
-Transient iteration : 6        Time : 0.03     Time step : 0.005    CFL : 2.350948653e-06
+Transient iteration : 6        Time : 0.03     Time step : 0.005    CFL : 2.336167281e-06
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.01923162793,  y: 0.0004999994399,  z: -0.0004999994408,  v_x: -0.1300795287,  v_y: -1.309426389e-07,  vz: 1.307677671e-07
+id: 0,  x: -0.01923162795,  y: 0.0004999994423,  z: -0.0004999994419,  v_x: -0.1300795312,  v_y: -1.301337938e-07,  vz: 1.303640701e-07
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 6
 DEM contact search at dem step 0
@@ -157,17 +157,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.705223032e-18 s^-1
-Max Local Mass Source: 4.02750165e-10 s^-1
+Mass Source: -7.394453411e-19 s^-1
+Max Local Mass Source: 4.04971564e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.55678502e-06
+Total particles kinetic energy: 2.314347856e-07
 
 *****************************************************************
-Transient iteration : 7        Time : 0.035    Time step : 0.005    CFL : 3.813467429e-06
+Transient iteration : 7        Time : 0.035    Time step : 0.005    CFL : 3.799779068e-06
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.01992894636,  y: 0.0004999982847,  z: -0.0004999982869,  v_x: -0.1486620188,  v_y: -3.29144845e-07,  vz: 3.288274444e-07
+id: 0,  x: -0.01992894638,  y: 0.0004999982921,  z: -0.0004999982901,  v_x: -0.1486620129,  v_y: -3.279461078e-07,  vz: 3.283661138e-07
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 7
 DEM contact search at dem step 0
@@ -182,17 +182,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.24031668e-18 s^-1
-Max Local Mass Source: 5.910301183e-10 s^-1
+Mass Source: -1.249894157e-18 s^-1
+Max Local Mass Source: 5.933878331e-10 s^-1
 Average Void Fraction in Bed: 0.9999926568
-Total particles kinetic energy: 1.722552996e-06
+Total particles kinetic energy: 2.833456097e-07
 
 *****************************************************************
-Transient iteration : 8        Time : 0.04     Time step : 0.005    CFL : 5.638357344e-06
+Transient iteration : 8        Time : 0.04     Time step : 0.005    CFL : 5.630592577e-06
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02071222639,  y: 0.0004999957203,  z: -0.0004999957245,  v_x: -0.1644916944,  v_y: -6.929881795e-07,  vz: 6.924807451e-07
+id: 0,  x: -0.02071222635,  y: 0.0004999957369,  z: -0.0004999957319,  v_x: -0.1644916795,  v_y: -6.904987552e-07,  vz: 6.912637844e-07
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 8
 DEM contact search at dem step 0
@@ -207,17 +207,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.59978914e-15 s^-1
-Max Local Mass Source: 1.807214297e-08 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 1.861509422e-06
+Mass Source: 1.594978753e-15 s^-1
+Max Local Mass Source: 1.807514359e-08 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 3.309038034e-07
 
 *****************************************************************
-Transient iteration : 9        Time : 0.045    Time step : 0.005    CFL : 4.011301491e-05
+Transient iteration : 9        Time : 0.045    Time step : 0.005    CFL : 4.011156635e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02156819,  y: 0.0004999908902,  z: -0.0004999908975,  v_x: -0.1777610557,  v_y: -1.233631894e-06,  vz: 1.232898711e-06
+id: 0,  x: -0.02156818987,  y: 0.0004999909244,  z: -0.0004999909143,  v_x: -0.1777610351,  v_y: -1.229137841e-06,  vz: 1.230418459e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 9
 DEM contact search at dem step 0
@@ -232,17 +232,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.302415552e-15 s^-1
-Max Local Mass Source: 6.794803165e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 1.976021539e-06
+Mass Source: 4.346973412e-15 s^-1
+Max Local Mass Source: 6.803896335e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 3.728675819e-07
 
 *****************************************************************
-Transient iteration : 10       Time : 0.05     Time step : 0.005    CFL : 1.088981138e-05
+Transient iteration : 10       Time : 0.05     Time step : 0.005    CFL : 1.088272137e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02248460641,  y: 0.0004999821738,  z: -0.0004999821853,  v_x: -0.1886961573,  v_y: -2.242832151e-06,  vz: 2.241917617e-06
+id: 0,  x: -0.02248460617,  y: 0.000499982237,  z: -0.0004999822163,  v_x: -0.1886961347,  v_y: -2.235748822e-06,  vz: 2.238692329e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 10
 DEM contact search at dem step 0
@@ -257,17 +257,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.076411934e-15 s^-1
-Max Local Mass Source: 3.30083684e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.069936253e-06
+Mass Source: 4.078085215e-15 s^-1
+Max Local Mass Source: 3.30257737e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 4.09152401e-07
 
 *****************************************************************
-Transient iteration : 11       Time : 0.055    Time step : 0.005    CFL : 1.014755569e-05
+Transient iteration : 11       Time : 0.055    Time step : 0.005    CFL : 1.015096562e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02345073189,  y: 0.0004999701726,  z: -0.0004999701921,  v_x: -0.1976643519,  v_y: -2.554528706e-06,  vz: 2.552234195e-06
+id: 0,  x: -0.02345073147,  y: 0.0004999702848,  z: -0.0004999702508,  v_x: -0.1976643019,  v_y: -2.542061761e-06,  vz: 2.544452107e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 11
 DEM contact search at dem step 0
@@ -282,17 +282,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.496692391e-15 s^-1
-Max Local Mass Source: 1.855991647e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.146069806e-06
+Mass Source: 3.512967822e-15 s^-1
+Max Local Mass Source: 1.859831722e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 4.398037203e-07
 
 *****************************************************************
-Transient iteration : 12       Time : 0.06     Time step : 0.005    CFL : 1.248845931e-05
+Transient iteration : 12       Time : 0.06     Time step : 0.005    CFL : 1.248654837e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02445741095,  y: 0.0004999576391,  z: -0.0004999576697,  v_x: -0.2049345707,  v_y: -2.459836606e-06,  vz: 2.457692402e-06
+id: 0,  x: -0.0244574103,  y: 0.0004999578119,  z: -0.0004999577661,  v_x: -0.2049345301,  v_y: -2.448038452e-06,  vz: 2.450361104e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 12
 DEM contact search at dem step 0
@@ -307,17 +307,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.975280068e-15 s^-1
-Max Local Mass Source: 1.565208007e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.207292951e-06
+Mass Source: 2.988719672e-15 s^-1
+Max Local Mass Source: 1.5693307e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 4.652551271e-07
 
 *****************************************************************
-Transient iteration : 13       Time : 0.065    Time step : 0.005    CFL : 1.570952557e-05
+Transient iteration : 13       Time : 0.065    Time step : 0.005    CFL : 1.571692141e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02549684591,  y: 0.0004999461181,  z: -0.00049994616,  v_x: -0.2107809504,  v_y: -2.151629093e-06,  vz: 2.149271545e-06
+id: 0,  x: -0.02549684506,  y: 0.0004999463529,  z: -0.0004999462928,  v_x: -0.2107809099,  v_y: -2.138671109e-06,  vz: 2.142025313e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 13
 DEM contact search at dem step 0
@@ -332,17 +332,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.554750646e-15 s^-1
-Max Local Mass Source: 1.55113932e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.25621775e-06
+Mass Source: 2.569261542e-15 s^-1
+Max Local Mass Source: 1.554993879e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 4.861085436e-07
 
 *****************************************************************
-Transient iteration : 14       Time : 0.07     Time step : 0.005    CFL : 1.951600371e-05
+Transient iteration : 14       Time : 0.07     Time step : 0.005    CFL : 1.952068368e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0265625474,  y: 0.0004999363416,  z: -0.0004999363957,  v_x: -0.2154529246,  v_y: -1.76285657e-06,  vz: 1.760349669e-06
+id: 0,  x: -0.02656254635,  y: 0.0004999366432,  z: -0.0004999365628,  v_x: -0.2154528871,  v_y: -1.749115828e-06,  vz: 1.753863353e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 14
 DEM contact search at dem step 0
@@ -357,17 +357,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.228871113e-15 s^-1
-Max Local Mass Source: 1.612599379e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.295122521e-06
+Mass Source: 2.245554725e-15 s^-1
+Max Local Mass Source: 1.616126739e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.030173988e-07
 
 *****************************************************************
-Transient iteration : 15       Time : 0.075    Time step : 0.005    CFL : 2.323721547e-05
+Transient iteration : 15       Time : 0.075    Time step : 0.005    CFL : 2.324509343e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02764919273,  y: 0.0004999284311,  z: -0.0004999284977,  v_x: -0.2191680565,  v_y: -1.404929504e-06,  vz: 1.402400999e-06
+id: 0,  x: -0.02764919151,  y: 0.0004999288036,  z: -0.000499928695,  v_x: -0.2191680252,  v_y: -1.390310411e-06,  vz: 1.396838199e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 15
 DEM contact search at dem step 0
@@ -382,17 +382,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.982629345e-15 s^-1
-Max Local Mass Source: 1.972032257e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.325940987e-06
+Mass Source: 2.001471992e-15 s^-1
+Max Local Mass Source: 1.973856856e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.166169626e-07
 
 *****************************************************************
-Transient iteration : 16       Time : 0.08     Time step : 0.005    CFL : 2.694370652e-05
+Transient iteration : 16       Time : 0.08     Time step : 0.005    CFL : 2.695121139e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02875246395,  y: 0.0004999219831,  z: -0.0004999220619,  v_x: -0.2221110032,  v_y: -1.176546742e-06,  vz: 1.174214622e-06
+id: 0,  x: -0.02875246259,  y: 0.0004999224304,  z: -0.000499922286,  v_x: -0.2221109767,  v_y: -1.161261366e-06,  vz: 1.169043087e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 16
 DEM contact search at dem step 0
@@ -407,17 +407,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.798629061e-15 s^-1
-Max Local Mass Source: 2.355698883e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.350282204e-06
+Mass Source: 1.819304597e-15 s^-1
+Max Local Mass Source: 2.357643719e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.274864484e-07
 
 *****************************************************************
-Transient iteration : 17       Time : 0.085    Time step : 0.005    CFL : 3.06566618e-05
+Transient iteration : 17       Time : 0.085    Time step : 0.005    CFL : 3.066424768e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.02986888811,  y: 0.0004999161304,  z: -0.0004999162202,  v_x: -0.2244354182,  v_y: -1.164669362e-06,  vz: 1.162560031e-06
+id: 0,  x: -0.02986888663,  y: 0.0004999166549,  z: -0.0004999164696,  v_x: -0.2244353925,  v_y: -1.149050831e-06,  vz: 1.157634843e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 17
 DEM contact search at dem step 0
@@ -432,17 +432,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.662456366e-15 s^-1
-Max Local Mass Source: 2.725088834e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.369465336e-06
+Mass Source: 1.684222255e-15 s^-1
+Max Local Mass Source: 2.727074057e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.36132325e-07
 
 *****************************************************************
-Transient iteration : 18       Time : 0.09     Time step : 0.005    CFL : 3.43824189e-05
+Transient iteration : 18       Time : 0.09     Time step : 0.005    CFL : 3.439051449e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03099569064,  y: 0.0004999095957,  z: -0.0004999096955,  v_x: -0.2262672724,  v_y: -1.446395718e-06,  vz: 1.444527501e-06
+id: 0,  x: -0.03099568901,  y: 0.0004999101982,  z: -0.0004999099686,  v_x: -0.2262672442,  v_y: -1.430822909e-06,  vz: 1.439915485e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 18
 DEM contact search at dem step 0
@@ -457,17 +457,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.561798423e-15 s^-1
-Max Local Mass Source: 3.083954354e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.384559716e-06
+Mass Source: 1.584593637e-15 s^-1
+Max Local Mass Source: 3.085991405e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.42984788e-07
 
 *****************************************************************
-Transient iteration : 19       Time : 0.095    Time step : 0.005    CFL : 3.811929139e-05
+Transient iteration : 19       Time : 0.095    Time step : 0.005    CFL : 3.81291136e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03213066655,  y: 0.000499900742,  z: -0.0004999008506,  v_x: -0.2277086795,  v_y: -2.088638014e-06,  vz: 2.086995135e-06
+id: 0,  x: -0.03213066478,  y: 0.000499901421,  z: -0.0004999011452,  v_x: -0.2277086468,  v_y: -2.073596427e-06,  vz: 2.08304507e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 19
 DEM contact search at dem step 0
@@ -482,17 +482,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.487924866e-15 s^-1
-Max Local Mass Source: 3.434408312e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.396424638e-06
+Mass Source: 1.51152875e-15 s^-1
+Max Local Mass Source: 3.436493829e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.484016964e-07
 
 *****************************************************************
-Transient iteration : 20       Time : 0.1      Time step : 0.005    CFL : 4.186444599e-05
+Transient iteration : 20       Time : 0.1      Time step : 0.005    CFL : 4.187666748e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03327207082,  y: 0.0004998876227,  z: -0.0004998877391,  v_x: -0.228841696,  v_y: -3.148497896e-06,  vz: 3.147003842e-06
+id: 0,  x: -0.03327206886,  y: 0.0004998883746,  z: -0.0004998880506,  v_x: -0.228841658,  v_y: -3.134388477e-06,  vz: 3.144149136e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 20
 DEM contact search at dem step 0
@@ -507,17 +507,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.433919434e-15 s^-1
-Max Local Mass Source: 3.777600965e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.405745983e-06
+Mass Source: 1.458339895e-15 s^-1
+Max Local Mass Source: 3.77973295e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.526761933e-07
 
 *****************************************************************
-Transient iteration : 21       Time : 0.105    Time step : 0.005    CFL : 4.561448008e-05
+Transient iteration : 21       Time : 0.105    Time step : 0.005    CFL : 4.562936961e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03441852686,  y: 0.0004998680297,  z: -0.0004998681535,  v_x: -0.2297318189,  v_y: -4.673445471e-06,  vz: 4.671984365e-06
+id: 0,  x: -0.0344185247,  y: 0.0004998688488,  z: -0.0004998684752,  v_x: -0.2297317758,  v_y: -4.660645498e-06,  vz: 4.670757606e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 21
 DEM contact search at dem step 0
@@ -532,17 +532,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.39490356e-15 s^-1
-Max Local Mass Source: 4.114170351e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.413068374e-06
+Mass Source: 1.420035161e-15 s^-1
+Max Local Mass Source: 4.116334227e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.560456633e-07
 
 *****************************************************************
-Transient iteration : 22       Time : 0.11     Time step : 0.005    CFL : 4.936645062e-05
+Transient iteration : 22       Time : 0.11     Time step : 0.005    CFL : 4.938378153e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03556895153,  y: 0.0004998395402,  z: -0.0004998396716,  v_x: -0.2304310557,  v_y: -6.702070292e-06,  vz: 6.700478762e-06
+id: 0,  x: -0.03556894914,  y: 0.0004998404192,  z: -0.0004998399939,  v_x: -0.230431008,  v_y: -6.690888574e-06,  vz: 6.701455217e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 22
 DEM contact search at dem step 0
@@ -557,17 +557,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.367117883e-15 s^-1
-Max Local Mass Source: 4.444446091e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.418822523e-06
+Mass Source: 1.392898669e-15 s^-1
+Max Local Mass Source: 4.446628039e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.587006734e-07
 
 *****************************************************************
-Transient iteration : 23       Time : 0.115    Time step : 0.005    CFL : 5.311760262e-05
+Transient iteration : 23       Time : 0.115    Time step : 0.005    CFL : 5.313702655e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03672249424,  y: 0.0004997995591,  z: -0.0004997996993,  v_x: -0.2309805362,  v_y: -9.264752246e-06,  vz: 9.26282952e-06
+id: 0,  x: -0.03672249161,  y: 0.0004998004892,  z: -0.0004998000095,  v_x: -0.2309804844,  v_y: -9.255480638e-06,  vz: 9.26665071e-06
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 23
 DEM contact search at dem step 0
@@ -582,17 +582,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.347836038e-15 s^-1
-Max Local Mass Source: 4.768588736e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.423347985e-06
+Mass Source: 1.374168179e-15 s^-1
+Max Local Mass Source: 4.770778936e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.607931968e-07
 
 *****************************************************************
-Transient iteration : 24       Time : 0.12     Time step : 0.005    CFL : 5.686551022e-05
+Transient iteration : 24       Time : 0.12     Time step : 0.005    CFL : 5.688673624e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0378784881,  y: 0.0004997453579,  z: -0.0004997455092,  v_x: -0.2314126857,  v_y: -1.238452599e-05,  vz: 1.238203464e-05
+id: 0,  x: -0.0378784852,  y: 0.0004997463288,  z: -0.0004997457913,  v_x: -0.2314126299,  v_y: -1.237743974e-05,  vz: 1.23893929e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 24
 DEM contact search at dem step 0
@@ -607,17 +607,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.334976782e-15 s^-1
-Max Local Mass Source: 5.086659434e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.426911801e-06
+Mass Source: 1.361793603e-15 s^-1
+Max Local Mass Source: 5.088857686e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.624438149e-07
 
 *****************************************************************
-Transient iteration : 25       Time : 0.125    Time step : 0.005    CFL : 6.0607991e-05
+Transient iteration : 25       Time : 0.125    Time step : 0.005    CFL : 6.063093141e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.03903641083,  y: 0.0004996741096,  z: -0.0004996742754,  v_x: -0.2317530046,  v_y: -1.607786775e-05,  vz: 1.607454035e-05
+id: 0,  x: -0.03903640764,  y: 0.0004996751097,  z: -0.00049967451,  v_x: -0.2317529449,  v_y: -1.607324504e-05,  vz: 1.608618114e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 25
 DEM contact search at dem step 0
@@ -632,17 +632,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.327010541e-15 s^-1
-Max Local Mass Source: 5.398667462e-09 s^-1
-Average Void Fraction in Bed: 0.9999925535
-Total particles kinetic energy: 2.42972358e-06
+Mass Source: 1.354256538e-15 s^-1
+Max Local Mass Source: 5.400881542e-09 s^-1
+Average Void Fraction in Bed: 0.9999925455
+Total particles kinetic energy: 5.637478285e-07
 
 *****************************************************************
-Transient iteration : 26       Time : 0.13     Time step : 0.005    CFL : 6.43431698e-05
+Transient iteration : 26       Time : 0.13     Time step : 0.005    CFL : 6.436791536e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04019585383,  y: 0.0004995829193,  z: -0.0004995831046,  v_x: -0.2320215091,  v_y: -2.035548749e-05,  vz: 2.035102975e-05
+id: 0,  x: -0.04019585033,  y: 0.0004995839356,  z: -0.0004995832682,  v_x: -0.2320214458,  v_y: -2.035360269e-05,  vz: 2.036773604e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 26
 DEM contact search at dem step 0
@@ -657,17 +657,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.281620447e-14 s^-1
-Max Local Mass Source: 2.272738605e-08 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.431945705e-06
+Mass Source: 1.278665508e-14 s^-1
+Max Local Mass Source: 2.272992315e-08 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.647794456e-07
 
 *****************************************************************
-Transient iteration : 27       Time : 0.135    Time step : 0.005    CFL : 5.850394733e-05
+Transient iteration : 27       Time : 0.135    Time step : 0.005    CFL : 5.852258123e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04135649717,  y: 0.0004994690344,  z: -0.0004994692456,  v_x: -0.2322337054,  v_y: -2.515050916e-05,  vz: 2.514462131e-05
+id: 0,  x: -0.04135649335,  y: 0.0004994700526,  z: -0.000499469311,  v_x: -0.2322336389,  v_y: -2.515160164e-05,  vz: 2.516714562e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 27
 DEM contact search at dem step 0
@@ -682,17 +682,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.61990258e-14 s^-1
-Max Local Mass Source: 1.122711804e-08 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.433189552e-06
+Mass Source: 1.61588802e-14 s^-1
+Max Local Mass Source: 1.123006815e-08 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.653573097e-07
 
 *****************************************************************
-Transient iteration : 28       Time : 0.14     Time step : 0.005    CFL : 6.590918251e-05
+Transient iteration : 28       Time : 0.14     Time step : 0.005    CFL : 6.5918004e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04251796561,  y: 0.0004993330893,  z: -0.0004993333336,  v_x: -0.2323524831,  v_y: -2.918714517e-05,  vz: 2.917983567e-05
+id: 0,  x: -0.04251796145,  y: 0.0004993340952,  z: -0.0004993332727,  v_x: -0.2323524146,  v_y: -2.91909989e-05,  vz: 2.920775343e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 28
 DEM contact search at dem step 0
@@ -707,17 +707,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.632595053e-14 s^-1
-Max Local Mass Source: 7.589481779e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.434530123e-06
+Mass Source: 1.630617916e-14 s^-1
+Max Local Mass Source: 7.595382832e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.659803268e-07
 
 *****************************************************************
-Transient iteration : 29       Time : 0.145    Time step : 0.005    CFL : 6.672908213e-05
+Transient iteration : 29       Time : 0.145    Time step : 0.005    CFL : 6.675016099e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04368005127,  y: 0.0004991807344,  z: -0.0004991810154,  v_x: -0.2324804976,  v_y: -3.172942475e-05,  vz: 3.17220215e-05
+id: 0,  x: -0.0436800467,  y: 0.0004991816985,  z: -0.0004991807743,  v_x: -0.2324804035,  v_y: -3.174216321e-05,  vz: 3.176600708e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 29
 DEM contact search at dem step 0
@@ -732,17 +732,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.605380577e-14 s^-1
-Max Local Mass Source: 6.07200647e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.435653952e-06
+Mass Source: 1.602787827e-14 s^-1
+Max Local Mass Source: 6.077260157e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.665029527e-07
 
 *****************************************************************
-Transient iteration : 30       Time : 0.15     Time step : 0.005    CFL : 6.901525877e-05
+Transient iteration : 30       Time : 0.15     Time step : 0.005    CFL : 6.905707972e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04484272473,  y: 0.0004990182631,  z: -0.0004990185896,  v_x: -0.232587815,  v_y: -3.324391741e-05,  vz: 3.323318813e-05
+id: 0,  x: -0.04484271967,  y: 0.0004990191686,  z: -0.0004990181186,  v_x: -0.2325877144,  v_y: -3.325464113e-05,  vz: 3.328112289e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 30
 DEM contact search at dem step 0
@@ -757,17 +757,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.579293018e-14 s^-1
-Max Local Mass Source: 5.668864942e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.436557057e-06
+Mass Source: 1.577088426e-14 s^-1
+Max Local Mass Source: 5.67677063e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.669231417e-07
 
 *****************************************************************
-Transient iteration : 31       Time : 0.155    Time step : 0.005    CFL : 7.282001907e-05
+Transient iteration : 31       Time : 0.155    Time step : 0.005    CFL : 7.28652092e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04600588156,  y: 0.0004988498276,  z: -0.0004988502117,  v_x: -0.2326740549,  v_y: -3.412152936e-05,  vz: 3.410922473e-05
+id: 0,  x: -0.04600587601,  y: 0.0004988506793,  z: -0.00049884949,  v_x: -0.2326739562,  v_y: -3.413232606e-05,  vz: 3.416154266e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 31
 DEM contact search at dem step 0
@@ -782,17 +782,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.561295655e-14 s^-1
-Max Local Mass Source: 5.732517568e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.437272985e-06
+Mass Source: 1.559407473e-14 s^-1
+Max Local Mass Source: 5.740040523e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.672563932e-07
 
 *****************************************************************
-Transient iteration : 32       Time : 0.16     Time step : 0.005    CFL : 7.6171348e-05
+Transient iteration : 32       Time : 0.16     Time step : 0.005    CFL : 7.622030127e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04716942446,  y: 0.0004986779035,  z: -0.0004986783522,  v_x: -0.2327424208,  v_y: -3.464289143e-05,  vz: 3.462936122e-05
+id: 0,  x: -0.04716941844,  y: 0.000498678704,  z: -0.000498677362,  v_x: -0.2327423317,  v_y: -3.465258979e-05,  vz: 3.468441392e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 32
 DEM contact search at dem step 0
@@ -807,17 +807,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.550970857e-14 s^-1
-Max Local Mass Source: 5.833726152e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.43783735e-06
+Mass Source: 1.549121553e-14 s^-1
+Max Local Mass Source: 5.841170927e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.675191712e-07
 
 *****************************************************************
-Transient iteration : 33       Time : 0.165    Time step : 0.005    CFL : 7.931237406e-05
+Transient iteration : 33       Time : 0.165    Time step : 0.005    CFL : 7.935749027e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04833327264,  y: 0.0004985037627,  z: -0.0004985042815,  v_x: -0.2327963135,  v_y: -3.50097598e-05,  vz: 3.499525017e-05
+id: 0,  x: -0.0483332662,  y: 0.0004985045171,  z: -0.0004985030111,  v_x: -0.2327962336,  v_y: -3.501851048e-05,  vz: 3.505227852e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 33
 DEM contact search at dem step 0
@@ -832,17 +832,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.546880126e-14 s^-1
-Max Local Mass Source: 5.946115797e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.438281123e-06
+Mass Source: 1.545109062e-14 s^-1
+Max Local Mass Source: 5.954020521e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.677258272e-07
 
 *****************************************************************
-Transient iteration : 34       Time : 0.17     Time step : 0.005    CFL : 8.233580064e-05
+Transient iteration : 34       Time : 0.17     Time step : 0.005    CFL : 8.237677742e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.04949736121,  y: 0.0004983277898,  z: -0.0004983283828,  v_x: -0.2328386907,  v_y: -3.537572626e-05,  vz: 3.536057067e-05
+id: 0,  x: -0.04949735438,  y: 0.0004983285035,  z: -0.0004983268247,  v_x: -0.2328386148,  v_y: -3.538328694e-05,  vz: 3.541859184e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 34
 DEM contact search at dem step 0
@@ -857,17 +857,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.547949141e-14 s^-1
-Max Local Mass Source: 6.060584509e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.438629788e-06
+Mass Source: 1.546137231e-14 s^-1
+Max Local Mass Source: 6.069001271e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.678881973e-07
 
 *****************************************************************
-Transient iteration : 35       Time : 0.175    Time step : 0.005    CFL : 8.528488847e-05
+Transient iteration : 35       Time : 0.175    Time step : 0.005    CFL : 8.532386539e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05066163873,  y: 0.0004981496863,  z: -0.0004981503561,  v_x: -0.2328719855,  v_y: -3.586082037e-05,  vz: 3.584527103e-05
+id: 0,  x: -0.05066163152,  y: 0.0004981503649,  z: -0.0004981485067,  v_x: -0.2328719083,  v_y: -3.586728964e-05,  vz: 3.59037835e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 35
 DEM contact search at dem step 0
@@ -882,17 +882,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.55294654e-14 s^-1
-Max Local Mass Source: 6.172952316e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.4389038e-06
+Mass Source: 1.551119776e-14 s^-1
+Max Local Mass Source: 6.181822527e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.680158059e-07
 
 *****************************************************************
-Transient iteration : 36       Time : 0.18     Time step : 0.005    CFL : 8.818252797e-05
+Transient iteration : 36       Time : 0.18     Time step : 0.005    CFL : 8.822200383e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05182606473,  y: 0.0004979686152,  z: -0.0004979693631,  v_x: -0.2328981516,  v_y: -3.656063752e-05,  vz: 3.654493914e-05
+id: 0,  x: -0.05182605712,  y: 0.0004979692631,  z: -0.0004979672201,  v_x: -0.2328980706,  v_y: -3.656646438e-05,  vz: 3.66038379e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 36
 DEM contact search at dem step 0
@@ -907,17 +907,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.561056689e-14 s^-1
-Max Local Mass Source: 6.281029254e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439119419e-06
+Mass Source: 1.559197163e-14 s^-1
+Max Local Mass Source: 6.290224902e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.681162247e-07
 
 *****************************************************************
-Transient iteration : 37       Time : 0.185    Time step : 0.005    CFL : 9.104244615e-05
+Transient iteration : 37       Time : 0.185    Time step : 0.005    CFL : 9.108408687e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05299060748,  y: 0.0004977833085,  z: -0.0004977841348,  v_x: -0.2329187414,  v_y: -3.755212504e-05,  vz: 3.753648264e-05
+id: 0,  x: -0.05299059945,  y: 0.000497783928,  z: -0.0004977816965,  v_x: -0.2329186562,  v_y: -3.755766461e-05,  vz: 3.759569495e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 37
 DEM contact search at dem step 0
@@ -932,17 +932,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.571581923e-14 s^-1
-Max Local Mass Source: 6.383461046e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439289486e-06
+Mass Source: 1.569713167e-14 s^-1
+Max Local Mass Source: 6.392881979e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.681954337e-07
 
 *****************************************************************
-Transient iteration : 38       Time : 0.19     Time step : 0.005    CFL : 9.387320866e-05
+Transient iteration : 38       Time : 0.19     Time step : 0.005    CFL : 9.391776357e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05415524219,  y: 0.0004975921528,  z: -0.0004975930568,  v_x: -0.2329349811,  v_y: -3.889669113e-05,  vz: 3.888126881e-05
+id: 0,  x: -0.05415523373,  y: 0.0004975927446,  z: -0.0004975903216,  v_x: -0.2329348924,  v_y: -3.890225065e-05,  vz: 3.894082593e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 38
 DEM contact search at dem step 0
@@ -957,17 +957,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.58404399e-14 s^-1
-Max Local Mass Source: 6.479373827e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439424112e-06
+Mass Source: 1.582168744e-14 s^-1
+Max Local Mass Source: 6.488963654e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.682581398e-07
 
 *****************************************************************
-Transient iteration : 39       Time : 0.195    Time step : 0.005    CFL : 9.668046002e-05
+Transient iteration : 39       Time : 0.195    Time step : 0.005    CFL : 9.672782844e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05531994956,  y: 0.00049739326,  z: -0.0004973942402,  v_x: -0.2329478363,  v_y: -4.06429815e-05,  vz: 4.062789289e-05
+id: 0,  x: -0.05531994064,  y: 0.0004973938234,  z: -0.0004973912062,  v_x: -0.2329477449,  v_y: -4.064873279e-05,  vz: 4.068784664e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 39
 DEM contact search at dem step 0
@@ -982,17 +982,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.598059942e-14 s^-1
-Max Local Mass Source: 6.568174585e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439531245e-06
+Mass Source: 1.59618386e-14 s^-1
+Max Local Mass Source: 6.577929876e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.683080416e-07
 
 *****************************************************************
-Transient iteration : 40       Time : 0.2      Time step : 0.005    CFL : 9.946788383e-05
+Transient iteration : 40       Time : 0.2      Time step : 0.005    CFL : 9.951747204e-05
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05648471457,  y: 0.000497184526,  z: -0.0004971855806,  v_x: -0.232958066,  v_y: -4.282878331e-05,  vz: 4.281409355e-05
+id: 0,  x: -0.05648470519,  y: 0.0004971850599,  z: -0.0004971822455,  v_x: -0.232957972,  v_y: -4.283483779e-05,  vz: 4.287456689e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 40
 DEM contact search at dem step 0
@@ -1007,17 +1007,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.613353885e-14 s^-1
-Max Local Mass Source: 6.649475085e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439617131e-06
+Mass Source: 1.611469946e-14 s^-1
+Max Local Mass Source: 6.659420852e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.683480439e-07
 
 *****************************************************************
-Transient iteration : 41       Time : 0.205    Time step : 0.005    CFL : 0.0001022378847
+Transient iteration : 41       Time : 0.205    Time step : 0.005    CFL : 0.0001022889669
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0576495256,  y: 0.0004969636808,  z: -0.0004969648078,  v_x: -0.2329662665,  v_y: -4.548273336e-05,  vz: 4.546845942e-05
+id: 0,  x: -0.05764951575,  y: 0.0004969641835,  z: -0.0004969611686,  v_x: -0.2329661697,  v_y: -4.548917444e-05,  vz: 4.552965046e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 41
 DEM contact search at dem step 0
@@ -1032,17 +1032,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.62970808e-14 s^-1
-Max Local Mass Source: 6.723029014e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439686675e-06
+Mass Source: 1.62780903e-14 s^-1
+Max Local Mass Source: 6.733196435e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.683804292e-07
 
 *****************************************************************
-Transient iteration : 42       Time : 0.21     Time step : 0.005    CFL : 0.0001049919941
+Transient iteration : 42       Time : 0.21     Time step : 0.005    CFL : 0.0001050440169
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0588143737,  y: 0.0004967283313,  z: -0.0004967295287,  v_x: -0.2329729062,  v_y: -4.862565104e-05,  vz: 4.86117657e-05
+id: 0,  x: -0.05881436335,  y: 0.0004967288005,  z: -0.0004967255809,  v_x: -0.2329728057,  v_y: -4.863259489e-05,  vz: 4.867397898e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 42
 DEM contact search at dem step 0
@@ -1057,17 +1057,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.646959043e-14 s^-1
-Max Local Mass Source: 6.788697049e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.439743733e-06
+Mass Source: 1.645037042e-14 s^-1
+Max Local Mass Source: 6.799103197e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.684069924e-07
 
 *****************************************************************
-Transient iteration : 43       Time : 0.215    Time step : 0.005    CFL : 0.0001084424848
+Transient iteration : 43       Time : 0.215    Time step : 0.005    CFL : 0.000108493278
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.05997925199,  y: 0.0004964759967,  z: -0.0004964772627,  v_x: -0.2329783533,  v_y: -5.227170867e-05,  vz: 5.225814341e-05
+id: 0,  x: -0.05997924112,  y: 0.0004964764295,  z: -0.0004964730003,  v_x: -0.232978248,  v_y: -5.227932083e-05,  vz: 5.232178516e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 43
 DEM contact search at dem step 0
@@ -1082,17 +1082,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.664977996e-14 s^-1
-Max Local Mass Source: 6.846415482e-09 s^-1
-Average Void Fraction in Bed: 0.9999925597
-Total particles kinetic energy: 2.43979134e-06
+Mass Source: 1.663029925e-14 s^-1
+Max Local Mass Source: 6.857056394e-09 s^-1
+Average Void Fraction in Bed: 0.9999925708
+Total particles kinetic energy: 5.684291473e-07
 
 *****************************************************************
-Transient iteration : 44       Time : 0.22     Time step : 0.005    CFL : 0.0001119660261
+Transient iteration : 44       Time : 0.22     Time step : 0.005    CFL : 0.0001120180113
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06114415523,  y: 0.00049620414,  z: -0.0004962054733,  v_x: -0.2329828975,  v_y: -5.642939401e-05,  vz: 5.641604209e-05
+id: 0,  x: -0.06114414382,  y: 0.0004962045325,  z: -0.0004962008878,  v_x: -0.2329827864,  v_y: -5.643788869e-05,  vz: 5.648160682e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 44
 DEM contact search at dem step 0
@@ -1107,17 +1107,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.661755487e-14 s^-1
-Max Local Mass Source: 2.155844891e-08 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439830332e-06
+Mass Source: 1.653049011e-14 s^-1
+Max Local Mass Source: 2.155745229e-08 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684472906e-07
 
 *****************************************************************
-Transient iteration : 45       Time : 0.225    Time step : 0.005    CFL : 0.0001126503384
+Transient iteration : 45       Time : 0.225    Time step : 0.005    CFL : 0.0001127042298
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06230907911,  y: 0.0004959129346,  z: -0.0004959143343,  v_x: -0.2329866191,  v_y: -6.001689187e-05,  vz: 6.000371132e-05
+id: 0,  x: -0.06230906714,  y: 0.0004959132813,  z: -0.0004959094149,  v_x: -0.2329865028,  v_y: -6.002671565e-05,  vz: 6.007167801e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 45
 DEM contact search at dem step 0
@@ -1132,17 +1132,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.108412073e-14 s^-1
-Max Local Mass Source: 1.004336027e-08 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.43938652e-06
+Mass Source: 2.104314974e-14 s^-1
+Max Local Mass Source: 1.0045055e-08 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.682404921e-07
 
 *****************************************************************
-Transient iteration : 46       Time : 0.23     Time step : 0.005    CFL : 0.0001147905084
+Transient iteration : 46       Time : 0.23     Time step : 0.005    CFL : 0.0001148399669
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06347390519,  y: 0.0004956038535,  z: -0.0004956053208,  v_x: -0.2329442363,  v_y: -6.357991997e-05,  vz: 6.356606482e-05
+id: 0,  x: -0.06347389263,  y: 0.0004956041632,  z: -0.0004956000685,  v_x: -0.2329441174,  v_y: -6.358494366e-05,  vz: 6.36312578e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 46
 DEM contact search at dem step 0
@@ -1157,17 +1157,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.136153234e-14 s^-1
-Max Local Mass Source: 6.977161519e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439394493e-06
+Mass Source: 2.13311668e-14 s^-1
+Max Local Mass Source: 6.98252355e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.682441813e-07
 
 *****************************************************************
-Transient iteration : 47       Time : 0.235    Time step : 0.005    CFL : 0.0001136011149
+Transient iteration : 47       Time : 0.235    Time step : 0.005    CFL : 0.0001136618737
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06463862829,  y: 0.0004952824717,  z: -0.0004952840018,  v_x: -0.2329449969,  v_y: -6.49590071e-05,  vz: 6.494771842e-05
+id: 0,  x: -0.06463861513,  y: 0.0004952827276,  z: -0.0004952783985,  v_x: -0.2329448728,  v_y: -6.497540257e-05,  vz: 6.502285017e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 47
 DEM contact search at dem step 0
@@ -1182,17 +1182,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.123481414e-14 s^-1
-Max Local Mass Source: 5.534907361e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439475838e-06
+Mass Source: 2.118687645e-14 s^-1
+Max Local Mass Source: 5.544131957e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.682820695e-07
 
 *****************************************************************
-Transient iteration : 48       Time : 0.24     Time step : 0.005    CFL : 0.0001137051343
+Transient iteration : 48       Time : 0.24     Time step : 0.005    CFL : 0.0001137595883
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06580337289,  y: 0.0004949572434,  z: -0.0004949588326,  v_x: -0.2329527647,  v_y: -6.513062296e-05,  vz: 6.511823258e-05
+id: 0,  x: -0.0658033591,  y: 0.0004949574336,  z: -0.0004949528694,  v_x: -0.2329526385,  v_y: -6.514051727e-05,  vz: 6.518714399e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 48
 DEM contact search at dem step 0
@@ -1207,17 +1207,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.110528765e-14 s^-1
-Max Local Mass Source: 5.416467438e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439565e-06
+Mass Source: 2.105398192e-14 s^-1
+Max Local Mass Source: 5.417103131e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.683236289e-07
 
 *****************************************************************
-Transient iteration : 49       Time : 0.245    Time step : 0.005    CFL : 0.0001137262657
+Transient iteration : 49       Time : 0.245    Time step : 0.005    CFL : 0.0001137881233
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06696815821,  y: 0.0004946328573,  z: -0.000494634507,  v_x: -0.2329612793,  v_y: -6.462883082e-05,  vz: 6.461700708e-05
+id: 0,  x: -0.0669681438,  y: 0.0004946329941,  z: -0.0004946281957,  v_x: -0.2329611567,  v_y: -6.464028459e-05,  vz: 6.468731466e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 49
 DEM contact search at dem step 0
@@ -1232,17 +1232,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.103332859e-14 s^-1
-Max Local Mass Source: 5.501632276e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439644753e-06
+Mass Source: 2.097986511e-14 s^-1
+Max Local Mass Source: 5.503378335e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.68360839e-07
 
 *****************************************************************
-Transient iteration : 50       Time : 0.25     Time step : 0.005    CFL : 0.0001138187674
+Transient iteration : 50       Time : 0.25     Time step : 0.005    CFL : 0.0001138772371
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06813298384,  y: 0.0004943118671,  z: -0.0004943135736,  v_x: -0.2329688957,  v_y: -6.377575458e-05,  vz: 6.376488473e-05
+id: 0,  x: -0.06813296884,  y: 0.0004943119444,  z: -0.0004943069111,  v_x: -0.2329687834,  v_y: -6.378811601e-05,  vz: 6.383504162e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 50
 DEM contact search at dem step 0
@@ -1257,17 +1257,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.102322691e-14 s^-1
-Max Local Mass Source: 5.631025567e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439710778e-06
+Mass Source: 2.097225851e-14 s^-1
+Max Local Mass Source: 5.631707052e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.683916244e-07
 
 *****************************************************************
-Transient iteration : 51       Time : 0.255    Time step : 0.005    CFL : 0.0001139912618
+Transient iteration : 51       Time : 0.255    Time step : 0.005    CFL : 0.0001140445868
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.06929784424,  y: 0.0004939955027,  z: -0.0004939972603,  v_x: -0.2329752011,  v_y: -6.277998798e-05,  vz: 6.277039083e-05
+id: 0,  x: -0.06929782869,  y: 0.0004939955127,  z: -0.0004939902445,  v_x: -0.2329750933,  v_y: -6.279450013e-05,  vz: 6.284156326e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 51
 DEM contact search at dem step 0
@@ -1282,17 +1282,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.107081931e-14 s^-1
-Max Local Mass Source: 5.778662041e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439762979e-06
+Mass Source: 2.10260336e-14 s^-1
+Max Local Mass Source: 5.779582178e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684159591e-07
 
 *****************************************************************
-Transient iteration : 52       Time : 0.26     Time step : 0.005    CFL : 0.0001142309369
+Transient iteration : 52       Time : 0.26     Time step : 0.005    CFL : 0.0001142797059
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07046273283,  y: 0.0004936840912,  z: -0.0004936858929,  v_x: -0.2329801865,  v_y: -6.179443604e-05,  vz: 6.178639225e-05
+id: 0,  x: -0.07046271675,  y: 0.0004936840246,  z: -0.0004936785204,  v_x: -0.232980081,  v_y: -6.181060151e-05,  vz: 6.185791327e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 52
 DEM contact search at dem step 0
@@ -1307,17 +1307,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.116891782e-14 s^-1
-Max Local Mass Source: 5.93476457e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439802712e-06
+Mass Source: 2.113172301e-14 s^-1
+Max Local Mass Source: 5.935989786e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684344769e-07
 
 *****************************************************************
-Transient iteration : 53       Time : 0.265    Time step : 0.005    CFL : 0.0001145226184
+Transient iteration : 53       Time : 0.265    Time step : 0.005    CFL : 0.0001145688295
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07162764335,  y: 0.0004933772918,  z: -0.0004933791289,  v_x: -0.2329839811,  v_y: -6.093395906e-05,  vz: 6.092779746e-05
+id: 0,  x: -0.07162762674,  y: 0.0004933771384,  z: -0.0004933713972,  v_x: -0.2329838764,  v_y: -6.095244425e-05,  vz: 6.099992472e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 53
 DEM contact search at dem step 0
@@ -1332,17 +1332,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.130922733e-14 s^-1
-Max Local Mass Source: 6.093125412e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439831659e-06
+Mass Source: 2.128002008e-14 s^-1
+Max Local Mass Source: 6.094668903e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684479699e-07
 
 *****************************************************************
-Transient iteration : 54       Time : 0.27     Time step : 0.005    CFL : 0.0001148554041
+Transient iteration : 54       Time : 0.27     Time step : 0.005    CFL : 0.000114900963
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07279257023,  y: 0.0004930742469,  z: -0.0004930761095,  v_x: -0.2329867457,  v_y: -6.029041855e-05,  vz: 6.028639703e-05
+id: 0,  x: -0.0727925531,  y: 0.0004930739936,  z: -0.0004930680148,  v_x: -0.2329866419,  v_y: -6.031190326e-05,  vz: 6.035943557e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 54
 DEM contact search at dem step 0
@@ -1357,17 +1357,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.148460737e-14 s^-1
-Max Local Mass Source: 6.250082023e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439851454e-06
+Mass Source: 2.14630007e-14 s^-1
+Max Local Mass Source: 6.251812944e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684572032e-07
 
 *****************************************************************
-Transient iteration : 55       Time : 0.275    Time step : 0.005    CFL : 0.000115222184
+Transient iteration : 55       Time : 0.275    Time step : 0.005    CFL : 0.0001152684151
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07395750874,  y: 0.0004927736868,  z: -0.0004927755635,  v_x: -0.2329886361,  v_y: -5.993715085e-05,  vz: 5.993551909e-05
+id: 0,  x: -0.07395749109,  y: 0.0004927733169,  z: -0.0004927671005,  v_x: -0.2329885343,  v_y: -5.996226715e-05,  vz: 6.000979401e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 55
 DEM contact search at dem step 0
@@ -1382,17 +1382,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.168866335e-14 s^-1
-Max Local Mass Source: 6.403231701e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439863545e-06
+Mass Source: 2.167421503e-14 s^-1
+Max Local Mass Source: 6.405023405e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684628533e-07
 
 *****************************************************************
-Transient iteration : 56       Time : 0.28     Time step : 0.005    CFL : 0.0001156184426
+Transient iteration : 56       Time : 0.28     Time step : 0.005    CFL : 0.0001156659766
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07512245483,  y: 0.000492474013,  z: -0.0004924758911,  v_x: -0.2329897908,  v_y: -5.993244268e-05,  vz: 5.99334346e-05
+id: 0,  x: -0.07512243668,  y: 0.0004924735068,  z: -0.0004924670527,  v_x: -0.2329896921,  v_y: -5.996175235e-05,  vz: 6.000931329e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 56
 DEM contact search at dem step 0
@@ -1407,17 +1407,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.191625378e-14 s^-1
-Max Local Mass Source: 6.550979623e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439869169e-06
+Mass Source: 2.190851537e-14 s^-1
+Max Local Mass Source: 6.552752241e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684654969e-07
 
 *****************************************************************
-Transient iteration : 57       Time : 0.285    Time step : 0.005    CFL : 0.000117297376
+Transient iteration : 57       Time : 0.285    Time step : 0.005    CFL : 0.0001173368866
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07628740514,  y: 0.0004921733668,  z: -0.0004921752328,  v_x: -0.2329903276,  v_y: -6.032213731e-05,  vz: 6.032596405e-05
+id: 0,  x: -0.07628738651,  y: 0.0004921727024,  z: -0.00049216601,  v_x: -0.2329902337,  v_y: -6.035609056e-05,  vz: 6.040382512e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 57
 DEM contact search at dem step 0
@@ -1432,17 +1432,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.216316718e-14 s^-1
-Max Local Mass Source: 6.692234766e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439869365e-06
+Mass Source: 2.216183338e-14 s^-1
+Max Local Mass Source: 6.693977961e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.68465618e-07
 
 *****************************************************************
-Transient iteration : 58       Time : 0.29     Time step : 0.005    CFL : 0.0001201515113
+Transient iteration : 58       Time : 0.29     Time step : 0.005    CFL : 0.0001201933932
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07745235683,  y: 0.000491869687,  z: -0.0004918715262,  v_x: -0.2329903459,  v_y: -6.114159445e-05,  vz: 6.114844596e-05
+id: 0,  x: -0.07745233774,  y: 0.0004918688401,  z: -0.0004918619081,  v_x: -0.2329902581,  v_y: -6.118056801e-05,  vz: 6.122869636e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 58
 DEM contact search at dem step 0
@@ -1457,17 +1457,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.242609294e-14 s^-1
-Max Local Mass Source: 6.826261322e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439865007e-06
+Mass Source: 2.243095861e-14 s^-1
+Max Local Mass Source: 6.828009892e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684636217e-07
 
 *****************************************************************
-Transient iteration : 59       Time : 0.295    Time step : 0.005    CFL : 0.0001229856655
+Transient iteration : 59       Time : 0.295    Time step : 0.005    CFL : 0.0001230294957
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0786173075,  y: 0.0004915607577,  z: -0.0004915625547,  v_x: -0.2329899291,  v_y: -6.241733758e-05,  vz: 6.242738673e-05
+id: 0,  x: -0.078617288,  y: 0.0004915597025,  z: -0.0004915525282,  v_x: -0.2329898483,  v_y: -6.246167157e-05,  vz: 6.251046176e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 59
 DEM contact search at dem step 0
@@ -1482,17 +1482,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.270238524e-14 s^-1
-Max Local Mass Source: 6.952569556e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439856829e-06
+Mass Source: 2.271334135e-14 s^-1
+Max Local Mass Source: 6.954371854e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684598489e-07
 
 *****************************************************************
-Transient iteration : 60       Time : 0.3      Time step : 0.005    CFL : 0.0001258011282
+Transient iteration : 60       Time : 0.3      Time step : 0.005    CFL : 0.0001258465941
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.07978225517,  y: 0.0004912442496,  z: -0.0004912459879,  v_x: -0.2329891472,  v_y: -6.416838455e-05,  vz: 6.41817937e-05
+id: 0,  x: -0.07978223529,  y: 0.0004912429583,  z: -0.0004912355377,  v_x: -0.2329890742,  v_y: -6.421843043e-05,  vz: 6.426816418e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 60
 DEM contact search at dem step 0
@@ -1507,17 +1507,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.29899517e-14 s^-1
-Max Local Mass Source: 7.070847103e-09 s^-1
-Average Void Fraction in Bed: 0.9999925594
-Total particles kinetic energy: 2.439845453e-06
+Mass Source: 2.300693401e-14 s^-1
+Max Local Mass Source: 7.07273603e-09 s^-1
+Average Void Fraction in Bed: 0.9999926104
+Total particles kinetic energy: 5.684545885e-07
 
 *****************************************************************
-Transient iteration : 61       Time : 0.305    Time step : 0.005    CFL : 0.0001285986918
+Transient iteration : 61       Time : 0.305    Time step : 0.005    CFL : 0.000128645653
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08094719816,  y: 0.0004909177543,  z: -0.0004909194165,  v_x: -0.2329880596,  v_y: -6.640738218e-05,  vz: 6.642430763e-05
+id: 0,  x: -0.08094717793,  y: 0.0004909161973,  z: -0.0004909085249,  v_x: -0.2329879949,  v_y: -6.646352264e-05,  vz: 6.65144702e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 61
 DEM contact search at dem step 0
@@ -1532,17 +1532,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 1.519038907e-14 s^-1
-Max Local Mass Source: 2.129196158e-08 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439857033e-06
+Mass Source: 1.512963674e-14 s^-1
+Max Local Mass Source: 2.129123016e-08 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.684600201e-07
 
 *****************************************************************
-Transient iteration : 62       Time : 0.31     Time step : 0.005    CFL : 0.0001325209667
+Transient iteration : 62       Time : 0.31     Time step : 0.005    CFL : 0.000132575081
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08211214125,  y: 0.0004905803036,  z: -0.000490581874,  v_x: -0.2329891642,  v_y: -6.855142032e-05,  vz: 6.857125659e-05
+id: 0,  x: -0.08211212071,  y: 0.0004905784527,  z: -0.000490570522,  v_x: -0.2329891068,  v_y: -6.861283856e-05,  vz: 6.866520852e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 62
 DEM contact search at dem step 0
@@ -1557,17 +1557,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.467109223e-14 s^-1
-Max Local Mass Source: 9.209868278e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439221532e-06
+Mass Source: 2.454700595e-14 s^-1
+Max Local Mass Source: 9.217689819e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.681639925e-07
 
 *****************************************************************
-Transient iteration : 63       Time : 0.315    Time step : 0.005    CFL : 0.0001345457897
+Transient iteration : 63       Time : 0.315    Time step : 0.005    CFL : 0.000134575014
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08327693383,  y: 0.0004902269676,  z: -0.0004902284318,  v_x: -0.2329284757,  v_y: -7.274110213e-05,  vz: 7.276367927e-05
+id: 0,  x: -0.08327691304,  y: 0.0004902248038,  z: -0.000490216606,  v_x: -0.2329284313,  v_y: -7.280479948e-05,  vz: 7.285922161e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 63
 DEM contact search at dem step 0
@@ -1582,17 +1582,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.560100818e-14 s^-1
-Max Local Mass Source: 6.210428887e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439186074e-06
+Mass Source: 2.551189918e-14 s^-1
+Max Local Mass Source: 6.211132506e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.681474054e-07
 
 *****************************************************************
-Transient iteration : 64       Time : 0.32     Time step : 0.005    CFL : 0.00013074889
+Transient iteration : 64       Time : 0.32     Time step : 0.005    CFL : 0.0001308014533
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08444156766,  y: 0.0004898624013,  z: -0.0004898637507,  v_x: -0.2329250895,  v_y: -7.308200809e-05,  vz: 7.31053545e-05
+id: 0,  x: -0.08444154661,  y: 0.0004898599002,  z: -0.0004898514088,  v_x: -0.232925031,  v_y: -7.315313329e-05,  vz: 7.321609508e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 64
 DEM contact search at dem step 0
@@ -1607,17 +1607,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.573756693e-14 s^-1
-Max Local Mass Source: 4.971101896e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439252303e-06
+Mass Source: 2.563841556e-14 s^-1
+Max Local Mass Source: 4.974498406e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.681782444e-07
 
 *****************************************************************
-Transient iteration : 65       Time : 0.325    Time step : 0.005    CFL : 0.0001283718198
+Transient iteration : 65       Time : 0.325    Time step : 0.005    CFL : 0.0001284148241
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08560620908,  y: 0.0004894975753,  z: -0.0004894988056,  v_x: -0.2329314141,  v_y: -7.285070096e-05,  vz: 7.28749753e-05
+id: 0,  x: -0.08560618773,  y: 0.0004894947343,  z: -0.0004894859247,  v_x: -0.2329313527,  v_y: -7.291559956e-05,  vz: 7.297992225e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 65
 DEM contact search at dem step 0
@@ -1632,17 +1632,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.600001074e-14 s^-1
-Max Local Mass Source: 4.329394774e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439318746e-06
+Mass Source: 2.590215379e-14 s^-1
+Max Local Mass Source: 4.331404253e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.682091869e-07
 
 *****************************************************************
-Transient iteration : 66       Time : 0.33     Time step : 0.005    CFL : 0.0001269051327
+Transient iteration : 66       Time : 0.33     Time step : 0.005    CFL : 0.0001269520853
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08677088217,  y: 0.0004891338387,  z: -0.0004891349465,  v_x: -0.232937759,  v_y: -7.264600765e-05,  vz: 7.267071363e-05
+id: 0,  x: -0.08677086051,  y: 0.000489130673,  z: -0.0004891215409,  v_x: -0.2329376953,  v_y: -7.271097538e-05,  vz: 7.277563952e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 66
 DEM contact search at dem step 0
@@ -1657,17 +1657,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.649317323e-14 s^-1
-Max Local Mass Source: 4.184844242e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439360143e-06
+Mass Source: 2.638658427e-14 s^-1
+Max Local Mass Source: 4.187176995e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.682284537e-07
 
 *****************************************************************
-Transient iteration : 67       Time : 0.335    Time step : 0.005    CFL : 0.0001258861655
+Transient iteration : 67       Time : 0.335    Time step : 0.005    CFL : 0.0001259317324
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08793558095,  y: 0.0004887705122,  z: -0.0004887714971,  v_x: -0.2329417122,  v_y: -7.268420001e-05,  vz: 7.270866886e-05
+id: 0,  x: -0.08793555896,  y: 0.0004887670324,  z: -0.0004887575703,  v_x: -0.2329416445,  v_y: -7.274493796e-05,  vz: 7.281222893e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 67
 DEM contact search at dem step 0
@@ -1682,17 +1682,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.718239026e-14 s^-1
-Max Local Mass Source: 4.057061876e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439370594e-06
+Mass Source: 2.708304166e-14 s^-1
+Max Local Mass Source: 4.060287605e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.682333167e-07
 
 *****************************************************************
-Transient iteration : 68       Time : 0.34     Time step : 0.005    CFL : 0.0001250979491
+Transient iteration : 68       Time : 0.34     Time step : 0.005    CFL : 0.0001251410136
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.08910029203,  y: 0.0004884060365,  z: -0.0004884069012,  v_x: -0.2329427099,  v_y: -7.310189664e-05,  vz: 7.312551391e-05
+id: 0,  x: -0.08910026969,  y: 0.0004884022537,  z: -0.000488392457,  v_x: -0.232942641,  v_y: -7.316236526e-05,  vz: 7.322893313e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 68
 DEM contact search at dem step 0
@@ -1707,17 +1707,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.804880104e-14 s^-1
-Max Local Mass Source: 4.223686927e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439349901e-06
+Mass Source: 2.795528704e-14 s^-1
+Max Local Mass Source: 4.213504135e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.682236785e-07
 
 *****************************************************************
-Transient iteration : 69       Time : 0.345    Time step : 0.005    CFL : 0.0001244392144
+Transient iteration : 69       Time : 0.345    Time step : 0.005    CFL : 0.0001244813047
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09026500059,  y: 0.0004880382422,  z: -0.0004880389923,  v_x: -0.2329407333,  v_y: -7.400679326e-05,  vz: 7.402904e-05
+id: 0,  x: -0.09026497791,  y: 0.0004880341494,  z: -0.0004880240281,  v_x: -0.2329406649,  v_y: -7.407029156e-05,  vz: 7.413357579e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 69
 DEM contact search at dem step 0
@@ -1732,17 +1732,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 2.905501888e-14 s^-1
-Max Local Mass Source: 4.443916413e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439299508e-06
+Mass Source: 2.896757348e-14 s^-1
+Max Local Mass Source: 4.433659476e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.682002174e-07
 
 *****************************************************************
-Transient iteration : 70       Time : 0.35     Time step : 0.005    CFL : 0.000123863166
+Transient iteration : 70       Time : 0.35     Time step : 0.005    CFL : 0.0001239049859
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0914296921,  y: 0.000487664472,  z: -0.0004876651172,  v_x: -0.2329359201,  v_y: -7.548647604e-05,  vz: 7.550619663e-05
+id: 0,  x: -0.09142966909,  y: 0.0004876600498,  z: -0.0004876496235,  v_x: -0.232935855,  v_y: -7.555467975e-05,  vz: 7.561343921e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 70
 DEM contact search at dem step 0
@@ -1757,17 +1757,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.017370152e-14 s^-1
-Max Local Mass Source: 4.661171262e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439221231e-06
+Mass Source: 3.009108954e-14 s^-1
+Max Local Mass Source: 4.65071186e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.681637773e-07
 
 *****************************************************************
-Transient iteration : 71       Time : 0.355    Time step : 0.005    CFL : 0.0001233453923
+Transient iteration : 71       Time : 0.355    Time step : 0.005    CFL : 0.0001233875975
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09259435282,  y: 0.0004872816752,  z: -0.0004872822307,  v_x: -0.2329284439,  v_y: -7.761097689e-05,  vz: 7.762719546e-05
+id: 0,  x: -0.0925943295,  y: 0.0004872768992,  z: -0.0004872661918,  v_x: -0.2329283841,  v_y: -7.7684288e-05,  vz: 7.773800446e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 71
 DEM contact search at dem step 0
@@ -1782,17 +1782,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.138216239e-14 s^-1
-Max Local Mass Source: 4.875019342e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.439116802e-06
+Mass Source: 3.130395444e-14 s^-1
+Max Local Mass Source: 4.864360161e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.681151618e-07
 
 *****************************************************************
-Transient iteration : 72       Time : 0.36     Time step : 0.005    CFL : 0.0001228734241
+Transient iteration : 72       Time : 0.36     Time step : 0.005    CFL : 0.0001229159501
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09375896986,  y: 0.0004868864917,  z: -0.0004868869772,  v_x: -0.2329184697,  v_y: -8.043418862e-05,  vz: 8.04460299e-05
+id: 0,  x: -0.09375894625,  y: 0.0004868813362,  z: -0.0004868703734,  v_x: -0.2329184166,  v_y: -8.051261124e-05,  vz: 8.056113386e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 72
 DEM contact search at dem step 0
@@ -1807,17 +1807,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.266418688e-14 s^-1
-Max Local Mass Source: 5.085419756e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.438987734e-06
+Mass Source: 3.258986332e-14 s^-1
+Max Local Mass Source: 5.074585325e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.680550733e-07
 
 *****************************************************************
-Transient iteration : 73       Time : 0.365    Time step : 0.005    CFL : 0.0001224396891
+Transient iteration : 73       Time : 0.365    Time step : 0.005    CFL : 0.0001224825812
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09492353108,  y: 0.0004864753258,  z: -0.0004864757652,  v_x: -0.2329061421,  v_y: -8.399655309e-05,  vz: 8.400318868e-05
+id: 0,  x: -0.09492350723,  y: 0.0004864697659,  z: -0.0004864585734,  v_x: -0.232906096,  v_y: -8.407984854e-05,  vz: 8.41232319e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 73
 DEM contact search at dem step 0
@@ -1832,17 +1832,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.400728598e-14 s^-1
-Max Local Mass Source: 5.29244437e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.438835302e-06
+Mass Source: 3.393672968e-14 s^-1
+Max Local Mass Source: 5.281462824e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.679841056e-07
 
 *****************************************************************
-Transient iteration : 74       Time : 0.37     Time step : 0.005    CFL : 0.0001220398231
+Transient iteration : 74       Time : 0.37     Time step : 0.005    CFL : 0.0001220830121
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09608802503,  y: 0.0004860444087,  z: -0.0004860448301,  v_x: -0.2328915828,  v_y: -8.832699202e-05,  vz: 8.832762758e-05
+id: 0,  x: -0.09608800096,  y: 0.0004860384207,  z: -0.0004860270239,  v_x: -0.2328915438,  v_y: -8.841484996e-05,  vz: 8.845327257e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 74
 DEM contact search at dem step 0
@@ -1857,17 +1857,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.540247305e-14 s^-1
-Max Local Mass Source: 5.496196655e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.438660574e-06
+Mass Source: 3.533561473e-14 s^-1
+Max Local Mass Source: 5.485086385e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.679027557e-07
 
 *****************************************************************
-Transient iteration : 75       Time : 0.375    Time step : 0.005    CFL : 0.0001216709216
+Transient iteration : 75       Time : 0.375    Time step : 0.005    CFL : 0.0001217143882
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0972524408,  y: 0.0004855898511,  z: -0.0004855902864,  v_x: -0.2328748934,  v_y: -9.344486987e-05,  vz: 9.343872824e-05
+id: 0,  x: -0.09725241656,  y: 0.0004855834133,  z: -0.0004855718363,  v_x: -0.2328748611,  v_y: -9.353689642e-05,  vz: 9.357061759e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 75
 DEM contact search at dem step 0
@@ -1882,17 +1882,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.684300706e-14 s^-1
-Max Local Mass Source: 5.696764668e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 2.438464438e-06
+Mass Source: 3.67799154e-14 s^-1
+Max Local Mass Source: 5.685538193e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 5.678114388e-07
 
 *****************************************************************
-Transient iteration : 76       Time : 0.38     Time step : 0.005    CFL : 0.0001222778452
+Transient iteration : 76       Time : 0.38     Time step : 0.005    CFL : 0.000122326909
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09841676796,  y: 0.0004851076872,  z: -0.0004851081723,  v_x: -0.2328561589,  v_y: -9.936151345e-05,  vz: 9.934783758e-05
+id: 0,  x: -0.09841674357,  y: 0.0004851007799,  z: -0.0004850890453,  v_x: -0.2328561327,  v_y: -9.945725313e-05,  vz: 9.948659107e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 76
 DEM contact search at dem step 0
@@ -1907,17 +1907,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.83240037e-14 s^-1
-Max Local Mass Source: 5.894216451e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 4.801219287e-07
+Mass Source: 3.826475039e-14 s^-1
+Max Local Mass Source: 5.882880321e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.20118056e-08
 
 *****************************************************************
-Transient iteration : 77       Time : 0.385    Time step : 0.005    CFL : 0.0001250607778
+Transient iteration : 77       Time : 0.385    Time step : 0.005    CFL : 0.0001251118355
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.0989309649,  y: 0.000484625687,  z: -0.0004846262551,  v_x: 0.04584803619,  v_y: -0.0001028687375,  vz: 0.0001028476854
+id: 0,  x: -0.09893097323,  y: 0.0004846183131,  z: -0.0004846064498,  v_x: 0.04584704341,  v_y: -0.0001029713252,  vz: 0.0001029960698
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 77
 DEM contact search at dem step 0
@@ -1932,17 +1932,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 3.964665464e-14 s^-1
-Max Local Mass Source: 5.791278719e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.50178861e-07
+Mass Source: 3.959129631e-14 s^-1
+Max Local Mass Source: 5.779387894e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.15344162e-09
 
 *****************************************************************
-Transient iteration : 78       Time : 0.39     Time step : 0.005    CFL : 0.000124457973
+Transient iteration : 78       Time : 0.39     Time step : 0.005    CFL : 0.0001245088414
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09878128188,  y: 0.0004841047809,  z: -0.0004841054617,  v_x: 0.01434024936,  v_y: -0.0001054677025,  vz: 0.0001054436842
+id: 0,  x: -0.09878129501,  y: 0.0004840968925,  z: -0.0004840849083,  v_x: 0.01433932466,  v_y: -0.0001055709043,  vz: 0.0001055945519
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 78
 DEM contact search at dem step 0
@@ -1957,17 +1957,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.083582346e-14 s^-1
-Max Local Mass Source: 5.718690624e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.624187625e-07
+Mass Source: 4.078957283e-14 s^-1
+Max Local Mass Source: 5.706452273e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.51938082e-09
 
 *****************************************************************
-Transient iteration : 79       Time : 0.395    Time step : 0.005    CFL : 0.0001240244307
+Transient iteration : 79       Time : 0.395    Time step : 0.005    CFL : 0.0001240708021
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09878495028,  y: 0.0004835742062,  z: -0.0004835750113,  v_x: -0.01550911478,  v_y: -0.0001067493675,  vz: 0.000106723693
+id: 0,  x: -0.09878496794,  y: 0.0004835658012,  z: -0.0004835537014,  v_x: -0.01551000666,  v_y: -0.000106852803,  vz: 0.0001068753926
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 79
 DEM contact search at dem step 0
@@ -1982,17 +1982,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.192973142e-14 s^-1
-Max Local Mass Source: 5.661491548e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 4.670247691e-07
+Mass Source: 4.189294195e-14 s^-1
+Max Local Mass Source: 5.648902308e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.082897757e-08
 
 *****************************************************************
-Transient iteration : 80       Time : 0.4      Time step : 0.005    CFL : 0.000123683106
+Transient iteration : 80       Time : 0.4      Time step : 0.005    CFL : 0.0001237276205
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09893594357,  y: 0.0004830373949,  z: -0.0004830383329,  v_x: -0.04459731904,  v_y: -0.0001079630181,  vz: 0.0001079355424
+id: 0,  x: -0.09893596561,  y: 0.0004830284713,  z: -0.0004830162617,  v_x: -0.04459817802,  v_y: -0.0001080670328,  vz: 0.0001080883782
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 80
 DEM contact search at dem step 0
@@ -2007,17 +2007,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.296518976e-14 s^-1
-Max Local Mass Source: 5.624227195e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 5.795441514e-08
+Mass Source: 4.29353955e-14 s^-1
+Max Local Mass Source: 5.611251899e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 3.206897911e-10
 
 *****************************************************************
-Transient iteration : 81       Time : 0.405    Time step : 0.005    CFL : 0.0001235193454
+Transient iteration : 81       Time : 0.405    Time step : 0.005    CFL : 0.0001235647935
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09899922436,  y: 0.0004825679687,  z: -0.0004825690323,  v_x: -0.005532646462,  v_y: -9.388624718e-05,  vz: 9.385980779e-05
+id: 0,  x: -0.09899921903,  y: 0.0004825601469,  z: -0.00048254785,  v_x: -0.005532282537,  v_y: -9.345096873e-05,  vz: 9.346724122e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 81
 DEM contact search at dem step 0
@@ -2032,17 +2032,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.394332645e-14 s^-1
-Max Local Mass Source: 5.572900245e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.543461424e-09
+Mass Source: 4.39231133e-14 s^-1
+Max Local Mass Source: 5.561429041e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.264676969e-13
 
 *****************************************************************
-Transient iteration : 82       Time : 0.41     Time step : 0.005    CFL : 0.0001231777109
+Transient iteration : 82       Time : 0.41     Time step : 0.005    CFL : 0.0001232254468
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192704,  y: 0.0004821637751,  z: -0.0004821649541,  v_x: 6.992716306e-05,  v_y: -9.175730776e-05,  vz: 9.173066383e-05
+id: 0,  x: -0.09900192709,  y: 0.0004821555181,  z: -0.0004821431518,  v_x: 7.000584897e-05,  v_y: -9.143974132e-05,  vz: 9.145505378e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 82
 DEM contact search at dem step 0
@@ -2057,17 +2057,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.488382443e-14 s^-1
-Max Local Mass Source: 5.524292414e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.236934891e-09
+Mass Source: 4.484999521e-14 s^-1
+Max Local Mass Source: 5.514809195e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.462059704e-13
 
 *****************************************************************
-Transient iteration : 83       Time : 0.415    Time step : 0.005    CFL : 0.0001228360246
+Transient iteration : 83       Time : 0.415    Time step : 0.005    CFL : 0.0001228836757
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192283,  y: 0.0004817564122,  z: -0.0004817577106,  v_x: -4.860981218e-07,  v_y: -8.353410388e-05,  vz: 8.350937941e-05
+id: 0,  x: -0.09900192283,  y: 0.0004817477021,  z: -0.0004817352683,  v_x: -4.871872513e-07,  v_y: -8.354376715e-05,  vz: 8.355742553e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 83
 DEM contact search at dem step 0
@@ -2082,17 +2082,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.578717429e-14 s^-1
-Max Local Mass Source: 5.478239529e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.107916953e-09
+Mass Source: 4.574546585e-14 s^-1
+Max Local Mass Source: 5.469961345e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.183973958e-13
 
 *****************************************************************
-Transient iteration : 84       Time : 0.42     Time step : 0.005    CFL : 0.0001225087605
+Transient iteration : 84       Time : 0.42     Time step : 0.005    CFL : 0.0001225561674
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.000481345377,  z: -0.0004813467984,  v_x: 1.478419538e-09,  v_y: -7.482200497e-05,  vz: 7.479934975e-05
+id: 0,  x: -0.09900192269,  y: 0.0004813362624,  z: -0.0004813237624,  v_x: 1.488832633e-09,  v_y: -7.518087672e-05,  vz: 7.519278056e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 84
 DEM contact search at dem step 0
@@ -2107,17 +2107,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.666530874e-14 s^-1
-Max Local Mass Source: 5.434174817e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.02065824e-09
+Mass Source: 4.661418548e-14 s^-1
+Max Local Mass Source: 5.426760101e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.012783619e-13
 
 *****************************************************************
-Transient iteration : 85       Time : 0.425    Time step : 0.005    CFL : 0.0001221920024
+Transient iteration : 85       Time : 0.425    Time step : 0.005    CFL : 0.0001222394019
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004809305673,  z: -0.0004809321151,  v_x: 2.081883897e-11,  v_y: -6.892935583e-05,  vz: 6.890793248e-05
+id: 0,  x: -0.09900192269,  y: 0.0004809211049,  z: -0.0004809085399,  v_x: 2.075300236e-11,  v_y: -6.953379406e-05,  vz: 6.954439326e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 85
 DEM contact search at dem step 0
@@ -2132,17 +2132,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.752112623e-14 s^-1
-Max Local Mass Source: 5.391583907e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.009581438e-09
+Mass Source: 4.746274222e-14 s^-1
+Max Local Mass Source: 5.384809236e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 9.926079107e-14
 
 *****************************************************************
-Transient iteration : 86       Time : 0.43     Time step : 0.005    CFL : 0.000121965755
+Transient iteration : 86       Time : 0.43     Time step : 0.005    CFL : 0.0001220166483
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004805123962,  z: -0.0004805140738,  v_x: -3.892581759e-13,  v_y: -6.818154585e-05,  vz: 6.815984864e-05
+id: 0,  x: -0.09900192269,  y: 0.0004805026302,  z: -0.0004804900015,  v_x: -3.525198585e-13,  v_y: -6.883791097e-05,  vz: 6.884801628e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 86
 DEM contact search at dem step 0
@@ -2157,17 +2157,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.835966823e-14 s^-1
-Max Local Mass Source: 5.350161534e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.081081125e-09
+Mass Source: 4.829504724e-14 s^-1
+Max Local Mass Source: 5.34384987e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.131795643e-13
 
 *****************************************************************
-Transient iteration : 87       Time : 0.435    Time step : 0.005    CFL : 0.000121960124
+Transient iteration : 87       Time : 0.435    Time step : 0.005    CFL : 0.0001220109665
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.000480091711,  z: -0.0004800935215,  v_x: -3.017014585e-13,  v_y: -7.301042144e-05,  vz: 7.298682306e-05
+id: 0,  x: -0.09900192269,  y: 0.0004800816563,  z: -0.0004800689654,  v_x: -3.390609356e-13,  v_y: -7.350615633e-05,  vz: 7.35166461e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 87
 DEM contact search at dem step 0
@@ -2182,17 +2182,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.918302864e-14 s^-1
-Max Local Mass Source: 5.309646275e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.21119084e-09
+Mass Source: 4.911376277e-14 s^-1
+Max Local Mass Source: 5.303919935e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.407749434e-13
 
 *****************************************************************
-Transient iteration : 88       Time : 0.44     Time step : 0.005    CFL : 0.0001219527087
+Transient iteration : 88       Time : 0.44     Time step : 0.005    CFL : 0.0001220030162
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004796695079,  z: -0.0004796714542,  v_x: -7.728771791e-13,  v_y: -8.179743868e-05,  vz: 8.177079042e-05
+id: 0,  x: -0.09900192269,  y: 0.000479659144,  z: -0.0004796463925,  v_x: -7.462692471e-13,  v_y: -8.197905718e-05,  vz: 8.199055464e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 88
 DEM contact search at dem step 0
@@ -2207,17 +2207,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 4.999357605e-14 s^-1
-Max Local Mass Source: 5.269872427e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.354383529e-09
+Mass Source: 4.992060516e-14 s^-1
+Max Local Mass Source: 5.264744234e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.745963515e-13
 
 *****************************************************************
-Transient iteration : 89       Time : 0.445    Time step : 0.005    CFL : 0.0001219430181
+Transient iteration : 89       Time : 0.445    Time step : 0.005    CFL : 0.0001219927907
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004792465889,  z: -0.0004792486737,  v_x: -1.17058287e-12,  v_y: -9.146799191e-05,  vz: 9.14380441e-05
+id: 0,  x: -0.09900192269,  y: 0.0004792358665,  z: -0.0004792230562,  v_x: -1.119272831e-12,  v_y: -9.12973557e-05,  vz: 9.131000096e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 89
 DEM contact search at dem step 0
@@ -2232,17 +2232,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.079256394e-14 s^-1
-Max Local Mass Source: 5.230710894e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.460272153e-09
+Mass Source: 5.07167328e-14 s^-1
+Max Local Mass Source: 5.226091432e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.019439241e-13
 
 *****************************************************************
-Transient iteration : 90       Time : 0.45     Time step : 0.005    CFL : 0.0001219310991
+Transient iteration : 90       Time : 0.45     Time step : 0.005    CFL : 0.0001219803768
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004788232869,  z: -0.0004788255127,  v_x: -1.322252658e-12,  v_y: -9.861926439e-05,  vz: 9.85867597e-05
+id: 0,  x: -0.09900192269,  y: 0.0004788121451,  z: -0.000478799278,  v_x: -1.280758944e-12,  v_y: -9.81875585e-05,  vz: 9.820095522e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 90
 DEM contact search at dem step 0
@@ -2257,17 +2257,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.158112502e-14 s^-1
-Max Local Mass Source: 5.192076428e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.4920839e-09
+Mass Source: 5.150293458e-14 s^-1
+Max Local Mass Source: 5.187888254e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.105672076e-13
 
 *****************************************************************
-Transient iteration : 91       Time : 0.455    Time step : 0.005    CFL : 0.0001219168798
+Transient iteration : 91       Time : 0.455    Time step : 0.005    CFL : 0.0001219658748
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004783993639,  z: -0.0004784017332,  v_x: -1.138747358e-12,  v_y: -0.0001007678588,  vz: 0.0001007342605
+id: 0,  x: -0.09900192269,  y: 0.0004783877524,  z: -0.0004783748301,  v_x: -1.109530224e-12,  v_y: -0.0001002621766,  vz: 0.0001002755359
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 91
 DEM contact search at dem step 0
@@ -2282,17 +2282,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.23599362e-14 s^-1
-Max Local Mass Source: 5.153904117e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.440143225e-09
+Mass Source: 5.227976182e-14 s^-1
+Max Local Mass Source: 5.150087755e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.966610644e-13
 
 *****************************************************************
-Transient iteration : 92       Time : 0.46     Time step : 0.005    CFL : 0.0001219004565
+Transient iteration : 92       Time : 0.46     Time step : 0.005    CFL : 0.0001219493664
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004779741215,  z: -0.0004779766371,  v_x: -5.908085967e-13,  v_y: -9.72603538e-05,  vz: 9.722730992e-05
+id: 0,  x: -0.09900192269,  y: 0.000477962018,  z: -0.0004779490423,  v_x: -5.832869084e-13,  v_y: -9.689514828e-05,  vz: 9.690757735e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 92
 DEM contact search at dem step 0
@@ -2307,17 +2307,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.312955503e-14 s^-1
-Max Local Mass Source: 5.116148113e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.325430335e-09
+Mass Source: 5.304760992e-14 s^-1
+Max Local Mass Source: 5.112661535e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.676070045e-13
 
 *****************************************************************
-Transient iteration : 93       Time : 0.465    Time step : 0.005    CFL : 0.0001218818901
+Transient iteration : 93       Time : 0.465    Time step : 0.005    CFL : 0.0001219309047
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004775466808,  z: -0.0004775493457,  v_x: 5.662613137e-14,  v_y: -8.951362035e-05,  vz: 8.948236044e-05
+id: 0,  x: -0.09900192269,  y: 0.0004775340978,  z: -0.0004775210703,  v_x: 4.178908259e-14,  v_y: -8.945208881e-05,  vz: 8.946291839e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 93
 DEM contact search at dem step 0
@@ -2332,17 +2332,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.389035694e-14 s^-1
-Max Local Mass Source: 5.078773048e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.191902432e-09
+Mass Source: 5.380677712e-14 s^-1
+Max Local Mass Source: 5.075593058e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.367184479e-13
 
 *****************************************************************
-Transient iteration : 94       Time : 0.47     Time step : 0.005    CFL : 0.0001218612833
+Transient iteration : 94       Time : 0.47     Time step : 0.005    CFL : 0.0001219105202
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004771163237,  z: -0.0004771191412,  v_x: 5.034368975e-13,  v_y: -8.049624659e-05,  vz: 8.046713173e-05
+id: 0,  x: -0.09900192269,  y: 0.0004771033031,  z: -0.0004770902251,  v_x: 4.658996071e-13,  v_y: -8.079044074e-05,  vz: 8.079947253e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 94
 DEM contact search at dem step 0
@@ -2357,17 +2357,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.46426528e-14 s^-1
-Max Local Mass Source: 5.041752709e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.090374699e-09
+Mass Source: 5.455750558e-14 s^-1
+Max Local Mass Source: 5.038872223e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.153578765e-13
 
 *****************************************************************
-Transient iteration : 95       Time : 0.475    Time step : 0.005    CFL : 0.0001218387212
+Transient iteration : 95       Time : 0.475    Time step : 0.005    CFL : 0.0001218882313
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004766827737,  z: -0.0004766857471,  v_x: 5.673611412e-13,  v_y: -7.363996281e-05,  vz: 7.361235448e-05
+id: 0,  x: -0.09900192269,  y: 0.0004766693701,  z: -0.000476656243,  v_x: 5.368234072e-13,  v_y: -7.421165799e-05,  vz: 7.421923999e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 95
 DEM contact search at dem step 0
@@ -2382,17 +2382,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.538667982e-14 s^-1
-Max Local Mass Source: 5.005066822e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.059872649e-09
+Mass Source: 5.530000819e-14 s^-1
+Max Local Mass Source: 5.002491378e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.093382772e-13
 
 *****************************************************************
-Transient iteration : 96       Time : 0.48     Time step : 0.005    CFL : 0.0001218142955
+Transient iteration : 96       Time : 0.48     Time step : 0.005    CFL : 0.0001218640567
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004762463145,  z: -0.0004762494471,  v_x: 3.144780046e-13,  v_y: -7.158029881e-05,  vz: 7.155279436e-05
+id: 0,  x: -0.09900192269,  y: 0.000476232574,  z: -0.0004762193991,  v_x: 3.190726121e-13,  v_y: -7.224970237e-05,  vz: 7.22566044e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 96
 DEM contact search at dem step 0
@@ -2407,17 +2407,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.612264015e-14 s^-1
-Max Local Mass Source: 4.968700074e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.113311002e-09
+Mass Source: 5.603448242e-14 s^-1
+Max Local Mass Source: 4.966442905e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.201610292e-13
 
 *****************************************************************
-Transient iteration : 97       Time : 0.485    Time step : 0.005    CFL : 0.0001217880899
+Transient iteration : 97       Time : 0.485    Time step : 0.005    CFL : 0.0001218380248
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004758077058,  z: -0.0004758110006,  v_x: -1.271736884e-13,  v_y: -7.518942891e-05,  vz: 7.516037725e-05
+id: 0,  x: -0.09900192269,  y: 0.000475793648,  z: -0.0004757804266,  v_x: -1.36956025e-13,  v_y: -7.574117834e-05,  vz: 7.574831325e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 97
 DEM contact search at dem step 0
@@ -2432,17 +2432,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.68506994e-14 s^-1
-Max Local Mass Source: 4.932640752e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.232760736e-09
+Mass Source: 5.676111318e-14 s^-1
+Max Local Mass Source: 4.930718201e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.46106128e-13
 
 *****************************************************************
-Transient iteration : 98       Time : 0.49     Time step : 0.005    CFL : 0.0001217601883
+Transient iteration : 98       Time : 0.49     Time step : 0.005    CFL : 0.0001218101802
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004753679238,  z: -0.0004753713837,  v_x: -6.557205836e-13,  v_y: -8.325653948e-05,  vz: 8.322464821e-05
+id: 0,  x: -0.09900192269,  y: 0.000475353533,  z: -0.0004753402666,  v_x: -6.313444663e-13,  v_y: -8.351872717e-05,  vz: 8.352682027e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 98
 DEM contact search at dem step 0
@@ -2457,17 +2457,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.757099873e-14 s^-1
-Max Local Mass Source: 4.899548705e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.3760348e-09
+Mass Source: 5.748006983e-14 s^-1
+Max Local Mass Source: 4.89966814e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 1.805388325e-13
 
 *****************************************************************
-Transient iteration : 99       Time : 0.495    Time step : 0.005    CFL : 0.0001217306703
+Transient iteration : 99       Time : 0.495    Time step : 0.005    CFL : 0.0001217805858
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004749278198,  z: -0.0004749314472,  v_x: -1.129845145e-12,  v_y: -9.293258642e-05,  vz: 9.28973975e-05
+id: 0,  x: -0.09900192269,  y: 0.0004749130492,  z: -0.0004748997393,  v_x: -1.073158163e-12,  v_y: -9.283979879e-05,  vz: 9.284912669e-05
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 99
 DEM contact search at dem step 0
@@ -2482,17 +2482,17 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.828365636e-14 s^-1
-Max Local Mass Source: 4.877728079e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.492165188e-09
+Mass Source: 5.819150163e-14 s^-1
+Max Local Mass Source: 4.877701486e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.11109728e-13
 
 *****************************************************************
-Transient iteration : 100      Time : 0.5      Time step : 0.005    CFL : 0.0001216996129
+Transient iteration : 100      Time : 0.5      Time step : 0.005    CFL : 0.0001217493218
 *****************************************************************
 Particle Summary
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-id: 0,  x: -0.09900192269,  y: 0.0004744878208,  z: -0.0004744916181,  v_x: -1.392539367e-12,  v_y: -0.0001007755183,  vz: 0.0001007375779
+id: 0,  x: -0.09900192269,  y: 0.0004744726083,  z: -0.0004744592563,  v_x: -1.341415224e-12,  v_y: -0.000100392796,  vz: 0.0001004030904
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 Starting DEM iterations at step 100
 DEM contact search at dem step 0
@@ -2507,7 +2507,7 @@ DEM contact search at dem step 80
 DEM contact search at dem step 90
 Finished 100 DEM iterations 
 ---------------------------------------------------------------
-Mass Source: 5.898877422e-14 s^-1
-Max Local Mass Source: 4.85623323e-09 s^-1
-Average Void Fraction in Bed: 0.9999928755
-Total particles kinetic energy: 1.540089654e-09
+Mass Source: 5.889553401e-14 s^-1
+Max Local Mass Source: 4.856099789e-09 s^-1
+Average Void Fraction in Bed: 0.9999928036
+Total particles kinetic energy: 2.244284662e-13

--- a/applications_tests/cfd_dem_coupling_3d/restart_particle_sedimentation.output
+++ b/applications_tests/cfd_dem_coupling_3d/restart_particle_sedimentation.output
@@ -37,7 +37,7 @@ Finished 100 DEM iterations
 Mass Source: 2.102603355e-14 s^-1
 Max Local Mass Source: 5.779583296e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439758491e-06
+Total particles kinetic energy: 5.684143823e-07
 
 *****************************************************************
 Transient iteration : 52       Time : 0.26     Time step : 0.005    CFL : 0.0001142797093
@@ -62,7 +62,7 @@ Finished 100 DEM iterations
 Mass Source: 2.113172288e-14 s^-1
 Max Local Mass Source: 5.935990369e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439798977e-06
+Total particles kinetic energy: 5.684332475e-07
 
 *****************************************************************
 Transient iteration : 53       Time : 0.265    Time step : 0.005    CFL : 0.0001145688307
@@ -87,7 +87,7 @@ Finished 100 DEM iterations
 Mass Source: 2.128002014e-14 s^-1
 Max Local Mass Source: 6.094668952e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439828515e-06
+Total particles kinetic energy: 5.684470113e-07
 
 *****************************************************************
 Transient iteration : 54       Time : 0.27     Time step : 0.005    CFL : 0.000114900963
@@ -112,7 +112,7 @@ Finished 100 DEM iterations
 Mass Source: 2.146300113e-14 s^-1
 Max Local Mass Source: 6.251812607e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439848783e-06
+Total particles kinetic energy: 5.684564558e-07
 
 *****************************************************************
 Transient iteration : 55       Time : 0.275    Time step : 0.005    CFL : 0.0001152684144
@@ -137,7 +137,7 @@ Finished 100 DEM iterations
 Mass Source: 2.167421561e-14 s^-1
 Max Local Mass Source: 6.405022803e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439861262e-06
+Total particles kinetic energy: 5.684622706e-07
 
 *****************************************************************
 Transient iteration : 56       Time : 0.28     Time step : 0.005    CFL : 0.0001156659753
@@ -162,7 +162,7 @@ Finished 100 DEM iterations
 Mass Source: 2.190851617e-14 s^-1
 Max Local Mass Source: 6.552751465e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439867211e-06
+Total particles kinetic energy: 5.684650425e-07
 
 *****************************************************************
 Transient iteration : 57       Time : 0.285    Time step : 0.005    CFL : 0.0001173368775
@@ -187,7 +187,7 @@ Finished 100 DEM iterations
 Mass Source: 2.216183438e-14 s^-1
 Max Local Mass Source: 6.693977077e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439867685e-06
+Total particles kinetic energy: 5.684652637e-07
 
 *****************************************************************
 Transient iteration : 58       Time : 0.29     Time step : 0.005    CFL : 0.0001201933821
@@ -212,7 +212,7 @@ Finished 100 DEM iterations
 Mass Source: 2.243095978e-14 s^-1
 Max Local Mass Source: 6.828008949e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439863569e-06
+Total particles kinetic energy: 5.684633455e-07
 
 *****************************************************************
 Transient iteration : 59       Time : 0.295    Time step : 0.005    CFL : 0.0001230294829
@@ -237,7 +237,7 @@ Finished 100 DEM iterations
 Mass Source: 2.271334267e-14 s^-1
 Max Local Mass Source: 6.954370889e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439855603e-06
+Total particles kinetic energy: 5.684596336e-07
 
 *****************************************************************
 Transient iteration : 60       Time : 0.3      Time step : 0.005    CFL : 0.0001258465801
@@ -262,7 +262,7 @@ Finished 100 DEM iterations
 Mass Source: 2.30069354e-14 s^-1
 Max Local Mass Source: 7.072735069e-09 s^-1
 Average Void Fraction in Bed: 0.9999926104
-Total particles kinetic energy: 2.439844416e-06
+Total particles kinetic energy: 5.684544206e-07
 
 *****************************************************************
 Transient iteration : 61       Time : 0.305    Time step : 0.005    CFL : 0.0001286456381
@@ -287,7 +287,7 @@ Finished 100 DEM iterations
 Mass Source: 1.512963371e-14 s^-1
 Max Local Mass Source: 2.129122947e-08 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439856152e-06
+Total particles kinetic energy: 5.684598893e-07
 
 *****************************************************************
 Transient iteration : 62       Time : 0.31     Time step : 0.005    CFL : 0.0001325750778
@@ -312,7 +312,7 @@ Finished 100 DEM iterations
 Mass Source: 2.454700246e-14 s^-1
 Max Local Mass Source: 9.217689261e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439220849e-06
+Total particles kinetic energy: 5.681638905e-07
 
 *****************************************************************
 Transient iteration : 63       Time : 0.315    Time step : 0.005    CFL : 0.0001345749993
@@ -337,7 +337,7 @@ Finished 100 DEM iterations
 Mass Source: 2.551189516e-14 s^-1
 Max Local Mass Source: 6.211132091e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439185291e-06
+Total particles kinetic energy: 5.681473259e-07
 
 *****************************************************************
 Transient iteration : 64       Time : 0.32     Time step : 0.005    CFL : 0.0001308014388
@@ -362,7 +362,7 @@ Finished 100 DEM iterations
 Mass Source: 2.563841118e-14 s^-1
 Max Local Mass Source: 4.974498097e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439251527e-06
+Total particles kinetic energy: 5.681781824e-07
 
 *****************************************************************
 Transient iteration : 65       Time : 0.325    Time step : 0.005    CFL : 0.0001284148098
@@ -387,7 +387,7 @@ Finished 100 DEM iterations
 Mass Source: 2.5902149e-14 s^-1
 Max Local Mass Source: 4.331404122e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439317976e-06
+Total particles kinetic energy: 5.682091387e-07
 
 *****************************************************************
 Transient iteration : 66       Time : 0.33     Time step : 0.005    CFL : 0.000126952071
@@ -412,7 +412,7 @@ Finished 100 DEM iterations
 Mass Source: 2.638657922e-14 s^-1
 Max Local Mass Source: 4.187176877e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439359354e-06
+Total particles kinetic energy: 5.682284161e-07
 
 *****************************************************************
 Transient iteration : 67       Time : 0.335    Time step : 0.005    CFL : 0.0001259317182
@@ -437,7 +437,7 @@ Finished 100 DEM iterations
 Mass Source: 2.708303629e-14 s^-1
 Max Local Mass Source: 4.060287497e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.43936981e-06
+Total particles kinetic energy: 5.682332875e-07
 
 *****************************************************************
 Transient iteration : 68       Time : 0.34     Time step : 0.005    CFL : 0.0001251409995
@@ -462,7 +462,7 @@ Finished 100 DEM iterations
 Mass Source: 2.795528133e-14 s^-1
 Max Local Mass Source: 4.213503071e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439349137e-06
+Total particles kinetic energy: 5.682236559e-07
 
 *****************************************************************
 Transient iteration : 69       Time : 0.345    Time step : 0.005    CFL : 0.0001244812907
@@ -487,7 +487,7 @@ Finished 100 DEM iterations
 Mass Source: 2.89675675e-14 s^-1
 Max Local Mass Source: 4.433658412e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439298788e-06
+Total particles kinetic energy: 5.682001998e-07
 
 *****************************************************************
 Transient iteration : 70       Time : 0.35     Time step : 0.005    CFL : 0.0001239049719
@@ -512,7 +512,7 @@ Finished 100 DEM iterations
 Mass Source: 3.009108322e-14 s^-1
 Max Local Mass Source: 4.650710799e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439220577e-06
+Total particles kinetic energy: 5.681637638e-07
 
 *****************************************************************
 Transient iteration : 71       Time : 0.355    Time step : 0.005    CFL : 0.0001233875836
@@ -537,7 +537,7 @@ Finished 100 DEM iterations
 Mass Source: 3.130394788e-14 s^-1
 Max Local Mass Source: 4.864359105e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.439116224e-06
+Total particles kinetic energy: 5.681151514e-07
 
 *****************************************************************
 Transient iteration : 72       Time : 0.36     Time step : 0.005    CFL : 0.0001229159362
@@ -562,7 +562,7 @@ Finished 100 DEM iterations
 Mass Source: 3.258985657e-14 s^-1
 Max Local Mass Source: 5.074584275e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.438987235e-06
+Total particles kinetic energy: 5.680550653e-07
 
 *****************************************************************
 Transient iteration : 73       Time : 0.365    Time step : 0.005    CFL : 0.0001224825673
@@ -587,7 +587,7 @@ Finished 100 DEM iterations
 Mass Source: 3.39367227e-14 s^-1
 Max Local Mass Source: 5.281461782e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.438834882e-06
+Total particles kinetic energy: 5.679840996e-07
 
 *****************************************************************
 Transient iteration : 74       Time : 0.37     Time step : 0.005    CFL : 0.0001220829982
@@ -612,7 +612,7 @@ Finished 100 DEM iterations
 Mass Source: 3.533560754e-14 s^-1
 Max Local Mass Source: 5.485085351e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.438660227e-06
+Total particles kinetic energy: 5.679027511e-07
 
 *****************************************************************
 Transient iteration : 75       Time : 0.375    Time step : 0.005    CFL : 0.0001217143743
@@ -637,7 +637,7 @@ Finished 100 DEM iterations
 Mass Source: 3.677990789e-14 s^-1
 Max Local Mass Source: 5.685537169e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 2.438464157e-06
+Total particles kinetic energy: 5.678114354e-07
 
 *****************************************************************
 Transient iteration : 76       Time : 0.38     Time step : 0.005    CFL : 0.0001223268883
@@ -662,7 +662,7 @@ Finished 100 DEM iterations
 Mass Source: 3.826474263e-14 s^-1
 Max Local Mass Source: 5.882879307e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 4.801084946e-07
+Total particles kinetic energy: 2.201152651e-08
 
 *****************************************************************
 Transient iteration : 77       Time : 0.385    Time step : 0.005    CFL : 0.0001251118149
@@ -687,7 +687,7 @@ Finished 100 DEM iterations
 Mass Source: 3.959128846e-14 s^-1
 Max Local Mass Source: 5.77938708e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.501663628e-07
+Total particles kinetic energy: 2.153360317e-09
 
 *****************************************************************
 Transient iteration : 78       Time : 0.39     Time step : 0.005    CFL : 0.0001245088231
@@ -712,7 +712,7 @@ Finished 100 DEM iterations
 Mass Source: 4.078956487e-14 s^-1
 Max Local Mass Source: 5.706451552e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.624308553e-07
+Total particles kinetic energy: 2.519465664e-09
 
 *****************************************************************
 Transient iteration : 79       Time : 0.395    Time step : 0.005    CFL : 0.0001240707848
@@ -737,7 +737,7 @@ Finished 100 DEM iterations
 Mass Source: 4.1892934e-14 s^-1
 Max Local Mass Source: 5.648901675e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 4.670364051e-07
+Total particles kinetic energy: 2.082921254e-08
 
 *****************************************************************
 Transient iteration : 80       Time : 0.4      Time step : 0.005    CFL : 0.0001237276043
@@ -762,7 +762,7 @@ Finished 100 DEM iterations
 Mass Source: 4.293538763e-14 s^-1
 Max Local Mass Source: 5.61125142e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 5.794883047e-08
+Total particles kinetic energy: 3.206717729e-10
 
 *****************************************************************
 Transient iteration : 81       Time : 0.405    Time step : 0.005    CFL : 0.0001235647792
@@ -787,7 +787,7 @@ Finished 100 DEM iterations
 Mass Source: 4.392310527e-14 s^-1
 Max Local Mass Source: 5.561428555e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.538615542e-09
+Total particles kinetic energy: 2.260641065e-13
 
 *****************************************************************
 Transient iteration : 82       Time : 0.41     Time step : 0.005    CFL : 0.000123225432
@@ -812,7 +812,7 @@ Finished 100 DEM iterations
 Mass Source: 4.48499868e-14 s^-1
 Max Local Mass Source: 5.514808737e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.237085248e-09
+Total particles kinetic energy: 1.461405166e-13
 
 *****************************************************************
 Transient iteration : 83       Time : 0.415    Time step : 0.005    CFL : 0.0001228836608
@@ -837,7 +837,7 @@ Finished 100 DEM iterations
 Mass Source: 4.574545717e-14 s^-1
 Max Local Mass Source: 5.469960896e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.11473049e-09
+Total particles kinetic energy: 1.186618574e-13
 
 *****************************************************************
 Transient iteration : 84       Time : 0.42     Time step : 0.005    CFL : 0.0001225561526
@@ -862,7 +862,7 @@ Finished 100 DEM iterations
 Mass Source: 4.661417677e-14 s^-1
 Max Local Mass Source: 5.426759647e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.032158493e-09
+Total particles kinetic energy: 1.017335415e-13
 
 *****************************************************************
 Transient iteration : 85       Time : 0.425    Time step : 0.005    CFL : 0.0001222393872
@@ -887,7 +887,7 @@ Finished 100 DEM iterations
 Mass Source: 4.746273363e-14 s^-1
 Max Local Mass Source: 5.384808764e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.022074297e-09
+Total particles kinetic energy: 9.975537741e-14
 
 *****************************************************************
 Transient iteration : 86       Time : 0.43     Time step : 0.005    CFL : 0.0001220166316
@@ -912,7 +912,7 @@ Finished 100 DEM iterations
 Mass Source: 4.829503878e-14 s^-1
 Max Local Mass Source: 5.343849377e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.090511049e-09
+Total particles kinetic energy: 1.135616052e-13
 
 *****************************************************************
 Transient iteration : 87       Time : 0.435    Time step : 0.005    CFL : 0.0001220109499
@@ -937,7 +937,7 @@ Finished 100 DEM iterations
 Mass Source: 4.91137544e-14 s^-1
 Max Local Mass Source: 5.303919422e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.214628767e-09
+Total particles kinetic energy: 1.408829728e-13
 
 *****************************************************************
 Transient iteration : 88       Time : 0.44     Time step : 0.005    CFL : 0.0001220029997
@@ -962,7 +962,7 @@ Finished 100 DEM iterations
 Mass Source: 4.992059669e-14 s^-1
 Max Local Mass Source: 5.264743716e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.351100819e-09
+Total particles kinetic energy: 1.743198711e-13
 
 *****************************************************************
 Transient iteration : 89       Time : 0.445    Time step : 0.005    CFL : 0.0001219927743
@@ -987,7 +987,7 @@ Finished 100 DEM iterations
 Mass Source: 5.071672421e-14 s^-1
 Max Local Mass Source: 5.226090926e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.452007497e-09
+Total particles kinetic energy: 2.01330281e-13
 
 *****************************************************************
 Transient iteration : 90       Time : 0.45     Time step : 0.005    CFL : 0.0001219803605
@@ -1012,7 +1012,7 @@ Finished 100 DEM iterations
 Mass Source: 5.150292555e-14 s^-1
 Max Local Mass Source: 5.187887773e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.482406103e-09
+Total particles kinetic energy: 2.098484524e-13
 
 *****************************************************************
 Transient iteration : 91       Time : 0.455    Time step : 0.005    CFL : 0.0001219658585
@@ -1037,7 +1037,7 @@ Finished 100 DEM iterations
 Mass Source: 5.227975242e-14 s^-1
 Max Local Mass Source: 5.150087303e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.433143547e-09
+Total particles kinetic energy: 1.961330432e-13
 
 *****************************************************************
 Transient iteration : 92       Time : 0.46     Time step : 0.005    CFL : 0.0001219493501
@@ -1062,7 +1062,7 @@ Finished 100 DEM iterations
 Mass Source: 5.30476002e-14 s^-1
 Max Local Mass Source: 5.112661109e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.324222615e-09
+Total particles kinetic energy: 1.674531737e-13
 
 *****************************************************************
 Transient iteration : 93       Time : 0.465    Time step : 0.005    CFL : 0.0001219308885
@@ -1087,7 +1087,7 @@ Finished 100 DEM iterations
 Mass Source: 5.38067671e-14 s^-1
 Max Local Mass Source: 5.075592648e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.197480316e-09
+Total particles kinetic energy: 1.36933008e-13
 
 *****************************************************************
 Transient iteration : 94       Time : 0.47     Time step : 0.005    CFL : 0.000121910504
@@ -1112,7 +1112,7 @@ Finished 100 DEM iterations
 Mass Source: 5.455749542e-14 s^-1
 Max Local Mass Source: 5.038871814e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.101246388e-09
+Total particles kinetic energy: 1.158084838e-13
 
 *****************************************************************
 Transient iteration : 95       Time : 0.475    Time step : 0.005    CFL : 0.0001218882152
@@ -1137,7 +1137,7 @@ Finished 100 DEM iterations
 Mass Source: 5.529999816e-14 s^-1
 Max Local Mass Source: 5.002490955e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.072608338e-09
+Total particles kinetic energy: 1.09863573e-13
 
 *****************************************************************
 Transient iteration : 96       Time : 0.48     Time step : 0.005    CFL : 0.0001218640407
@@ -1162,7 +1162,7 @@ Finished 100 DEM iterations
 Mass Source: 5.60344725e-14 s^-1
 Max Local Mass Source: 4.966442461e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.123801855e-09
+Total particles kinetic energy: 1.206009896e-13
 
 *****************************************************************
 Transient iteration : 97       Time : 0.485    Time step : 0.005    CFL : 0.0001218380089
@@ -1187,7 +1187,7 @@ Finished 100 DEM iterations
 Mass Source: 5.676110333e-14 s^-1
 Max Local Mass Source: 4.930717739e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.237726549e-09
+Total particles kinetic energy: 1.462920733e-13
 
 *****************************************************************
 Transient iteration : 98       Time : 0.49     Time step : 0.005    CFL : 0.0001218101644
@@ -1212,7 +1212,7 @@ Finished 100 DEM iterations
 Mass Source: 5.748005999e-14 s^-1
 Max Local Mass Source: 4.899667809e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.374226846e-09
+Total particles kinetic energy: 1.80338411e-13
 
 *****************************************************************
 Transient iteration : 99       Time : 0.495    Time step : 0.005    CFL : 0.0001217805702
@@ -1237,7 +1237,7 @@ Finished 100 DEM iterations
 Mass Source: 5.819149168e-14 s^-1
 Max Local Mass Source: 4.877701141e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.484823613e-09
+Total particles kinetic energy: 2.105334527e-13
 
 *****************************************************************
 Transient iteration : 100      Time : 0.5      Time step : 0.005    CFL : 0.0001217493062
@@ -1262,4 +1262,4 @@ Finished 100 DEM iterations
 Mass Source: 5.889552371e-14 s^-1
 Max Local Mass Source: 4.856099419e-09 s^-1
 Average Void Fraction in Bed: 0.9999928036
-Total particles kinetic energy: 1.530488716e-09
+Total particles kinetic energy: 2.236823134e-13

--- a/applications_tests/dem_3d/insert_list_3d.output
+++ b/applications_tests/dem_3d/insert_list_3d.output
@@ -17,6 +17,12 @@ This feature is useful in geometries with concave boundaries.
 *****************************************************************
 Transient iteration : 10000    Time : 0.1      Time step : 1e-05   
 *****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 7.5000e+01  | 7.5000e+01 | 7.5000e+01 | 
+| Velocity magnitude           | 4.9990e-01 | 9.9990e-01  | 7.4990e-01 | 4.4994e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 1.6356e-05 | 6.5437e-05  | 4.0896e-05 | 2.4538e-04 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 ***************************************************************** 
 3 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***************************************************************** 

--- a/applications_tests/dem_3d/insert_list_3d.output
+++ b/applications_tests/dem_3d/insert_list_3d.output
@@ -21,7 +21,7 @@ Transient iteration : 10000    Time : 0.1      Time step : 1e-05
 | Contact list generation      | 0.0000e+00 | 7.5000e+01  | 7.5000e+01 | 7.5000e+01 | 
 | Velocity magnitude           | 4.9990e-01 | 9.9990e-01  | 7.4990e-01 | 4.4994e+00 | 
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
-| Translational kinetic energy | 1.6356e-05 | 6.5437e-05  | 4.0896e-05 | 2.4538e-04 | 
+| Translational kinetic energy | 8.1780e-06 | 3.2718e-05  | 2.0448e-05 | 1.2269e-04 | 
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 ***************************************************************** 
 3 particles of type 0 were inserted, 0 particles of type 0 remaining

--- a/applications_tests/dem_3d/insert_periodic_boundary_gmsh.output
+++ b/applications_tests/dem_3d/insert_periodic_boundary_gmsh.output
@@ -1,22 +1,28 @@
 Running on 1 rank(s)
-*****************************************************************
+***************************************************************** 
 
 DEM time-step is 7.71088% of Rayleigh time step
-Reading triangulation
+Reading triangulation 
 
-Finished reading triangulation
+Finished reading triangulation 
 
 Warning: There are diamond-shaped cells in the input triangulation. It is strongly recommended to use a different triangulation without such cells. It should be mentioned that these cells are not detected if you have grid motion
-Warning: expansion of particle-wall contact list is disabled.
-This feature is useful in geometries with concave boundaries.
+Warning: expansion of particle-wall contact list is disabled. 
+This feature is useful in geometries with concave boundaries. 
 
 *****************************************************************
-Transient iteration : 1        Time : 1.5e-06  Time step : 1.5e-06
+Transient iteration : 1        Time : 1.5e-06  Time step : 1.5e-06 
 *****************************************************************
-*****************************************************************
+| Variable                     | Min         | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00  | 0.0000e+00  | 0.0000e+00 | 0.0000e+00 | 
+| Velocity magnitude           | 1.7977e+308 | 2.2251e-308 | -nan       | 0.0000e+00 | 
+| Angular velocity magnitude   | 1.7977e+308 | 2.2251e-308 | -nan       | 0.0000e+00 | 
+| Translational kinetic energy | 1.7977e+308 | 2.2251e-308 | -nan       | 0.0000e+00 | 
+| Rotational kinetic energy    | 1.7977e+308 | 2.2251e-308 | -nan       | 0.0000e+00 | 
+***************************************************************** 
 3 particles of type 0 were inserted, 0 particles of type 0 remaining
-*****************************************************************
-id, type, dp, x, y, z
+***************************************************************** 
+id, type, dp, x, y, z 
 0 0 0.00020 0.0100 0.0020 0.0050
 1 0 0.00020 0.0050 0.0020 0.0050
 2 0 0.00020 0.0020 0.0020 0.0050

--- a/applications_tests/dem_3d/outlet_boundary.output
+++ b/applications_tests/dem_3d/outlet_boundary.output
@@ -5,7 +5,7 @@ DEM time-step is 1.46845% of Rayleigh time step
 Reading triangulation 
 
 Finished reading triangulation 
-Warning: expansion of particle-wall contact list is enabled.
+Warning: expansion of particle-wall contact list is enabled. 
 This feature should only be activated in geometries with concave boundaries. (For example, for particles flow inside a cylinder or sphere). In geometries with convex boundaries, this feature MUST NOT be activated.
 ***************************************************************** 
 200 particles of type 0 were inserted, 0 particles of type 0 remaining

--- a/applications_tests/dem_3d/periodic_boundary_box.output
+++ b/applications_tests/dem_3d/periodic_boundary_box.output
@@ -1,20 +1,26 @@
 Running on 1 rank(s)
-*****************************************************************
+***************************************************************** 
 
 DEM time-step is 1.31342% of Rayleigh time step
-Reading triangulation
+Reading triangulation 
 
-Finished reading triangulation
-Warning: expansion of particle-wall contact list is disabled.
-This feature is useful in geometries with concave boundaries.
-*****************************************************************
+Finished reading triangulation 
+Warning: expansion of particle-wall contact list is disabled. 
+This feature is useful in geometries with concave boundaries. 
+***************************************************************** 
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
-*****************************************************************
+***************************************************************** 
 
 *****************************************************************
-Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05
+Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05 
 *****************************************************************
-id, type, dp, x, y, z
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 2.0000e+02  | 2.0000e+02 | 2.0000e+02 | 
+| Velocity magnitude           | 1.4998e-01 | 1.4998e-01  | 1.4998e-01 | 1.4998e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 1.2423e-05 | 1.2423e-05  | 1.2423e-05 | 1.2423e-04 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+id, type, dp, x, y, z 
 0 0 0.00750 0.0055 0.0443 0.0055
 1 0 0.00750 0.0163 0.0440 0.0050
 2 0 0.00750 0.0274 0.0441 0.0049

--- a/applications_tests/dem_3d/periodic_boundary_box.output
+++ b/applications_tests/dem_3d/periodic_boundary_box.output
@@ -18,7 +18,7 @@ Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05
 | Contact list generation      | 0.0000e+00 | 2.0000e+02  | 2.0000e+02 | 2.0000e+02 | 
 | Velocity magnitude           | 1.4998e-01 | 1.4998e-01  | 1.4998e-01 | 1.4998e+00 | 
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
-| Translational kinetic energy | 1.2423e-05 | 1.2423e-05  | 1.2423e-05 | 1.2423e-04 | 
+| Translational kinetic energy | 6.2114e-06 | 6.2114e-06  | 6.2114e-06 | 6.2114e-05 | 
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 id, type, dp, x, y, z 
 0 0 0.00750 0.0055 0.0443 0.0055

--- a/applications_tests/dem_3d/periodic_boundary_load_balancing.mpirun=2.output
+++ b/applications_tests/dem_3d/periodic_boundary_load_balancing.mpirun=2.output
@@ -1,28 +1,34 @@
 Running on 2 rank(s)
-*****************************************************************
+***************************************************************** 
 
 DEM time-step is 1.31342% of Rayleigh time step
-Reading triangulation
+Reading triangulation 
 
-Finished reading triangulation
-Warning: expansion of particle-wall contact list is disabled.
-This feature is useful in geometries with concave boundaries.
-*****************************************************************
+Finished reading triangulation 
+Warning: expansion of particle-wall contact list is disabled. 
+This feature is useful in geometries with concave boundaries. 
+***************************************************************** 
 10 particles of type 0 were inserted, 0 particles of type 0 remaining
-*****************************************************************
+***************************************************************** 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 5 , 4 and 6
 Minimum and maximum number of cells owned by the processors are 64 and 64
 
 *****************************************************************
-Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05
+Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05 
 *****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 2.0000e+02  | 2.0000e+02 | 2.0000e+02 | 
+| Velocity magnitude           | 1.4998e-01 | 1.4998e-01  | 1.4998e-01 | 1.4998e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 1.2423e-05 | 1.2423e-05  | 1.2423e-05 | 1.2423e-04 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 5 , 2 and 8
 Minimum and maximum number of cells owned by the processors are 64 and 64
-id, type, dp, x, y, z
+id, type, dp, x, y, z 
 0 0 0.00750 0.0055 0.0443 0.0055
 1 0 0.00750 0.0163 0.0440 0.0050
 2 0 0.00750 0.0274 0.0441 0.0049

--- a/applications_tests/dem_3d/periodic_boundary_load_balancing.mpirun=2.output
+++ b/applications_tests/dem_3d/periodic_boundary_load_balancing.mpirun=2.output
@@ -22,7 +22,7 @@ Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05
 | Contact list generation      | 0.0000e+00 | 2.0000e+02  | 2.0000e+02 | 2.0000e+02 | 
 | Velocity magnitude           | 1.4998e-01 | 1.4998e-01  | 1.4998e-01 | 1.4998e+00 | 
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
-| Translational kinetic energy | 1.2423e-05 | 1.2423e-05  | 1.2423e-05 | 1.2423e-04 | 
+| Translational kinetic energy | 6.2114e-06 | 6.2114e-06  | 6.2114e-06 | 6.2114e-05 | 
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 -->Repartitionning triangulation
 Load balance finished 

--- a/applications_tests/dem_3d/periodic_multiple_boundaries.output
+++ b/applications_tests/dem_3d/periodic_multiple_boundaries.output
@@ -18,7 +18,7 @@ Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05
 | Contact list generation      | 0.0000e+00 | 2.0800e+02  | 2.0800e+02 | 2.0800e+02 | 
 | Velocity magnitude           | 2.1211e+00 | 2.1211e+00  | 2.1211e+00 | 4.2422e+00 | 
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
-| Translational kinetic energy | 2.4846e-03 | 2.4846e-03  | 2.4846e-03 | 4.9691e-03 | 
+| Translational kinetic energy | 1.2423e-03 | 1.2423e-03  | 1.2423e-03 | 2.4846e-03 | 
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 id, type, dp, x, y, z 
 0 0 0.00750 0.0400 0.0200 0.0400

--- a/applications_tests/dem_3d/periodic_multiple_boundaries.output
+++ b/applications_tests/dem_3d/periodic_multiple_boundaries.output
@@ -1,19 +1,25 @@
 Running on 1 rank(s)
-*****************************************************************
+***************************************************************** 
 
 DEM time-step is 1.31342% of Rayleigh time step
-Reading triangulation
+Reading triangulation 
 
-Finished reading triangulation
-Warning: expansion of particle-wall contact list is disabled.
-This feature is useful in geometries with concave boundaries.
-*****************************************************************
+Finished reading triangulation 
+Warning: expansion of particle-wall contact list is disabled. 
+This feature is useful in geometries with concave boundaries. 
+***************************************************************** 
 2 particles of type 0 were inserted, 0 particles of type 0 remaining
-*****************************************************************
+***************************************************************** 
 
 *****************************************************************
-Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05
+Transient iteration : 10000    Time : 0.15     Time step : 1.5e-05 
 *****************************************************************
-id, type, dp, x, y, z
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 2.0800e+02  | 2.0800e+02 | 2.0800e+02 | 
+| Velocity magnitude           | 2.1211e+00 | 2.1211e+00  | 2.1211e+00 | 4.2422e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 2.4846e-03 | 2.4846e-03  | 2.4846e-03 | 4.9691e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+id, type, dp, x, y, z 
 0 0 0.00750 0.0400 0.0200 0.0400
 1 0 0.00750 0.0100 0.0400 0.0100

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -387,6 +387,12 @@ public:
     return subdivision;
   }
 
+  unsigned int
+  get_log_frequency() const
+  {
+    return log_frequency;
+  }
+
   Parameters::SimulationControl::TimeSteppingMethod
   get_assembly_method() const
   {

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -33,9 +33,13 @@ using namespace dealii;
 
 class statistics
 {
-
 public:
-  statistics(): min(0),max(0),total(0),average(0){}
+  statistics()
+    : min(0)
+    , max(0)
+    , total(0)
+    , average(0)
+  {}
 
   double min;
   double max;
@@ -49,14 +53,15 @@ public:
  */
 
 inline void
-  add_statistics_to_table_handler(const std::string variable, const statistics stats, TableHandler& table)
+add_statistics_to_table_handler(const std::string variable,
+                                const statistics  stats,
+                                TableHandler &    table)
 {
-    table.add_value("Variable",variable);
-    table.add_value("Min", stats.min);
-    table.add_value("Max", stats.max);
-    table.add_value("Total", stats.total);
-    table.add_value("Average", stats.average);
-
+  table.add_value("Variable", variable);
+  table.add_value("Min", stats.min);
+  table.add_value("Max", stats.max);
+  table.add_value("Total", stats.total);
+  table.add_value("Average", stats.average);
 };
 
 /**
@@ -218,4 +223,3 @@ create_output_folder(const std::string &dirname);
 
 
 #endif
-

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -29,8 +29,9 @@ using namespace dealii;
 
 /**
  * @brief Small class that is used to store statistics (min,max,total,average) of variables that are used in simulations.
- * This small class allows us to agglomerate the statistics instead of returning tuples.
- * For example, this class is used to store the kinetic energy of the particles in the DEM model.
+ * This small class allows us to agglomerate the statistics instead of returning
+ * tuples. For example, this class is used to store the kinetic energy of the
+ * particles in the DEM model.
  */
 
 class statistics

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -31,8 +31,12 @@ using namespace dealii;
  * @brief Small structure used to house statistics (min,max,total,average) that are used in multiple simulations
  */
 
-struct statistics
+class statistics
 {
+
+public:
+  statistics(): min(0),max(0),total(0),average(0){}
+
   double min;
   double max;
   double total;

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -55,7 +55,7 @@ public:
 inline void
 add_statistics_to_table_handler(const std::string variable,
                                 const statistics  stats,
-                                TableHandler     &table)
+                                TableHandler &    table)
 {
   table.add_value("Variable", variable);
   table.add_value("Min", stats.min);
@@ -82,20 +82,20 @@ add_statistics_to_table_handler(const std::string variable,
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T>              &independent_values,
-  const std::string                 &independent_column_name,
+  const std::vector<T> &             independent_values,
+  const std::string &                independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string>    &dependent_column_name,
+  const std::vector<std::string> &   dependent_column_name,
   const unsigned int                 display_precision);
 
 
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T>                           &independent_values,
-  const std::string                              &independent_column_name,
+  const std::vector<T> &                          independent_values,
+  const std::string &                             independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vector,
-  const std::vector<std::string>                 &dependent_column_name,
+  const std::vector<std::string> &                dependent_column_name,
   const unsigned int                              display_precision);
 
 /**
@@ -119,9 +119,9 @@ template <int dim>
 TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string>    &independent_column_name,
+  const std::vector<std::string> &   independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string>    &dependent_column_name,
+  const std::vector<std::string> &   dependent_column_name,
   const unsigned int                 display_precision);
 
 
@@ -144,9 +144,9 @@ template <int dim>
 TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string>    &independent_column_name,
-  const std::vector<double>         &dependent_values,
-  const std::string                 &dependent_column_name,
+  const std::vector<std::string> &   independent_column_name,
+  const std::vector<double> &        dependent_values,
+  const std::string &                dependent_column_name,
   const unsigned int                 display_precision);
 
 
@@ -194,7 +194,7 @@ calculate_point_property(const double phase,
  *   @param delimiter The delimiter used to read the table.
  */
 void
-fill_table_from_file(TableHandler     &table,
+fill_table_from_file(TableHandler &    table,
                      const std::string file_name,
                      const std::string delimiter = " ");
 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -28,7 +28,9 @@
 using namespace dealii;
 
 /**
- * @brief Small structure used to house statistics (min,max,total,average) that are used in multiple simulations
+ * @brief Small class that is used to store statistics (min,max,total,average) of variables that are used in simulations.
+ * This small class allows us to agglomerate the statistics instead of returning tuples.
+ * For example, this class is used to store the kinetic energy of the particles in the DEM model.
  */
 
 class statistics

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -55,14 +55,14 @@ public:
 inline void
 add_statistics_to_table_handler(const std::string variable,
                                 const statistics  stats,
-                                TableHandler &    table)
+                                TableHandler     &table)
 {
   table.add_value("Variable", variable);
   table.add_value("Min", stats.min);
   table.add_value("Max", stats.max);
   table.add_value("Total", stats.total);
   table.add_value("Average", stats.average);
-};
+}
 
 /**
  * @brief Generate a table from a vector of scalar and a vector of tensor<1,dim>
@@ -82,20 +82,20 @@ add_statistics_to_table_handler(const std::string variable,
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T> &             independent_values,
-  const std::string &                independent_column_name,
+  const std::vector<T>              &independent_values,
+  const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string> &   dependent_column_name,
+  const std::vector<std::string>    &dependent_column_name,
   const unsigned int                 display_precision);
 
 
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T> &                          independent_values,
-  const std::string &                             independent_column_name,
+  const std::vector<T>                           &independent_values,
+  const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vector,
-  const std::vector<std::string> &                dependent_column_name,
+  const std::vector<std::string>                 &dependent_column_name,
   const unsigned int                              display_precision);
 
 /**
@@ -119,9 +119,9 @@ template <int dim>
 TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string> &   independent_column_name,
+  const std::vector<std::string>    &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string> &   dependent_column_name,
+  const std::vector<std::string>    &dependent_column_name,
   const unsigned int                 display_precision);
 
 
@@ -144,9 +144,9 @@ template <int dim>
 TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string> &   independent_column_name,
-  const std::vector<double> &        dependent_values,
-  const std::string &                dependent_column_name,
+  const std::vector<std::string>    &independent_column_name,
+  const std::vector<double>         &dependent_values,
+  const std::string                 &dependent_column_name,
   const unsigned int                 display_precision);
 
 
@@ -194,7 +194,7 @@ calculate_point_property(const double phase,
  *   @param delimiter The delimiter used to read the table.
  */
 void
-fill_table_from_file(TableHandler &    table,
+fill_table_from_file(TableHandler     &table,
                      const std::string file_name,
                      const std::string delimiter = " ");
 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -27,7 +27,33 @@
 
 using namespace dealii;
 
+/**
+ * @brief Small structure used to house statistics (min,max,total,average) that are used in multiple simulations
+ */
 
+struct statistics
+{
+  double min;
+  double max;
+  double total;
+  double average;
+};
+
+
+/**
+ * @brief add_statistics_to_table_handler Add statistics to a TableHandler under the indicated variable name
+ */
+
+inline void
+  add_statistics_to_table_handler(const std::string variable, const statistics stats, TableHandler& table)
+{
+    table.add_value("Variable",variable);
+    table.add_value("Min", stats.min);
+    table.add_value("Max", stats.max);
+    table.add_value("Total", stats.total);
+    table.add_value("Average", stats.average);
+
+};
 
 /**
  * @brief Generate a table from a vector of scalar and a vector of tensor<1,dim>
@@ -188,3 +214,4 @@ create_output_folder(const std::string &dirname);
 
 
 #endif
+

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -372,6 +372,10 @@ private:
   PVDHandler      grid_pvdhandler;
   bool            floating_mesh;
 
+  // Storage of statistics about time and contact lists
+  statistics contact_list;
+  statistics simulation_time;
+
   // Solid DEM objects
   std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> solids;
 };

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -254,10 +254,17 @@ private:
   write_output_results();
 
   /**
-   * @brief post_process_results
+   * @brief post_process_results Calculates average velocity and other post-processed quantities that need to be outputted to files
    */
   void
   post_process_results();
+
+
+  /**
+   * @brief reports_statistics Calculates statistics on the particles and report them to the terminal. This function is notably used to calculate min/max/avg/total values of the linear kinetic energy, angular kinetic energy, linear velocity, angular velocity
+   */
+  void
+  report_statistics();
 
   MPI_Comm                                  mpi_communicator;
   const unsigned int                        n_mpi_processes;

--- a/include/dem/post_processing.h
+++ b/include/dem/post_processing.h
@@ -17,6 +17,7 @@
 #ifndef dem_post_processing_h
 #define dem_post_processing_h
 
+#include <core/utilities.h>
 #include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
@@ -31,8 +32,8 @@ using namespace dealii;
 namespace DEM
 {
   template <int dim>
-  double
-  calculate_total_granular_kinetic_energy(
+  statistics
+  calculate_granular_kinetic_energy(
     const Particles::ParticleHandler<dim> &particle_handler,
     const MPI_Comm &                       mpi_communicator);
 }

--- a/include/dem/post_processing.h
+++ b/include/dem/post_processing.h
@@ -18,6 +18,7 @@
 #define dem_post_processing_h
 
 #include <core/utilities.h>
+
 #include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
@@ -31,10 +32,20 @@ using namespace dealii;
 
 namespace DEM
 {
-  template <int dim>
+  enum class dem_statistic_variable
+  {
+    translational_kinetic_energy,
+    rotational_kinetic_energy,
+    velocity,
+    omega,
+  };
+
+  template <int dim, dem_statistic_variable var>
   statistics
-  calculate_granular_kinetic_energy(
+  calculate_granular_statistics(
     const Particles::ParticleHandler<dim> &particle_handler,
-    const MPI_Comm &                       mpi_communicator);
-}
+    const MPI_Comm                        &mpi_communicator);
+
+
+} // namespace DEM
 #endif

--- a/include/dem/post_processing.h
+++ b/include/dem/post_processing.h
@@ -23,15 +23,14 @@
 
 using namespace dealii;
 
-/**
- * @brief Calculate total kinetic energy of particles
- *
- * @param particle_handler A reference to the particle handler being used for DEM
- * @param mpi_communicator
- */
 
 namespace DEM
 {
+
+/**
+* @brief enum that is used to identify which variables are calculated in the granular statistics
+*
+*/
   enum class dem_statistic_variable
   {
     translational_kinetic_energy,
@@ -40,6 +39,19 @@ namespace DEM
     omega,
   };
 
+/**
+* @brief Calculate statistics on a DEM ParticleHandler. At the moment, the following statistics are supported:
+ * - Translational kinetic energy
+ * - Rotational (angular) kinetic energy
+ * - Translational velocity
+ * - Rotational (angular) velocity
+*
+* @tparam dim Dimensionality of the problem (2D or 3D)
+* @tparam dem_statistics_variable Enum variable used to identify which granular statistics is being calculated
+*
+* @param particle_handler A reference to the particle handler being used for DEM
+* @param mpi_communicator The MPI communicator
+*/
   template <int dim, dem_statistic_variable var>
   statistics
   calculate_granular_statistics(

--- a/include/dem/post_processing.h
+++ b/include/dem/post_processing.h
@@ -44,7 +44,7 @@ namespace DEM
   statistics
   calculate_granular_statistics(
     const Particles::ParticleHandler<dim> &particle_handler,
-    const MPI_Comm                        &mpi_communicator);
+    const MPI_Comm &                       mpi_communicator);
 
 
 } // namespace DEM

--- a/include/dem/post_processing.h
+++ b/include/dem/post_processing.h
@@ -26,11 +26,10 @@ using namespace dealii;
 
 namespace DEM
 {
-
-/**
-* @brief enum that is used to identify which variables are calculated in the granular statistics
-*
-*/
+  /**
+   * @brief enum that is used to identify which variables are calculated in the granular statistics
+   *
+   */
   enum class dem_statistic_variable
   {
     translational_kinetic_energy,
@@ -39,19 +38,19 @@ namespace DEM
     omega,
   };
 
-/**
-* @brief Calculate statistics on a DEM ParticleHandler. At the moment, the following statistics are supported:
- * - Translational kinetic energy
- * - Rotational (angular) kinetic energy
- * - Translational velocity
- * - Rotational (angular) velocity
-*
-* @tparam dim Dimensionality of the problem (2D or 3D)
-* @tparam dem_statistics_variable Enum variable used to identify which granular statistics is being calculated
-*
-* @param particle_handler A reference to the particle handler being used for DEM
-* @param mpi_communicator The MPI communicator
-*/
+  /**
+   * @brief Calculate statistics on a DEM ParticleHandler. At the moment, the following statistics are supported:
+   * - Translational kinetic energy
+   * - Rotational (angular) kinetic energy
+   * - Translational velocity
+   * - Rotational (angular) velocity
+   *
+   * @tparam dim Dimensionality of the problem (2D or 3D)
+   * @tparam dem_statistics_variable Enum variable used to identify which granular statistics is being calculated
+   *
+   * @param particle_handler A reference to the particle handler being used for DEM
+   * @param mpi_communicator The MPI communicator
+   */
   template <int dim, dem_statistic_variable var>
   statistics
   calculate_granular_statistics(

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -826,8 +826,6 @@ DEMSolver<dim>::report_statistics()
                          (simulation_control->get_step_number()) *
                          simulation_control->get_log_frequency();
 
-  // Update statistics on time
-
   // Calculate statistics on the particles
   statistics translational_kinetic_energy = calculate_granular_statistics<
     dim,

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -816,7 +816,11 @@ template <int dim>
 void
 DEMSolver<dim>::report_statistics()
 {
-  statistics kinetic_energy = calculate_granular_kinetic_energy(particle_handler,mpi_communicator);
+  statistics translational_kinetic_energy = calculate_granular_statistics<dim,DEM::dem_statistic_variable::translational_kinetic_energy>(particle_handler, mpi_communicator);
+  statistics rotational_kinetic_energy = calculate_granular_statistics<dim,DEM::dem_statistic_variable::rotational_kinetic_energy>(particle_handler, mpi_communicator);
+  statistics velocity = calculate_granular_statistics<dim,DEM::dem_statistic_variable::velocity>(particle_handler, mpi_communicator);
+  statistics omega = calculate_granular_statistics<dim,DEM::dem_statistic_variable::omega>(particle_handler, mpi_communicator);
+
 
   if (this_mpi_process==0)
     {
@@ -827,7 +831,15 @@ DEMSolver<dim>::report_statistics()
       report.declare_column("Max");
       report.declare_column("Average");
       report.declare_column("Total");
-      add_statistics_to_table_handler("Kinetic Energy",kinetic_energy,report);
+      add_statistics_to_table_handler("Velocity magnitude",
+                                      velocity,report);
+      add_statistics_to_table_handler("Angular velocity magnitude",
+                                      omega,report);
+      add_statistics_to_table_handler("Translational kinetic energy",
+                                      translational_kinetic_energy,report);
+      add_statistics_to_table_handler("Rotational kinetic energy",
+                                      rotational_kinetic_energy,report);
+
 
       report.set_scientific("Min",true);
       report.set_scientific("Max",true);

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -14,10 +14,9 @@
  * ---------------------------------------------------------------------
  */
 
-#include <core/utilities.h>
 #include <core/manifolds.h>
 #include <core/solutions_output.h>
-#include <dem/post_processing.h>
+#include <core/utilities.h>
 
 #include <dem/data_containers.h>
 #include <dem/dem.h>
@@ -31,6 +30,7 @@
 #include <dem/locate_local_particles.h>
 #include <dem/non_uniform_insertion.h>
 #include <dem/particle_wall_nonlinear_force.h>
+#include <dem/post_processing.h>
 #include <dem/print_initial_information.h>
 #include <dem/read_checkpoint.h>
 #include <dem/read_mesh.h>
@@ -206,7 +206,6 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
   // Resize particle_floating_mesh_in_contact
   if (floating_mesh)
     particle_floating_mesh_in_contact.resize(solids.size());
-
 }
 
 template <int dim>
@@ -816,21 +815,36 @@ void
 DEMSolver<dim>::report_statistics()
 {
   // Update statistics on contact list
-  double number_of_list_built_since_last_log = double(contact_build_number) - contact_list.total;
-  contact_list.max = std::max(number_of_list_built_since_last_log,contact_list.max);
-  contact_list.min = std::min(number_of_list_built_since_last_log,contact_list.min);
+  double number_of_list_built_since_last_log =
+    double(contact_build_number) - contact_list.total;
+  contact_list.max =
+    std::max(number_of_list_built_since_last_log, contact_list.max);
+  contact_list.min =
+    std::min(number_of_list_built_since_last_log, contact_list.min);
   contact_list.total += number_of_list_built_since_last_log;
-  contact_list.average = contact_list.total  / (simulation_control->get_step_number()) * simulation_control->get_log_frequency();
+  contact_list.average = contact_list.total /
+                         (simulation_control->get_step_number()) *
+                         simulation_control->get_log_frequency();
 
   // Update statistics on time
 
   // Calculate statistics on the particles
-  statistics translational_kinetic_energy = calculate_granular_statistics<dim,DEM::dem_statistic_variable::translational_kinetic_energy>(particle_handler, mpi_communicator);
-  statistics rotational_kinetic_energy = calculate_granular_statistics<dim,DEM::dem_statistic_variable::rotational_kinetic_energy>(particle_handler, mpi_communicator);
-  statistics velocity = calculate_granular_statistics<dim,DEM::dem_statistic_variable::velocity>(particle_handler, mpi_communicator);
-  statistics omega = calculate_granular_statistics<dim,DEM::dem_statistic_variable::omega>(particle_handler, mpi_communicator);
+  statistics translational_kinetic_energy = calculate_granular_statistics<
+    dim,
+    DEM::dem_statistic_variable::translational_kinetic_energy>(
+    particle_handler, mpi_communicator);
+  statistics rotational_kinetic_energy = calculate_granular_statistics<
+    dim,
+    DEM::dem_statistic_variable::rotational_kinetic_energy>(particle_handler,
+                                                            mpi_communicator);
+  statistics velocity =
+    calculate_granular_statistics<dim, DEM::dem_statistic_variable::velocity>(
+      particle_handler, mpi_communicator);
+  statistics omega =
+    calculate_granular_statistics<dim, DEM::dem_statistic_variable::omega>(
+      particle_handler, mpi_communicator);
 
-  if (this_mpi_process==0)
+  if (this_mpi_process == 0)
     {
       TableHandler report;
 
@@ -840,24 +854,27 @@ DEMSolver<dim>::report_statistics()
       report.declare_column("Average");
       report.declare_column("Total");
       add_statistics_to_table_handler("Contact list generation",
-                                      contact_list,report);
-      add_statistics_to_table_handler("Velocity magnitude",
-                                      velocity,report);
+                                      contact_list,
+                                      report);
+      add_statistics_to_table_handler("Velocity magnitude", velocity, report);
       add_statistics_to_table_handler("Angular velocity magnitude",
-                                      omega,report);
+                                      omega,
+                                      report);
       add_statistics_to_table_handler("Translational kinetic energy",
-                                      translational_kinetic_energy,report);
+                                      translational_kinetic_energy,
+                                      report);
       add_statistics_to_table_handler("Rotational kinetic energy",
-                                      rotational_kinetic_energy,report);
+                                      rotational_kinetic_energy,
+                                      report);
 
 
 
-      report.set_scientific("Min",true);
-      report.set_scientific("Max",true);
-      report.set_scientific("Average",true);
-      report.set_scientific("Total",true);
+      report.set_scientific("Min", true);
+      report.set_scientific("Max", true);
+      report.set_scientific("Average", true);
+      report.set_scientific("Total", true);
 
-      report.write_text(std::cout,dealii::TableHandler::org_mode_table);
+      report.write_text(std::cout, dealii::TableHandler::org_mode_table);
     }
 
   // Timer output
@@ -963,7 +980,8 @@ DEMSolver<dim>::solve()
   while (simulation_control->integrate())
     {
       simulation_control->print_progression(pcout);
-      if (simulation_control->is_verbose_iteration()) report_statistics();
+      if (simulation_control->is_verbose_iteration())
+        report_statistics();
 
       // Grid motion
       if (parameters.grid_motion.motion_type !=

--- a/source/dem/post_processing.cc
+++ b/source/dem/post_processing.cc
@@ -5,15 +5,16 @@ namespace DEM
 {
 
 
-  template <int dim>
+
+  template <int dim, dem_statistic_variable var>
   statistics
-  calculate_granular_kinetic_energy(
+  calculate_granular_statistics(
     const Particles::ParticleHandler<dim> &particle_handler,
     const MPI_Comm &                       mpi_communicator)
   {
-    double total_kinetic_energy = 0;
-    double max_kinetic_energy = DBL_MIN;
-    double min_kinetic_energy = DBL_MAX;
+    double total_variable = 0;
+    double max_variable = DBL_MIN;
+    double min_variable = DBL_MAX;
 
 
     for (auto &particle : particle_handler)
@@ -21,43 +22,126 @@ namespace DEM
         // Get the properties of the particle
         auto particle_properties = particle.get_properties();
 
+        double variable =0;
 
-        // Put particle velocity in a tensor
-        Tensor<1, dim> velocity;
-        for (unsigned d = 0; d < dim; ++d)
-          velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
+        if constexpr(var==dem_statistic_variable::translational_kinetic_energy)
+        {
+            // Put particle velocity in a tensor
+            Tensor<1, dim> velocity;
+            for (unsigned d = 0; d < dim; ++d)
+                velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
 
-        const double kinetic_energy = particle_properties[DEM::PropertiesIndex::mass] * velocity.norm();
+          variable = particle_properties[DEM::PropertiesIndex::mass] * velocity.norm_square();
+        }
+          if constexpr(var==dem_statistic_variable::rotational_kinetic_energy)
+          {
+              // Put angular velocity in a tensor
+              Tensor<1, 3> omega;
+              if constexpr(dim==2)
+              {
+                  omega[2]=particle_properties[DEM::PropertiesIndex::omega_z];
+              }
+              if constexpr(dim==3)
+              {
+                  for (unsigned d = 0; d < dim; ++d)
+                      omega[d] = particle_properties[DEM::PropertiesIndex::omega_x + d];
 
-        total_kinetic_energy += kinetic_energy;
+              }
 
-        max_kinetic_energy = std::max(kinetic_energy,max_kinetic_energy);
-        min_kinetic_energy = std::min(kinetic_energy,min_kinetic_energy);
+              variable = 0.1* particle_properties[DEM::PropertiesIndex::mass] * Utilities::fixed_power<2>(particle_properties[DEM::PropertiesIndex::dp])* omega.norm_square();
+          }
+
+          if constexpr(var==dem_statistic_variable::velocity)
+          {
+              // Put particle velocity in a tensor
+              Tensor<1, dim> velocity;
+              for (unsigned d = 0; d < dim; ++d)
+                  velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
+
+              variable = velocity.norm();
+          }
+
+          if constexpr(var==dem_statistic_variable::omega)
+          {
+              // Put angular velocity in a tensor
+              Tensor<1, 3> omega;
+              if constexpr(dim==2)
+              {
+                  omega[2]=particle_properties[DEM::PropertiesIndex::omega_z];
+              }
+              if constexpr(dim==3)
+              {
+                  for (unsigned d = 0; d < dim; ++d)
+                      omega[d] = particle_properties[DEM::PropertiesIndex::omega_x + d];
+
+              }
+
+              variable = omega.norm();
+          }
+
+          total_variable += variable;
+
+          max_variable = std::max(variable, max_variable);
+          min_variable = std::min(variable, min_variable);
       }
 
-    total_kinetic_energy = Utilities::MPI::sum(total_kinetic_energy, mpi_communicator);
-    max_kinetic_energy = Utilities::MPI::max(max_kinetic_energy, mpi_communicator);
-    min_kinetic_energy = Utilities::MPI::min(min_kinetic_energy, mpi_communicator);
+      total_variable = Utilities::MPI::sum(total_variable, mpi_communicator);
+      max_variable = Utilities::MPI::max(max_variable, mpi_communicator);
+      min_variable = Utilities::MPI::min(min_variable, mpi_communicator);
 
     statistics stats;
-    stats.total=total_kinetic_energy;
-    stats.max=max_kinetic_energy;
-    stats.min=min_kinetic_energy;
-    stats.average=total_kinetic_energy / particle_handler.n_global_particles();
+    stats.total=total_variable;
+    stats.max=max_variable;
+    stats.min=min_variable;
+    stats.average= total_variable / particle_handler.n_global_particles();
 
 
     return stats;
   }
 
 
-  template statistics
-  calculate_granular_kinetic_energy(
+  template  statistics
+  calculate_granular_statistics<2, dem_statistic_variable::translational_kinetic_energy>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
   template statistics
-  calculate_granular_kinetic_energy(
+          calculate_granular_statistics<3, dem_statistic_variable::translational_kinetic_energy>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
+
+  template  statistics
+  calculate_granular_statistics<2, dem_statistic_variable::rotational_kinetic_energy>(
+    const Particles::ParticleHandler<2, 2> &particle_handler,
+    const MPI_Comm &                        mpi_communicator);
+
+  template statistics
+  calculate_granular_statistics<3, dem_statistic_variable::rotational_kinetic_energy>(
+    const Particles::ParticleHandler<3, 3> &particle_handler,
+    const MPI_Comm &                        mpi_communicator);
+
+  template  statistics
+  calculate_granular_statistics<2, dem_statistic_variable::velocity>(
+    const Particles::ParticleHandler<2, 2> &particle_handler,
+    const MPI_Comm &                        mpi_communicator);
+
+  template statistics
+  calculate_granular_statistics<3, dem_statistic_variable::velocity>(
+    const Particles::ParticleHandler<3, 3> &particle_handler,
+    const MPI_Comm &                        mpi_communicator);
+
+  template  statistics
+  calculate_granular_statistics<2, dem_statistic_variable::omega>(
+    const Particles::ParticleHandler<2, 2> &particle_handler,
+    const MPI_Comm &                        mpi_communicator);
+
+  template statistics
+  calculate_granular_statistics<3, dem_statistic_variable::omega>(
+    const Particles::ParticleHandler<3, 3> &particle_handler,
+    const MPI_Comm &                        mpi_communicator);
+
+
+
+
 
 } // namespace DEM

--- a/source/dem/post_processing.cc
+++ b/source/dem/post_processing.cc
@@ -1,16 +1,21 @@
 #include <core/dem_properties.h>
-
 #include <dem/post_processing.h>
 
 namespace DEM
 {
+
+
   template <int dim>
-  double
-  calculate_total_granular_kinetic_energy(
+  statistics
+  calculate_granular_kinetic_energy(
     const Particles::ParticleHandler<dim> &particle_handler,
     const MPI_Comm &                       mpi_communicator)
   {
-    double kinetic_energy = 0;
+    double total_kinetic_energy = 0;
+    double max_kinetic_energy = DBL_MIN;
+    double min_kinetic_energy = DBL_MAX;
+
+
     for (auto &particle : particle_handler)
       {
         // Get the properties of the particle
@@ -22,23 +27,36 @@ namespace DEM
         for (unsigned d = 0; d < dim; ++d)
           velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
 
-        kinetic_energy +=
-          particle_properties[DEM::PropertiesIndex::mass] * velocity.norm();
+        const double kinetic_energy = particle_properties[DEM::PropertiesIndex::mass] * velocity.norm();
+
+        total_kinetic_energy += kinetic_energy;
+
+        max_kinetic_energy = std::max(kinetic_energy,max_kinetic_energy);
+        min_kinetic_energy = std::min(kinetic_energy,min_kinetic_energy);
       }
 
-    kinetic_energy = Utilities::MPI::sum(kinetic_energy, mpi_communicator);
+    total_kinetic_energy = Utilities::MPI::sum(total_kinetic_energy, mpi_communicator);
+    max_kinetic_energy = Utilities::MPI::max(max_kinetic_energy, mpi_communicator);
+    min_kinetic_energy = Utilities::MPI::min(min_kinetic_energy, mpi_communicator);
 
-    return kinetic_energy;
+    statistics stats;
+    stats.total=total_kinetic_energy;
+    stats.max=max_kinetic_energy;
+    stats.min=min_kinetic_energy;
+    stats.average=total_kinetic_energy / particle_handler.n_global_particles();
+
+
+    return stats;
   }
 
 
-  template double
-  calculate_total_granular_kinetic_energy(
+  template statistics
+  calculate_granular_kinetic_energy(
     const Particles::ParticleHandler<2, 2> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
-  template double
-  calculate_total_granular_kinetic_energy(
+  template statistics
+  calculate_granular_kinetic_energy(
     const Particles::ParticleHandler<3, 3> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 

--- a/source/dem/post_processing.cc
+++ b/source/dem/post_processing.cc
@@ -31,7 +31,7 @@ namespace DEM
               velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
 
             // Kinetic energy is 0.5*m*u^2
-            variable = 0.5*particle_properties[DEM::PropertiesIndex::mass] *
+            variable = 0.5 * particle_properties[DEM::PropertiesIndex::mass] *
                        velocity.norm_square();
           }
         if constexpr (var == dem_statistic_variable::rotational_kinetic_energy)

--- a/source/dem/post_processing.cc
+++ b/source/dem/post_processing.cc
@@ -30,7 +30,8 @@ namespace DEM
             for (unsigned d = 0; d < dim; ++d)
               velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
 
-            variable = particle_properties[DEM::PropertiesIndex::mass] *
+            // Kinetic energy is 0.5*m*u^2
+            variable = 0.5*particle_properties[DEM::PropertiesIndex::mass] *
                        velocity.norm_square();
           }
         if constexpr (var == dem_statistic_variable::rotational_kinetic_energy)
@@ -48,6 +49,7 @@ namespace DEM
                     particle_properties[DEM::PropertiesIndex::omega_x + d];
               }
 
+            // Kinetic energy is 0.1*m*d^2 * w^2
             variable = 0.1 * particle_properties[DEM::PropertiesIndex::mass] *
                        Utilities::fixed_power<2>(
                          particle_properties[DEM::PropertiesIndex::dp]) *

--- a/source/dem/post_processing.cc
+++ b/source/dem/post_processing.cc
@@ -1,11 +1,9 @@
 #include <core/dem_properties.h>
+
 #include <dem/post_processing.h>
 
 namespace DEM
 {
-
-
-
   template <int dim, dem_statistic_variable var>
   statistics
   calculate_granular_statistics(
@@ -13,8 +11,8 @@ namespace DEM
     const MPI_Comm &                       mpi_communicator)
   {
     double total_variable = 0;
-    double max_variable = DBL_MIN;
-    double min_variable = DBL_MAX;
+    double max_variable   = DBL_MIN;
+    double min_variable   = DBL_MAX;
 
 
     for (auto &particle : particle_handler)
@@ -22,105 +20,118 @@ namespace DEM
         // Get the properties of the particle
         auto particle_properties = particle.get_properties();
 
-        double variable =0;
+        double variable = 0;
 
-        if constexpr(var==dem_statistic_variable::translational_kinetic_energy)
-        {
+        if constexpr (var ==
+                      dem_statistic_variable::translational_kinetic_energy)
+          {
             // Put particle velocity in a tensor
             Tensor<1, dim> velocity;
             for (unsigned d = 0; d < dim; ++d)
-                velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
+              velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
 
-          variable = particle_properties[DEM::PropertiesIndex::mass] * velocity.norm_square();
-        }
-          if constexpr(var==dem_statistic_variable::rotational_kinetic_energy)
+            variable = particle_properties[DEM::PropertiesIndex::mass] *
+                       velocity.norm_square();
+          }
+        if constexpr (var == dem_statistic_variable::rotational_kinetic_energy)
           {
-              // Put angular velocity in a tensor
-              Tensor<1, 3> omega;
-              if constexpr(dim==2)
+            // Put angular velocity in a tensor
+            Tensor<1, 3> omega;
+            if constexpr (dim == 2)
               {
-                  omega[2]=particle_properties[DEM::PropertiesIndex::omega_z];
+                omega[2] = particle_properties[DEM::PropertiesIndex::omega_z];
               }
-              if constexpr(dim==3)
+            if constexpr (dim == 3)
               {
-                  for (unsigned d = 0; d < dim; ++d)
-                      omega[d] = particle_properties[DEM::PropertiesIndex::omega_x + d];
-
+                for (unsigned d = 0; d < dim; ++d)
+                  omega[d] =
+                    particle_properties[DEM::PropertiesIndex::omega_x + d];
               }
 
-              variable = 0.1* particle_properties[DEM::PropertiesIndex::mass] * Utilities::fixed_power<2>(particle_properties[DEM::PropertiesIndex::dp])* omega.norm_square();
+            variable = 0.1 * particle_properties[DEM::PropertiesIndex::mass] *
+                       Utilities::fixed_power<2>(
+                         particle_properties[DEM::PropertiesIndex::dp]) *
+                       omega.norm_square();
           }
 
-          if constexpr(var==dem_statistic_variable::velocity)
+        if constexpr (var == dem_statistic_variable::velocity)
           {
-              // Put particle velocity in a tensor
-              Tensor<1, dim> velocity;
-              for (unsigned d = 0; d < dim; ++d)
-                  velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
+            // Put particle velocity in a tensor
+            Tensor<1, dim> velocity;
+            for (unsigned d = 0; d < dim; ++d)
+              velocity[d] = particle_properties[DEM::PropertiesIndex::v_x + d];
 
-              variable = velocity.norm();
+            variable = velocity.norm();
           }
 
-          if constexpr(var==dem_statistic_variable::omega)
+        if constexpr (var == dem_statistic_variable::omega)
           {
-              // Put angular velocity in a tensor
-              Tensor<1, 3> omega;
-              if constexpr(dim==2)
+            // Put angular velocity in a tensor
+            Tensor<1, 3> omega;
+            if constexpr (dim == 2)
               {
-                  omega[2]=particle_properties[DEM::PropertiesIndex::omega_z];
+                omega[2] = particle_properties[DEM::PropertiesIndex::omega_z];
               }
-              if constexpr(dim==3)
+            if constexpr (dim == 3)
               {
-                  for (unsigned d = 0; d < dim; ++d)
-                      omega[d] = particle_properties[DEM::PropertiesIndex::omega_x + d];
-
+                for (unsigned d = 0; d < dim; ++d)
+                  omega[d] =
+                    particle_properties[DEM::PropertiesIndex::omega_x + d];
               }
 
-              variable = omega.norm();
+            variable = omega.norm();
           }
 
-          total_variable += variable;
+        total_variable += variable;
 
-          max_variable = std::max(variable, max_variable);
-          min_variable = std::min(variable, min_variable);
+        max_variable = std::max(variable, max_variable);
+        min_variable = std::min(variable, min_variable);
       }
 
-      total_variable = Utilities::MPI::sum(total_variable, mpi_communicator);
-      max_variable = Utilities::MPI::max(max_variable, mpi_communicator);
-      min_variable = Utilities::MPI::min(min_variable, mpi_communicator);
+    total_variable = Utilities::MPI::sum(total_variable, mpi_communicator);
+    max_variable   = Utilities::MPI::max(max_variable, mpi_communicator);
+    min_variable   = Utilities::MPI::min(min_variable, mpi_communicator);
 
     statistics stats;
-    stats.total=total_variable;
-    stats.max=max_variable;
-    stats.min=min_variable;
-    stats.average= total_variable / particle_handler.n_global_particles();
+    stats.total   = total_variable;
+    stats.max     = max_variable;
+    stats.min     = min_variable;
+    stats.average = total_variable / particle_handler.n_global_particles();
 
 
     return stats;
   }
 
 
-  template  statistics
-  calculate_granular_statistics<2, dem_statistic_variable::translational_kinetic_energy>(
+  template statistics
+  calculate_granular_statistics<
+    2,
+    dem_statistic_variable::translational_kinetic_energy>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
   template statistics
-          calculate_granular_statistics<3, dem_statistic_variable::translational_kinetic_energy>(
+  calculate_granular_statistics<
+    3,
+    dem_statistic_variable::translational_kinetic_energy>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
-  template  statistics
-  calculate_granular_statistics<2, dem_statistic_variable::rotational_kinetic_energy>(
+  template statistics
+  calculate_granular_statistics<
+    2,
+    dem_statistic_variable::rotational_kinetic_energy>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
   template statistics
-  calculate_granular_statistics<3, dem_statistic_variable::rotational_kinetic_energy>(
+  calculate_granular_statistics<
+    3,
+    dem_statistic_variable::rotational_kinetic_energy>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
-  template  statistics
+  template statistics
   calculate_granular_statistics<2, dem_statistic_variable::velocity>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
@@ -130,7 +141,7 @@ namespace DEM
     const Particles::ParticleHandler<3, 3> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
 
-  template  statistics
+  template statistics
   calculate_granular_statistics<2, dem_statistic_variable::omega>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
@@ -139,8 +150,6 @@ namespace DEM
   calculate_granular_statistics<3, dem_statistic_variable::omega>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
     const MPI_Comm &                        mpi_communicator);
-
-
 
 
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1257,9 +1257,7 @@ CFDDEMSolver<dim>::post_processing()
   if (this->cfd_dem_simulation_parameters.cfd_dem.post_processing)
     {
       this->GLSVANSSolver<dim>::post_processing();
-      double particle_total_kinetic_energy =
-        DEM::calculate_granular_kinetic_energy(this->particle_handler,
-                                                     this->mpi_communicator).total;
+      double particle_total_kinetic_energy = calculate_granular_statistics<dim,DEM::dem_statistic_variable::translational_kinetic_energy>(this->particle_handler, this->mpi_communicator).total;
 
       this->pcout << "Total particles kinetic energy: "
                   << particle_total_kinetic_energy << std::endl;

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1257,7 +1257,12 @@ CFDDEMSolver<dim>::post_processing()
   if (this->cfd_dem_simulation_parameters.cfd_dem.post_processing)
     {
       this->GLSVANSSolver<dim>::post_processing();
-      double particle_total_kinetic_energy = calculate_granular_statistics<dim,DEM::dem_statistic_variable::translational_kinetic_energy>(this->particle_handler, this->mpi_communicator).total;
+      double particle_total_kinetic_energy =
+        calculate_granular_statistics<
+          dim,
+          DEM::dem_statistic_variable::translational_kinetic_energy>(
+          this->particle_handler, this->mpi_communicator)
+          .total;
 
       this->pcout << "Total particles kinetic energy: "
                   << particle_total_kinetic_energy << std::endl;

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1258,8 +1258,8 @@ CFDDEMSolver<dim>::post_processing()
     {
       this->GLSVANSSolver<dim>::post_processing();
       double particle_total_kinetic_energy =
-        DEM::calculate_total_granular_kinetic_energy(this->particle_handler,
-                                                     this->mpi_communicator);
+        DEM::calculate_granular_kinetic_energy(this->particle_handler,
+                                                     this->mpi_communicator).total;
 
       this->pcout << "Total particles kinetic energy: "
                   << particle_total_kinetic_energy << std::endl;


### PR DESCRIPTION
# Description of the problem

- The Log when running DEM simulations only output the number of the iteration. This is problematic since it does not allow one to monitor how the simulation is going
- There was a mistake in how the kinetic energy was calculated for the particles

# Description of the solution

- Add a few statistics to monitor the DEM. Min/Max/Average/Total kinetic energy for translation and rotation as well as for translational and rotational velocity.

# How Has This Been Tested?

- This does not change the code, just allows for more monitoring.

