### PR TITLE
Add thermal post-processing to nitsche IB

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/gls_ht_heated-walls_heat-flux_steady.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_ht_heated-walls_heat-flux_steady.output
@@ -3,36 +3,36 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3267
    Volume of triangulation:      0.2
    Number of thermal degrees of freedom: 1089
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0
 	     Max : 3.94338
 	 Average : 0.09375
 	 Std-Dev : 0.511903
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 64
 	 boundary 1 : 12.8
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
-Thermal energy in entire_domain : 0.01875
+Thermal energy in fluid : 0.01875
 
 *****************************************************************
 Steady iteration :        1/1
 *****************************************************************
 L2 error velocity : 0
 L2 error temperature : 1.31683e-19
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 1.02642
 	     Max : 4.97358
 	 Average : 3
 	 Std-Dev : 1.1547
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 1.6
 	 boundary 1 : -1.6
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
-Thermal energy in entire_domain : 0.6
+Thermal energy in fluid : 0.6
 cells error_velocity error_pressure 
  1024 0.000000e+00 - 0.000000e+00 - 
 cells error_temperature 

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_ht_heated-walls_heat-flux.output
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_ht_heated-walls_heat-flux.output
@@ -9,10 +9,10 @@ Temperature statistics on fluid_1 :
 	     Max : 3.94338
 	 Average : 0.151515
 	 Std-Dev : 0.69433
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 64
 	 boundary 1 : 0.64
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
 Thermal energy in fluid_1 : 0.015625
@@ -27,10 +27,10 @@ Temperature statistics on fluid_1 :
 	     Max : 4.9604
 	 Average : 3.87484
 	 Std-Dev : 0.532331
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 2.39833
 	 boundary 1 : 0.0905848
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
 Thermal energy in fluid_1 : 0.399593
@@ -46,10 +46,10 @@ Temperature statistics on fluid_1 :
 	     Max : 4.98783
 	 Average : 4.57062
 	 Std-Dev : 0.230306
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0.737056
 	 boundary 1 : -0.012363
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
 Thermal energy in fluid_1 : 0.471345
@@ -65,10 +65,10 @@ Temperature statistics on fluid_1 :
 	     Max : 4.99373
 	 Average : 4.76612
 	 Std-Dev : 0.131429
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0.379891
 	 boundary 1 : -0.0720555
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
 Thermal energy in fluid_1 : 0.491977
@@ -84,10 +84,10 @@ Temperature statistics on fluid_1 :
 	     Max : 4.99569
 	 Average : 4.83519
 	 Std-Dev : 0.0948586
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0.260893
 	 boundary 1 : -0.110035
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
 Thermal energy in fluid_1 : 0.499108
@@ -103,10 +103,10 @@ Temperature statistics on fluid_1 :
 	     Max : 4.9965
 	 Average : 4.86434
 	 Std-Dev : 0.0789895
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0.212121
 	 boundary 1 : -0.133064
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
 	 boundary 1 : 0
 Thermal energy in fluid_1 : 0.502118

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_laser.output
@@ -3,7 +3,7 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3267
    Volume of triangulation:      0.01
    Number of thermal degrees of freedom: 1089
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0
 	     Max : 0
 	 Average : 0
@@ -12,7 +12,7 @@ Temperature statistics on entire_domain :
 *****************************************************************
 Transient iteration : 1        Time : 0.01     Time step : 0.01     CFL : 0       
 *****************************************************************
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0.000179891
 	     Max : 1540.48
 	 Average : 21.9343
@@ -21,7 +21,7 @@ Temperature statistics on entire_domain :
 *****************************************************************
 Transient iteration : 2        Time : 0.02     Time step : 0.01     CFL : 0       
 *****************************************************************
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0.0162123
 	     Max : 1722.86
 	 Average : 45.0885
@@ -30,7 +30,7 @@ Temperature statistics on entire_domain :
 *****************************************************************
 Transient iteration : 3        Time : 0.03     Time step : 0.01     CFL : 0       
 *****************************************************************
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0.0911536
 	     Max : 1726.81
 	 Average : 67.9798
@@ -39,7 +39,7 @@ Temperature statistics on entire_domain :
 *****************************************************************
 Transient iteration : 4        Time : 0.04     Time step : 0.01     CFL : 0       
 *****************************************************************
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0.180836
 	     Max : 1080.52
 	 Average : 67.3216
@@ -48,7 +48,7 @@ Temperature statistics on entire_domain :
 *****************************************************************
 Transient iteration : 5        Time : 0.05     Time step : 0.01     CFL : 0       
 *****************************************************************
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 0.281314
 	     Max : 789.985
 	 Average : 66.8228

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_radiation.output
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_radiation.output
@@ -3,7 +3,7 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 27
    Volume of triangulation:      0.0001
    Number of thermal degrees of freedom: 9
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 1000
 	     Max : 1000
 	 Average : 1000
@@ -14,7 +14,7 @@ Transient iteration : 1        Time : 0.01     Time step : 0.01     CFL : 0
 *****************************************************************
 L2 error velocity : 0
 L2 error temperature : 0.000338465
-Temperature statistics on entire_domain : 
+Temperature statistics on fluid : 
 	     Min : 979.082
 	     Max : 979.232
 	 Average : 979.157

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction.prm
@@ -8,7 +8,7 @@ subsection simulation control
   set time step               		= 1
   set number mesh adapt       		= 0
   set output name             		= conduction
-  set output frequency        		= 1
+  set output frequency        		= 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction_bdf3.prm
+++ b/applications_tests/gls_navier_stokes_2d/heat_transfer_transient_conduction_bdf3.prm
@@ -8,7 +8,7 @@ subsection simulation control
   set time step               		= 0.5
   set number mesh adapt       		= 0
   set output name             		= conduction
-  set output frequency        		= 1
+  set output frequency        		= 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.output
+++ b/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3267
    Volume of triangulation:      2
    Number of thermal degrees of freedom: 1089
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
-Thermal energy in entire_domain : 0
-Heat flux on nitsche immersed boundary : 
+Thermal energy in fluid : 0
+Heat flux at the nitsche immersed boundary : 
 	 Nitsche boundary 0 : 1000
 
 *****************************************************************
@@ -16,12 +16,12 @@ Steady iteration :        1/1
 *****************************************************************
 L2 error velocity : 0
 L2 error temperature : 0.000255471
-Heat flux on heat transfer boundary conditions : 
+Total heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : -0.973213
-Convective flux on heat transfer boundary conditions : 
+Convective heat flux at the heat transfer boundary conditions : 
 	 boundary 0 : 0
-Thermal energy in entire_domain : 1.48563
-Heat flux on nitsche immersed boundary : 
+Thermal energy in fluid : 1.48563
+Heat flux at the nitsche immersed boundary : 
 	 Nitsche boundary 0 : 0.973213
 cells error_velocity error_pressure 
  1024 0.000000e+00 - 0.000000e+00 - 

--- a/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.output
+++ b/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.output
@@ -1,0 +1,29 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      2
+   Number of thermal degrees of freedom: 1089
+Heat flux on heat transfer boundary conditions : 
+	 boundary 0 : 0
+Convective flux on heat transfer boundary conditions : 
+	 boundary 0 : 0
+Thermal energy in entire_domain : 0
+Heat flux on nitsche immersed boundary : 
+	 Nitsche boundary 0 : 1000
+
+*****************************************************************
+Steady iteration :        1/1
+*****************************************************************
+L2 error velocity : 0
+L2 error temperature : 0.000255471
+Heat flux on heat transfer boundary conditions : 
+	 boundary 0 : -0.973213
+Convective flux on heat transfer boundary conditions : 
+	 boundary 0 : 0
+Thermal energy in entire_domain : 1.48563
+Heat flux on nitsche immersed boundary : 
+	 Nitsche boundary 0 : 0.973213
+cells error_velocity error_pressure 
+ 1024 0.000000e+00 - 0.000000e+00 - 
+cells error_temperature 
+ 1024 2.554706e-04    - 

--- a/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.prm
@@ -1,0 +1,146 @@
+# Listing of Parameters
+# ---------------------
+# --------------------------------------------------
+# Simulation and IO Control
+#---------------------------------------------------
+subsection simulation control
+  set method                  = steady
+  set output frequency        = 1
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+subsection multiphysics
+  set heat transfer = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+subsection initial conditions
+    set type = nodal
+    subsection temperature
+            set Function expression = 0
+    end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+subsection physical properties
+    set number of fluids = 1
+    subsection fluid 1 
+        set density = 2.
+	set specific heat = 500
+	set thermal conductivity = 0.5
+    end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+subsection mesh
+	set type = dealii
+	set grid type = hyper_rectangle
+	set grid arguments = 0, 0 : 1, 2 : true
+	set initial refinement = 5
+end
+
+#---------------------------------------------------
+# Nitsche
+#---------------------------------------------------
+subsection nitsche
+  set number of solids = 1
+  subsection nitsche solid 0
+    subsection mesh
+	set type = dealii
+	set grid type = hyper_rectangle
+	set grid arguments = 0, 0 : 1, 1 : true
+	set initial refinement = 4
+    end
+    subsection solid velocity
+      set Function expression = 0 ; 0
+    end
+    subsection solid temperature
+        set Function expression = 1
+    end
+    set enable heat boundary condition = true
+    set beta heat = 1000
+  end
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+subsection analytical solution
+  set enable     	= true
+  set verbosity 	= verbose
+    subsection temperature
+	set Function expression = if(y>1,2-y,1)
+    end
+end
+
+# --------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+subsection post-processing
+# Thermal postprocesses
+  set verbosity                   = verbose
+  set output frequency            = 1
+  set calculate heat flux         = true
+end
+
+
+# --------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+subsection boundary conditions
+  set number                  = 4
+    subsection bc 0
+        set id = 0
+        set type              = slip
+    end
+    subsection bc 1
+	set id = 1
+        set type              = slip
+    end
+    subsection bc 2
+        set id = 2
+        set type              = slip
+    end
+    subsection bc 3
+        set id = 3
+        set type              = slip
+    end
+end
+
+subsection boundary conditions heat transfer
+  set number                  = 1
+    subsection bc 0
+    	set id = 3
+	      set type	      = temperature
+        set value	      = 0
+    end
+end
+
+# --------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+subsection mesh adaptation
+  set type                    = uniform
+end
+
+# --------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+subsection non-linear solver
+  set verbosity               = quiet
+end
+
+# --------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+subsection linear solver
+  set verbosity               = quiet
+end

--- a/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.prm
+++ b/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_couette.prm
@@ -5,7 +5,7 @@
 #---------------------------------------------------
 subsection simulation control
   set method                  = steady
-  set output frequency        = 1
+  set output frequency        = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_moving.output
+++ b/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_moving.output
@@ -8,31 +8,31 @@ Running on 1 MPI rank(s)...
 Transient iteration : 1        Time : 1        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.0686776
+L2 error temperature : 1.39953
 
 *****************************************************************
 Transient iteration : 2        Time : 2        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 7.97708e-05
+L2 error temperature : 0.0655257
 
 *****************************************************************
 Transient iteration : 3        Time : 3        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 4.9612e-07
+L2 error temperature : 0.00379066
 
 *****************************************************************
 Transient iteration : 4        Time : 4        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 6.16936e-10
+L2 error temperature : 0.00017627
 
 *****************************************************************
 Transient iteration : 5        Time : 5        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 3.82436e-12
+L2 error temperature : 1.02291e-05
  time  error_velocity 
 1.0000 0.000000e+00   
 2.0000 0.000000e+00   
@@ -40,8 +40,8 @@ L2 error temperature : 3.82436e-12
 4.0000 0.000000e+00   
 5.0000 0.000000e+00   
 cells error_temperature 
-1024  6.867765e-02      
-1024  7.977085e-05      
-1024  4.961198e-07      
-1024  6.169359e-10      
-1024  3.824359e-12
+1024  1.399534e+00      
+1024  6.552569e-02      
+1024  3.790657e-03      
+1024  1.762695e-04      
+1024  1.022915e-05      

--- a/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_static.output
+++ b/applications_tests/gls_nitsche_navier_stokes_22/nitsche_heating_static.output
@@ -8,31 +8,31 @@ Running on 1 MPI rank(s)...
 Transient iteration : 1        Time : 1        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.208261
+L2 error temperature : 1.84297
 
 *****************************************************************
 Transient iteration : 2        Time : 2        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 0.00351671
+L2 error temperature : 0.150636
 
 *****************************************************************
 Transient iteration : 3        Time : 3        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 5.94912e-05
+L2 error temperature : 0.0123688
 
 *****************************************************************
 Transient iteration : 4        Time : 4        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 1.00643e-06
+L2 error temperature : 0.00101581
 
 *****************************************************************
 Transient iteration : 5        Time : 5        Time step : 1        CFL : 0       
 *****************************************************************
 L2 error velocity : 0
-L2 error temperature : 1.70214e-08
+L2 error temperature : 8.34265e-05
  time  error_velocity 
 1.0000 0.000000e+00   
 2.0000 0.000000e+00   
@@ -40,8 +40,8 @@ L2 error temperature : 1.70214e-08
 4.0000 0.000000e+00   
 5.0000 0.000000e+00   
 cells error_temperature 
-1024  2.082612e-01      
-1024  3.516711e-03      
-1024  5.949123e-05      
-1024  1.006428e-06      
-1024  1.702143e-08
+1024  1.842965e+00      
+1024  1.506358e-01      
+1024  1.236878e-02      
+1024  1.015811e-03      
+1024  8.342655e-05      

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -53,6 +53,7 @@ This subsection controls the post-processing other than the forces and torque on
     set calculate heat flux              = false
     set heat flux name                   = heat_flux
     set convective flux name             = convective_flux
+    set nitsche flux name             = nitsche_heat_flux
 
   end
  
@@ -132,12 +133,17 @@ This subsection controls the post-processing other than the forces and torque on
 
         Do not forget to ``set heat transfer = true`` in the :doc:`multiphysics` subsection of the ``.prm``.
 
-    * ``heat flux name``: output filename for temperature statistics calculations.
+    * ``heat flux name``: output filename for heat flux calculations.
 
     .. admonition:: Example of heat flux table:
 
         .. code-block:: text
 
-             time   bc_0    bc_1       thermal_energy_fluid_1 
+             time   bc_0    bc_1                heat_flux 
             0.0000 64.0000  0.6400               0.0313 
             0.2000  3.6963  0.0976               0.6965 
+    
+    * ``nitsche flux name``: output filename for heat flux calculations on a Nitsche immersed boundary
+
+
+        

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -52,8 +52,6 @@ This subsection controls the post-processing other than the forces and torque on
     set temperature statistics name      = temperature_statistics
     set calculate heat flux              = false
     set heat flux name                   = heat_flux
-    set convective flux name             = convective_flux
-    set nitsche flux name             = nitsche_heat_flux
 
   end
  
@@ -110,40 +108,49 @@ This subsection controls the post-processing other than the forces and torque on
             0.0000 0.0000 3.9434  0.1515  0.6943 
             0.2000 2.5183 4.9390  3.3917  0.7229 
 
-* ``calculate heat flux``: controls if calculation of heat flux is enabled. If enabled, two quantities are postprocessed: 
-    * the total heat flux :math:`q_{tot}` for each :ref:`heat transfer bc` boundary condition. The total heat flux on a boundary :math:`\Gamma` is defined as:
+* ``calculate heat flux``: controls if calculation of heat flux is enabled. If enabled, these quantities are postprocessed: 
 
-    .. math:: 
+  .. warning::
 
-        q_{tot} = \int_\Gamma (\rho C_p \mathbf{u} T - k \nabla T) \cdot \mathbf{n}
+      Do not forget to ``set heat transfer = true`` in the :doc:`multiphysics` subsection of the ``.prm``.
 
+  1. the total heat flux :math:`q_{tot}` for each :ref:`heat transfer bc` boundary condition. The total heat flux on a boundary :math:`\Gamma` is defined as:
 
-    The output table is appended with one column per boundary condition, named ``bc_i`` where ``i`` is the index of the boundary in the parameter file.
+  .. math:: 
 
-    * the convective heat flux :math:`q_{conv}` for each :ref:`heat transfer bc` boundary condition. The convective heat flux on a boundary :math:`\Gamma` is defined as:
-
-    .. math:: 
-
-        q_{conv} = \int_\Gamma  h (T-T_\infty)
+      q_\text{tot} = \int_\Gamma (\rho C_p \mathbf{u} \mathbf{T} - k \nabla \mathbf{T}) \cdot \mathbf{n}
 
 
-    * the thermal energy (:math:`\mathbf{Q} = m c_p \mathbf{T}`) over the domain defined by ``postprocessed fluid``. 
+  The output table is appended with one column per :ref:`heat transfer bc` boundary condition, named ``bc_i`` where ``i`` is the index of the boundary in the parameter file.
 
-    .. warning::
+  2. the convective heat flux :math:`q_\text{conv}` for each :ref:`heat transfer bc` boundary condition. The convective heat flux on a boundary :math:`\Gamma` is defined as:
 
-        Do not forget to ``set heat transfer = true`` in the :doc:`multiphysics` subsection of the ``.prm``.
+  .. math:: 
 
-    * ``heat flux name``: output filename for heat flux calculations.
+      q_\text{conv} = \int_\Gamma  h (\mathbf{T}-\mathbf{T}_\infty)
+
+  The output table is appended with one column per :ref:`heat transfer bc` boundary condition, named ``bc_i`` where ``i`` is the index of the boundary in the parameter file.
+
+  3. the thermal energy (:math:`\mathbf{Q} = m c_p \mathbf{T}`) over the domain defined by ``postprocessed fluid``. 
+
+  4. if there is a :doc:`nitsche`, the total heat fluxes on each solid: :math:`q_\text{nitsche} = \beta_\text{heat} \left( \mathbf{T}_\text{nitsche} - \mathbf{T} \right)`
+
+  The output table is appended with one column per solid, named ``nitsche_solid_i`` where ``i`` is the index of the ``nitsche solid`` in the parameter file.
+
+  .. warning ::
+      
+      Do not forget to ``set enable heat boundary condition = true`` in the :doc:`nitsche` subsection of the ``.prm``.
+
+
+  * ``heat flux name``: output filename for heat flux calculations.
 
     .. admonition:: Example of heat flux table:
 
         .. code-block:: text
 
-             time   bc_0    bc_1                heat_flux 
-            0.0000 64.0000  0.6400               0.0313 
-            0.2000  3.6963  0.0976               0.6965 
-    
-    * ``nitsche flux name``: output filename for heat flux calculations on a Nitsche immersed boundary
+		 time  total_flux_bc_0 convective_flux_bc_0 thermal_energy_fluid flux_nitsche_solid_0 
+		0.0000          0.0000               0.0000               0.0000            1000.0000 
+		1.0000         -0.9732               0.0000               1.4856               0.9732 
 
 
         

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -617,12 +617,6 @@ namespace Parameters
     // Prefix for the total heat flux output
     std::string heat_flux_output_name;
 
-    // Prefix for the convective heat flux output
-    std::string convective_flux_output_name;
-
-    // Prefix for the nitsche heat flux output
-    std::string nitsche_flux_output_name;
-
     // Fluid domain, used when post-processing a multiphase simulation
     Parameters::FluidIndicator postprocessed_fluid;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -620,6 +620,9 @@ namespace Parameters
     // Prefix for the convective heat flux output
     std::string convective_flux_output_name;
 
+    // Prefix for the nitsche heat flux output
+    std::string nitsche_flux_output_name;
+
     // Fluid domain, used when post-processing a multiphase simulation
     Parameters::FluidIndicator postprocessed_fluid;
 

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -402,11 +402,7 @@ private:
                               const VectorType &current_solution_fd);
 
   /**
-   * Post-processing. Calculate the heat flux in the Nitsche immersed boundary
-   *
-   * @param i_solid identifier of the nitsche solid
-   *
-   * @return The heat flux (in W) on the nitsche solid identified by i_solid
+   * Post-processing. Calculate the heat flux in the Nitsche immersed boundary.
    *
    */
   void
@@ -455,6 +451,9 @@ private:
    * more information,
    * - a boolean: point_is_in_postprocessed_fluid, true if the quadrature point
    * is in the postprocessed_fluid (used for min_max_temperature calculation)
+   *
+   * @param gather_vof boolean true when VOF=true (multiphase flow), used to gather
+   * VOF information
    *
    * @param monitored_fluid Fluid indicator (fluid0 or fluid1 or both) corresponding
    * to the phase of interest.

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -402,6 +402,17 @@ private:
                               const VectorType &current_solution_fd);
 
   /**
+   * Post-processing. Calculate the heat flux in the Nitsche immersed boundary
+   *
+   * @param i_solid identifier of the nitsche solid
+   *
+   * @return The heat flux (in W) on the nitsche solid identified by i_solid
+   *
+   */
+  void
+  postprocess_heat_flux_on_nitsche_ib();
+
+  /**
    * Post-processing. Calculate the thermal energy (rho*Cp*T) in a fluid domain.
    *
    * @param gather_vof boolean true when VOF=true (multiphase flow), used to gather
@@ -524,6 +535,10 @@ private:
   // The convective flux table contains the convective heat flux on a boundary:
   // h(T-T_inf)
   TableHandler convective_flux_table;
+
+  // The Nitsche flux table contains the total fluxes on the nitsche immersed
+  // boundaries
+  TableHandler nitsche_flux_table;
 };
 
 

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -528,17 +528,11 @@ private:
   TableHandler statistics_table;
 
   // Post-processing table
-  // The heat flux table contains the total fluxes on a boundary: (-k grad T + u
-  // * rho * Cp) * n
+  // The heat flux table contains :
+  // - the total fluxes on a boundary: (-k grad T + u * rho * Cp) * n
+  // - the convective heat flux on a boundary: h(T-T_inf)
+  // - the total fluxes on the nitsche immersed boundaries (if active)
   TableHandler heat_flux_table;
-
-  // The convective flux table contains the convective heat flux on a boundary:
-  // h(T-T_inf)
-  TableHandler convective_flux_table;
-
-  // The Nitsche flux table contains the total fluxes on the nitsche immersed
-  // boundaries
-  TableHandler nitsche_flux_table;
 };
 
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1179,12 +1179,9 @@ namespace Parameters
       tracer_output_name          = prm.get("tracer statistics name");
       calculate_temperature_statistics =
         prm.get_bool("calculate temperature statistics");
-      temperature_output_name     = prm.get("temperature statistics name");
-      calculate_heat_flux         = prm.get_bool("calculate heat flux");
-      heat_flux_output_name       = prm.get("heat flux name");
-      convective_flux_output_name = prm.get("convective flux name");
-      nitsche_flux_output_name    = prm.get("nitsche flux name");
-
+      temperature_output_name = prm.get("temperature statistics name");
+      calculate_heat_flux     = prm.get_bool("calculate heat flux");
+      heat_flux_output_name   = prm.get("heat flux name");
 
 
       // Viscous dissipative fluid

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1183,7 +1183,7 @@ namespace Parameters
       calculate_heat_flux         = prm.get_bool("calculate heat flux");
       heat_flux_output_name       = prm.get("heat flux name");
       convective_flux_output_name = prm.get("convective flux name");
-      nitsche_flux_output_name = prm.get("nitsche flux name");
+      nitsche_flux_output_name    = prm.get("nitsche flux name");
 
 
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1130,6 +1130,11 @@ namespace Parameters
                         Patterns::FileName(),
                         "File name output for the convective flux");
 
+      prm.declare_entry("nitsche flux name",
+                        "nitsche_heat_flux",
+                        Patterns::FileName(),
+                        "File name output for the convective flux");
+
       prm.declare_entry("postprocessed fluid",
                         "both",
                         Patterns::Selection("fluid 0|fluid 1|both"),
@@ -1178,6 +1183,8 @@ namespace Parameters
       calculate_heat_flux         = prm.get_bool("calculate heat flux");
       heat_flux_output_name       = prm.get("heat flux name");
       convective_flux_output_name = prm.get("convective flux name");
+      convective_flux_output_name = prm.get("nitsche flux name");
+
 
 
       // Viscous dissipative fluid

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1183,7 +1183,7 @@ namespace Parameters
       calculate_heat_flux         = prm.get_bool("calculate heat flux");
       heat_flux_output_name       = prm.get("heat flux name");
       convective_flux_output_name = prm.get("convective flux name");
-      convective_flux_output_name = prm.get("nitsche flux name");
+      nitsche_flux_output_name = prm.get("nitsche flux name");
 
 
 

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -701,10 +701,6 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
 
   this->setup_dofs();
 
-  this->set_initial_condition(
-    this->simulation_parameters.initial_condition->type,
-    this->simulation_parameters.restart_parameters.restart);
-
   // Solid setup
   if (!this->simulation_parameters.restart_parameters.restart)
     {
@@ -721,7 +717,18 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
               output_solid_triangulation(i_solid);
             }
         }
+      if constexpr (dim == spacedim)
+        {
+          // Parse the nitsche solids to the multiphysics interface
+          this->multiphysics->set_solid(&solids);
+        }
     }
+
+  this->set_initial_condition(
+    this->simulation_parameters.initial_condition->type,
+    this->simulation_parameters.restart_parameters.restart);
+
+
 
   // Time integration
   while (this->simulation_control->integrate())

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -273,7 +273,7 @@ HeatTransfer<dim>::postprocess_heat_flux_on_nitsche_ib()
   for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
     {
       this->nitsche_flux_table.add_value(
-        "bc_" + Utilities::int_to_string(i_solid, 1),
+        "solid_" + Utilities::int_to_string(i_solid, 1),
         heat_flux_on_nitsche_ib_vector[i_solid]);
     }
 }
@@ -1856,7 +1856,7 @@ HeatTransfer<dim>::write_heat_flux(const std::string domain_name)
           domain_name + ".dat";
         std::ofstream output(filename.c_str());
 
-        this->convective_flux_table.write_text(output);
+        this->nitsche_flux_table.write_text(output);
       }
     }
 }

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -376,8 +376,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim>                         &scratch_data,
-  StabilizedMethodsCopyData                            &copy_data)
+  HeatTransferScratchData<dim> &                        scratch_data,
+  StabilizedMethodsCopyData &                           copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -522,8 +522,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim>                         &scratch_data,
-  StabilizedMethodsCopyData                            &copy_data)
+  HeatTransferScratchData<dim> &                        scratch_data,
+  StabilizedMethodsCopyData &                           copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -751,15 +751,18 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
       gather_vof = true;
       switch (monitored_fluid)
         {
-            default: {
+          default:
+            {
               domain_name = "entire_domain";
               break;
             }
-            case Parameters::FluidIndicator::fluid0: {
+          case Parameters::FluidIndicator::fluid0:
+            {
               domain_name = "fluid_0";
               break;
             }
-            case Parameters::FluidIndicator::fluid1: {
+          case Parameters::FluidIndicator::fluid1:
+            {
               domain_name = "fluid_1";
               break;
             }
@@ -1138,7 +1141,7 @@ HeatTransfer<dim>::postprocess_temperature_statistics(
                              update_values | update_JxW_values);
 
   // Initialize VOF information
-  const DoFHandler<dim>         *dof_handler_vof = NULL;
+  const DoFHandler<dim> *        dof_handler_vof = NULL;
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            phase_values(n_q_points);
 
@@ -1337,7 +1340,7 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
                                       update_values);
 
   // Initialize VOF information
-  DoFHandler<dim>                   *dof_handler_vof = NULL;
+  DoFHandler<dim> *                  dof_handler_vof = NULL;
   std::shared_ptr<FEFaceValues<dim>> fe_face_values_vof;
   std::vector<double>                phase_values(n_q_points_face);
 
@@ -1372,7 +1375,8 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
 
   switch (properties_manager.get_number_of_fluids())
     {
-        default: {
+      default:
+        {
           // Get values for monophase flow
           const auto density_model = properties_manager.get_density();
           const auto specific_heat_model =
@@ -1386,7 +1390,8 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
 
           break;
         }
-        case 2: {
+      case 2:
+        {
           // Get prm values for multiphase flow - will be blended in the
           // integration loop
           const auto density_models = properties_manager.get_density_vector();
@@ -1612,7 +1617,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
   const bool                       gather_vof,
   const Parameters::FluidIndicator monitored_fluid,
   const std::string                domain_name,
-  const VectorType                &current_solution_fd)
+  const VectorType &               current_solution_fd)
 {
   const unsigned int n_q_points       = this->cell_quadrature->size();
   const MPI_Comm     mpi_communicator = this->dof_handler.get_communicator();
@@ -1636,7 +1641,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
                              update_values);
 
   // Initialize VOF information
-  const DoFHandler<dim>         *dof_handler_vof = NULL;
+  const DoFHandler<dim> *        dof_handler_vof = NULL;
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            phase_values(n_q_points);
 
@@ -1668,7 +1673,8 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
 
   switch (properties_manager.get_number_of_fluids())
     {
-        default: {
+      default:
+        {
           // Get values for monophase flow
           const auto density_model = properties_manager.get_density();
           const auto specific_heat_model =
@@ -1679,7 +1685,8 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
 
           break;
         }
-        case 2: {
+      case 2:
+        {
           // Get prm values for multiphase flow - will be blended in the
           // integration loop
           const auto density_models = properties_manager.get_density_vector();
@@ -1866,13 +1873,15 @@ HeatTransfer<dim>::set_phase_coefficient(
 
   switch (monitored_fluid)
     {
-        default: {
+      default:
+        {
           // Parameters::FluidIndicator::both
           phase_coefficient               = 1.;
           point_is_in_postprocessed_fluid = true;
           break;
         }
-        case Parameters::FluidIndicator::fluid0: {
+      case Parameters::FluidIndicator::fluid0:
+        {
           if (gather_vof)
             {
               phase_coefficient = 1. - phase_value_q;
@@ -1888,7 +1897,8 @@ HeatTransfer<dim>::set_phase_coefficient(
             }
           break;
         }
-        case Parameters::FluidIndicator::fluid1: {
+      case Parameters::FluidIndicator::fluid1:
+        {
           if (gather_vof)
             {
               phase_coefficient = phase_value_q;

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -56,17 +56,17 @@ HeatTransfer<dim>::assemble_nitsche_heat_restriction(bool assemble_matrix)
     RequiresConstantViscosity("assemble_nitsche_heat_restriction"));
 
   // Evaluate fluid properties
-  auto density_model =
-    this->simulation_parameters.physical_properties_manager.get_density();
-  auto specific_heat_model =
-    this->simulation_parameters.physical_properties_manager.get_specific_heat();
-  auto conductivity_model =
-    this->simulation_parameters.physical_properties_manager
-      .get_thermal_conductivity();
-  std::map<field, double> field_values;
+  // auto density_model =
+  //  this->simulation_parameters.physical_properties_manager.get_density();
+  // auto specific_heat_model =
+  //  this->simulation_parameters.physical_properties_manager.get_specific_heat();
+  // auto conductivity_model =
+  //  this->simulation_parameters.physical_properties_manager
+  //    .get_thermal_conductivity();
+  // std::map<field, double> field_values;
 
-  double rho_cp = density_model->value(field_values) *
-                  specific_heat_model->value(field_values);
+  // double rho_cp = density_model->value(field_values) *
+  //                 specific_heat_model->value(field_values);
 
   auto solids = *this->multiphysics->get_solids(
     this->simulation_parameters.nitsche->number_solids);
@@ -147,7 +147,7 @@ HeatTransfer<dim>::assemble_nitsche_heat_restriction(bool assemble_matrix)
                           for (unsigned int j = 0; j < dofs_per_cell; ++j)
                             {
                               local_matrix(i, j) +=
-                                rho_cp * penalty_parameter * beta *
+                                penalty_parameter * beta *
                                 this->fe->shape_value(i, ref_q) *
                                 this->fe->shape_value(j, ref_q) * JxW;
                             }
@@ -155,7 +155,7 @@ HeatTransfer<dim>::assemble_nitsche_heat_restriction(bool assemble_matrix)
                       else
                         {
                           // Regular residual
-                          local_rhs(i) += rho_cp * penalty_parameter * beta *
+                          local_rhs(i) += penalty_parameter * beta *
                                           (solid_temperature->value(real_q, 0) -
                                            temperature) *
                                           this->fe->shape_value(i, ref_q) * JxW;
@@ -376,8 +376,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  HeatTransferScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -522,8 +522,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  HeatTransferScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -751,18 +751,15 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
       gather_vof = true;
       switch (monitored_fluid)
         {
-          default:
-            {
+            default: {
               domain_name = "entire_domain";
               break;
             }
-          case Parameters::FluidIndicator::fluid0:
-            {
+            case Parameters::FluidIndicator::fluid0: {
               domain_name = "fluid_0";
               break;
             }
-          case Parameters::FluidIndicator::fluid1:
-            {
+            case Parameters::FluidIndicator::fluid1: {
               domain_name = "fluid_1";
               break;
             }
@@ -1141,7 +1138,7 @@ HeatTransfer<dim>::postprocess_temperature_statistics(
                              update_values | update_JxW_values);
 
   // Initialize VOF information
-  const DoFHandler<dim> *        dof_handler_vof = NULL;
+  const DoFHandler<dim>         *dof_handler_vof = NULL;
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            phase_values(n_q_points);
 
@@ -1340,7 +1337,7 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
                                       update_values);
 
   // Initialize VOF information
-  DoFHandler<dim> *                  dof_handler_vof = NULL;
+  DoFHandler<dim>                   *dof_handler_vof = NULL;
   std::shared_ptr<FEFaceValues<dim>> fe_face_values_vof;
   std::vector<double>                phase_values(n_q_points_face);
 
@@ -1375,8 +1372,7 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
 
   switch (properties_manager.get_number_of_fluids())
     {
-      default:
-        {
+        default: {
           // Get values for monophase flow
           const auto density_model = properties_manager.get_density();
           const auto specific_heat_model =
@@ -1390,8 +1386,7 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
 
           break;
         }
-      case 2:
-        {
+        case 2: {
           // Get prm values for multiphase flow - will be blended in the
           // integration loop
           const auto density_models = properties_manager.get_density_vector();
@@ -1617,7 +1612,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
   const bool                       gather_vof,
   const Parameters::FluidIndicator monitored_fluid,
   const std::string                domain_name,
-  const VectorType &               current_solution_fd)
+  const VectorType                &current_solution_fd)
 {
   const unsigned int n_q_points       = this->cell_quadrature->size();
   const MPI_Comm     mpi_communicator = this->dof_handler.get_communicator();
@@ -1641,7 +1636,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
                              update_values);
 
   // Initialize VOF information
-  const DoFHandler<dim> *        dof_handler_vof = NULL;
+  const DoFHandler<dim>         *dof_handler_vof = NULL;
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            phase_values(n_q_points);
 
@@ -1673,8 +1668,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
 
   switch (properties_manager.get_number_of_fluids())
     {
-      default:
-        {
+        default: {
           // Get values for monophase flow
           const auto density_model = properties_manager.get_density();
           const auto specific_heat_model =
@@ -1685,8 +1679,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
 
           break;
         }
-      case 2:
-        {
+        case 2: {
           // Get prm values for multiphase flow - will be blended in the
           // integration loop
           const auto density_models = properties_manager.get_density_vector();
@@ -1873,15 +1866,13 @@ HeatTransfer<dim>::set_phase_coefficient(
 
   switch (monitored_fluid)
     {
-      default:
-        {
+        default: {
           // Parameters::FluidIndicator::both
           phase_coefficient               = 1.;
           point_is_in_postprocessed_fluid = true;
           break;
         }
-      case Parameters::FluidIndicator::fluid0:
-        {
+        case Parameters::FluidIndicator::fluid0: {
           if (gather_vof)
             {
               phase_coefficient = 1. - phase_value_q;
@@ -1897,8 +1888,7 @@ HeatTransfer<dim>::set_phase_coefficient(
             }
           break;
         }
-      case Parameters::FluidIndicator::fluid1:
-        {
+        case Parameters::FluidIndicator::fluid1: {
           if (gather_vof)
             {
               phase_coefficient = phase_value_q;


### PR DESCRIPTION
# Description of the problem

- The nitsche beta heat coefficient for heat transfer was scaled with the mesh size. This enabled good dirichlet boundary conditions but made it difficult to carry industrial analysis with it. 
- There was no way to post-process the heat extracted by the Nitsche IB

# Description of the solution

- The beta heat coefficient is now mesh independent. This parameter now has a physical meaning, it is the heat extracted W/m^2 (in 2D) or W/m^3 in 3D
- The nitsche heat flux is now post-processed when other heat fluxes are calculated.

# How Has This Been Tested?

- A new test has been added to validate this approach

# Documentation

-  Documentation has been modified accordingly

