### PR TITLE
Fix crash in debug for Lagrangian post-processing and documentation

### DIFF
--- a/doc/source/parameters/dem/post-processing.rst
+++ b/doc/source/parameters/dem/post-processing.rst
@@ -23,4 +23,4 @@ The post-processing subsection of the ``.prm`` file is according to the followin
 .. note::
  By default, the post-processing is set to ``false``.
 
-* The ``Lagrangian post processing`` enables the built-in post-processing. The current outputs include the grid of the domain, the granular temperature, and the average velocity of particles (in x, y, z and its norm).
+* The ``Lagrangian post-processing`` enables the built-in post-processing. The current outputs include the grid of the domain, the granular temperature, and the average velocity of particles (in x, y, z and its norm).

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -190,6 +190,8 @@ LagrangianPostProcessing<dim>::write_post_processing_results(
     dem_parameters.simulation_control.group_files;
 
   DataOut<dim> data_out;
+  // Write grid
+  // data_out.attach_dof_handler(background_dh);
   data_out.attach_triangulation(triangulation);
 
   std::vector<std::string> average_solution_names;
@@ -233,8 +235,7 @@ LagrangianPostProcessing<dim>::write_post_processing_results(
                            average_solution_names.back(),
                            DataOut<dim>::type_cell_data);
 
-  // Write grid
-  data_out.attach_dof_handler(background_dh);
+
 
   // Attach the solution data to data_out object
   Vector<float> subdomain(triangulation.n_active_cells());


### PR DESCRIPTION
# Description of the problem

- The Lagrangian post-processing was crashing in debug because of a conflicting DataOut attachment

# Description of the solution

- Fixed it
- Also fixed a typo in the documentation


