### PR TITLE
fix spouted bed example prm

### DIFF
--- a/doc/source/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.rst
+++ b/doc/source/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.rst
@@ -339,7 +339,7 @@ We also enable grad-div stabilization in order to improve local mass conservatio
       set shear force                   = true
       set pressure force                = true
       set saffman lift force            = false
-      set drag model                    = gidaspow
+      set drag model                    = rong
       set post processing               = true
       set coupling frequency            = 100
       set implicit stabilization        = false

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set output frequency     = 50
   set startup time scaling = 0.6
   set time end             = 5
-  set time step            = 0.0001
+  set time step            = 0.001
   set subdivision          = 1
   set log precision        = 10
   set output path          = ./output/
@@ -82,7 +82,7 @@ subsection cfd-dem
   set shear force                   = true
   set pressure force                = true
   set saffman lift force            = false
-  set drag model                    = gidaspow
+  set drag model                    = rong
   set post processing               = true
   set coupling frequency            = 100
   set implicit stabilization        = false
@@ -114,14 +114,7 @@ end
 #---------------------------------------------------
 
 subsection post-processing
-  set Lagrangian post processing           = false
-  set calculate particles average velocity = false
-  set calculate granular temperature       = false
-  set initial step                         = 100
-  set end step                             = 20000
-  set output frequency                     = 50
-  set particles velocity output name       = average_velocity
-  set granular temperature output name     = granular_temperature
+  set Lagrangian post-processing           = false
 end
 
 #---------------------------------------------------
@@ -240,14 +233,14 @@ subsection lagrangian physical properties
     set young modulus particles           = 1e6
     set poisson ratio particles           = 0.25
     set restitution coefficient particles = 0.97
-    set friction coefficient particles    = 0.3
-    set rolling friction particles        = 0.1
+    set friction coefficient particles    = 0.4
+    set rolling friction particles        = 0.3
   end
   set young modulus wall           = 1e6
   set poisson ratio wall           = 0.25
   set restitution coefficient wall = 0.33
-  set friction coefficient wall    = 0.3
-  set rolling friction wall        = 0.1
+  set friction coefficient wall    = 0.2
+  set rolling friction wall        = 0.3
 end
 
 #---------------------------------------------------


### PR DESCRIPTION
Fix PRM file for spouted bed example

# Description of the problem

- The prm was giving results different from the example due to the wrong choice of the drag model.


# Description of the solution

- The gidaspow drag model has been replaced in the prm by the rong drag model. Additionally, some parameters were modified to match those found in the documentation example.

# How Has This Been Tested?

- N/A

# Documentation

- No change in the documentation

# Future changes

- N/A

# Comments

- N/A
