### PR TITLE
Ensure that the output name doesn't contain '/'

### DIFF
--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -192,8 +192,12 @@ namespace Parameters
       startup_timestep_scaling = prm.get_double("startup time scaling");
       number_mesh_adaptation   = prm.get_integer("number mesh adapt");
 
-      output_folder     = prm.get("output path");
-      output_name       = prm.get("output name");
+      output_folder = prm.get("output path");
+      output_name   = prm.get("output name");
+      output_name.erase(std::remove(output_name.begin(),
+                                    output_name.end(),
+                                    '/'),
+                        output_name.end());
       output_frequency  = prm.get_integer("output frequency");
       output_time       = prm.get_double("output time");
       output_boundaries = prm.get_bool("output boundaries");


### PR DESCRIPTION
Ensure that the output name doesn't contain a '/', which is a problem for the output.

# Description of the problem

- Having a '/' character in the output name was allowed by the parameter handler, but it caused problems for the 'pvd' and 'pvtu' output files.

# Description of the solution

- Erase the '/' characters directly after parsing the output name.

# How Has This Been Tested?

- Simulations with and without the '/' character were ran.

# Comments

- Only the '/' were removed, but maybe another character may cause problems in the future.
