### PR TITLE
Alphabetize items in the documentation

### DIFF
--- a/doc/source/parameters/cfd/cfd.rst
+++ b/doc/source/parameters/cfd/cfd.rst
@@ -6,28 +6,28 @@ General, CFD and Multiphysics
 .. toctree::
    :maxdepth: 1
 
-   simulation_control
+   analytical_solution
+   boundary_conditions_cfd
+   boundary_conditions_multiphysics
+   box_refinement
    dimensionality
-   physical_properties
+   dynamic_flow_control
+   fem
+   force_and_torque
    initial_conditions
+   laser_heat_source
+   linear_solver_control
    mesh
    mesh_adaptation_control
-   fem
-   boundary_conditions_cfd
-   source_term
-   analytical_solution
-   force_and_torque
-   post_processing
-   timer
-   non-linear_solver_control
-   linear_solver_control
-   stabilization
    multiphysics
-   volume_of_fluid
-   boundary_conditions_multiphysics
    nitsche
+   non-linear_solver_control
+   physical_properties
+   post_processing
    restart
-   dynamic_flow_control
-   laser_heat_source
-   box_refinement
+   simulation_control
+   source_term
+   stabilization
+   timer
    velocity_source.rst
+   volume_of_fluid

--- a/doc/source/parameters/dem/dem.rst
+++ b/doc/source/parameters/dem/dem.rst
@@ -6,14 +6,14 @@ There are two discrete element method (DEM) solvers in Lethe: ``dem_2d`` and ``d
 .. toctree::
    :maxdepth: 1
 
-   simulation_control
-   timer
-   test
-   model_parameters
-   lagrangian_physical_properties
-   insertion_info
-   floating_wall
-   floating_mesh
-   mesh
    boundary_conditions
+   floating_mesh
+   floating_wall
+   insertion_info
+   lagrangian_physical_properties
+   mesh
+   model_parameters
    post-processing
+   simulation_control
+   test
+   timer

--- a/doc/source/parameters/rpt/rpt.rst
+++ b/doc/source/parameters/rpt/rpt.rst
@@ -9,7 +9,7 @@ The parameter file is composed of different subsections. The principal subsectio
 .. toctree::
    :maxdepth: 1
    
-   rpt_parameters
    detector_parameters
-   parameter_tuning
    fem_reconstruction
+   parameter_tuning
+   rpt_parameters

--- a/doc/source/parameters/unresolved-cfd-dem/unresolved-cfd-dem.rst
+++ b/doc/source/parameters/unresolved-cfd-dem/unresolved-cfd-dem.rst
@@ -6,6 +6,6 @@ The CFD-DEM solver templates are available in both 2D (``cfd_dem_coupling_2d``) 
 .. toctree::
    :maxdepth: 1
 
-   void-fraction
    cfd-dem
+   void-fraction
 


### PR DESCRIPTION
# Description of the problem

- Items in the parameter documentation were in a completely random order

# Description of the solution

- Order them
