### PR TITLE
Add velocity divergence post-processor

### DIFF
--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -892,7 +892,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto &                           present_solution = this->present_solution;
+  auto                            &present_solution = this->present_solution;
 
   // Global flags
   // Their dimension is consistent with the dimension returned by
@@ -1669,6 +1669,9 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
   VorticityPostprocessor<dim> vorticity;
   data_out.add_data_vector(solution, vorticity);
 
+  DivergencePostprocessor<dim> divergence;
+  data_out.add_data_vector(solution, divergence);
+
   QCriterionPostprocessor<dim>                      qcriterion;
   QcriterionPostProcessorSmoothing<dim, VectorType> qcriterion_smoothing(
     *this->triangulation,
@@ -1687,7 +1690,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
           1, DataComponentInterpretation::component_is_scalar);
 
       std::vector<std::string> qcriterion_name = {"qcriterion"};
-      const DoFHandler<dim> &  dof_handler_qcriterion =
+      const DoFHandler<dim>   &dof_handler_qcriterion =
         qcriterion_smoothing.get_dof_handler();
       data_out.add_data_vector(dof_handler_qcriterion,
                                qcriterion_field,


### PR DESCRIPTION
# Description of the problem

- For some problems we are doing right now it is worthwhile to be able to calculate the velocity divergence within every cell

# Description of the solution

- Add a velocity divergence post-processor

# How Has This Been Tested?

- It has been used for a few test cases. Gives the expected results.


# Documentation

- No need to document this, it is automatically added to vtu files now.

# Future changes

- This made me realize an additional term will need to be added to the strong residual for the Navier-Stokes equations for VOF problems


