### PR TITLE
Dem wall container map

### DIFF
--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -157,7 +157,7 @@ namespace DEM
       particle_wall_candidates;
 
     // <particle id, <global_face_id, particle-wall info>>
-    typedef std::unordered_map<
+    typedef ankerl::unordered_dense::map<
       types::particle_index,
       std::map<global_face_id, particle_wall_contact_info<dim>>>
       particle_wall_in_contact;

--- a/include/dem/grid_motion.h
+++ b/include/dem/grid_motion.h
@@ -85,9 +85,7 @@ public:
    */
   void
   update_boundary_points_and_normal_vectors_in_contact_list(
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info<spacedim>>>
+    typename DEM::dem_data_structures<spacedim>::particle_wall_in_contact
       &particle_wall_pairs_in_contact,
     const typename DEM::dem_data_structures<
       spacedim>::boundary_points_and_normal_vectors

--- a/performance_analyses/dem/short_packing_10k_particles/packing_10kparticles_dynamic.prm
+++ b/performance_analyses/dem/short_packing_10k_particles/packing_10kparticles_dynamic.prm
@@ -7,7 +7,7 @@ subsection simulation control
   set time step                 			 = 1e-6
   set time end       					 = 0.10
   set output path                                        = output/
-  set log frequency				         = 1000
+  set log frequency				         = 10000
   set output frequency            			 = 1000000
 end
 

--- a/source/dem/grid_motion.cc
+++ b/source/dem/grid_motion.cc
@@ -32,8 +32,7 @@ GridMotion<dim, spacedim>::GridMotion(
 }
 
 template <>
-void
-GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
+void GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
 {
   throw ExcImpossibleInDim(1);
   // TODO We need to add this function to GridTools for dim=1
@@ -41,15 +40,13 @@ GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
 }
 
 template <>
-void
-GridMotion<2, 2>::move_grid_rotational(Triangulation<2, 2> &triangulation)
+void GridMotion<2, 2>::move_grid_rotational(Triangulation<2, 2> &triangulation)
 {
   GridTools::rotate(rotation_angle, triangulation);
 }
 
 template <>
-void
-GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
+void GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
 {
   Tensor<1, 3> axis({0, 0, 0});
   axis[rotation_axis] = 1;
@@ -57,8 +54,7 @@ GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
 }
 
 template <>
-void
-GridMotion<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
+void GridMotion<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
 {
   Tensor<1, 3> axis({0, 0, 0});
   axis[rotation_axis] = 1;

--- a/source/dem/grid_motion.cc
+++ b/source/dem/grid_motion.cc
@@ -32,7 +32,8 @@ GridMotion<dim, spacedim>::GridMotion(
 }
 
 template <>
-void GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
+void
+GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
 {
   throw ExcImpossibleInDim(1);
   // TODO We need to add this function to GridTools for dim=1
@@ -40,13 +41,15 @@ void GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
 }
 
 template <>
-void GridMotion<2, 2>::move_grid_rotational(Triangulation<2, 2> &triangulation)
+void
+GridMotion<2, 2>::move_grid_rotational(Triangulation<2, 2> &triangulation)
 {
   GridTools::rotate(rotation_angle, triangulation);
 }
 
 template <>
-void GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
+void
+GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
 {
   Tensor<1, 3> axis({0, 0, 0});
   axis[rotation_axis] = 1;
@@ -54,7 +57,8 @@ void GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
 }
 
 template <>
-void GridMotion<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
+void
+GridMotion<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
 {
   Tensor<1, 3> axis({0, 0, 0});
   axis[rotation_axis] = 1;
@@ -73,9 +77,7 @@ template <int dim, int spacedim>
 void
 GridMotion<dim, spacedim>::
   update_boundary_points_and_normal_vectors_in_contact_list(
-    std::unordered_map<
-      types::particle_index,
-      std::map<types::boundary_id, particle_wall_contact_info<spacedim>>>
+    typename DEM::dem_data_structures<spacedim>::particle_wall_in_contact
       &particle_wall_pairs_in_contact,
     const typename DEM::dem_data_structures<
       spacedim>::boundary_points_and_normal_vectors

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -165,8 +165,7 @@ test()
 
   // Particle-Wall fine search
   ParticleWallFineSearch<dim> particle_wall_fine_search_object;
-  std::unordered_map<unsigned int,
-                     std::map<unsigned int, particle_wall_contact_info<dim>>>
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
                                   particle_wall_contact_information;
   ParticleWallNonLinearForce<dim> particle_wall_force_object(
     dem_parameters.boundary_conditions.boundary_translational_velocity,

--- a/tests/dem/particle_wall_contact_force_linear.cc
+++ b/tests/dem/particle_wall_contact_force_linear.cc
@@ -172,8 +172,7 @@ test()
 
   // Calling fine search
   ParticleWallFineSearch<dim> fine_search_object;
-  std::unordered_map<unsigned int,
-                     std::map<unsigned int, particle_wall_contact_info<dim>>>
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
     particle_wall_contact_information;
   fine_search_object.particle_wall_fine_search(
     particle_wall_contact_list, particle_wall_contact_information);

--- a/tests/dem/particle_wall_contact_force_nonlinear.cc
+++ b/tests/dem/particle_wall_contact_force_nonlinear.cc
@@ -164,8 +164,7 @@ test()
 
   // Calling fine search
   ParticleWallFineSearch<dim> fine_search_object;
-  std::unordered_map<unsigned int,
-                     std::map<unsigned int, particle_wall_contact_info<dim>>>
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
     particle_wall_contact_information;
   fine_search_object.particle_wall_fine_search(
     particle_wall_contact_list, particle_wall_contact_information);

--- a/tests/dem/particle_wall_fine_search.cc
+++ b/tests/dem/particle_wall_fine_search.cc
@@ -109,8 +109,7 @@ test()
 
   // Calling particle-wall fine search
   ParticleWallFineSearch<dim> fine_search_object;
-  std::unordered_map<unsigned int,
-                     std::map<unsigned int, particle_wall_contact_info<dim>>>
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
     particle_wall_contact_information;
   fine_search_object.particle_wall_fine_search(
     particle_wall_contact_list, particle_wall_contact_information);

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -168,8 +168,7 @@ test(double coefficient_of_restitution)
 
   // P-W fine search
   ParticleWallFineSearch<dim> particle_wall_fine_search_object;
-  std::unordered_map<unsigned int,
-                     std::map<unsigned int, particle_wall_contact_info<dim>>>
+  typename DEM::dem_data_structures<dim>::particle_wall_in_contact
                                   particle_wall_contact_information;
   ParticleWallNonLinearForce<dim> particle_wall_force_object(
     dem_parameters.boundary_conditions.boundary_translational_velocity,


### PR DESCRIPTION
# Description of the problem

- The Ankerl map was only being used for the particle-particle data structure. I was wondering if it would be promising for the particle-wall data structure

# Description of the solution

- Switching to the new map for the particle-wall interaction has a good impact. Some cases are 2-3% faster, while some ass significantly more (the square hopper, for example, goes from 86 minutes to 74 minutes on my desktop at home)

# How Has This Been Tested?

- All previous DEM tests pass without any changes



# Comments

- It will be worthwhile to try with some of the other containers if there are not more possible gains to be obtained.
- 
