### PR TITLE
Add parameter to impose initial conditions to DEM particles + fix Magnus force parameter

### DIFF
--- a/applications_tests/dem_3d/initial_value_insertion.output
+++ b/applications_tests/dem_3d/initial_value_insertion.output
@@ -1,0 +1,64 @@
+Running on 1 rank(s)
+***************************************************************** 
+
+DEM time-step is 13.1342% of Rayleigh time step
+Reading triangulation 
+
+Finished reading triangulation 
+Warning: expansion of particle-wall contact list is disabled. 
+This feature is useful in geometries with concave boundaries. 
+***************************************************************** 
+1 particles of type 0 were inserted, 0 particles of type 0 remaining
+***************************************************************** 
+
+*****************************************************************
+Transient iteration : 2        Time : 0.0002   Time step : 0.0001  
+*****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.0000e+00  | 1.0000e+00 | 1.0000e+00 | 
+| Velocity magnitude           | 9.9990e+00 | 9.9990e+00  | 9.9990e+00 | 9.9990e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 8.1796e-03 | 8.1796e-03  | 8.1796e-03 | 8.1796e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+
+*****************************************************************
+Transient iteration : 4        Time : 0.0004   Time step : 0.0001  
+*****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.0000e+00  | 1.0000e+00 | 2.0000e+00 | 
+| Velocity magnitude           | 9.9971e+00 | 9.9971e+00  | 9.9971e+00 | 9.9971e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 8.1764e-03 | 8.1764e-03  | 8.1764e-03 | 8.1764e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+
+*****************************************************************
+Transient iteration : 6        Time : 0.0006   Time step : 0.0001  
+*****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.0000e+00  | 1.0000e+00 | 3.0000e+00 | 
+| Velocity magnitude           | 9.9951e+00 | 9.9951e+00  | 9.9951e+00 | 9.9951e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 8.1732e-03 | 8.1732e-03  | 8.1732e-03 | 8.1732e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+
+*****************************************************************
+Transient iteration : 8        Time : 0.0008   Time step : 0.0001  
+*****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.0000e+00  | 1.0000e+00 | 4.0000e+00 | 
+| Velocity magnitude           | 9.9931e+00 | 9.9931e+00  | 9.9931e+00 | 9.9931e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 8.1700e-03 | 8.1700e-03  | 8.1700e-03 | 8.1700e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+
+*****************************************************************
+Transient iteration : 10       Time : 0.001    Time step : 0.0001  
+*****************************************************************
+| Variable                     | Min        | Max         | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.0000e+00  | 1.0000e+00 | 5.0000e+00 | 
+| Velocity magnitude           | 9.9912e+00 | 9.9912e+00  | 9.9912e+00 | 9.9912e+00 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+| Translational kinetic energy | 8.1668e-03 | 8.1668e-03  | 8.1668e-03 | 8.1668e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
+id, type, dp, x, y, z 
+0 0 0.00500 -0.0010 -0.0690 -0.0035

--- a/applications_tests/dem_3d/initial_value_insertion.prm
+++ b/applications_tests/dem_3d/initial_value_insertion.prm
@@ -1,0 +1,97 @@
+# Listing of Parameters
+# ---------------------
+# --------------------------------------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set time step                 			 = 0.0001
+  set time end       					 = 0.001
+  set log frequency				         = 2
+  set output frequency            			 = 100000
+  #set output path                                      = ./output_dem/
+end
+
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+subsection timer
+    set type    					 = none
+end
+
+#---------------------------------------------------
+# Test
+#---------------------------------------------------
+subsection test
+    set enable 						 = true
+end
+
+# --------------------------------------------------
+# Model parameters
+#---------------------------------------------------
+subsection model parameters
+  set contact detection method 		   		 = dynamic
+  set contact detection frequency                 	 = 10
+  set neighborhood threshold				 = 1.8
+  set particle particle contact force method             = hertz_mindlin_limit_overlap
+  set particle wall contact force method                 = nonlinear
+  set rolling resistance torque method			 = no_resistance
+  set integration method				 = velocity_verlet
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection lagrangian physical properties
+    set gx            		 			= 0.0
+    set gy            		 			= -9.81
+    set gz						= 0
+    set number of particle types	                = 1
+    subsection particle type 0
+		set size distribution type		= uniform
+    		set diameter            	 	= 0.005
+    		set number				= 1
+    		set density particles         	        = 2500
+    		set young modulus particles         	= 1000000
+    		set poisson ratio particles          	= 0.3
+    		set restitution coefficient particles	= 0.2
+    		set friction coefficient particles      = 0.1
+    		set rolling friction particles        	= 0.2
+	end
+    set young modulus wall            			= 1000000
+    set poisson ratio wall            			= 0.3
+    set restitution coefficient wall           		= 0.2
+    set friction coefficient wall         		= 0.1
+    set rolling friction wall         	      	  	= 0.3
+end
+
+
+#---------------------------------------------------
+# Insertion Info
+#---------------------------------------------------
+subsection insertion info
+    set insertion method				= uniform
+    set inserted number of particles at each time step  = 1
+    set insertion frequency            		 	= 2000
+    set insertion box minimum x            	 	= -0.006
+    set insertion box minimum y            	        = -0.084
+    set insertion box minimum z            	        = -0.006
+    set insertion box maximum x            	        = 0.006
+    set insertion box maximum y           	 	= 0.090
+    set insertion box maximum z            	        = 0.006
+    set insertion distance threshold			= 1.01
+    set insertion random number range			= 0.5
+    set insertion random number seed			= 19
+
+    set velocity y = 10.0
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+    set type                 				= dealii
+    set grid type            				= subdivided_hyper_rectangle
+    set grid arguments       				= 5,24,5:-0.05,-0.1,-0.05:0.05,0.1,0.05:false
+    set initial refinement   				= 0
+end
+

--- a/doc/source/parameters/dem/insertion_info.rst
+++ b/doc/source/parameters/dem/insertion_info.rst
@@ -29,6 +29,14 @@ Particle insertion information is defined in this section. This information incl
   set insertion box maximum y                   = 0.05
   set insertion box maximum z                   = 0.07
 
+  # Initial conditions at insertion
+  set velocity x = 0.0
+  set velocity y = 0.0
+  set velocity z = 0.0
+  set omega x = 0.0
+  set omega y = 0.0
+  set omega z = 0.0
+
   # insertion distance threshold controls the distance between the center of inserted particles (the distance is: [distance threshold] * [diameter of particles]). The distance is modified by a random number if non_uniform insertion is chosen
   set insertion distance threshold              = 2
 
@@ -57,6 +65,13 @@ Particle insertion information is defined in this section. This information incl
 
 .. note::
     We recommend that the defined insertion box have at least a distance of :math:`{d^{max}_p}` (maximum diameter of particles) from the triangulation boundaries. Otherwise, particles may have an overlap with the triangulation walls in the insertion.
+
+* The ``velocity x``, ``velocity y``, and ``velocity z`` determine the initial translational velocity (in :math:`\frac{m}{s}`) at which particles are inserted in the x, y, and z directions, respectively.
+
+* The ``omega x``, ``omega y``, and ``omega z`` determine the initial rotational velocity (in :math:`\frac{rad}{s}`) at which particles are inserted in the x, y, and z directions, respectively. 
+
+.. note:: 
+    Since the ``insertion info`` subsection is valid for all particle types, by using ``velocity x``, ``velocity y``, ``velocity z``, ``omega x``, ``omega y``, or ``omega z``, the given condition is applied to all particles, indistinctively.
 
 * The ``insertion distance threshold`` parameter determines the initial distance between the particles in the insertion. As a result, it must be larger than 1 to avoid any initial collision between the inserted particles.
 

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -139,6 +139,9 @@ namespace Parameters
       // Insertion box info (xmin,xmax,ymin,ymax,zmin,zmax)
       double x_min, y_min, z_min, x_max, y_max, z_max;
 
+      // Insertion initial conditions
+      double vel_x, vel_y, vel_z, omega_x, omega_y, omega_z;
+
       // Insertion distance threshold
       double distance_threshold;
 

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -320,6 +320,31 @@ namespace Parameters
                           "0",
                           Patterns::List(Patterns::Double()),
                           "List of particles z positions");
+
+        prm.declare_entry("velocity x",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial velocity x");
+        prm.declare_entry("velocity y",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial velocity y");
+        prm.declare_entry("velocity z",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial velocity z");
+        prm.declare_entry("omega x",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial omega x");
+        prm.declare_entry("omega y",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial omega y");
+        prm.declare_entry("omega z",
+                          "0.0",
+                          Patterns::Double(),
+                          "Initial omega z");
       }
       prm.leave_subsection();
     }
@@ -352,6 +377,13 @@ namespace Parameters
         distance_threshold  = prm.get_double("insertion distance threshold");
         random_number_range = prm.get_double("insertion random number range");
         random_number_seed  = prm.get_double("insertion random number seed");
+
+        vel_x   = prm.get_double("velocity x");
+        vel_y   = prm.get_double("velocity y");
+        vel_z   = prm.get_double("velocity z");
+        omega_x = prm.get_double("omega x");
+        omega_y = prm.get_double("omega y");
+        omega_z = prm.get_double("omega z");
 
         // Read x, y and z list as a single string
         std::string x_str = prm.get("list x");

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -74,12 +74,12 @@ Insertion<dim>::assign_particle_properties(
         -particle_sizes[particle_counter];
       double density =
         physical_properties.density_particle[current_inserting_particle_type];
-      double vel_x                   = 0.;
-      double vel_y                   = 0.;
-      double vel_z                   = 0.;
-      double omega_x                 = 0.;
-      double omega_y                 = 0.;
-      double omega_z                 = 0.;
+      double vel_x                   = dem_parameters.insertion_info.vel_x;
+      double vel_y                   = dem_parameters.insertion_info.vel_y;
+      double vel_z                   = dem_parameters.insertion_info.vel_z;
+      double omega_x                 = dem_parameters.insertion_info.omega_x;
+      double omega_y                 = dem_parameters.insertion_info.omega_y;
+      double omega_z                 = dem_parameters.insertion_info.omega_z;
       double fem_force_x             = 0.;
       double fem_force_y             = 0.;
       double fem_force_z             = 0.;

--- a/source/fem-dem/parameters_cfd_dem.cc
+++ b/source/fem-dem/parameters_cfd_dem.cc
@@ -184,7 +184,7 @@ namespace Parameters
     shear_force                = prm.get_bool("shear force");
     pressure_force             = prm.get_bool("pressure force");
     saffman_lift_force         = prm.get_bool("saffman lift force");
-    magnus_lift_force         = prm.get_bool("magnus lift force");
+    magnus_lift_force          = prm.get_bool("magnus lift force");
     post_processing            = prm.get_bool("post processing");
     inlet_boundary_id          = prm.get_integer("inlet boundary id");
     outlet_boundary_id         = prm.get_integer("outlet boundary id");

--- a/source/fem-dem/parameters_cfd_dem.cc
+++ b/source/fem-dem/parameters_cfd_dem.cc
@@ -184,6 +184,7 @@ namespace Parameters
     shear_force                = prm.get_bool("shear force");
     pressure_force             = prm.get_bool("pressure force");
     saffman_lift_force         = prm.get_bool("saffman lift force");
+    magnus_lift_force         = prm.get_bool("magnus lift force");
     post_processing            = prm.get_bool("post processing");
     inlet_boundary_id          = prm.get_integer("inlet boundary id");
     outlet_boundary_id         = prm.get_integer("outlet boundary id");


### PR DESCRIPTION
# Description of the problem

- DEM particles were always inserted with velocities and omegas equal to 0;
- Magnus force on/off parameter was not parsed.

# Description of the solution

- Added parameters for initial velocities and omegas in the insertion info section of the DEM;
- Added Magnus force to parse_parameters.

# How Has This Been Tested?
- [x] CFD-DEM Sedimentation of single particle

# Tests added
- [x] launching of a single particle with an initial velocity.

# Documentation

- [x] Add parameters to DEM documentation

# Comments

- The parameter is applied equally to all particles. It works currently, but future changes can be applied to make it so that types are inserted with different initial conditions.