### PR TITLE
Dem optimize particle-particle forces by templating rolling friction model

### DIFF
--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -41,6 +41,13 @@ namespace Parameters
       hertz
     };
 
+    enum RollingResistanceMethod
+    {
+      no_resistance,
+      constant_resistance,
+      viscous_resistance
+    };
+
     struct LagrangianPhysicalProperties
     {
     public:
@@ -221,12 +228,7 @@ namespace Parameters
       } particle_wall_contact_force_method;
 
       // Rolling resistance torque method
-      enum class RollingResistanceMethod
-      {
-        no_resistance,
-        constant_resistance,
-        viscous_resistance
-      } rolling_resistance_method;
+      RollingResistanceMethod rolling_resistance_method;
 
       // Itegration method
       enum class IntegrationMethod

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -122,9 +122,16 @@ public:
 };
 
 /**
- * Class that carry out the calculation of
+ * @brief Class that carries out the calculation of
  * particle-particle contact force including non-linear and linear contact
- * models
+ * models. Instead of using a inheritance hiearchy to distinguish between
+ * the contact model, the class is templated with the type of force model
+ * and rolling friction model. Consequently, the code for each
+ * combination of force model is generated at compile time.
+ *
+ * @tparam dim The dimension of the problem
+ * @tparam force_model The particle-particle contact force model
+ * @tparam rolling_friction_model The rolling resistance model used
  */
 template <
   int                                                       dim,
@@ -352,7 +359,7 @@ protected:
    * @param particle_one_force Force acting on particle one
    */
   inline void
-  apply_force_and_torque_on_ghost_particles(
+  apply_force_and_torque_on_single_local_particle(
     const Tensor<1, 3> &normal_force,
     const Tensor<1, 3> &tangential_force,
     const Tensor<1, 3> &particle_one_tangential_torque,

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -358,11 +358,8 @@ protected:
     Tensor<1, 3> &      particle_one_torque,
     Tensor<1, 3> &      particle_one_force)
   {
-    // Calculation of total force
-    Tensor<1, 3> total_force = normal_force + tangential_force;
-
     // Updating the force and torque acting on particles in the particle handler
-    particle_one_force -= total_force;
+    particle_one_force -= normal_force + tangential_force;
     particle_one_torque +=
       -particle_one_tangential_torque + rolling_resistance_torque;
   }

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -126,13 +126,15 @@ public:
  * particle-particle contact force including non-linear and linear contact
  * models
  */
-template <int                                                       dim,
-          Parameters::Lagrangian::ParticleParticleContactForceModel force_model>
+template <
+  int                                                       dim,
+  Parameters::Lagrangian::ParticleParticleContactForceModel force_model,
+  Parameters::Lagrangian::RollingResistanceMethod rolling_friction_model>
 class ParticleParticleContactForce
   : public ParticleParticleContactForceBase<dim>
 {
 public:
-  ParticleParticleContactForce<dim, force_model>(
+  ParticleParticleContactForce<dim, force_model, rolling_friction_model>(
     const DEMSolverParameters<dim> &dem_parameters);
 
 
@@ -389,7 +391,6 @@ protected:
             particle_two_properties[DEM::PropertiesIndex::dp]));
   }
 
-
   /**
    * Carries out the calculation of the particle-particle linear contact
    * force and torques based on the updated values in contact_info
@@ -517,8 +518,9 @@ protected:
       particle_one_properties[PropertiesIndex::dp];
 
     // Rolling resistance torque
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::no_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance)
       rolling_resistance_torque = no_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -527,8 +529,9 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::constant_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance)
       rolling_resistance_torque = constant_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -537,8 +540,8 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::viscous_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::viscous_resistance)
       rolling_resistance_torque = viscous_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -667,8 +670,9 @@ protected:
 
 
     // Rolling resistance torque
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::no_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance)
       rolling_resistance_torque = no_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -677,8 +681,9 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::constant_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance)
       rolling_resistance_torque = constant_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -687,8 +692,8 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::viscous_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::viscous_resistance)
       rolling_resistance_torque = viscous_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -810,8 +815,9 @@ protected:
 
 
     // Rolling resistance torque
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::no_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance)
       rolling_resistance_torque = no_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -820,8 +826,9 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::constant_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance)
       rolling_resistance_torque = constant_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -830,8 +837,8 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::viscous_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::viscous_resistance)
       rolling_resistance_torque = viscous_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -946,8 +953,9 @@ protected:
 
 
     // Rolling resistance torque
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::no_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance)
       rolling_resistance_torque = no_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -956,8 +964,9 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::constant_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance)
       rolling_resistance_torque = constant_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -966,8 +975,8 @@ protected:
           particle_one_type, particle_two_type)],
         normal_force.norm(),
         normal_unit_vector);
-    if (this->rolling_resistance_model ==
-        RollingResistanceTorqueModel::viscous_rolling_resistance)
+    if constexpr (rolling_friction_model ==
+                  Parameters::Lagrangian::viscous_resistance)
       rolling_resistance_torque = viscous_rolling_resistance_torque(
         this->effective_radius,
         particle_one_properties,
@@ -1005,14 +1014,13 @@ private:
   // Normal and tangential contact forces, tangential and rolling torques,
   // normal unit vector of the contact and contact relative velocity in the
   // normal direction
-  Tensor<1, 3>                 normal_unit_vector;
-  Tensor<1, 3>                 normal_force;
-  Tensor<1, 3>                 tangential_force;
-  Tensor<1, 3>                 particle_one_tangential_torque;
-  Tensor<1, 3>                 particle_two_tangential_torque;
-  Tensor<1, 3>                 rolling_resistance_torque;
-  double                       normal_relative_velocity_value;
-  RollingResistanceTorqueModel rolling_resistance_model;
+  Tensor<1, 3> normal_unit_vector;
+  Tensor<1, 3> normal_force;
+  Tensor<1, 3> tangential_force;
+  Tensor<1, 3> particle_one_tangential_torque;
+  Tensor<1, 3> particle_two_tangential_torque;
+  Tensor<1, 3> rolling_resistance_torque;
+  double       normal_relative_velocity_value;
 };
 
 #endif /* particle_particle_contact_force_h */

--- a/include/dem/rolling_resistance_torque_models.h
+++ b/include/dem/rolling_resistance_torque_models.h
@@ -23,14 +23,6 @@
 #ifndef rolling_resistance_torque_models_h
 #  define rolling_resistance_torque_models_h
 
-enum class RollingResistanceTorqueModel
-{
-  no_rolling_resistance,
-  constant_rolling_resistance,
-  viscous_rolling_resistance
-};
-
-
 /**
  * @brief
  */

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -104,18 +104,15 @@ ParticleParticleContactForce<dim, contact_model>::ParticleParticleContactForce(
     }
 
   if (dem_parameters.model_parameters.rolling_resistance_method ==
-      Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-        no_resistance)
+      Parameters::Lagrangian::RollingResistanceMethod::no_resistance)
     this->rolling_resistance_model =
       RollingResistanceTorqueModel::no_rolling_resistance;
   else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-             constant_resistance)
+           Parameters::Lagrangian::RollingResistanceMethod::constant_resistance)
     this->rolling_resistance_model =
       RollingResistanceTorqueModel::constant_rolling_resistance;
   else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-             viscous_resistance)
+           Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance)
     this->rolling_resistance_model =
       RollingResistanceTorqueModel::viscous_rolling_resistance;
 }

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -457,7 +457,7 @@ ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
 
                   // Apply the calculated forces and torques on the particle
                   // pair
-                  this->apply_force_and_torque_on_ghost_particles(
+                  this->apply_force_and_torque_on_single_local_particle(
                     this->normal_force,
                     this->tangential_force,
                     this->particle_one_tangential_torque,
@@ -804,7 +804,7 @@ ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
 
                   // Apply the calculated forces and torques on the particle
                   // pair
-                  this->apply_force_and_torque_on_ghost_particles(
+                  this->apply_force_and_torque_on_single_local_particle(
                     this->normal_force,
                     this->tangential_force,
                     this->particle_one_tangential_torque,
@@ -970,7 +970,7 @@ ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
 
                   // Apply the calculated forces and torques on the particle
                   // pair
-                  this->apply_force_and_torque_on_ghost_particles(
+                  this->apply_force_and_torque_on_single_local_particle(
                     this->normal_force,
                     this->tangential_force,
                     this->particle_two_tangential_torque,

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -27,9 +27,10 @@ using namespace DEM;
 
 template <
   int                                                       dim,
-  Parameters::Lagrangian::ParticleParticleContactForceModel contact_model>
-ParticleParticleContactForce<dim, contact_model>::ParticleParticleContactForce(
-  const DEMSolverParameters<dim> &dem_parameters)
+  Parameters::Lagrangian::ParticleParticleContactForceModel contact_model,
+  Parameters::Lagrangian::RollingResistanceMethod rolling_friction_model>
+ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
+  ParticleParticleContactForce(const DEMSolverParameters<dim> &dem_parameters)
 {
   auto properties  = dem_parameters.lagrangian_physical_properties;
   n_particle_types = properties.particle_type_number;
@@ -102,26 +103,14 @@ ParticleParticleContactForce<dim, contact_model>::ParticleParticleContactForce(
                  9.8696);
         }
     }
-
-  if (dem_parameters.model_parameters.rolling_resistance_method ==
-      Parameters::Lagrangian::RollingResistanceMethod::no_resistance)
-    this->rolling_resistance_model =
-      RollingResistanceTorqueModel::no_rolling_resistance;
-  else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::RollingResistanceMethod::constant_resistance)
-    this->rolling_resistance_model =
-      RollingResistanceTorqueModel::constant_rolling_resistance;
-  else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance)
-    this->rolling_resistance_model =
-      RollingResistanceTorqueModel::viscous_rolling_resistance;
 }
 
 template <
   int                                                       dim,
-  Parameters::Lagrangian::ParticleParticleContactForceModel contact_model>
+  Parameters::Lagrangian::ParticleParticleContactForceModel contact_model,
+  Parameters::Lagrangian::RollingResistanceMethod rolling_friction_model>
 void
-ParticleParticleContactForce<dim, contact_model>::
+ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
   calculate_particle_particle_contact_force(
     DEMContainerManager<dim> & container_manager,
     const double               dt,
@@ -1002,9 +991,10 @@ ParticleParticleContactForce<dim, contact_model>::
 
 template <
   int                                                       dim,
-  Parameters::Lagrangian::ParticleParticleContactForceModel contact_model>
+  Parameters::Lagrangian::ParticleParticleContactForceModel contact_model,
+  Parameters::Lagrangian::RollingResistanceMethod rolling_friction_model>
 void
-ParticleParticleContactForce<dim, contact_model>::
+ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
   calculate_IB_particle_particle_contact_force(
     const double                         normal_overlap,
     particle_particle_contact_info<dim> &contact_info,
@@ -1360,28 +1350,111 @@ ParticleParticleContactForce<dim, contact_model>::
 template class ParticleParticleContactForce<
   2,
   Parameters::Lagrangian::ParticleParticleContactForceModel::
-    hertz_mindlin_limit_force>;
+    hertz_mindlin_limit_force,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   3,
   Parameters::Lagrangian::ParticleParticleContactForceModel::
-    hertz_mindlin_limit_force>;
+    hertz_mindlin_limit_force,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   2,
   Parameters::Lagrangian::ParticleParticleContactForceModel::
-    hertz_mindlin_limit_overlap>;
+    hertz_mindlin_limit_overlap,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   3,
   Parameters::Lagrangian::ParticleParticleContactForceModel::
-    hertz_mindlin_limit_overlap>;
+    hertz_mindlin_limit_overlap,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   2,
-  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz>;
+  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   3,
-  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz>;
+  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   2,
-  Parameters::Lagrangian::ParticleParticleContactForceModel::linear>;
+  Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
 template class ParticleParticleContactForce<
   3,
-  Parameters::Lagrangian::ParticleParticleContactForceModel::linear>;
+  Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+  Parameters::Lagrangian::RollingResistanceMethod::no_resistance>;
+
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_force,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_force,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_overlap,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_overlap,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+  Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>;
+
+
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_force,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_force,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_overlap,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::
+    hertz_mindlin_limit_overlap,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  2,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;
+template class ParticleParticleContactForce<
+  3,
+  Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+  Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance>;

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -79,22 +79,19 @@ ParticleWallLinearForce<dim>::ParticleWallLinearForce(
     }
 
   if (dem_parameters.model_parameters.rolling_resistance_method ==
-      Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-        no_resistance)
+      Parameters::Lagrangian::RollingResistanceMethod::no_resistance)
     {
       calculate_rolling_resistance_torque =
         &ParticleWallLinearForce<dim>::no_resistance;
     }
   else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-             constant_resistance)
+           Parameters::Lagrangian::RollingResistanceMethod::constant_resistance)
     {
       calculate_rolling_resistance_torque =
         &ParticleWallLinearForce<dim>::constant_resistance;
     }
   else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-             viscous_resistance)
+           Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance)
     {
       calculate_rolling_resistance_torque =
         &ParticleWallLinearForce<dim>::viscous_resistance;

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -86,22 +86,19 @@ ParticleWallNonLinearForce<dim>::ParticleWallNonLinearForce(
     }
 
   if (dem_parameters.model_parameters.rolling_resistance_method ==
-      Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-        no_resistance)
+      Parameters::Lagrangian::RollingResistanceMethod::no_resistance)
     {
       calculate_rolling_resistance_torque =
         &ParticleWallNonLinearForce<dim>::no_resistance;
     }
   else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-             constant_resistance)
+           Parameters::Lagrangian::RollingResistanceMethod::constant_resistance)
     {
       calculate_rolling_resistance_torque =
         &ParticleWallNonLinearForce<dim>::constant_resistance;
     }
   else if (dem_parameters.model_parameters.rolling_resistance_method ==
-           Parameters::Lagrangian::ModelParameters::RollingResistanceMethod::
-             viscous_resistance)
+           Parameters::Lagrangian::RollingResistanceMethod::viscous_resistance)
     {
       calculate_rolling_resistance_torque =
         &ParticleWallNonLinearForce<dim>::viscous_resistance;

--- a/source/dem/set_particle_particle_contact_force_model.cc
+++ b/source/dem/set_particle_particle_contact_force_model.cc
@@ -51,7 +51,8 @@ set_particle_particle_contact_force_model(
               break;
             }
           default:
-            throw std::runtime_error("Invalid contact force model combination");
+            throw std::runtime_error(
+              "Invalid contact force model and rolling resistance method combination");
         }
     }
   else if (dem_parameters.model_parameters
@@ -97,7 +98,8 @@ set_particle_particle_contact_force_model(
               break;
             }
           default:
-            throw std::runtime_error("Invalid contact force model combination");
+            throw std::runtime_error(
+              "Invalid contact force model and rolling resistance method combination");
         }
     }
   else if (dem_parameters.model_parameters
@@ -143,7 +145,8 @@ set_particle_particle_contact_force_model(
               break;
             }
           default:
-            throw std::runtime_error("Invalid contact force model combination");
+            throw std::runtime_error(
+              "Invalid contact force model and rolling resistance method combination");
         }
     }
   else if (dem_parameters.model_parameters
@@ -188,7 +191,8 @@ set_particle_particle_contact_force_model(
               break;
             }
           default:
-            throw std::runtime_error("Invalid contact force model combination");
+            throw std::runtime_error(
+              "Invalid contact force model and rolling resistance method combination");
         }
     }
   else

--- a/source/dem/set_particle_particle_contact_force_model.cc
+++ b/source/dem/set_particle_particle_contact_force_model.cc
@@ -13,43 +13,183 @@ set_particle_particle_contact_force_model(
   if (dem_parameters.model_parameters.particle_particle_contact_force_model ==
       Parameters::Lagrangian::ParticleParticleContactForceModel::linear)
     {
-      particle_particle_contact_force_object =
-        std::make_shared<ParticleParticleContactForce<
-          dim,
-          Parameters::Lagrangian::ParticleParticleContactForceModel::linear>>(
-          dem_parameters);
+      switch (dem_parameters.model_parameters.rolling_resistance_method)
+        {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    linear,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    linear,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    linear,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    viscous_resistance>>(dem_parameters);
+              break;
+            }
+          default:
+            throw std::runtime_error("Invalid contact force model combination");
+        }
     }
   else if (dem_parameters.model_parameters
              .particle_particle_contact_force_model ==
            Parameters::Lagrangian::ParticleParticleContactForceModel::
              hertz_mindlin_limit_overlap)
     {
-      particle_particle_contact_force_object =
-        std::make_shared<ParticleParticleContactForce<
-          dim,
-          Parameters::Lagrangian::ParticleParticleContactForceModel::
-            hertz_mindlin_limit_overlap>>(dem_parameters);
+      switch (dem_parameters.model_parameters.rolling_resistance_method)
+        {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz_mindlin_limit_overlap,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz_mindlin_limit_overlap,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz_mindlin_limit_overlap,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    viscous_resistance>>(dem_parameters);
+              break;
+            }
+          default:
+            throw std::runtime_error("Invalid contact force model combination");
+        }
     }
   else if (dem_parameters.model_parameters
              .particle_particle_contact_force_model ==
            Parameters::Lagrangian::ParticleParticleContactForceModel::
              hertz_mindlin_limit_force)
     {
-      particle_particle_contact_force_object =
-        std::make_shared<ParticleParticleContactForce<
-          dim,
-          Parameters::Lagrangian::ParticleParticleContactForceModel::
-            hertz_mindlin_limit_force>>(dem_parameters);
+      switch (dem_parameters.model_parameters.rolling_resistance_method)
+        {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz_mindlin_limit_force,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz_mindlin_limit_force,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz_mindlin_limit_force,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    viscous_resistance>>(dem_parameters);
+              break;
+            }
+          default:
+            throw std::runtime_error("Invalid contact force model combination");
+        }
     }
   else if (dem_parameters.model_parameters
              .particle_particle_contact_force_model ==
            Parameters::Lagrangian::ParticleParticleContactForceModel::hertz)
     {
-      particle_particle_contact_force_object =
-        std::make_shared<ParticleParticleContactForce<
-          dim,
-          Parameters::Lagrangian::ParticleParticleContactForceModel::hertz>>(
-          dem_parameters);
+      switch (dem_parameters.model_parameters.rolling_resistance_method)
+        {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    no_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    constant_resistance>>(dem_parameters);
+              break;
+            }
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
+              particle_particle_contact_force_object =
+                std::make_shared<ParticleParticleContactForce<
+                  dim,
+                  Parameters::Lagrangian::ParticleParticleContactForceModel::
+                    hertz,
+                  Parameters::Lagrangian::RollingResistanceMethod::
+                    viscous_resistance>>(dem_parameters);
+              break;
+            }
+          default:
+            throw std::runtime_error("Invalid contact force model combination");
+        }
     }
   else
     {

--- a/source/fem-dem/ib_particles_dem.cc
+++ b/source/fem-dem/ib_particles_dem.cc
@@ -55,7 +55,8 @@ IBParticlesDEM<dim>::initialize(
   particle_particle_contact_force_object =
     std::make_shared<ParticleParticleContactForce<
       dim,
-      Parameters::Lagrangian::ParticleParticleContactForceModel::hertz>>(
+      Parameters::Lagrangian::ParticleParticleContactForceModel::hertz,
+      Parameters::Lagrangian::RollingResistanceMethod::no_resistance>>(
       dem_parameters);
   std::vector<types::boundary_id> boundary_index(0);
   particle_wall_contact_force_object =

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -92,8 +92,8 @@ test()
     .rolling_friction_coefficient_particle[0]                         = 0.1;
   dem_parameters.lagrangian_physical_properties.rolling_friction_wall = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0]   = 7850;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_veclocity;

--- a/tests/dem/particle_particle_contact_force_linear.cc
+++ b/tests/dem/particle_particle_contact_force_linear.cc
@@ -83,8 +83,8 @@ test()
     .rolling_friction_coefficient_particle[0]                         = 0.1;
   dem_parameters.lagrangian_physical_properties.rolling_friction_wall = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0]   = 2500;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
   Particles::ParticleHandler<dim> particle_handler(
@@ -168,7 +168,8 @@ test()
   // Calling linear force
   ParticleParticleContactForce<
     dim,
-    Parameters::Lagrangian::ParticleParticleContactForceModel::linear>
+    Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
     linear_force_object(dem_parameters);
   linear_force_object.calculate_particle_particle_contact_force(
     container_manager, dt, torque, force);

--- a/tests/dem/particle_particle_contact_force_nonlinear.cc
+++ b/tests/dem/particle_particle_contact_force_nonlinear.cc
@@ -81,8 +81,8 @@ test()
   dem_parameters.lagrangian_physical_properties
     .rolling_friction_coefficient_particle[0]                       = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0] = 2500;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -168,7 +168,8 @@ test()
   ParticleParticleContactForce<
     dim,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
-      hertz_mindlin_limit_overlap>
+      hertz_mindlin_limit_overlap,
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object.calculate_particle_particle_contact_force(
     container_manager, dt, torque, force);

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -107,8 +107,8 @@ test()
   dem_parameters.lagrangian_physical_properties
     .rolling_friction_coefficient_particle[0]                       = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0] = 2500;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -137,7 +137,8 @@ test()
   ParticleParticleContactForce<
     dim,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
-      hertz_mindlin_limit_overlap>
+      hertz_mindlin_limit_overlap,
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
                                 nonlinear_force_object(dem_parameters);
   VelocityVerletIntegrator<dim> integrator_object;
 
@@ -195,16 +196,7 @@ test()
   std::vector<double>       MOI;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
   for (unsigned i = 0; i < MOI.size(); ++i)

--- a/tests/dem/particle_wall_contact_force_linear.cc
+++ b/tests/dem/particle_wall_contact_force_linear.cc
@@ -89,8 +89,8 @@ test()
     .rolling_friction_coefficient_particle[0]                         = 0.1;
   dem_parameters.lagrangian_physical_properties.rolling_friction_wall = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0]   = 2500;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_veclocity;

--- a/tests/dem/particle_wall_contact_force_nonlinear.cc
+++ b/tests/dem/particle_wall_contact_force_nonlinear.cc
@@ -89,8 +89,8 @@ test()
     .rolling_friction_coefficient_particle[0]                         = 0.1;
   dem_parameters.lagrangian_physical_properties.rolling_friction_wall = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0]   = 2500;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_veclocity;

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -91,8 +91,8 @@ test(double coefficient_of_restitution)
     .rolling_friction_coefficient_particle[0]                         = 0.1;
   dem_parameters.lagrangian_physical_properties.rolling_friction_wall = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0]   = 2500;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_veclocity;

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -84,8 +84,8 @@ test()
     .rolling_friction_coefficient_particle[0]                       = 0.1;
   dem_parameters.lagrangian_physical_properties.density_particle[0] = 2500;
   double neighborhood_threshold = 1.3 * particle_diameter;
-  dem_parameters.model_parameters.rolling_resistance_method = Parameters::
-    Lagrangian::ModelParameters::RollingResistanceMethod::constant_resistance;
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   Particles::ParticleHandler<dim> particle_handler(
     triangulation, mapping, DEM::get_number_properties());
@@ -112,7 +112,8 @@ test()
   ParticleParticleContactForce<
     dim,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
-      hertz_mindlin_limit_overlap>
+      hertz_mindlin_limit_overlap,
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
                                 nonlinear_force_object(dem_parameters);
   VelocityVerletIntegrator<dim> integrator_object;
 
@@ -168,16 +169,8 @@ test()
   std::vector<double>       MOI;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
+
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
   for (unsigned i = 0; i < MOI.size(); ++i)


### PR DESCRIPTION
# Description of the problem

- Rolling friction was still passed as a parameter and the model was checked using an if condition for all partice ij pair

# Description of the solution

- The type of rolling friction model has been templated. The if is now a if constexpr so this prevents billion of ifs checks

# How Has This Been Tested?

- All tests pass

# Comments

- I tried a ton of optimizations and I have not found anything else where I could increase the speed of the simulations. I think we are reaching the limit...

