### PR TITLE
Unique mesh reader

### DIFF
--- a/applications/initial_conditions/initial_conditions.cc
+++ b/applications/initial_conditions/initial_conditions.cc
@@ -49,7 +49,7 @@ void
 InitialConditionsNavierStokes<dim>::run()
 {
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -41,9 +41,22 @@ using namespace dealii;
 template <int dim, int spacedim = dim>
 void
 attach_grid_to_triangulation(
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  const Parameters::Mesh &                               mesh_parameters);
+
+
+/**
+ * @brief Modifies the triangulation to setup periodic boundary conditions in the case of CFD simulations
+ *
+ * @param triangulation The triangulation to which a grid is attached
+ *
+ * @param boundary_conditions The information about the boundary conditions id. This is used to set-up the periodicity of the domain
+ */
+template <int dim, int spacedim = dim>
+void
+setup_periodic_boundary_conditions(
   std::shared_ptr<parallel::DistributedTriangulationBase<dim, spacedim>>
                                                           triangulation,
-  const Parameters::Mesh &                                mesh_parameters,
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
 
 /**

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -55,8 +55,7 @@ attach_grid_to_triangulation(
 template <int dim, int spacedim = dim>
 void
 setup_periodic_boundary_conditions(
-  std::shared_ptr<parallel::DistributedTriangulationBase<dim, spacedim>>
-                                                          triangulation,
+  parallel::DistributedTriangulationBase<dim, spacedim> & triangulation,
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
 
 /**
@@ -73,8 +72,7 @@ setup_periodic_boundary_conditions(
 template <int dim, int spacedim = dim>
 void
 read_mesh_and_manifolds(
-  std::shared_ptr<parallel::DistributedTriangulationBase<dim, spacedim>>
-                                                          triangulation,
+  parallel::DistributedTriangulationBase<dim, spacedim> & triangulation,
   const Parameters::Mesh &                                mesh_parameters,
   const Parameters::Manifolds &                           manifolds_parameters,
   const bool &                                            restart,

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -173,9 +173,8 @@ public:
 template <int dim, int spacedim = dim>
 void
 attach_manifolds_to_triangulation(
-  std::shared_ptr<parallel::DistributedTriangulationBase<dim, spacedim>>
-                              triangulation,
-  const Parameters::Manifolds manifolds);
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  const Parameters::Manifolds                            manifolds);
 
 /**
  * @brief Attaches CAD manifolds using IGES files to boundaries of the triangulation
@@ -189,19 +188,19 @@ attach_manifolds_to_triangulation(
  * @param manifold_id Identifier of the manifold
  */
 void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<2>> triangulation,
-  std::string                                                cad_name,
-  unsigned int                                               manifold_id);
+  parallel::DistributedTriangulationBase<2> &triangulation,
+  std::string                                cad_name,
+  unsigned int                               manifold_id);
 
 void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<2, 3>> triangulation,
-  std::string                                                   cad_name,
-  unsigned int                                                  manifold_id);
+  parallel::DistributedTriangulationBase<2, 3> &triangulation,
+  std::string                                   cad_name,
+  unsigned int                                  manifold_id);
 
 void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<3>> triangulation,
-  std::string                                                cad_name,
-  unsigned int                                               manifold_id);
+  parallel::DistributedTriangulationBase<3> &triangulation,
+  std::string                                cad_name,
+  unsigned int                               manifold_id);
 
 
 

--- a/include/dem/read_mesh.h
+++ b/include/dem/read_mesh.h
@@ -45,10 +45,10 @@ using namespace std;
  */
 template <int dim, int spacedim = dim>
 void
-read_mesh(const Parameters::Mesh &             mesh_parameters,
-          const bool                           restart,
-          const ConditionalOStream &           pcout,
-          Triangulation<dim, spacedim> &       triangulation,
+read_mesh(const Parameters::Mesh &  mesh_parameters,
+          const bool                restart,
+          const ConditionalOStream &pcout,
+          parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
           double &                             triangulation_cell_diameter,
           const Parameters::Lagrangian::BCDEM &bc_params);
 

--- a/include/fem-dem/cfd_dem_coupling.h
+++ b/include/fem-dem/cfd_dem_coupling.h
@@ -105,6 +105,18 @@ private:
   dem_contact_build(unsigned int counter);
 
   /**
+   * @brief Sets up the various parameters related to the DEM contacts
+   */
+  void
+  dem_setup_contact_parameters();
+
+  /**
+   * @brief Connect triangulation for load balancing and particles
+   */
+  void
+  manage_triangulation_connections();
+
+  /**
    * @brief Carries out the initialization of DEM parameters
    */
   void
@@ -240,7 +252,5 @@ private:
   const unsigned int            this_mpi_process;
   const unsigned int            n_mpi_processes;
   LagrangianPostProcessing<dim> dem_post_processing_object;
-
-  Triangulation<dim> tria;
 };
 #endif

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -274,7 +274,7 @@ attach_grid_to_triangulation(
   // Rotate the mesh
   if (mesh_parameters.rotate)
     throw std::runtime_error(
-      "Main grid can't be rotated: the solid mesh must be rotated instead. Grid will not be rotated.");
+      "Main grid cannot be rotated: the solid mesh must be rotated instead. The grid will not be rotated.");
 }
 
 

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -257,9 +257,8 @@ namespace Parameters
 template <int dim, int spacedim>
 void
 attach_manifolds_to_triangulation(
-  std::shared_ptr<parallel::DistributedTriangulationBase<dim, spacedim>>
-                        triangulation,
-  Parameters::Manifolds manifolds)
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  Parameters::Manifolds                                  manifolds)
 {
   for (unsigned int i = 0; i < manifolds.types.size(); ++i)
     {
@@ -275,9 +274,9 @@ attach_manifolds_to_triangulation(
                                            manifolds.arg3[i]);
           static const SphericalManifold<dim, spacedim> manifold_description(
             circleCenter);
-          triangulation->set_manifold(manifolds.id[i], manifold_description);
-          triangulation->set_all_manifold_ids_on_boundary(manifolds.id[i],
-                                                          manifolds.id[i]);
+          triangulation.set_manifold(manifolds.id[i], manifold_description);
+          triangulation.set_all_manifold_ids_on_boundary(manifolds.id[i],
+                                                         manifolds.id[i]);
         }
       else if (manifolds.types[i] == Parameters::Manifolds::ManifoldType::iges)
         {
@@ -292,32 +291,30 @@ attach_manifolds_to_triangulation(
     }
 }
 
-void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<2>>,
-  std::string,
-  unsigned int)
+void attach_cad_to_manifold(parallel::DistributedTriangulationBase<2> &,
+                            std::string,
+                            unsigned int)
 {
   throw std::runtime_error("IGES manifolds are not supported in 2D");
 }
 
-void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<2, 3>>,
-  std::string,
-  unsigned int)
+void attach_cad_to_manifold(parallel::DistributedTriangulationBase<2, 3> &,
+                            std::string,
+                            unsigned int)
 {
   throw std::runtime_error("IGES manifolds are not supported in 2D/3D");
 }
 
 #ifdef DEAL_II_WITH_OPENCASCADE
 void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<3>> triangulation,
-  std::string                                                cad_name,
-  unsigned int                                               manifold_id)
+  parallel::DistributedTriangulationBase<3> &triangulation,
+  std::string                                cad_name,
+  unsigned int                               manifold_id)
 {
   TopoDS_Shape cad_surface = OpenCASCADE::read_IGES(cad_name, 1e-3);
 
   // Enforce manifold over boundary ID
-  for (const auto &cell : triangulation->active_cell_iterators())
+  for (const auto &cell : triangulation.active_cell_iterators())
     {
       for (const auto &face : cell->face_iterators())
         {
@@ -336,13 +333,12 @@ void attach_cad_to_manifold(
   OpenCASCADE::NormalToMeshProjectionManifold<3, 3> normal_projector(
     cad_surface, tolerance);
 
-  triangulation->set_manifold(manifold_id, normal_projector);
+  triangulation.set_manifold(manifold_id, normal_projector);
 }
 #else
-void attach_cad_to_manifold(
-  std::shared_ptr<parallel::DistributedTriangulationBase<3>>,
-  std::string,
-  unsigned int)
+void attach_cad_to_manifold(parallel::DistributedTriangulationBase<3> &,
+                            std::string,
+                            unsigned int)
 {
   throw std::runtime_error(
     "IGES manifolds require DEAL_II to be compiled with OPENCASCADE");
@@ -351,13 +347,13 @@ void attach_cad_to_manifold(
 
 
 template void attach_manifolds_to_triangulation(
-  std::shared_ptr<parallel::DistributedTriangulationBase<2>> triangulation,
-  Parameters::Manifolds                                      manifolds);
+  parallel::DistributedTriangulationBase<2> &triangulation,
+  Parameters::Manifolds                      manifolds);
 
 template void attach_manifolds_to_triangulation(
-  std::shared_ptr<parallel::DistributedTriangulationBase<3>> triangulation,
-  Parameters::Manifolds                                      manifolds);
+  parallel::DistributedTriangulationBase<3> &triangulation,
+  Parameters::Manifolds                      manifolds);
 
 template void attach_manifolds_to_triangulation(
-  std::shared_ptr<parallel::DistributedTriangulationBase<2, 3>> triangulation,
-  Parameters::Manifolds                                         manifolds);
+  parallel::DistributedTriangulationBase<2, 3> &triangulation,
+  Parameters::Manifolds                         manifolds);

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -1,194 +1,20 @@
-#include <core/periodic_hills_grid.h>
+#include <core/grids.h>
 
 #include <dem/read_mesh.h>
 
 
 template <int dim, int spacedim>
 void
-read_mesh(const Parameters::Mesh &             mesh_parameters,
-          const bool                           restart,
-          const ConditionalOStream &           pcout,
-          Triangulation<dim, spacedim> &       triangulation,
+read_mesh(const Parameters::Mesh &  mesh_parameters,
+          const bool                restart,
+          const ConditionalOStream &pcout,
+          parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
           double &                             triangulation_cell_diameter,
           const Parameters::Lagrangian::BCDEM &bc_params)
 {
   pcout << "Reading triangulation " << std::endl;
-  // GMSH input
-  if (mesh_parameters.type == Parameters::Mesh::Type::gmsh)
-    {
-      GridIn<dim, spacedim> grid_in;
-      grid_in.attach_triangulation(triangulation);
-      std::ifstream input_file(mesh_parameters.file_name);
-      grid_in.read_msh(input_file);
-    }
 
-  // Dealii grids
-  else if (mesh_parameters.type == Parameters::Mesh::Type::dealii)
-    {
-      GridGenerator::generate_from_name_and_arguments(
-        triangulation,
-        mesh_parameters.grid_type,
-        mesh_parameters.grid_arguments);
-    }
-
-  // Customizable cylinder mesh
-  else if (mesh_parameters.type == Parameters::Mesh::Type::cylinder)
-    {
-      if (mesh_parameters.simplex)
-        {
-          throw std::runtime_error(
-            "Unsupported mesh type - custom cylinder mesh with simplex is not supported. Use a dealii cylinder to use simplex mesh.");
-        }
-      else if (dim != 3)
-        {
-          throw std::runtime_error(
-            "Unsupported mesh type - custom cylinder mesh is only supported in 3d.");
-        }
-
-      if constexpr (dim == 3)
-        {
-          // Separate arguments of the string
-          std::vector<std::string> arguments;
-          std::stringstream        s_stream(mesh_parameters.grid_arguments);
-          while (s_stream.good())
-            {
-              std::string substr;
-              getline(s_stream, substr, ':');
-              arguments.push_back(substr);
-            }
-
-          // Arguments declaration
-          unsigned int subdivisions;
-          double       radius, half_height;
-          if (arguments.size() != 3)
-            {
-              throw std::runtime_error(
-                "Mandatory cylinder parameters are (x subdivisions: radius : half height)");
-            }
-          else
-            {
-              std::vector<double> arguments_double =
-                dealii::Utilities::string_to_double(arguments);
-              subdivisions = static_cast<int>(arguments_double[0]);
-              radius       = arguments_double[1];
-              half_height  = arguments_double[2];
-            }
-
-          if (mesh_parameters.grid_type == "classic")
-            {
-              // Create a subdivided cylinder from deal.ii
-              GridGenerator::subdivided_cylinder(triangulation,
-                                                 subdivisions,
-                                                 radius,
-                                                 half_height);
-            }
-          else
-            {
-              // Create a temporary 2d mesh
-              Triangulation<2, spacedim - 1> temporary_triangulation;
-
-              // Create a spherical manifold for 2d mesh
-              Point<2>                                 center(0.0, 0.0);
-              const SphericalManifold<2, spacedim - 1> m0(center);
-
-              if (mesh_parameters.grid_type == "regularized" ||
-                  mesh_parameters.grid_type == "squared")
-                {
-                  // Create a square mesh
-                  double real_radius = radius * std::sin(M_PI_4);
-                  GridGenerator::hyper_cube(temporary_triangulation,
-                                            -real_radius,
-                                            real_radius,
-                                            true);
-
-                  // Assign boundary 0 to perimeter as for cylinder
-                  for (const auto &cell :
-                       temporary_triangulation.active_cell_iterators())
-                    {
-                      if (cell->is_locally_owned())
-                        {
-                          // Looping through all the faces of the cell
-                          for (const auto &face : cell->face_iterators())
-                            {
-                              // Check to see if the face is located at boundary
-                              if (face->at_boundary())
-                                {
-                                  face->set_boundary_id(0);
-                                }
-                            }
-                        }
-                    }
-                }
-              else if (mesh_parameters.grid_type == "balanced")
-                {
-                  GridGenerator::hyper_ball_balanced(temporary_triangulation,
-                                                     center,
-                                                     radius);
-                }
-              else
-                {
-                  throw std::runtime_error(
-                    "Unknown grid type. Choices are <classic|balanced|squared|regularized>.");
-                }
-
-              temporary_triangulation.reset_all_manifolds();
-              temporary_triangulation.set_all_manifold_ids_on_boundary(0);
-              temporary_triangulation.set_manifold(0, m0);
-
-              if (mesh_parameters.grid_type == "regularized")
-                {
-                  // Pre-refinement to reduce mesh size at corners before
-                  // regularization
-                  temporary_triangulation.refine_global(2);
-                  GridTools::regularize_corner_cells(temporary_triangulation);
-
-                  // Flatten the triangulation
-                  Triangulation<2, spacedim - 1> flat_temporary_triangulation;
-                  flat_temporary_triangulation.copy_triangulation(
-                    temporary_triangulation);
-                  temporary_triangulation.clear();
-                  GridGenerator::flatten_triangulation(
-                    flat_temporary_triangulation, temporary_triangulation);
-                }
-
-              // Extrude the 2d temporary mesh to 3d cylinder
-              GridGenerator::extrude_triangulation(temporary_triangulation,
-                                                   subdivisions + 1,
-                                                   2.0 * half_height,
-                                                   triangulation,
-                                                   true);
-
-              // Rotate mesh in x-axis and set the (0,0,0) at the barycenter
-              // to be comparable to dealii cylinder meshes
-              Tensor<1, spacedim> axis_vector({0.0, 1.0, 0.0});
-              GridTools::rotate(axis_vector, M_PI_2, triangulation);
-              Tensor<1, spacedim> shift_vector({-half_height, 0.0, 0.0});
-              GridTools::shift(shift_vector, triangulation);
-
-              // Add a cylindrical manifold on the final unrefined mesh
-              const CylindricalManifold<3, spacedim> m1(0);
-              triangulation.set_manifold(0, m1);
-            }
-        }
-    }
-  // Periodic Hills grid
-  else if (mesh_parameters.type == Parameters::Mesh::Type::periodic_hills &&
-           !mesh_parameters.simplex)
-    {
-      if (mesh_parameters.simplex)
-        {
-          throw std::runtime_error(
-            "Unsupported mesh type - periodic hills mesh with simplex is not supported");
-        }
-      else
-        {
-          PeriodicHillsGrid<dim, spacedim> grid(mesh_parameters.grid_arguments);
-          grid.make_grid(triangulation);
-        }
-    }
-  else
-    throw std::runtime_error(
-      "Unsupported mesh type - mesh will not be created");
+  attach_grid_to_triangulation(triangulation, mesh_parameters);
 
   triangulation_cell_diameter = 0.5 * GridTools::diameter(triangulation);
 
@@ -243,35 +69,26 @@ match_periodic_boundaries(Triangulation<dim, spacedim> &       triangulation,
     }
 }
 
-
 template void
-read_mesh<1, 2>(const Parameters::Mesh &  mesh_parameters,
-                const bool                restart,
-                const ConditionalOStream &pcout,
-                Triangulation<1, 2> &     triangulation,
-                double &                  triangulation_cell_diameter,
+read_mesh<2, 2>(const Parameters::Mesh &                      mesh_parameters,
+                const bool                                    restart,
+                const ConditionalOStream &                    pcout,
+                parallel::DistributedTriangulationBase<2, 2> &triangulation,
+                double &triangulation_cell_diameter,
                 const Parameters::Lagrangian::BCDEM &bc_params);
 
 template void
-read_mesh<2, 2>(const Parameters::Mesh &  mesh_parameters,
-                const bool                restart,
-                const ConditionalOStream &pcout,
-                Triangulation<2, 2> &     triangulation,
-                double &                  triangulation_cell_diameter,
+read_mesh<2, 3>(const Parameters::Mesh &                      mesh_parameters,
+                const bool                                    restart,
+                const ConditionalOStream &                    pcout,
+                parallel::DistributedTriangulationBase<2, 3> &triangulation,
+                double &triangulation_cell_diameter,
                 const Parameters::Lagrangian::BCDEM &bc_params);
 
 template void
-read_mesh<2, 3>(const Parameters::Mesh &  mesh_parameters,
-                const bool                restart,
-                const ConditionalOStream &pcout,
-                Triangulation<2, 3> &     triangulation,
-                double &                  triangulation_cell_diameter,
-                const Parameters::Lagrangian::BCDEM &bc_params);
-
-template void
-read_mesh<3, 3>(const Parameters::Mesh &  mesh_parameters,
-                const bool                restart,
-                const ConditionalOStream &pcout,
-                Triangulation<3, 3> &     triangulation,
-                double &                  triangulation_cell_diameter,
+read_mesh<3, 3>(const Parameters::Mesh &                      mesh_parameters,
+                const bool                                    restart,
+                const ConditionalOStream &                    pcout,
+                parallel::DistributedTriangulationBase<3, 3> &triangulation,
+                double &triangulation_cell_diameter,
                 const Parameters::Lagrangian::BCDEM &bc_params);

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1236,7 +1236,7 @@ CFDDEMSolver<dim>::solve()
   MultithreadInfo::set_thread_limit(1);
 
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->cfd_dem_simulation_parameters.cfd_parameters.mesh,
     this->cfd_dem_simulation_parameters.cfd_parameters.manifolds_parameters,
     true,

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -170,9 +170,12 @@ CFDDEMSolver<dim>::CFDDEMSolver(CFDDEMSimulationParameters<dim> &nsparam)
                maximum_particle_diameter,
              2);
 
-  attach_grid_to_triangulation(
+  read_mesh_and_manifolds(
     *this->triangulation,
-    this->cfd_dem_simulation_parameters.dem_parameters.mesh);
+    this->cfd_dem_simulation_parameters.cfd_parameters.mesh,
+    this->cfd_dem_simulation_parameters.cfd_parameters.manifolds_parameters,
+    true,
+    this->cfd_dem_simulation_parameters.cfd_parameters.boundary_conditions);
 
   triangulation_cell_diameter = 0.5 * GridTools::diameter(tria);
 
@@ -1222,12 +1225,7 @@ CFDDEMSolver<dim>::solve()
   // better speed-up than using MPI. This could be eventually changed...
   MultithreadInfo::set_thread_limit(1);
 
-  read_mesh_and_manifolds(
-    *this->triangulation,
-    this->cfd_dem_simulation_parameters.cfd_parameters.mesh,
-    this->cfd_dem_simulation_parameters.cfd_parameters.manifolds_parameters,
-    true,
-    this->cfd_dem_simulation_parameters.cfd_parameters.boundary_conditions);
+
 
   // Reading DEM start file information
   if (this->cfd_dem_simulation_parameters.void_fraction->read_dem == true &&

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1,3 +1,4 @@
+#include <core/grids.h>
 #include <core/solutions_output.h>
 
 #include <dem/dem_solver_parameters.h>
@@ -169,23 +170,9 @@ CFDDEMSolver<dim>::CFDDEMSolver(CFDDEMSimulationParameters<dim> &nsparam)
                maximum_particle_diameter,
              2);
 
-  if (dem_parameters.mesh.type == Parameters::Mesh::Type::dealii)
-    {
-      GridGenerator::generate_from_name_and_arguments(
-        tria,
-        this->cfd_dem_simulation_parameters.dem_parameters.mesh.grid_type,
-        this->cfd_dem_simulation_parameters.dem_parameters.mesh.grid_arguments);
-    }
-  else if (dem_parameters.mesh.type == Parameters::Mesh::Type::gmsh)
-    {
-      GridIn<dim> grid_in;
-      grid_in.attach_triangulation(tria);
-      std::ifstream input_file(dem_parameters.mesh.file_name);
-      grid_in.read_msh(input_file);
-    }
-  else
-    throw std::runtime_error(
-      "Unsupported mesh type - mesh will not be created");
+  attach_grid_to_triangulation(
+    *this->triangulation,
+    this->cfd_dem_simulation_parameters.dem_parameters.mesh);
 
   triangulation_cell_diameter = 0.5 * GridTools::diameter(tria);
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -137,132 +137,7 @@ CFDDEMSolver<dim>::CFDDEMSolver(CFDDEMSimulationParameters<dim> &nsparam)
   : GLSVANSSolver<dim>(nsparam)
   , this_mpi_process(Utilities::MPI::this_mpi_process(this->mpi_communicator))
   , n_mpi_processes(Utilities::MPI::n_mpi_processes(this->mpi_communicator))
-{
-  coupling_frequency =
-    this->cfd_dem_simulation_parameters.cfd_dem.coupling_frequency;
-
-  standard_deviation_multiplier = 2.5;
-
-  // Initialize DEM Parameters
-  dem_parameters.lagrangian_physical_properties =
-    this->cfd_dem_simulation_parameters.dem_parameters
-      .lagrangian_physical_properties;
-  dem_parameters.boundary_conditions =
-    this->cfd_dem_simulation_parameters.dem_parameters.boundary_conditions;
-  dem_parameters.floating_walls =
-    this->cfd_dem_simulation_parameters.dem_parameters.floating_walls;
-  dem_parameters.model_parameters =
-    this->cfd_dem_simulation_parameters.dem_parameters.model_parameters;
-  dem_parameters.simulation_control =
-    this->cfd_dem_simulation_parameters.dem_parameters.simulation_control;
-  dem_parameters.post_processing =
-    this->cfd_dem_simulation_parameters.dem_parameters.post_processing;
-  dem_parameters.mesh = this->cfd_dem_simulation_parameters.dem_parameters.mesh;
-  dem_parameters.restart =
-    this->cfd_dem_simulation_parameters.dem_parameters.restart;
-
-
-  maximum_particle_diameter =
-    find_maximum_particle_size(dem_parameters.lagrangian_physical_properties,
-                               standard_deviation_multiplier);
-  neighborhood_threshold_squared =
-    std::pow(dem_parameters.model_parameters.neighborhood_threshold *
-               maximum_particle_diameter,
-             2);
-
-  read_mesh_and_manifolds(
-    *this->triangulation,
-    this->cfd_dem_simulation_parameters.cfd_parameters.mesh,
-    this->cfd_dem_simulation_parameters.cfd_parameters.manifolds_parameters,
-    true,
-    this->cfd_dem_simulation_parameters.cfd_parameters.boundary_conditions);
-
-  triangulation_cell_diameter = 0.5 * GridTools::diameter(tria);
-
-  //   Finding the smallest contact search frequency criterion between (smallest
-  //   cell size - largest particle radius) and (security factor * (blab
-  //   diamater - 1) *  largest particle radius). This value is used in
-  //   find_contact_detection_frequency function
-  smallest_contact_search_criterion =
-    std::min((GridTools::minimal_cell_diameter(tria) -
-              maximum_particle_diameter * 0.5),
-             (dem_parameters.model_parameters.dynamic_contact_search_factor *
-              (dem_parameters.model_parameters.neighborhood_threshold - 1) *
-              maximum_particle_diameter * 0.5));
-
-  dem_time_step =
-    this->simulation_control->get_time_step() / coupling_frequency;
-
-  double rayleigh_time_step = 0;
-
-  for (unsigned int i = 0;
-       i < dem_parameters.lagrangian_physical_properties.particle_type_number;
-       ++i)
-    rayleigh_time_step = std::max(
-      M_PI_2 *
-        dem_parameters.lagrangian_physical_properties
-          .particle_average_diameter[i] *
-        sqrt(2 *
-             dem_parameters.lagrangian_physical_properties.density_particle[i] *
-             (2 + dem_parameters.lagrangian_physical_properties
-                    .poisson_ratio_particle[i]) *
-             (1 - dem_parameters.lagrangian_physical_properties
-                    .poisson_ratio_particle[i]) /
-             dem_parameters.lagrangian_physical_properties
-               .youngs_modulus_particle[i]) /
-        (0.1631 * dem_parameters.lagrangian_physical_properties
-                    .poisson_ratio_particle[i] +
-         0.8766),
-      rayleigh_time_step);
-
-  const double time_step_rayleigh_ratio = dem_time_step / rayleigh_time_step;
-  this->pcout << "DEM time-step is " << time_step_rayleigh_ratio * 100
-              << "% of Rayleigh time step" << std::endl;
-
-  // Necessary signals for load balancing. This signals are only connected if
-  // load balancing is enabled. This helps prevent errors in read_dem function
-  // for Deal.II version 9.3
-  //  const auto parallel_triangulation =
-  //    dynamic_cast<parallel::distributed::Triangulation<dim> *>(
-  //      &*this->triangulation);
-
-  const auto parallel_triangulation =
-    dynamic_cast<parallel::distributed::Triangulation<dim> *>(
-      &*this->triangulation);
-
-  if (dem_parameters.model_parameters.load_balance_method !=
-      Parameters::Lagrangian::ModelParameters::LoadBalanceMethod::none)
-    {
-      parallel_triangulation->signals.weight.connect(
-        [](const typename Triangulation<dim>::cell_iterator &,
-           const typename Triangulation<dim>::CellStatus) -> unsigned int {
-          return 1000;
-        });
-
-      parallel_triangulation->signals.weight.connect(
-        [&](const typename parallel::distributed::Triangulation<
-              dim>::cell_iterator &cell,
-            const typename parallel::distributed::Triangulation<dim>::CellStatus
-              status) -> unsigned int {
-          return this->cell_weight(cell, status);
-        });
-    }
-
-  // Initilize contact detection step
-  contact_detection_step = false;
-  load_balance_step      = false;
-
-  // In the case the simulation is being restarted from a checkpoint file, the
-  // checkpoint_step parameter is set to true. This allows to perform all
-  // operations related to restarting a simulation. Once all operations have
-  // been performed, this checkpoint_step is reset to false. It is only set once
-  // and reset once since restarting only occurs once.
-  if (this->cfd_dem_simulation_parameters.cfd_parameters.restart_parameters
-        .restart == true)
-    checkpoint_step = true;
-  else
-    checkpoint_step = false;
-}
+{}
 
 template <int dim>
 CFDDEMSolver<dim>::~CFDDEMSolver()
@@ -1219,13 +1094,141 @@ CFDDEMSolver<dim>::print_particles_summary()
 
 template <int dim>
 void
+CFDDEMSolver<dim>::dem_setup_contact_parameters()
+{
+  coupling_frequency =
+    this->cfd_dem_simulation_parameters.cfd_dem.coupling_frequency;
+
+  standard_deviation_multiplier = 2.5;
+
+  // Initialize DEM Parameters
+  dem_parameters.lagrangian_physical_properties =
+    this->cfd_dem_simulation_parameters.dem_parameters
+      .lagrangian_physical_properties;
+  dem_parameters.boundary_conditions =
+    this->cfd_dem_simulation_parameters.dem_parameters.boundary_conditions;
+  dem_parameters.floating_walls =
+    this->cfd_dem_simulation_parameters.dem_parameters.floating_walls;
+  dem_parameters.model_parameters =
+    this->cfd_dem_simulation_parameters.dem_parameters.model_parameters;
+  dem_parameters.simulation_control =
+    this->cfd_dem_simulation_parameters.dem_parameters.simulation_control;
+  dem_parameters.post_processing =
+    this->cfd_dem_simulation_parameters.dem_parameters.post_processing;
+  dem_parameters.mesh = this->cfd_dem_simulation_parameters.dem_parameters.mesh;
+  dem_parameters.restart =
+    this->cfd_dem_simulation_parameters.dem_parameters.restart;
+
+
+  maximum_particle_diameter =
+    find_maximum_particle_size(dem_parameters.lagrangian_physical_properties,
+                               standard_deviation_multiplier);
+  neighborhood_threshold_squared =
+    std::pow(dem_parameters.model_parameters.neighborhood_threshold *
+               maximum_particle_diameter,
+             2);
+
+
+  triangulation_cell_diameter = 0.5 * GridTools::diameter(*this->triangulation);
+
+  //   Finding the smallest contact search frequency criterion between (smallest
+  //   cell size - largest particle radius) and (security factor * (blab
+  //   diamater - 1) *  largest particle radius). This value is used in
+  //   find_contact_detection_frequency function
+  smallest_contact_search_criterion =
+    std::min((GridTools::minimal_cell_diameter(*this->triangulation) -
+              maximum_particle_diameter * 0.5),
+             (dem_parameters.model_parameters.dynamic_contact_search_factor *
+              (dem_parameters.model_parameters.neighborhood_threshold - 1) *
+              maximum_particle_diameter * 0.5));
+
+  dem_time_step =
+    this->simulation_control->get_time_step() / coupling_frequency;
+
+  double rayleigh_time_step = 0;
+
+  for (unsigned int i = 0;
+       i < dem_parameters.lagrangian_physical_properties.particle_type_number;
+       ++i)
+    rayleigh_time_step = std::max(
+      M_PI_2 *
+        dem_parameters.lagrangian_physical_properties
+          .particle_average_diameter[i] *
+        sqrt(2 *
+             dem_parameters.lagrangian_physical_properties.density_particle[i] *
+             (2 + dem_parameters.lagrangian_physical_properties
+                    .poisson_ratio_particle[i]) *
+             (1 - dem_parameters.lagrangian_physical_properties
+                    .poisson_ratio_particle[i]) /
+             dem_parameters.lagrangian_physical_properties
+               .youngs_modulus_particle[i]) /
+        (0.1631 * dem_parameters.lagrangian_physical_properties
+                    .poisson_ratio_particle[i] +
+         0.8766),
+      rayleigh_time_step);
+
+  const double time_step_rayleigh_ratio = dem_time_step / rayleigh_time_step;
+  this->pcout << "DEM time-step is " << time_step_rayleigh_ratio * 100
+              << "% of Rayleigh time step" << std::endl;
+
+  // Initilize contact detection step
+  contact_detection_step = false;
+  load_balance_step      = false;
+}
+
+template <int dim>
+void
+CFDDEMSolver<dim>::manage_triangulation_connections()
+{
+  // Necessary signals for load balancing. This signals are only connected if
+  // load balancing is enabled. This helps prevent errors in read_dem function
+  // for Deal.II version 9.3
+  //  const auto parallel_triangulation =
+  //    dynamic_cast<parallel::distributed::Triangulation<dim> *>(
+  //      &*this->triangulation);
+
+  const auto parallel_triangulation =
+    dynamic_cast<parallel::distributed::Triangulation<dim> *>(
+      &*this->triangulation);
+
+  if (dem_parameters.model_parameters.load_balance_method !=
+      Parameters::Lagrangian::ModelParameters::LoadBalanceMethod::none)
+    {
+      parallel_triangulation->signals.weight.connect(
+        [](const typename Triangulation<dim>::cell_iterator &,
+           const typename Triangulation<dim>::CellStatus) -> unsigned int {
+          return 1000;
+        });
+
+      parallel_triangulation->signals.weight.connect(
+        [&](const typename parallel::distributed::Triangulation<
+              dim>::cell_iterator &cell,
+            const typename parallel::distributed::Triangulation<dim>::CellStatus
+              status) -> unsigned int {
+          return this->cell_weight(cell, status);
+        });
+    }
+}
+
+template <int dim>
+void
 CFDDEMSolver<dim>::solve()
 {
   // This is enforced to 1 right now because it does not provide
   // better speed-up than using MPI. This could be eventually changed...
   MultithreadInfo::set_thread_limit(1);
 
+  read_mesh_and_manifolds(
+    *this->triangulation,
+    this->cfd_dem_simulation_parameters.cfd_parameters.mesh,
+    this->cfd_dem_simulation_parameters.cfd_parameters.manifolds_parameters,
+    true,
+    this->cfd_dem_simulation_parameters.cfd_parameters.boundary_conditions);
 
+
+  manage_triangulation_connections();
+
+  dem_setup_contact_parameters();
 
   // Reading DEM start file information
   if (this->cfd_dem_simulation_parameters.void_fraction->read_dem == true &&
@@ -1239,6 +1242,18 @@ CFDDEMSolver<dim>::solve()
     this->cfd_dem_simulation_parameters.cfd_parameters.initial_condition->type,
     this->cfd_dem_simulation_parameters.cfd_parameters.restart_parameters
       .restart);
+
+
+  // In the case the simulation is being restarted from a checkpoint file, the
+  // checkpoint_step parameter is set to true. This allows to perform all
+  // operations related to restarting a simulation. Once all operations have
+  // been performed, this checkpoint_step is reset to false. It is only set once
+  // and reset once since restarting only occurs once.
+  if (this->cfd_dem_simulation_parameters.cfd_parameters.restart_parameters
+        .restart == true)
+    checkpoint_step = true;
+  else
+    checkpoint_step = false;
 
   // Initilize DEM parameters
   initialize_dem_parameters();

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -3648,7 +3648,7 @@ GLSSharpNavierStokesSolver<dim>::solve()
 {
   MultithreadInfo::set_thread_limit(1);
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1685,7 +1685,7 @@ GLSVANSSolver<dim>::solve()
   MultithreadInfo::set_thread_limit(1);
 
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->cfd_dem_simulation_parameters.cfd_parameters.mesh,
     this->cfd_dem_simulation_parameters.cfd_parameters.manifolds_parameters,
     this->cfd_dem_simulation_parameters.cfd_parameters.restart_parameters

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -1187,7 +1187,7 @@ GDNavierStokesSolver<dim>::solve()
   MultithreadInfo::set_thread_limit(1);
 
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1556,7 +1556,7 @@ GLSNavierStokesSolver<dim>::solve()
   MultithreadInfo::set_thread_limit(1);
 
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -693,7 +693,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
 
   // Fluid setup
   read_mesh_and_manifolds(
-    this->triangulation,
+    *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,


### PR DESCRIPTION
# Description of the problem

- The DEM module contained a lot of code duplication from the CFD module. The entire part related to the attachment of the grid to the triangulation was fully duplicated. This was a total mess.

# Description of the solution

- Refactor the reader to at least use the same attachment mechanism
- I also took the opportunity to clean the interface to use references instead of pointers. This make the code more portable and easier to use everywhere.

# How Has This Been Tested?

- All tests pass without a change

# Comments

- Ongoing process to clean the DEM code
- Closes #561 
