### PR TITLE
Fix the error on Lethe building when DEAL_II_WITH_64BIT_INDICES is on

### DIFF
--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -113,7 +113,7 @@ public:
   }
 
   std::unordered_map<
-    unsigned int,
+    types::particle_index,
     std::set<typename Triangulation<dim>::active_cell_iterator>> &
   get_boundary_cells_with_floating_walls()
   {
@@ -269,7 +269,7 @@ private:
 
   // Structure that contains the boundary cells with floating walls
   std::unordered_map<
-    unsigned int,
+    types::particle_index,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
     boundary_cells_for_floating_walls;
 


### PR DESCRIPTION
# Description of the problem 
## Behaviour
When deal.ii is built with “DEAL_II_WITH_64BIT_INDICES” flag, Lethe will show the following error when building:

```
[ 25%] Building CXX object source/dem/CMakeFiles/lethe-dem.dir/dem_solver_parameters.cc.o
/*/Lethe/packs/lethe/source/dem/dem_container_manager.cc: In instantiation of ‘void DEMContainerManager<dim>::execute_particle_wall_broad_search(const dealii::Particles::ParticleHandler<dim>&, BoundaryCellsInformation<dim>&, const Parameters::Lagrangian::FloatingWalls<dim>&, double, bool) [with int dim = 2]’:
/*/Lethe/packs/lethe/source/dem/dem_container_manager.cc:410:16:   required from here
/*/Lethe/packs/lethe/source/dem/**dem_container_manager.cc:272:51**: error: **cannot convert** ‘std::unordered_map<**unsigned int**, std::set<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> >, std::less<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > >, std::allocator<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > > >, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<const unsigned int, std::set<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> >, std::less<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > >, std::allocator<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > > > > > >’ **to** ‘const std::unordered_map<**long unsigned int**, std::set<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> >, std::less<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > >, std::allocator<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > > >, std::hash<long unsigned int>, std::equal_to<long unsigned int>, std::allocator<std::pair<const long unsigned int, std::set<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> >, std::less<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > >, std::allocator<dealii::TriaActiveIterator<dealii::CellAccessor<2, 2> > > > > > >&’
  271 |       particle_wall_broad_search_object
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            
  272 |         .find_particle_floating_wall_contact_pairs(
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  273 |           boundary_cell_object.get_boundary_cells_with_floating_walls(),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  274 |           particle_handler,
      |           ~~~~~~~~~~~~~~~~~                        
  275 |           floating_walls,
      |           ~~~~~~~~~~~~~~~                          
  276 |           simulation_time,
      |           ~~~~~~~~~~~~~~~~                         
  277 |           particle_floating_wall_candidates);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [source/dem/CMakeFiles/lethe-dem.dir/build.make:104: source/dem/CMakeFiles/lethe-dem.dir/dem_container_manager.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 25%] Building CXX object source/solvers/CMakeFiles/lethe-solvers.dir/gls_navier_stokes.cc.o
make[1]: *** [CMakeFiles/Makefile2:1333: source/dem/CMakeFiles/lethe-dem.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
## Reason
-  In L70 of **lethe/source/dem/particle_wall_broad_search.cc**, function **find_particle_floating_wall_contact_pairs()** taken the 1st parameter as a const unordered map of **types::particle_index** and a set.
- In L271 of **lethe/include/dem/find_boundary_cells_information.h**, **boundary_cells_for_floating_walls** is declared as an unordered map of **unsigned int** and a set.
- In L268 of **lethe/source/dem/dem_container_manager.cc**, **boundary_cells_for_floating_walls** is past to function **find_particle_floating_wall_contact_pairs()** as the 1st argument.
- **particle_index** is defined in L31 of **property_pool.h** of deal.ii as
```
#ifdef DEAL_II_WITH_64BIT_INDICES
        using particle_index = std::uint64_t;
…
#else
        using particle_index = unsigned int;
#endif
``` 
- As can be seen from the code pieces above, everything will be fine if **DEAL_II_WITH_64BIT_INDICES** flag is not used when building deal.ii, as “particle_index” will be equivalent to “unsigned int”, but the declaration of **boundary_cells_for_floating_walls** will brake the code if **DEAL_II_WITH_64BIT_INDICES** flag is on.

# Description of the solution

- Change the declaration of **boundary_cells_for_floating_walls** from an unordered map of **unsigned int** and a set to an unordered map of ** types::particle_index ** and a set.

# How Has This Been Tested?
- OS: Ubuntu 22.04.1 LTS
- deal.ii was installed with candi ( GIT commit: beef9258162adcdc80ed0d8166600d5009640332) with [pull#312](https://github.com/dealii/candi/pull/312) and [pull#313](https://github.com/dealii/candi/pull/313) implemented. Also taken the suggestions from [issue#261](https://github.com/dealii/candi/issues/261) 
- Lethe was built with its master branch (GIT commit: 49153d6abdca81639a5ffb2cdbfb66b3676f0245)

# Documentation
- I don’t think it needs documentation. Please let me know otherwise.

# Future changes
- I think some parts of the test suite need changes for the same reason as well.

