### PR TITLE
Add the Mixing-ANN paper to the publications

### DIFF
--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -7,6 +7,8 @@ This section regroups the peer-reviewed journal articles that **describe** core 
 2023
 ----
 
+* `V. Bibeau, L. Barbeau, D. C. Boffito and B. Blais, "Artificial neural network to predict the power number of agitated tanks fed by CFD simulations", The Canadian Journal of Chemical Engineering, 1-11, 2023 <https://doi.org/10.1002/cjce.24870>`_.
+
 * `T. El Geitani, S. Golshan and B. Blais, "A High Order Stabilized Solver for the Volume Averaged Navier-Stokes Equations", International Journal for Numerical Methods in Fluids, 1-23, 2023 <https://doi.org/10.1002/fld.5182>`_.
 
 * `C.-A. Daunais, L. Barbeau and B. Blais, "An Extensive Study of Shear Thinning Flow Around a Spherical Particle for Power-Law and Carreau Fluids", Journal of Non-Newtonian Fluid Mechanics, 311, 104951, 2023 <https://doi.org/10.1016/j.jnnfm.2022.104951>`_.


### PR DESCRIPTION
# Description of the problem

- Some publications were missing.

# Description of the solution

- Add the new paper about mixing and artificial neural network in the Lethe documentation.

# Documentation

- **publications.rst**: the DOI of the Mixing-ANN article has been added to the publications list.
