### PR TITLE
Fix wetting

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/gls_vof_peeling.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_peeling.prm
@@ -24,7 +24,7 @@ end
 #---------------------------------------------------
 subsection VOF	
 	subsection peeling wetting
-		set enable = true
+		set enable peeling = true
 		set verbosity = verbose
 	end
 	subsection interface sharpening

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_wetting-inverted.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_wetting-inverted.prm
@@ -26,7 +26,7 @@ subsection VOF
 	set diffusivity = 5e-3
 
 	subsection peeling wetting
-		set enable = true
+		set enable wetting = true
 		set verbosity = verbose
 	end
 	subsection interface sharpening

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_wetting_mesh-adapt.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_wetting_mesh-adapt.prm
@@ -26,7 +26,7 @@ subsection VOF
 	set diffusivity = 5e-3
 
 	subsection peeling wetting
-		set enable = true
+		set enable wetting = true
 		set verbosity = verbose
 	end
 	subsection interface sharpening

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -136,7 +136,7 @@ The default values of the VOF parameters are given in the text box below.
 * ``subsection peeling wetting``: Peeling and wetting mechanisms are very important to consider when there are solid boundaries in the domain, like a wall. If the fluid is already on the wall and its velocity drives it away from it, the fluid should be able to detach from the wall, meaning to `peel` from it. If the fluid is not already on the wall and its velocity drives it toward it, the fluid should be able to attach to the wall, meaning to `wet` it. This subsection defines the parameters for peeling and wetting mechanisms at the VOF boundaries, as defined in :doc:`boundary_conditions_multiphysics`. 
 
   .. important::
-    This peeling/wetting mechanism implementation is a heuristic. It has been developed to meet the need of specific projects and gave satisfactory results as is, but it has not been broadly tested nor demonstrated, so its results should be considered with cautions. Do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
+    This peeling/wetting mechanism implementation is a heuristic. It has been developed to meet the need of specific projects and gave satisfactory results as is, but it has not been broadly tested nor demonstrated, so its results should be considered with caution. Do not hesitate to write to the team through the `Lethe GitHub page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
 
   .. warning::
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -151,7 +151,7 @@ The default values of the VOF parameters are given in the text box below.
     The cell is then filled with the lower density fluid by changing its phase value progressively.
 
     .. important::
-      Even if ``monitoring`` is not enabled, the ``monitored fluid`` (``fluid 1`` by default) will be considered as the fluid of interest for the average pressure calculation in the peeling/wetting mechanism.
+      Even if ``monitoring`` is not enabled, the ``monitored fluid`` (``fluid 1`` by default) will be considered the fluid of interest for the average pressure calculation in the peeling/wetting mechanism.
 
   * ``enable wetting``: controls if wetting mechanism is enabled. Wetting occurs in a cell where those conditions are met: 
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -164,7 +164,7 @@ The default values of the VOF parameters are given in the text box below.
     .. tip ::
       Using ``set enable wetting = false`` and relying on the ``diffusivity`` to wet the boundaries (see :ref:`improve wetting`) can give better results when the densities of the two fluids are of a very different order of magnitude. 
 
-      Typically, when one fluid is more than a hundred times denser than the other, the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
+      Typically, when one fluid is more than a hundred times denser than the other, the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe GitHub page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
 
   * ``verbosity``: enables the display of the number of peeled and wet cells at each time-step. Choices are: ``quiet`` (default, no output) and ``verbose``.
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -162,7 +162,9 @@ The default values of the VOF parameters are given in the text box below.
     The cell is then filled with the higher density fluid by changing its phase value progressively.
 
     .. tip ::
-      When the densities of the two fluids are of very different order of magnitude (typically, one fluid is more than a hundred times denser than the other), the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Then, using ``set enable wetting = false`` and relying on the ``diffusivity`` parameter to wet the boundaries (see :ref:`improve wetting`) can give better results. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
+      Using ``set enable wetting = false`` and relying on the ``diffusivity`` to wet the boundaries (see :ref:`improve wetting`) can give better results when the densities of the two fluids are of very different order of magnitude. 
+
+      Typically, when one fluid is more than a hundred times denser than the other, the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
 
   * ``verbosity``: enables the display of the number of peeled and wet cells at each time-step. Choices are: ``quiet`` (default, no output) and ``verbose``.
 
@@ -180,11 +182,14 @@ The default values of the VOF parameters are given in the text box below.
 
     Choices are: ``fluid 0``, ``fluid 1`` or ``both`` (default), with the fluid IDs defined in Physical properties - :ref:`two phase simulations`.
 
-  * ``monitoring``: controls if conservation is monitored at each iteration, through the volume computation of the fluid given as ``monitored fluid`` (``fluid 0`` or ``fluid 1`` (default)). Results are outputted in a data table (`VOF_monitoring_fluid_0.dat` or `VOF_monitoring_fluid_1.dat`).
+  * ``monitoring``: controls if conservation is monitored at each iteration, through the volume (3D) or surface (2D) computation of the fluid given as ``monitored fluid`` (``fluid 1`` (default) or ``fluid 0``). Results are outputted in a data table (`VOF_monitoring_fluid_0.dat` or `VOF_monitoring_fluid_1.dat`).
+
+    .. tip::
+      In 2D, the mass returned is in the dimension of :math:`\left[\text{mass}/\text{length}\right]`: multiply this value by the depth of your system to get the ``monitored fluid`` mass (in :math:`\text{kg}` if using SI units).
 
     .. admonition:: Example of file output, `VOF_monitoring_fluid_1.dat`:
 
-      The ``volume_fluid_1`` column gives the surface/volume (2D/3D) occupied by the fluid with index 1, its total mass, and the sharpening threshold used for this iteration.
+      The ``volume_fluid_1`` column gives the volume occupied by the fluid with index 1, its total mass, and the sharpening threshold used for this iteration.
   
       .. code-block:: text
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -153,7 +153,7 @@ The default values of the VOF parameters are given in the text box below.
     .. important::
       Even if ``monitoring`` is not enabled, the ``monitored fluid`` (``fluid 1`` by default) will be considered the fluid of interest for the average pressure calculation in the peeling/wetting mechanism.
 
-  * ``enable wetting``: controls if wetting mechanism is enabled. Wetting occurs in a cell where those conditions are met: 
+  * ``enable wetting``: controls if the wetting mechanism is enabled. Wetting occurs in a cell where those conditions are met: 
 
     * the cell is in the domain of the lower density fluid,
     * the cell pressure value is above the average pressure of the ``monitored fluid`` (``fluid 1`` by default, see ``subsection mass conservation``), and

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -1,4 +1,4 @@
-Multiphase Flow - Volume of Fluid
+Volume of Fluid (Multiphase Flow)
 ----------------------------------
 
 In this subsection, the parameters for multiphase flow simulation using the volume of fluid method (VOF) are specified. 
@@ -35,8 +35,9 @@ The default values of the VOF parameters are given in the text box below.
 		end
 
 		subsection peeling wetting
-			set enable 	= false
-			set verbosity 	= quiet
+			set enable peeling	= false
+			set enable wetting	= false
+			set verbosity 		= quiet
 		end
 
 		subsection mass conservation
@@ -135,10 +136,34 @@ The default values of the VOF parameters are given in the text box below.
 * ``subsection peeling wetting``: Peeling and wetting mechanisms are very important to consider when there are solid boundaries in the domain, like a wall. If the fluid is already on the wall and its velocity drives it away from it, the fluid should be able to detach from the wall, meaning to `peel` from it. If the fluid is not already on the wall and its velocity drives it toward it, the fluid should be able to attach to the wall, meaning to `wet` it. This subsection defines the parameters for peeling and wetting mechanisms at the VOF boundaries, as defined in :doc:`boundary_conditions_multiphysics`. 
 
   .. important::
-    This peeling/wetting mechanism implementation is an heuristic. It has been developed to meet the need of specific projects and gave satisfactory results as is, but it has not been broadly tested nor demonstrated, so its results should be considered with cautions. Do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
+    This peeling/wetting mechanism implementation is a heuristic. It has been developed to meet the need of specific projects and gave satisfactory results as is, but it has not been broadly tested nor demonstrated, so its results should be considered with cautions. Do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
 
+  .. warning::
 
-  * ``enable``: controls if peeling/wetting mechanism is enabled.
+    As peeling/wetting mechanisms result in fluid generation and loss, is it highly advised to monitor the mass conservation of the fluid of interest (``subsection mass conservation``) and to change the type of sharpening threshold to adaptative (``subsection sharpening``).
+
+  * ``enable peeling``: controls if peeling mechanism is enabled. Peeling occurs in a cell where the following conditions are met:
+
+    * the cell is in the domain of the higher density fluid,
+    * the cell pressure value is below the average pressure of the ``monitored fluid`` (``fluid 1`` by default, see ``subsection mass conservation``), and
+    * the pressure gradient is negative for more than half of the quadrature points.
+
+    The cell is then filled with the lower density fluid by changing its phase value progressively.
+
+    .. important::
+      Even if ``monitoring`` is not enabled, the ``monitored fluid`` (``fluid 1`` by default) will be considered as the fluid of interest for the average pressure calculation in the peeling/wetting mechanism.
+
+  * ``enable wetting``: controls if wetting mechanism is enabled. Wetting occurs in a cell where those conditions are met: 
+
+    * the cell is in the domain of the lower density fluid,
+    * the cell pressure value is above the average pressure of the ``monitored fluid`` (``fluid 1`` by default, see ``subsection mass conservation``), and
+    * the pressure gradient is positive for more than half of the quadrature points.
+
+    The cell is then filled with the higher density fluid by changing its phase value progressively.
+
+    .. tip ::
+      When the densities of the two fluids are of very different order of magnitude (typically, one fluid is more than a hundred times denser than the other), the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Then, using ``set enable wetting = false`` and relying on the ``diffusivity`` parameter to wet the boundaries (see :ref:`improve wetting`) can give better results. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
+
   * ``verbosity``: enables the display of the number of peeled and wet cells at each time-step. Choices are: ``quiet`` (default, no output) and ``verbose``.
 
     .. admonition:: Example of a ``set verbosity = verbose`` output:
@@ -148,29 +173,6 @@ The default values of the VOF parameters are given in the text box below.
         Peeling/wetting correction at step 2
           -number of wet cells: 24
           -number of peeled cells: 1
-
-  * Peeling occurs in a cell where the following conditions are met:
-
-    * the cell is in the domain of the higher density fluid,
-    * the cell pressure value is below the average pressure of the ``monitored fluid`` (``fluid 1`` by default, see ``subsection mass conservation``), and
-    * the pressure gradient is negative for more than half of the quadrature points.
-
-    The cell is then filled with the lower density fluid by changing its phase value progressively.
-
-  * Wetting occurs in a cell where those conditions are met: 
-
-    * the cell is in the domain of the lower density fluid,
-    * the cell pressure value is above the average pressure of the ``monitored fluid`` (``fluid 1`` by default, see ``subsection mass conservation``), and
-    * the pressure gradient is positive for more than half of the quadrature points.
-
-    The cell is then filled with the higher density fluid by changing its phase value.
-
-    .. tip::
-      Even if ``monitoring`` is not enabled, the ``monitored fluid`` (``fluid 1`` by default) will be considered as the fluid of interest for the average pressure calculation in the peeling/wetting mechanism.
-
-.. warning::
-
-  As peeling/wetting mechanisms result in fluid generation and loss, is it highly advised to monitor the mass conservation of the fluid of interest (``subsection mass conservation``) and to change the type of sharpening threshold to adaptative (``subsection sharpening``).
 
 * ``subsection mass conservation``: By default, mass conservation (continuity) equations are solved on the whole domain, i.e. on both fluids (``set conservative fluid = both``). However, replacing the mass conservation by a zero-pressure condition on one of the fluid (typically, the air), so that it can get in and out of the domain, can be useful to :ref:`improve wetting`. This subsection defines parameters that can be used to solve mass conservation in one fluid instead of both, and to monitor the surface/volume (2D/3D) occupied by the other fluid of interest.
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -162,7 +162,7 @@ The default values of the VOF parameters are given in the text box below.
     The cell is then filled with the higher density fluid by changing its phase value progressively.
 
     .. tip ::
-      Using ``set enable wetting = false`` and relying on the ``diffusivity`` to wet the boundaries (see :ref:`improve wetting`) can give better results when the densities of the two fluids are of very different order of magnitude. 
+      Using ``set enable wetting = false`` and relying on the ``diffusivity`` to wet the boundaries (see :ref:`improve wetting`) can give better results when the densities of the two fluids are of a very different order of magnitude. 
 
       Typically, when one fluid is more than a hundred times denser than the other, the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe github page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -140,7 +140,7 @@ The default values of the VOF parameters are given in the text box below.
 
   .. warning::
 
-    As peeling/wetting mechanisms result in fluid generation and loss, is it highly advised to monitor the mass conservation of the fluid of interest (``subsection mass conservation``) and to change the type of sharpening threshold to adaptative (``subsection sharpening``).
+    As peeling/wetting mechanisms result in fluid generation and loss, it is highly advised to monitor the mass conservation of the fluid of interest (``subsection mass conservation``) and to change the type of sharpening threshold to adaptative (``subsection sharpening``).
 
   * ``enable peeling``: controls if peeling mechanism is enabled. Peeling occurs in a cell where the following conditions are met:
 

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -69,7 +69,8 @@ namespace Parameters
    */
   struct VOF_PeelingWetting
   {
-    bool enable;
+    bool enable_peeling;
+    bool enable_wetting;
 
     // Type of verbosity for the peeling-wetting mechanism
     Parameters::Verbosity verbosity;

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -378,10 +378,16 @@ Parameters::VOF_PeelingWetting::declare_parameters(ParameterHandler &prm)
   prm.enter_subsection("peeling wetting");
   {
     prm.declare_entry(
-      "enable",
+      "enable peeling",
       "false",
       Patterns::Bool(),
-      "Enable peeling/wetting mechanism in free surface simulation <true|false>");
+      "Enable peeling mechanism in free surface simulation <true|false>");
+
+    prm.declare_entry(
+      "enable wetting",
+      "false",
+      Patterns::Bool(),
+      "Enable wetting mechanism in free surface simulation <true|false>");
 
     prm.declare_entry(
       "verbosity",
@@ -398,7 +404,8 @@ Parameters::VOF_PeelingWetting::parse_parameters(ParameterHandler &prm)
 {
   prm.enter_subsection("peeling wetting");
   {
-    enable = prm.get_bool("enable");
+    enable_peeling = prm.get_bool("enable peeling");
+    enable_wetting = prm.get_bool("enable wetting");
 
     const std::string op = prm.get("verbosity");
     if (op == "verbose")

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -628,7 +628,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
               this->table_monitoring_vof.add_value("mass_per_length_" +
                                                      fluid_id,
                                                    this->mass_monitored);
-              this->table_monitoring_vof.set_scientific("mass_" + fluid_id,
+              this->table_monitoring_vof.set_scientific("mass_per_length_" +
+                                                          fluid_id,
                                                         true);
             }
           else if (dim == 3)

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -616,15 +616,35 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
               fluid_id = "fluid_0";
             }
 
-          // Add volume column
-          this->table_monitoring_vof.add_value("volume_" + fluid_id,
-                                               this->volume_monitored);
-          this->table_monitoring_vof.set_scientific("volume_" + fluid_id, true);
+          if (dim == 2)
+            {
+              // Add surface column
+              this->table_monitoring_vof.add_value("surface_" + fluid_id,
+                                                   this->volume_monitored);
+              this->table_monitoring_vof.set_scientific("surface_" + fluid_id,
+                                                        true);
 
-          // Add mass column
-          this->table_monitoring_vof.add_value("mass_" + fluid_id,
-                                               this->mass_monitored);
-          this->table_monitoring_vof.set_scientific("mass_" + fluid_id, true);
+              // Add mass per length column
+              this->table_monitoring_vof.add_value("mass_per_length_" +
+                                                     fluid_id,
+                                                   this->mass_monitored);
+              this->table_monitoring_vof.set_scientific("mass_" + fluid_id,
+                                                        true);
+            }
+          else if (dim == 3)
+            {
+              // Add volume column
+              this->table_monitoring_vof.add_value("volume_" + fluid_id,
+                                                   this->volume_monitored);
+              this->table_monitoring_vof.set_scientific("volume_" + fluid_id,
+                                                        true);
+
+              // Add mass column
+              this->table_monitoring_vof.add_value("mass_" + fluid_id,
+                                                   this->mass_monitored);
+              this->table_monitoring_vof.set_scientific("mass_" + fluid_id,
+                                                        true);
+            }
 
           // Add sharpening threshold column
           this->table_monitoring_vof.add_value("sharpening_threshold",


### PR DESCRIPTION
# Description of the problem

- pressure gradient condition in peeling/wetting incorrect (at the level of dim, rather than quadrature_points)
- when one fluid is more than a hundred times denser than the other, the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way
- in 2D, mass and volume monitored are in fact mass/length and surface. This was not clear for the users.

# Description of the solution

- condition on pressure gradient changed to be at the level of the quadrature_points
- enable to turn off wetting (and so peeling, for good measure), which gives better results (tested on industrial case)
- clarify monitoring output

# How Has This Been Tested?

Tests have been updated, there is no change when we consider the two phases to be water and air for instance.

# Documentation

Updated and clarified in volume of fluid

# Future changes

When we come up with an approach that is less of a heuristic, this fix can be removed. However for now it gives very satisfactory results on industrial case, while not breaking more academic cases (breaking-dam, bouncing fluid etc.)
