### PR TITLE
Change default rolling friction model

### DIFF
--- a/applications_tests/cfd_dem_coupling_3d/dynamic_contact_search.prm
+++ b/applications_tests/cfd_dem_coupling_3d/dynamic_contact_search.prm
@@ -178,6 +178,7 @@ subsection model parameters
   set particle particle contact force method             = hertz_mindlin_limit_overlap
   set particle wall contact force method                 = nonlinear
   set integration method				 = velocity_verlet
+  set rolling resistance torque method                  = no_resistance
 end
 
 # --------------------------------------------------

--- a/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.prm
+++ b/applications_tests/cfd_dem_coupling_3d/liquid_fluidized_bed.prm
@@ -194,6 +194,7 @@ subsection model parameters
   set particle particle contact force method             = hertz_mindlin_limit_overlap
   set particle wall contact force method                 = nonlinear
   set integration method				 = velocity_verlet
+  set rolling resistance torque method                  = no_resistance
 end
 
 #---------------------------------------------------

--- a/applications_tests/cfd_dem_coupling_3d/particle_sedimentation.prm
+++ b/applications_tests/cfd_dem_coupling_3d/particle_sedimentation.prm
@@ -177,6 +177,7 @@ subsection model parameters
   set particle particle contact force method             = hertz_mindlin_limit_force
   set particle wall contact force method                 = nonlinear
   set integration method				 = velocity_verlet
+  set rolling resistance torque method                  = no_resistance
 end
 
 # --------------------------------------------------

--- a/applications_tests/cfd_dem_coupling_3d/restart_particle_sedimentation.prm
+++ b/applications_tests/cfd_dem_coupling_3d/restart_particle_sedimentation.prm
@@ -177,6 +177,7 @@ subsection model parameters
   set particle particle contact force method             = hertz_mindlin_limit_force
   set particle wall contact force method                 = nonlinear
   set integration method				 = velocity_verlet
+  set rolling resistance torque method                  = no_resistance
 end
 
 # --------------------------------------------------

--- a/applications_tests/dem_3d/floating_mesh.prm
+++ b/applications_tests/dem_3d/floating_mesh.prm
@@ -29,6 +29,7 @@ subsection model parameters
   set particle particle contact force method             = hertz_mindlin_limit_overlap
   set particle wall contact force method                 = nonlinear
   set integration method				 = velocity_verlet
+  set rolling resistance torque method                  = no_resistance
 end
 
 #---------------------------------------------------

--- a/doc/source/parameters/dem/model_parameters.rst
+++ b/doc/source/parameters/dem/model_parameters.rst
@@ -36,7 +36,7 @@ In this subsection, DEM simulation parameters are defined. These parameters incl
 
   # Rolling resistance method
   # choices are no_resistance|constant_resistance|viscous_resistance
-  set rolling resistance torque method                  = no_resistance
+  set rolling resistance torque method                  = constant_resistance
  end
 
 

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -59,7 +59,7 @@ namespace Parameters
     void
     LagrangianPhysicalProperties::parse_particle_properties(
       const unsigned int &particle_type,
-      ParameterHandler &  prm)
+      ParameterHandler   &prm)
     {
       const std::string size_distribution_type =
         prm.get("size distribution type");
@@ -228,7 +228,7 @@ namespace Parameters
     LagrangianPhysicalProperties::initialize_containers(
       std::unordered_map<unsigned int, double> &particle_average_diameter,
       std::unordered_map<unsigned int, double> &particle_size_std,
-      std::unordered_map<unsigned int, int> &   number,
+      std::unordered_map<unsigned int, int>    &number,
       std::unordered_map<unsigned int, double> &density_particle,
       std::unordered_map<unsigned int, double> &youngs_modulus_particle,
       std::unordered_map<unsigned int, double> &poisson_ratio_particle,
@@ -485,7 +485,7 @@ namespace Parameters
 
         prm.declare_entry(
           "rolling resistance torque method",
-          "no_resistance",
+          "constant_resistance",
           Patterns::Selection(
             "no_resistance|constant_resistance|viscous_resistance"),
           "Choosing rolling resistance torque model"
@@ -1015,10 +1015,10 @@ namespace Parameters
     void
     BCDEM::initialize_containers(
       std::unordered_map<unsigned int, Tensor<1, 3>>
-        &                                       boundary_translational_velocity,
+                                               &boundary_translational_velocity,
       std::unordered_map<unsigned int, double> &boundary_rotational_speed,
       std::unordered_map<unsigned int, Tensor<1, 3>>
-        &                        boundary_rotational_vector,
+                                &boundary_rotational_vector,
       std::vector<unsigned int> &outlet_boundaries,
       std::vector<unsigned int> &periodic_boundaries,
       std::vector<unsigned int> &periodic_direction)

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -59,7 +59,7 @@ namespace Parameters
     void
     LagrangianPhysicalProperties::parse_particle_properties(
       const unsigned int &particle_type,
-      ParameterHandler   &prm)
+      ParameterHandler &  prm)
     {
       const std::string size_distribution_type =
         prm.get("size distribution type");
@@ -228,7 +228,7 @@ namespace Parameters
     LagrangianPhysicalProperties::initialize_containers(
       std::unordered_map<unsigned int, double> &particle_average_diameter,
       std::unordered_map<unsigned int, double> &particle_size_std,
-      std::unordered_map<unsigned int, int>    &number,
+      std::unordered_map<unsigned int, int> &   number,
       std::unordered_map<unsigned int, double> &density_particle,
       std::unordered_map<unsigned int, double> &youngs_modulus_particle,
       std::unordered_map<unsigned int, double> &poisson_ratio_particle,
@@ -1015,10 +1015,10 @@ namespace Parameters
     void
     BCDEM::initialize_containers(
       std::unordered_map<unsigned int, Tensor<1, 3>>
-                                               &boundary_translational_velocity,
+        &                                       boundary_translational_velocity,
       std::unordered_map<unsigned int, double> &boundary_rotational_speed,
       std::unordered_map<unsigned int, Tensor<1, 3>>
-                                &boundary_rotational_vector,
+        &                        boundary_rotational_vector,
       std::vector<unsigned int> &outlet_boundaries,
       std::vector<unsigned int> &periodic_boundaries,
       std::vector<unsigned int> &periodic_direction)


### PR DESCRIPTION
# Description of the problem

- The default rolling friction was no friction which maybe was not the wisest decision

# Description of the solution

- Put the default rolling friction to the constant model

# How Has This Been Tested?

- All test pass. Some of them were using default rolling friction and I manually put them to no_friction

# Documentation

- Fixed the default value in the documentation



# Comments

- We  can keep on improving the theory guide on these issues :). We could also compare the different models.
- 