### PR TITLE
Flux postprocessing options

### DIFF
--- a/applications_tests/gls_vans_3d/beetstra_packed_bed.output
+++ b/applications_tests/gls_vans_3d/beetstra_packed_bed.output
@@ -8,7 +8,7 @@ Total pressure drop: 0 Pa
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 39.99872011 Pa
+Pressure drop: 40.47276122 Pa
 Total pressure drop: 40.47276186 Pa
 Mass Source: 8.527914948e-13 s^-1
 Max Local Mass Source: 8.141667298e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2194770617
 *****************************************************************
-Pressure drop: 26.0868311 Pa
+Pressure drop: 26.08585282 Pa
 Total pressure drop: 26.08633753 Pa
 Mass Source: -3.432880331e-07 s^-1
 Max Local Mass Source: 7.964573385e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2196560133
 *****************************************************************
-Pressure drop: 26.46032496 Pa
+Pressure drop: 26.46432352 Pa
 Total pressure drop: 26.46383733 Pa
 Mass Source: 3.432967504e-07 s^-1
 Max Local Mass Source: 8.066553916e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.221619556
 *****************************************************************
-Pressure drop: 26.03449776 Pa
+Pressure drop: 26.03064416 Pa
 Total pressure drop: 26.03112891 Pa
 Mass Source: -3.433050155e-07 s^-1
 Max Local Mass Source: 7.974216631e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2195549911
 *****************************************************************
-Pressure drop: 26.46016419 Pa
+Pressure drop: 26.4641568 Pa
 Total pressure drop: 26.46367054 Pa
 Mass Source: 3.432996425e-07 s^-1
 Max Local Mass Source: 8.068671768e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2216697475
 *****************************************************************
-Pressure drop: 26.03449141 Pa
+Pressure drop: 26.03063816 Pa
 Total pressure drop: 26.03112278 Pa
 Mass Source: -3.433007706e-07 s^-1
 Max Local Mass Source: 7.974885069e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2195735936
 *****************************************************************
-Pressure drop: 26.46016849 Pa
+Pressure drop: 26.46416159 Pa
 Total pressure drop: 26.46367516 Pa
 Mass Source: 3.433010221e-07 s^-1
 Max Local Mass Source: 8.068816679e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2216842662
 *****************************************************************
-Pressure drop: 26.03449833 Pa
+Pressure drop: 26.0306456 Pa
 Total pressure drop: 26.03113002 Pa
 Mass Source: -3.433029575e-07 s^-1
 Max Local Mass Source: 7.974819213e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2195840306
 *****************************************************************
-Pressure drop: 26.46017765 Pa
+Pressure drop: 26.46417131 Pa
 Total pressure drop: 26.46368464 Pa
 Mass Source: 3.433019734e-07 s^-1
 Max Local Mass Source: 8.068683777e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2216923848
 *****************************************************************
-Pressure drop: 26.03450845 Pa
+Pressure drop: 26.0306562 Pa
 Total pressure drop: 26.03114037 Pa
 Mass Source: -3.433010813e-07 s^-1
 Max Local Mass Source: 7.974663741e-08 s^-1

--- a/applications_tests/gls_vans_3d/beetstra_packed_bed.output
+++ b/applications_tests/gls_vans_3d/beetstra_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 40.47276122 Pa
-Total pressure drop: 40.47276186 Pa
+Total pressure drop: 40.47276154 Pa
 Mass Source: 8.527914948e-13 s^-1
 Max Local Mass Source: 8.141667298e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2194770617
 *****************************************************************
 Pressure drop: 26.08585282 Pa
-Total pressure drop: 26.08633753 Pa
+Total pressure drop: 26.08609517 Pa
 Mass Source: -3.432880331e-07 s^-1
 Max Local Mass Source: 7.964573385e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2196560133
 *****************************************************************
 Pressure drop: 26.46432352 Pa
-Total pressure drop: 26.46383733 Pa
+Total pressure drop: 26.46408043 Pa
 Mass Source: 3.432967504e-07 s^-1
 Max Local Mass Source: 8.066553916e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.221619556
 *****************************************************************
 Pressure drop: 26.03064416 Pa
-Total pressure drop: 26.03112891 Pa
+Total pressure drop: 26.03088653 Pa
 Mass Source: -3.433050155e-07 s^-1
 Max Local Mass Source: 7.974216631e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2195549911
 *****************************************************************
 Pressure drop: 26.4641568 Pa
-Total pressure drop: 26.46367054 Pa
+Total pressure drop: 26.46391367 Pa
 Mass Source: 3.432996425e-07 s^-1
 Max Local Mass Source: 8.068671768e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2216697475
 *****************************************************************
 Pressure drop: 26.03063816 Pa
-Total pressure drop: 26.03112278 Pa
+Total pressure drop: 26.03088047 Pa
 Mass Source: -3.433007706e-07 s^-1
 Max Local Mass Source: 7.974885069e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2195735936
 *****************************************************************
 Pressure drop: 26.46416159 Pa
-Total pressure drop: 26.46367516 Pa
+Total pressure drop: 26.46391838 Pa
 Mass Source: 3.433010221e-07 s^-1
 Max Local Mass Source: 8.068816679e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2216842662
 *****************************************************************
 Pressure drop: 26.0306456 Pa
-Total pressure drop: 26.03113002 Pa
+Total pressure drop: 26.03088781 Pa
 Mass Source: -3.433029575e-07 s^-1
 Max Local Mass Source: 7.974819213e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2195840306
 *****************************************************************
 Pressure drop: 26.46417131 Pa
-Total pressure drop: 26.46368464 Pa
+Total pressure drop: 26.46392798 Pa
 Mass Source: 3.433019734e-07 s^-1
 Max Local Mass Source: 8.068683777e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2216923848
 *****************************************************************
 Pressure drop: 26.0306562 Pa
-Total pressure drop: 26.03114037 Pa
+Total pressure drop: 26.03089828 Pa
 Mass Source: -3.433010813e-07 s^-1
 Max Local Mass Source: 7.974663741e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/beetstra_packed_bed.output
+++ b/applications_tests/gls_vans_3d/beetstra_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 39.99872011 Pa
+Total pressure drop: 40.47276186 Pa
 Mass Source: 8.527914948e-13 s^-1
 Max Local Mass Source: 8.141667298e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2194770617
 *****************************************************************
 Pressure drop: 26.0868311 Pa
+Total pressure drop: 26.08633753 Pa
 Mass Source: -3.432880331e-07 s^-1
 Max Local Mass Source: 7.964573385e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2196560133
 *****************************************************************
 Pressure drop: 26.46032496 Pa
+Total pressure drop: 26.46383733 Pa
 Mass Source: 3.432967504e-07 s^-1
 Max Local Mass Source: 8.066553916e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.221619556
 *****************************************************************
 Pressure drop: 26.03449776 Pa
+Total pressure drop: 26.03112891 Pa
 Mass Source: -3.433050155e-07 s^-1
 Max Local Mass Source: 7.974216631e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2195549911
 *****************************************************************
 Pressure drop: 26.46016419 Pa
+Total pressure drop: 26.46367054 Pa
 Mass Source: 3.432996425e-07 s^-1
 Max Local Mass Source: 8.068671768e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2216697475
 *****************************************************************
 Pressure drop: 26.03449141 Pa
+Total pressure drop: 26.03112278 Pa
 Mass Source: -3.433007706e-07 s^-1
 Max Local Mass Source: 7.974885069e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2195735936
 *****************************************************************
 Pressure drop: 26.46016849 Pa
+Total pressure drop: 26.46367516 Pa
 Mass Source: 3.433010221e-07 s^-1
 Max Local Mass Source: 8.068816679e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2216842662
 *****************************************************************
 Pressure drop: 26.03449833 Pa
+Total pressure drop: 26.03113002 Pa
 Mass Source: -3.433029575e-07 s^-1
 Max Local Mass Source: 7.974819213e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2195840306
 *****************************************************************
 Pressure drop: 26.46017765 Pa
+Total pressure drop: 26.46368464 Pa
 Mass Source: 3.433019734e-07 s^-1
 Max Local Mass Source: 8.068683777e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2216923848
 *****************************************************************
 Pressure drop: 26.03450845 Pa
+Total pressure drop: 26.03114037 Pa
 Mass Source: -3.433010813e-07 s^-1
 Max Local Mass Source: 7.974663741e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/dallavalle_packed_bed.output
+++ b/applications_tests/gls_vans_3d/dallavalle_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 22.40889078 Pa
-Total pressure drop: 22.40889108 Pa
+Total pressure drop: 22.40889093 Pa
 Mass Source: -1.16028794e-11 s^-1
 Max Local Mass Source: 8.351200952e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2227393107
 *****************************************************************
 Pressure drop: 8.617588875 Pa
-Total pressure drop: 8.61807344 Pa
+Total pressure drop: 8.617831158 Pa
 Mass Source: -3.433021311e-07 s^-1
 Max Local Mass Source: 8.372155802e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2251381238
 *****************************************************************
 Pressure drop: 8.857633282 Pa
-Total pressure drop: 8.857146977 Pa
+Total pressure drop: 8.857390129 Pa
 Mass Source: 3.43289882e-07 s^-1
 Max Local Mass Source: 8.448660765e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2273244901
 *****************************************************************
 Pressure drop: 8.552868908 Pa
-Total pressure drop: 8.55335353 Pa
+Total pressure drop: 8.553111219 Pa
 Mass Source: -3.432882022e-07 s^-1
 Max Local Mass Source: 8.349162728e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2252107542
 *****************************************************************
 Pressure drop: 8.857517442 Pa
-Total pressure drop: 8.857031108 Pa
+Total pressure drop: 8.857274275 Pa
 Mass Source: 3.432835398e-07 s^-1
 Max Local Mass Source: 8.438206419e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2274340644
 *****************************************************************
 Pressure drop: 8.552813893 Pa
-Total pressure drop: 8.553298406 Pa
+Total pressure drop: 8.553056149 Pa
 Mass Source: -3.43285363e-07 s^-1
 Max Local Mass Source: 8.343397673e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2252892839
 *****************************************************************
 Pressure drop: 8.857478467 Pa
-Total pressure drop: 8.856991987 Pa
+Total pressure drop: 8.857235227 Pa
 Mass Source: 3.432830845e-07 s^-1
 Max Local Mass Source: 8.434665234e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2274931322
 *****************************************************************
 Pressure drop: 8.552789949 Pa
-Total pressure drop: 8.553274287 Pa
+Total pressure drop: 8.553032118 Pa
 Mass Source: -3.432843865e-07 s^-1
 Max Local Mass Source: 8.341012481e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.225334905
 *****************************************************************
 Pressure drop: 8.857459973 Pa
-Total pressure drop: 8.856973298 Pa
+Total pressure drop: 8.857216636 Pa
 Mass Source: 3.43283415e-07 s^-1
 Max Local Mass Source: 8.432940228e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2275299284
 *****************************************************************
 Pressure drop: 8.552776817 Pa
-Total pressure drop: 8.553260947 Pa
+Total pressure drop: 8.553018882 Pa
 Mass Source: -3.432838358e-07 s^-1
 Max Local Mass Source: 8.339676281e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/dallavalle_packed_bed.output
+++ b/applications_tests/gls_vans_3d/dallavalle_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 8.482844148e-311 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 21.93484816 Pa
+Total pressure drop: 22.40889108 Pa
 Mass Source: -1.16028794e-11 s^-1
 Max Local Mass Source: 8.351200952e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2227393107
 *****************************************************************
 Pressure drop: 8.618562782 Pa
+Total pressure drop: 8.61807344 Pa
 Mass Source: -3.433021311e-07 s^-1
 Max Local Mass Source: 8.372155802e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2251381238
 *****************************************************************
 Pressure drop: 8.853630115 Pa
+Total pressure drop: 8.857146977 Pa
 Mass Source: 3.43289882e-07 s^-1
 Max Local Mass Source: 8.448660765e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2273244901
 *****************************************************************
 Pressure drop: 8.556717709 Pa
+Total pressure drop: 8.55335353 Pa
 Mass Source: -3.432882022e-07 s^-1
 Max Local Mass Source: 8.349162728e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2252107542
 *****************************************************************
 Pressure drop: 8.853520295 Pa
+Total pressure drop: 8.857031108 Pa
 Mass Source: 3.432835398e-07 s^-1
 Max Local Mass Source: 8.438206419e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2274340644
 *****************************************************************
 Pressure drop: 8.556662368 Pa
+Total pressure drop: 8.553298406 Pa
 Mass Source: -3.43285363e-07 s^-1
 Max Local Mass Source: 8.343397673e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2252892839
 *****************************************************************
 Pressure drop: 8.853481062 Pa
+Total pressure drop: 8.856991987 Pa
 Mass Source: 3.432830845e-07 s^-1
 Max Local Mass Source: 8.434665234e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2274931322
 *****************************************************************
 Pressure drop: 8.556638202 Pa
+Total pressure drop: 8.553274287 Pa
 Mass Source: -3.432843865e-07 s^-1
 Max Local Mass Source: 8.341012481e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.225334905
 *****************************************************************
 Pressure drop: 8.853462452 Pa
+Total pressure drop: 8.856973298 Pa
 Mass Source: 3.43283415e-07 s^-1
 Max Local Mass Source: 8.432940228e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2275299284
 *****************************************************************
 Pressure drop: 8.556625039 Pa
+Total pressure drop: 8.553260947 Pa
 Mass Source: -3.432838358e-07 s^-1
 Max Local Mass Source: 8.339676281e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/dallavalle_packed_bed.output
+++ b/applications_tests/gls_vans_3d/dallavalle_packed_bed.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
-Total pressure drop: 8.482844148e-311 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 21.93484816 Pa
+Pressure drop: 22.40889078 Pa
 Total pressure drop: 22.40889108 Pa
 Mass Source: -1.16028794e-11 s^-1
 Max Local Mass Source: 8.351200952e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2227393107
 *****************************************************************
-Pressure drop: 8.618562782 Pa
+Pressure drop: 8.617588875 Pa
 Total pressure drop: 8.61807344 Pa
 Mass Source: -3.433021311e-07 s^-1
 Max Local Mass Source: 8.372155802e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2251381238
 *****************************************************************
-Pressure drop: 8.853630115 Pa
+Pressure drop: 8.857633282 Pa
 Total pressure drop: 8.857146977 Pa
 Mass Source: 3.43289882e-07 s^-1
 Max Local Mass Source: 8.448660765e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2273244901
 *****************************************************************
-Pressure drop: 8.556717709 Pa
+Pressure drop: 8.552868908 Pa
 Total pressure drop: 8.55335353 Pa
 Mass Source: -3.432882022e-07 s^-1
 Max Local Mass Source: 8.349162728e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2252107542
 *****************************************************************
-Pressure drop: 8.853520295 Pa
+Pressure drop: 8.857517442 Pa
 Total pressure drop: 8.857031108 Pa
 Mass Source: 3.432835398e-07 s^-1
 Max Local Mass Source: 8.438206419e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2274340644
 *****************************************************************
-Pressure drop: 8.556662368 Pa
+Pressure drop: 8.552813893 Pa
 Total pressure drop: 8.553298406 Pa
 Mass Source: -3.43285363e-07 s^-1
 Max Local Mass Source: 8.343397673e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2252892839
 *****************************************************************
-Pressure drop: 8.853481062 Pa
+Pressure drop: 8.857478467 Pa
 Total pressure drop: 8.856991987 Pa
 Mass Source: 3.432830845e-07 s^-1
 Max Local Mass Source: 8.434665234e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2274931322
 *****************************************************************
-Pressure drop: 8.556638202 Pa
+Pressure drop: 8.552789949 Pa
 Total pressure drop: 8.553274287 Pa
 Mass Source: -3.432843865e-07 s^-1
 Max Local Mass Source: 8.341012481e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.225334905
 *****************************************************************
-Pressure drop: 8.853462452 Pa
+Pressure drop: 8.857459973 Pa
 Total pressure drop: 8.856973298 Pa
 Mass Source: 3.43283415e-07 s^-1
 Max Local Mass Source: 8.432940228e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2275299284
 *****************************************************************
-Pressure drop: 8.556625039 Pa
+Pressure drop: 8.552776817 Pa
 Total pressure drop: 8.553260947 Pa
 Mass Source: -3.432838358e-07 s^-1
 Max Local Mass Source: 8.339676281e-08 s^-1

--- a/applications_tests/gls_vans_3d/difelice_packed_bed.output
+++ b/applications_tests/gls_vans_3d/difelice_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 31.910005 Pa
-Total pressure drop: 31.91000486 Pa
+Total pressure drop: 31.91000493 Pa
 Mass Source: 1.300659094e-11 s^-1
 Max Local Mass Source: 8.004418758e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2154150631
 *****************************************************************
 Pressure drop: 21.89739127 Pa
-Total pressure drop: 21.8978758 Pa
+Total pressure drop: 21.89763353 Pa
 Mass Source: -3.432949593e-07 s^-1
 Max Local Mass Source: 8.279706038e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2216188764
 *****************************************************************
 Pressure drop: 22.23556987 Pa
-Total pressure drop: 22.23508361 Pa
+Total pressure drop: 22.23532674 Pa
 Mass Source: 3.432876686e-07 s^-1
 Max Local Mass Source: 8.247437218e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.220408421
 *****************************************************************
 Pressure drop: 21.84124337 Pa
-Total pressure drop: 21.84172806 Pa
+Total pressure drop: 21.84148571 Pa
 Mass Source: -3.433138273e-07 s^-1
 Max Local Mass Source: 8.148428883e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.218639659
 *****************************************************************
 Pressure drop: 22.2350376 Pa
-Total pressure drop: 22.23455123 Pa
+Total pressure drop: 22.23479442 Pa
 Mass Source: 3.432977508e-07 s^-1
 Max Local Mass Source: 8.234736851e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.220702861
 *****************************************************************
 Pressure drop: 21.8413198 Pa
-Total pressure drop: 21.84180427 Pa
+Total pressure drop: 21.84156203 Pa
 Mass Source: -3.433095757e-07 s^-1
 Max Local Mass Source: 8.137821767e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2186236691
 *****************************************************************
 Pressure drop: 22.23504108 Pa
-Total pressure drop: 22.23455443 Pa
+Total pressure drop: 22.23479775 Pa
 Mass Source: 3.433062879e-07 s^-1
 Max Local Mass Source: 8.229789413e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2207217194
 *****************************************************************
 Pressure drop: 21.84133003 Pa
-Total pressure drop: 21.84181427 Pa
+Total pressure drop: 21.84157215 Pa
 Mass Source: -3.433557759e-07 s^-1
 Max Local Mass Source: 8.134636932e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2186346421
 *****************************************************************
 Pressure drop: 22.23505621 Pa
-Total pressure drop: 22.23456921 Pa
+Total pressure drop: 22.23481271 Pa
 Mass Source: 3.43341325e-07 s^-1
 Max Local Mass Source: 8.227602626e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.22073094
 *****************************************************************
 Pressure drop: 21.8413349 Pa
-Total pressure drop: 21.84181883 Pa
+Total pressure drop: 21.84157687 Pa
 Mass Source: -3.433523719e-07 s^-1
 Max Local Mass Source: 8.133003864e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/difelice_packed_bed.output
+++ b/applications_tests/gls_vans_3d/difelice_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 8.2461166e-311 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 31.43596062 Pa
+Total pressure drop: 31.91000486 Pa
 Mass Source: 1.300659094e-11 s^-1
 Max Local Mass Source: 8.004418758e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2154150631
 *****************************************************************
 Pressure drop: 21.89836851 Pa
+Total pressure drop: 21.8978758 Pa
 Mass Source: -3.432949593e-07 s^-1
 Max Local Mass Source: 8.279706038e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2216188764
 *****************************************************************
 Pressure drop: 22.23157052 Pa
+Total pressure drop: 22.23508361 Pa
 Mass Source: 3.432876686e-07 s^-1
 Max Local Mass Source: 8.247437218e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.220408421
 *****************************************************************
 Pressure drop: 21.84509556 Pa
+Total pressure drop: 21.84172806 Pa
 Mass Source: -3.433138273e-07 s^-1
 Max Local Mass Source: 8.148428883e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.218639659
 *****************************************************************
 Pressure drop: 22.23104333 Pa
+Total pressure drop: 22.23455123 Pa
 Mass Source: 3.432977508e-07 s^-1
 Max Local Mass Source: 8.234736851e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.220702861
 *****************************************************************
 Pressure drop: 21.84517136 Pa
+Total pressure drop: 21.84180427 Pa
 Mass Source: -3.433095757e-07 s^-1
 Max Local Mass Source: 8.137821767e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2186236691
 *****************************************************************
 Pressure drop: 22.23104617 Pa
+Total pressure drop: 22.23455443 Pa
 Mass Source: 3.433062879e-07 s^-1
 Max Local Mass Source: 8.229789413e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2207217194
 *****************************************************************
 Pressure drop: 21.84518138 Pa
+Total pressure drop: 21.84181427 Pa
 Mass Source: -3.433557759e-07 s^-1
 Max Local Mass Source: 8.134636932e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2186346421
 *****************************************************************
 Pressure drop: 22.23106045 Pa
+Total pressure drop: 22.23456921 Pa
 Mass Source: 3.43341325e-07 s^-1
 Max Local Mass Source: 8.227602626e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.22073094
 *****************************************************************
 Pressure drop: 21.8451861 Pa
+Total pressure drop: 21.84181883 Pa
 Mass Source: -3.433523719e-07 s^-1
 Max Local Mass Source: 8.133003864e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/difelice_packed_bed.output
+++ b/applications_tests/gls_vans_3d/difelice_packed_bed.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
-Total pressure drop: 8.2461166e-311 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 31.43596062 Pa
+Pressure drop: 31.910005 Pa
 Total pressure drop: 31.91000486 Pa
 Mass Source: 1.300659094e-11 s^-1
 Max Local Mass Source: 8.004418758e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2154150631
 *****************************************************************
-Pressure drop: 21.89836851 Pa
+Pressure drop: 21.89739127 Pa
 Total pressure drop: 21.8978758 Pa
 Mass Source: -3.432949593e-07 s^-1
 Max Local Mass Source: 8.279706038e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2216188764
 *****************************************************************
-Pressure drop: 22.23157052 Pa
+Pressure drop: 22.23556987 Pa
 Total pressure drop: 22.23508361 Pa
 Mass Source: 3.432876686e-07 s^-1
 Max Local Mass Source: 8.247437218e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.220408421
 *****************************************************************
-Pressure drop: 21.84509556 Pa
+Pressure drop: 21.84124337 Pa
 Total pressure drop: 21.84172806 Pa
 Mass Source: -3.433138273e-07 s^-1
 Max Local Mass Source: 8.148428883e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.218639659
 *****************************************************************
-Pressure drop: 22.23104333 Pa
+Pressure drop: 22.2350376 Pa
 Total pressure drop: 22.23455123 Pa
 Mass Source: 3.432977508e-07 s^-1
 Max Local Mass Source: 8.234736851e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.220702861
 *****************************************************************
-Pressure drop: 21.84517136 Pa
+Pressure drop: 21.8413198 Pa
 Total pressure drop: 21.84180427 Pa
 Mass Source: -3.433095757e-07 s^-1
 Max Local Mass Source: 8.137821767e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2186236691
 *****************************************************************
-Pressure drop: 22.23104617 Pa
+Pressure drop: 22.23504108 Pa
 Total pressure drop: 22.23455443 Pa
 Mass Source: 3.433062879e-07 s^-1
 Max Local Mass Source: 8.229789413e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2207217194
 *****************************************************************
-Pressure drop: 21.84518138 Pa
+Pressure drop: 21.84133003 Pa
 Total pressure drop: 21.84181427 Pa
 Mass Source: -3.433557759e-07 s^-1
 Max Local Mass Source: 8.134636932e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2186346421
 *****************************************************************
-Pressure drop: 22.23106045 Pa
+Pressure drop: 22.23505621 Pa
 Total pressure drop: 22.23456921 Pa
 Mass Source: 3.43341325e-07 s^-1
 Max Local Mass Source: 8.227602626e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.22073094
 *****************************************************************
-Pressure drop: 21.8451861 Pa
+Pressure drop: 21.8413349 Pa
 Total pressure drop: 21.84181883 Pa
 Mass Source: -3.433523719e-07 s^-1
 Max Local Mass Source: 8.133003864e-08 s^-1

--- a/applications_tests/gls_vans_3d/gidaspow_packed_bed.output
+++ b/applications_tests/gls_vans_3d/gidaspow_packed_bed.output
@@ -8,7 +8,7 @@ Total pressure drop: 0 Pa
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 60.87482911 Pa
+Pressure drop: 61.34887012 Pa
 Total pressure drop: 61.34887077 Pa
 Mass Source: -3.446202714e-12 s^-1
 Max Local Mass Source: 7.819604909e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2125517999
 *****************************************************************
-Pressure drop: 57.73561833 Pa
+Pressure drop: 57.73463692 Pa
 Total pressure drop: 57.73512166 Pa
 Mass Source: -3.432877542e-07 s^-1
 Max Local Mass Source: 7.354459296e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2151095802
 *****************************************************************
-Pressure drop: 58.29405938 Pa
+Pressure drop: 58.29805179 Pa
 Total pressure drop: 58.29756566 Pa
 Mass Source: 3.432813087e-07 s^-1
 Max Local Mass Source: 7.454525641e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2161313186
 *****************************************************************
-Pressure drop: 57.65711721 Pa
+Pressure drop: 57.65325795 Pa
 Total pressure drop: 57.6537427 Pa
 Mass Source: -3.432906224e-07 s^-1
 Max Local Mass Source: 7.358581828e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.214323852
 *****************************************************************
-Pressure drop: 58.29400466 Pa
+Pressure drop: 58.29799117 Pa
 Total pressure drop: 58.29750494 Pa
 Mass Source: 3.432858109e-07 s^-1
 Max Local Mass Source: 7.455450134e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2163079556
 *****************************************************************
-Pressure drop: 57.65719951 Pa
+Pressure drop: 57.65334064 Pa
 Total pressure drop: 57.65382524 Pa
 Mass Source: -3.432914974e-07 s^-1
 Max Local Mass Source: 7.358855466e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.214315228
 *****************************************************************
-Pressure drop: 58.29410491 Pa
+Pressure drop: 58.29809212 Pa
 Total pressure drop: 58.29760567 Pa
 Mass Source: 3.432914675e-07 s^-1
 Max Local Mass Source: 7.455373038e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2163260208
 *****************************************************************
-Pressure drop: 57.65727616 Pa
+Pressure drop: 57.65341801 Pa
 Total pressure drop: 57.65390235 Pa
 Mass Source: -3.432912232e-07 s^-1
 Max Local Mass Source: 7.358693959e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2143247746
 *****************************************************************
-Pressure drop: 58.29417268 Pa
+Pressure drop: 58.29816067 Pa
 Total pressure drop: 58.29767393 Pa
 Mass Source: 3.432916053e-07 s^-1
 Max Local Mass Source: 7.455198555e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.216334791
 *****************************************************************
-Pressure drop: 57.65733605 Pa
+Pressure drop: 57.65347866 Pa
 Total pressure drop: 57.65396269 Pa
 Mass Source: -3.432910789e-07 s^-1
 Max Local Mass Source: 7.358530725e-08 s^-1

--- a/applications_tests/gls_vans_3d/gidaspow_packed_bed.output
+++ b/applications_tests/gls_vans_3d/gidaspow_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 60.87482911 Pa
+Total pressure drop: 61.34887077 Pa
 Mass Source: -3.446202714e-12 s^-1
 Max Local Mass Source: 7.819604909e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2125517999
 *****************************************************************
 Pressure drop: 57.73561833 Pa
+Total pressure drop: 57.73512166 Pa
 Mass Source: -3.432877542e-07 s^-1
 Max Local Mass Source: 7.354459296e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2151095802
 *****************************************************************
 Pressure drop: 58.29405938 Pa
+Total pressure drop: 58.29756566 Pa
 Mass Source: 3.432813087e-07 s^-1
 Max Local Mass Source: 7.454525641e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2161313186
 *****************************************************************
 Pressure drop: 57.65711721 Pa
+Total pressure drop: 57.6537427 Pa
 Mass Source: -3.432906224e-07 s^-1
 Max Local Mass Source: 7.358581828e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.214323852
 *****************************************************************
 Pressure drop: 58.29400466 Pa
+Total pressure drop: 58.29750494 Pa
 Mass Source: 3.432858109e-07 s^-1
 Max Local Mass Source: 7.455450134e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2163079556
 *****************************************************************
 Pressure drop: 57.65719951 Pa
+Total pressure drop: 57.65382524 Pa
 Mass Source: -3.432914974e-07 s^-1
 Max Local Mass Source: 7.358855466e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.214315228
 *****************************************************************
 Pressure drop: 58.29410491 Pa
+Total pressure drop: 58.29760567 Pa
 Mass Source: 3.432914675e-07 s^-1
 Max Local Mass Source: 7.455373038e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2163260208
 *****************************************************************
 Pressure drop: 57.65727616 Pa
+Total pressure drop: 57.65390235 Pa
 Mass Source: -3.432912232e-07 s^-1
 Max Local Mass Source: 7.358693959e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2143247746
 *****************************************************************
 Pressure drop: 58.29417268 Pa
+Total pressure drop: 58.29767393 Pa
 Mass Source: 3.432916053e-07 s^-1
 Max Local Mass Source: 7.455198555e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.216334791
 *****************************************************************
 Pressure drop: 57.65733605 Pa
+Total pressure drop: 57.65396269 Pa
 Mass Source: -3.432910789e-07 s^-1
 Max Local Mass Source: 7.358530725e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/gidaspow_packed_bed.output
+++ b/applications_tests/gls_vans_3d/gidaspow_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 61.34887012 Pa
-Total pressure drop: 61.34887077 Pa
+Total pressure drop: 61.34887044 Pa
 Mass Source: -3.446202714e-12 s^-1
 Max Local Mass Source: 7.819604909e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2125517999
 *****************************************************************
 Pressure drop: 57.73463692 Pa
-Total pressure drop: 57.73512166 Pa
+Total pressure drop: 57.73487929 Pa
 Mass Source: -3.432877542e-07 s^-1
 Max Local Mass Source: 7.354459296e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2151095802
 *****************************************************************
 Pressure drop: 58.29805179 Pa
-Total pressure drop: 58.29756566 Pa
+Total pressure drop: 58.29780872 Pa
 Mass Source: 3.432813087e-07 s^-1
 Max Local Mass Source: 7.454525641e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2161313186
 *****************************************************************
 Pressure drop: 57.65325795 Pa
-Total pressure drop: 57.6537427 Pa
+Total pressure drop: 57.65350033 Pa
 Mass Source: -3.432906224e-07 s^-1
 Max Local Mass Source: 7.358581828e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.214323852
 *****************************************************************
 Pressure drop: 58.29799117 Pa
-Total pressure drop: 58.29750494 Pa
+Total pressure drop: 58.29774806 Pa
 Mass Source: 3.432858109e-07 s^-1
 Max Local Mass Source: 7.455450134e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2163079556
 *****************************************************************
 Pressure drop: 57.65334064 Pa
-Total pressure drop: 57.65382524 Pa
+Total pressure drop: 57.65358294 Pa
 Mass Source: -3.432914974e-07 s^-1
 Max Local Mass Source: 7.358855466e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.214315228
 *****************************************************************
 Pressure drop: 58.29809212 Pa
-Total pressure drop: 58.29760567 Pa
+Total pressure drop: 58.29784889 Pa
 Mass Source: 3.432914675e-07 s^-1
 Max Local Mass Source: 7.455373038e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2163260208
 *****************************************************************
 Pressure drop: 57.65341801 Pa
-Total pressure drop: 57.65390235 Pa
+Total pressure drop: 57.65366018 Pa
 Mass Source: -3.432912232e-07 s^-1
 Max Local Mass Source: 7.358693959e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2143247746
 *****************************************************************
 Pressure drop: 58.29816067 Pa
-Total pressure drop: 58.29767393 Pa
+Total pressure drop: 58.2979173 Pa
 Mass Source: 3.432916053e-07 s^-1
 Max Local Mass Source: 7.455198555e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.216334791
 *****************************************************************
 Pressure drop: 57.65347866 Pa
-Total pressure drop: 57.65396269 Pa
+Total pressure drop: 57.65372068 Pa
 Mass Source: -3.432910789e-07 s^-1
 Max Local Mass Source: 7.358530725e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/kochhill_packed_bed.output
+++ b/applications_tests/gls_vans_3d/kochhill_packed_bed.output
@@ -8,7 +8,7 @@ Total pressure drop: 0 Pa
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 39.71610912 Pa
+Pressure drop: 40.19015029 Pa
 Total pressure drop: 40.19015091 Pa
 Mass Source: 1.713282925e-12 s^-1
 Max Local Mass Source: 8.156598383e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.219369895
 *****************************************************************
-Pressure drop: 25.77712303 Pa
+Pressure drop: 25.77614508 Pa
 Total pressure drop: 25.77662976 Pa
 Mass Source: -3.432891587e-07 s^-1
 Max Local Mass Source: 8.017178207e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2177655972
 *****************************************************************
-Pressure drop: 26.15901836 Pa
+Pressure drop: 26.16301771 Pa
 Total pressure drop: 26.16253147 Pa
 Mass Source: 3.432938119e-07 s^-1
 Max Local Mass Source: 8.120404161e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2199200775
 *****************************************************************
-Pressure drop: 25.72111683 Pa
+Pressure drop: 25.71726398 Pa
 Total pressure drop: 25.71774868 Pa
 Mass Source: -3.433029105e-07 s^-1
 Max Local Mass Source: 8.029573456e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2178479935
 *****************************************************************
-Pressure drop: 26.15887053 Pa
+Pressure drop: 26.16286381 Pa
 Total pressure drop: 26.16237749 Pa
 Mass Source: 3.432927803e-07 s^-1
 Max Local Mass Source: 8.123687578e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2199553783
 *****************************************************************
-Pressure drop: 25.72109537 Pa
+Pressure drop: 25.71724287 Pa
 Total pressure drop: 25.71772742 Pa
 Mass Source: -3.433028368e-07 s^-1
 Max Local Mass Source: 8.030512852e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2178712167
 *****************************************************************
-Pressure drop: 26.15888268 Pa
+Pressure drop: 26.16287655 Pa
 Total pressure drop: 26.16239003 Pa
 Mass Source: 3.433035339e-07 s^-1
 Max Local Mass Source: 8.123862157e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2199716287
 *****************************************************************
-Pressure drop: 25.72109731 Pa
+Pressure drop: 25.71724531 Pa
 Total pressure drop: 25.71772963 Pa
 Mass Source: -3.43303745e-07 s^-1
 Max Local Mass Source: 8.030394873e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2178831401
 *****************************************************************
-Pressure drop: 26.15889105 Pa
+Pressure drop: 26.16288552 Pa
 Total pressure drop: 26.16239872 Pa
 Mass Source: 3.433041649e-07 s^-1
 Max Local Mass Source: 8.123638943e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2199808839
 *****************************************************************
-Pressure drop: 25.7211078 Pa
+Pressure drop: 25.71725634 Pa
 Total pressure drop: 25.71774035 Pa
 Mass Source: -3.433020166e-07 s^-1
 Max Local Mass Source: 8.030134859e-08 s^-1

--- a/applications_tests/gls_vans_3d/kochhill_packed_bed.output
+++ b/applications_tests/gls_vans_3d/kochhill_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 39.71610912 Pa
+Total pressure drop: 40.19015091 Pa
 Mass Source: 1.713282925e-12 s^-1
 Max Local Mass Source: 8.156598383e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.219369895
 *****************************************************************
 Pressure drop: 25.77712303 Pa
+Total pressure drop: 25.77662976 Pa
 Mass Source: -3.432891587e-07 s^-1
 Max Local Mass Source: 8.017178207e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2177655972
 *****************************************************************
 Pressure drop: 26.15901836 Pa
+Total pressure drop: 26.16253147 Pa
 Mass Source: 3.432938119e-07 s^-1
 Max Local Mass Source: 8.120404161e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2199200775
 *****************************************************************
 Pressure drop: 25.72111683 Pa
+Total pressure drop: 25.71774868 Pa
 Mass Source: -3.433029105e-07 s^-1
 Max Local Mass Source: 8.029573456e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2178479935
 *****************************************************************
 Pressure drop: 26.15887053 Pa
+Total pressure drop: 26.16237749 Pa
 Mass Source: 3.432927803e-07 s^-1
 Max Local Mass Source: 8.123687578e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2199553783
 *****************************************************************
 Pressure drop: 25.72109537 Pa
+Total pressure drop: 25.71772742 Pa
 Mass Source: -3.433028368e-07 s^-1
 Max Local Mass Source: 8.030512852e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2178712167
 *****************************************************************
 Pressure drop: 26.15888268 Pa
+Total pressure drop: 26.16239003 Pa
 Mass Source: 3.433035339e-07 s^-1
 Max Local Mass Source: 8.123862157e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2199716287
 *****************************************************************
 Pressure drop: 25.72109731 Pa
+Total pressure drop: 25.71772963 Pa
 Mass Source: -3.43303745e-07 s^-1
 Max Local Mass Source: 8.030394873e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2178831401
 *****************************************************************
 Pressure drop: 26.15889105 Pa
+Total pressure drop: 26.16239872 Pa
 Mass Source: 3.433041649e-07 s^-1
 Max Local Mass Source: 8.123638943e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2199808839
 *****************************************************************
 Pressure drop: 25.7211078 Pa
+Total pressure drop: 25.71774035 Pa
 Mass Source: -3.433020166e-07 s^-1
 Max Local Mass Source: 8.030134859e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/kochhill_packed_bed.output
+++ b/applications_tests/gls_vans_3d/kochhill_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 40.19015029 Pa
-Total pressure drop: 40.19015091 Pa
+Total pressure drop: 40.1901506 Pa
 Mass Source: 1.713282925e-12 s^-1
 Max Local Mass Source: 8.156598383e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.219369895
 *****************************************************************
 Pressure drop: 25.77614508 Pa
-Total pressure drop: 25.77662976 Pa
+Total pressure drop: 25.77638742 Pa
 Mass Source: -3.432891587e-07 s^-1
 Max Local Mass Source: 8.017178207e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2177655972
 *****************************************************************
 Pressure drop: 26.16301771 Pa
-Total pressure drop: 26.16253147 Pa
+Total pressure drop: 26.16277459 Pa
 Mass Source: 3.432938119e-07 s^-1
 Max Local Mass Source: 8.120404161e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2199200775
 *****************************************************************
 Pressure drop: 25.71726398 Pa
-Total pressure drop: 25.71774868 Pa
+Total pressure drop: 25.71750633 Pa
 Mass Source: -3.433029105e-07 s^-1
 Max Local Mass Source: 8.029573456e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2178479935
 *****************************************************************
 Pressure drop: 26.16286381 Pa
-Total pressure drop: 26.16237749 Pa
+Total pressure drop: 26.16262065 Pa
 Mass Source: 3.432927803e-07 s^-1
 Max Local Mass Source: 8.123687578e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2199553783
 *****************************************************************
 Pressure drop: 25.71724287 Pa
-Total pressure drop: 25.71772742 Pa
+Total pressure drop: 25.71748515 Pa
 Mass Source: -3.433028368e-07 s^-1
 Max Local Mass Source: 8.030512852e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2178712167
 *****************************************************************
 Pressure drop: 26.16287655 Pa
-Total pressure drop: 26.16239003 Pa
+Total pressure drop: 26.16263329 Pa
 Mass Source: 3.433035339e-07 s^-1
 Max Local Mass Source: 8.123862157e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2199716287
 *****************************************************************
 Pressure drop: 25.71724531 Pa
-Total pressure drop: 25.71772963 Pa
+Total pressure drop: 25.71748747 Pa
 Mass Source: -3.43303745e-07 s^-1
 Max Local Mass Source: 8.030394873e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2178831401
 *****************************************************************
 Pressure drop: 26.16288552 Pa
-Total pressure drop: 26.16239872 Pa
+Total pressure drop: 26.16264212 Pa
 Mass Source: 3.433041649e-07 s^-1
 Max Local Mass Source: 8.123638943e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2199808839
 *****************************************************************
 Pressure drop: 25.71725634 Pa
-Total pressure drop: 25.71774035 Pa
+Total pressure drop: 25.71749834 Pa
 Mass Source: -3.433020166e-07 s^-1
 Max Local Mass Source: 8.030134859e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/pcm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/pcm_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 1.298947828e-310 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 31.5942532 Pa
+Total pressure drop: 32.06829646 Pa
 Mass Source: -1.408159088e-11 s^-1
 Max Local Mass Source: 8.027467254e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2165621926
 *****************************************************************
 Pressure drop: 22.57009881 Pa
+Total pressure drop: 22.56960656 Pa
 Mass Source: -3.432835289e-07 s^-1
 Max Local Mass Source: 8.271625181e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2214957629
 *****************************************************************
 Pressure drop: 22.90968878 Pa
+Total pressure drop: 22.9132019 Pa
 Mass Source: 3.43273989e-07 s^-1
 Max Local Mass Source: 8.23107266e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2205178886
 *****************************************************************
 Pressure drop: 22.51906546 Pa
+Total pressure drop: 22.51569794 Pa
 Mass Source: -3.433148422e-07 s^-1
 Max Local Mass Source: 8.133983491e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2187156648
 *****************************************************************
 Pressure drop: 22.90904137 Pa
+Total pressure drop: 22.91254916 Pa
 Mass Source: 3.432988122e-07 s^-1
 Max Local Mass Source: 8.220077274e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2207881787
 *****************************************************************
 Pressure drop: 22.51915627 Pa
+Total pressure drop: 22.51578903 Pa
 Mass Source: -3.433082806e-07 s^-1
 Max Local Mass Source: 8.123294893e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2187043906
 *****************************************************************
 Pressure drop: 22.90903681 Pa
+Total pressure drop: 22.91254473 Pa
 Mass Source: 3.432665021e-07 s^-1
 Max Local Mass Source: 8.215302121e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2208069386
 *****************************************************************
 Pressure drop: 22.51916966 Pa
+Total pressure drop: 22.5158026 Pa
 Mass Source: -3.433492006e-07 s^-1
 Max Local Mass Source: 8.120202874e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2187152089
 *****************************************************************
 Pressure drop: 22.90905345 Pa
+Total pressure drop: 22.91256188 Pa
 Mass Source: 3.433197502e-07 s^-1
 Max Local Mass Source: 8.213197807e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2208160365
 *****************************************************************
 Pressure drop: 22.51917257 Pa
+Total pressure drop: 22.51580516 Pa
 Mass Source: -3.433635395e-07 s^-1
 Max Local Mass Source: 8.118639249e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/pcm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/pcm_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 32.06829627 Pa
-Total pressure drop: 32.06829646 Pa
+Total pressure drop: 32.06829637 Pa
 Mass Source: -1.408159088e-11 s^-1
 Max Local Mass Source: 8.027467254e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2165621926
 *****************************************************************
 Pressure drop: 22.56912194 Pa
-Total pressure drop: 22.56960656 Pa
+Total pressure drop: 22.56936425 Pa
 Mass Source: -3.432835289e-07 s^-1
 Max Local Mass Source: 8.271625181e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2214957629
 *****************************************************************
 Pressure drop: 22.91368809 Pa
-Total pressure drop: 22.9132019 Pa
+Total pressure drop: 22.91344499 Pa
 Mass Source: 3.43273989e-07 s^-1
 Max Local Mass Source: 8.23107266e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2205178886
 *****************************************************************
 Pressure drop: 22.51521322 Pa
-Total pressure drop: 22.51569794 Pa
+Total pressure drop: 22.51545558 Pa
 Mass Source: -3.433148422e-07 s^-1
 Max Local Mass Source: 8.133983491e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2187156648
 *****************************************************************
 Pressure drop: 22.91303551 Pa
-Total pressure drop: 22.91254916 Pa
+Total pressure drop: 22.91279233 Pa
 Mass Source: 3.432988122e-07 s^-1
 Max Local Mass Source: 8.220077274e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2207881787
 *****************************************************************
 Pressure drop: 22.51530454 Pa
-Total pressure drop: 22.51578903 Pa
+Total pressure drop: 22.51554678 Pa
 Mass Source: -3.433082806e-07 s^-1
 Max Local Mass Source: 8.123294893e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2187043906
 *****************************************************************
 Pressure drop: 22.91303131 Pa
-Total pressure drop: 22.91254473 Pa
+Total pressure drop: 22.91278802 Pa
 Mass Source: 3.432665021e-07 s^-1
 Max Local Mass Source: 8.215302121e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2208069386
 *****************************************************************
 Pressure drop: 22.51531835 Pa
-Total pressure drop: 22.5158026 Pa
+Total pressure drop: 22.51556048 Pa
 Mass Source: -3.433492006e-07 s^-1
 Max Local Mass Source: 8.120202874e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2187152089
 *****************************************************************
 Pressure drop: 22.91304883 Pa
-Total pressure drop: 22.91256188 Pa
+Total pressure drop: 22.91280535 Pa
 Mass Source: 3.433197502e-07 s^-1
 Max Local Mass Source: 8.213197807e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2208160365
 *****************************************************************
 Pressure drop: 22.5153212 Pa
-Total pressure drop: 22.51580516 Pa
+Total pressure drop: 22.51556318 Pa
 Mass Source: -3.433635395e-07 s^-1
 Max Local Mass Source: 8.118639249e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/pcm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/pcm_packed_bed.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
-Total pressure drop: 1.298947828e-310 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 31.5942532 Pa
+Pressure drop: 32.06829627 Pa
 Total pressure drop: 32.06829646 Pa
 Mass Source: -1.408159088e-11 s^-1
 Max Local Mass Source: 8.027467254e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2165621926
 *****************************************************************
-Pressure drop: 22.57009881 Pa
+Pressure drop: 22.56912194 Pa
 Total pressure drop: 22.56960656 Pa
 Mass Source: -3.432835289e-07 s^-1
 Max Local Mass Source: 8.271625181e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2214957629
 *****************************************************************
-Pressure drop: 22.90968878 Pa
+Pressure drop: 22.91368809 Pa
 Total pressure drop: 22.9132019 Pa
 Mass Source: 3.43273989e-07 s^-1
 Max Local Mass Source: 8.23107266e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2205178886
 *****************************************************************
-Pressure drop: 22.51906546 Pa
+Pressure drop: 22.51521322 Pa
 Total pressure drop: 22.51569794 Pa
 Mass Source: -3.433148422e-07 s^-1
 Max Local Mass Source: 8.133983491e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2187156648
 *****************************************************************
-Pressure drop: 22.90904137 Pa
+Pressure drop: 22.91303551 Pa
 Total pressure drop: 22.91254916 Pa
 Mass Source: 3.432988122e-07 s^-1
 Max Local Mass Source: 8.220077274e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2207881787
 *****************************************************************
-Pressure drop: 22.51915627 Pa
+Pressure drop: 22.51530454 Pa
 Total pressure drop: 22.51578903 Pa
 Mass Source: -3.433082806e-07 s^-1
 Max Local Mass Source: 8.123294893e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2187043906
 *****************************************************************
-Pressure drop: 22.90903681 Pa
+Pressure drop: 22.91303131 Pa
 Total pressure drop: 22.91254473 Pa
 Mass Source: 3.432665021e-07 s^-1
 Max Local Mass Source: 8.215302121e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2208069386
 *****************************************************************
-Pressure drop: 22.51916966 Pa
+Pressure drop: 22.51531835 Pa
 Total pressure drop: 22.5158026 Pa
 Mass Source: -3.433492006e-07 s^-1
 Max Local Mass Source: 8.120202874e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2187152089
 *****************************************************************
-Pressure drop: 22.90905345 Pa
+Pressure drop: 22.91304883 Pa
 Total pressure drop: 22.91256188 Pa
 Mass Source: 3.433197502e-07 s^-1
 Max Local Mass Source: 8.213197807e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2208160365
 *****************************************************************
-Pressure drop: 22.51917257 Pa
+Pressure drop: 22.5153212 Pa
 Total pressure drop: 22.51580516 Pa
 Mass Source: -3.433635395e-07 s^-1
 Max Local Mass Source: 8.118639249e-08 s^-1

--- a/applications_tests/gls_vans_3d/qcm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/qcm_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 36.50662994 Pa
-Total pressure drop: 36.50646995 Pa
+Total pressure drop: 36.50654994 Pa
 Mass Source: 1.126901212e-07 s^-1
 Max Local Mass Source: 2.966665574e-07 s^-1
 Average Void Fraction in Bed: 0.7778631901
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7778631901
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2870529838
 *****************************************************************
 Pressure drop: 30.94019474 Pa
-Total pressure drop: 30.95238922 Pa
+Total pressure drop: 30.94629198 Pa
 Mass Source: -9.405895239e-06 s^-1
 Max Local Mass Source: 2.558979598e-07 s^-1
 Average Void Fraction in Bed: 0.7786563358

--- a/applications_tests/gls_vans_3d/qcm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/qcm_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 1.312555698e-310 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 36.03193581 Pa
+Total pressure drop: 36.50646995 Pa
 Mass Source: 1.126901212e-07 s^-1
 Max Local Mass Source: 2.966665574e-07 s^-1
 Average Void Fraction in Bed: 0.7778631901
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7778631901
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2870529838
 *****************************************************************
 Pressure drop: 30.99354699 Pa
+Total pressure drop: 30.95238922 Pa
 Mass Source: -9.405895239e-06 s^-1
 Max Local Mass Source: 2.558979598e-07 s^-1
 Average Void Fraction in Bed: 0.7786563358

--- a/applications_tests/gls_vans_3d/qcm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/qcm_packed_bed.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
-Total pressure drop: 1.312555698e-310 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 36.03193581 Pa
+Pressure drop: 36.50662994 Pa
 Total pressure drop: 36.50646995 Pa
 Mass Source: 1.126901212e-07 s^-1
 Max Local Mass Source: 2.966665574e-07 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7778631901
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2870529838
 *****************************************************************
-Pressure drop: 30.99354699 Pa
+Pressure drop: 30.94019474 Pa
 Total pressure drop: 30.95238922 Pa
 Mass Source: -9.405895239e-06 s^-1
 Max Local Mass Source: 2.558979598e-07 s^-1

--- a/applications_tests/gls_vans_3d/rong_packed_bed.output
+++ b/applications_tests/gls_vans_3d/rong_packed_bed.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
-Total pressure drop: 8.734236424e-311 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 31.5942532 Pa
+Pressure drop: 32.06829627 Pa
 Total pressure drop: 32.06829646 Pa
 Mass Source: -1.408159088e-11 s^-1
 Max Local Mass Source: 8.027467254e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2165621926
 *****************************************************************
-Pressure drop: 22.57009881 Pa
+Pressure drop: 22.56912194 Pa
 Total pressure drop: 22.56960656 Pa
 Mass Source: -3.432835289e-07 s^-1
 Max Local Mass Source: 8.271625181e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2214957629
 *****************************************************************
-Pressure drop: 22.90968878 Pa
+Pressure drop: 22.91368809 Pa
 Total pressure drop: 22.9132019 Pa
 Mass Source: 3.43273989e-07 s^-1
 Max Local Mass Source: 8.23107266e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2205178886
 *****************************************************************
-Pressure drop: 22.51906546 Pa
+Pressure drop: 22.51521322 Pa
 Total pressure drop: 22.51569794 Pa
 Mass Source: -3.433148422e-07 s^-1
 Max Local Mass Source: 8.133983491e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2187156648
 *****************************************************************
-Pressure drop: 22.90904137 Pa
+Pressure drop: 22.91303551 Pa
 Total pressure drop: 22.91254916 Pa
 Mass Source: 3.432988122e-07 s^-1
 Max Local Mass Source: 8.220077274e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2207881787
 *****************************************************************
-Pressure drop: 22.51915627 Pa
+Pressure drop: 22.51530454 Pa
 Total pressure drop: 22.51578903 Pa
 Mass Source: -3.433082806e-07 s^-1
 Max Local Mass Source: 8.123294893e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2187043906
 *****************************************************************
-Pressure drop: 22.90903681 Pa
+Pressure drop: 22.91303131 Pa
 Total pressure drop: 22.91254473 Pa
 Mass Source: 3.432665021e-07 s^-1
 Max Local Mass Source: 8.215302121e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2208069386
 *****************************************************************
-Pressure drop: 22.51916966 Pa
+Pressure drop: 22.51531835 Pa
 Total pressure drop: 22.5158026 Pa
 Mass Source: -3.433492006e-07 s^-1
 Max Local Mass Source: 8.120202874e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931023626
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2187152089
 *****************************************************************
-Pressure drop: 22.90905345 Pa
+Pressure drop: 22.91304883 Pa
 Total pressure drop: 22.91256188 Pa
 Mass Source: 3.433197502e-07 s^-1
 Max Local Mass Source: 8.213197807e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930753133
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2208160365
 *****************************************************************
-Pressure drop: 22.51917257 Pa
+Pressure drop: 22.5153212 Pa
 Total pressure drop: 22.51580516 Pa
 Mass Source: -3.433635395e-07 s^-1
 Max Local Mass Source: 8.118639249e-08 s^-1

--- a/applications_tests/gls_vans_3d/rong_packed_bed.output
+++ b/applications_tests/gls_vans_3d/rong_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: 8.734236424e-311 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 31.5942532 Pa
+Total pressure drop: 32.06829646 Pa
 Mass Source: -1.408159088e-11 s^-1
 Max Local Mass Source: 8.027467254e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2165621926
 *****************************************************************
 Pressure drop: 22.57009881 Pa
+Total pressure drop: 22.56960656 Pa
 Mass Source: -3.432835289e-07 s^-1
 Max Local Mass Source: 8.271625181e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2214957629
 *****************************************************************
 Pressure drop: 22.90968878 Pa
+Total pressure drop: 22.9132019 Pa
 Mass Source: 3.43273989e-07 s^-1
 Max Local Mass Source: 8.23107266e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2205178886
 *****************************************************************
 Pressure drop: 22.51906546 Pa
+Total pressure drop: 22.51569794 Pa
 Mass Source: -3.433148422e-07 s^-1
 Max Local Mass Source: 8.133983491e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2187156648
 *****************************************************************
 Pressure drop: 22.90904137 Pa
+Total pressure drop: 22.91254916 Pa
 Mass Source: 3.432988122e-07 s^-1
 Max Local Mass Source: 8.220077274e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2207881787
 *****************************************************************
 Pressure drop: 22.51915627 Pa
+Total pressure drop: 22.51578903 Pa
 Mass Source: -3.433082806e-07 s^-1
 Max Local Mass Source: 8.123294893e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2187043906
 *****************************************************************
 Pressure drop: 22.90903681 Pa
+Total pressure drop: 22.91254473 Pa
 Mass Source: 3.432665021e-07 s^-1
 Max Local Mass Source: 8.215302121e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2208069386
 *****************************************************************
 Pressure drop: 22.51916966 Pa
+Total pressure drop: 22.5158026 Pa
 Mass Source: -3.433492006e-07 s^-1
 Max Local Mass Source: 8.120202874e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2187152089
 *****************************************************************
 Pressure drop: 22.90905345 Pa
+Total pressure drop: 22.91256188 Pa
 Mass Source: 3.433197502e-07 s^-1
 Max Local Mass Source: 8.213197807e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2208160365
 *****************************************************************
 Pressure drop: 22.51917257 Pa
+Total pressure drop: 22.51580516 Pa
 Mass Source: -3.433635395e-07 s^-1
 Max Local Mass Source: 8.118639249e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/rong_packed_bed.output
+++ b/applications_tests/gls_vans_3d/rong_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 32.06829627 Pa
-Total pressure drop: 32.06829646 Pa
+Total pressure drop: 32.06829637 Pa
 Mass Source: -1.408159088e-11 s^-1
 Max Local Mass Source: 8.027467254e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2165621926
 *****************************************************************
 Pressure drop: 22.56912194 Pa
-Total pressure drop: 22.56960656 Pa
+Total pressure drop: 22.56936425 Pa
 Mass Source: -3.432835289e-07 s^-1
 Max Local Mass Source: 8.271625181e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2214957629
 *****************************************************************
 Pressure drop: 22.91368809 Pa
-Total pressure drop: 22.9132019 Pa
+Total pressure drop: 22.91344499 Pa
 Mass Source: 3.43273989e-07 s^-1
 Max Local Mass Source: 8.23107266e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2205178886
 *****************************************************************
 Pressure drop: 22.51521322 Pa
-Total pressure drop: 22.51569794 Pa
+Total pressure drop: 22.51545558 Pa
 Mass Source: -3.433148422e-07 s^-1
 Max Local Mass Source: 8.133983491e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2187156648
 *****************************************************************
 Pressure drop: 22.91303551 Pa
-Total pressure drop: 22.91254916 Pa
+Total pressure drop: 22.91279233 Pa
 Mass Source: 3.432988122e-07 s^-1
 Max Local Mass Source: 8.220077274e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2207881787
 *****************************************************************
 Pressure drop: 22.51530454 Pa
-Total pressure drop: 22.51578903 Pa
+Total pressure drop: 22.51554678 Pa
 Mass Source: -3.433082806e-07 s^-1
 Max Local Mass Source: 8.123294893e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2187043906
 *****************************************************************
 Pressure drop: 22.91303131 Pa
-Total pressure drop: 22.91254473 Pa
+Total pressure drop: 22.91278802 Pa
 Mass Source: 3.432665021e-07 s^-1
 Max Local Mass Source: 8.215302121e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.2208069386
 *****************************************************************
 Pressure drop: 22.51531835 Pa
-Total pressure drop: 22.5158026 Pa
+Total pressure drop: 22.51556048 Pa
 Mass Source: -3.433492006e-07 s^-1
 Max Local Mass Source: 8.120202874e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931023626
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2187152089
 *****************************************************************
 Pressure drop: 22.91304883 Pa
-Total pressure drop: 22.91256188 Pa
+Total pressure drop: 22.91280535 Pa
 Mass Source: 3.433197502e-07 s^-1
 Max Local Mass Source: 8.213197807e-08 s^-1
 Average Void Fraction in Bed: 0.7930753133
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930753133
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2208160365
 *****************************************************************
 Pressure drop: 22.5153212 Pa
-Total pressure drop: 22.51580516 Pa
+Total pressure drop: 22.51556318 Pa
 Mass Source: -3.433635395e-07 s^-1
 Max Local Mass Source: 8.118639249e-08 s^-1
 Average Void Fraction in Bed: 0.7931023626

--- a/applications_tests/gls_vans_3d/spm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/spm_packed_bed.output
@@ -9,7 +9,7 @@ Total pressure drop: 0 Pa
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 32.1004576 Pa
-Total pressure drop: 32.10045739 Pa
+Total pressure drop: 32.10045749 Pa
 Mass Source: 2.467101038e-11 s^-1
 Max Local Mass Source: 8.133708646e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -18,7 +18,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2170897896
 *****************************************************************
 Pressure drop: 22.64155772 Pa
-Total pressure drop: 22.6420399 Pa
+Total pressure drop: 22.64179881 Pa
 Mass Source: -3.417876932e-07 s^-1
 Max Local Mass Source: 8.193898459e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -27,7 +27,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2216487497
 *****************************************************************
 Pressure drop: 22.98606814 Pa
-Total pressure drop: 22.98558359 Pa
+Total pressure drop: 22.98582586 Pa
 Mass Source: 3.41770236e-07 s^-1
 Max Local Mass Source: 8.154302746e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -36,7 +36,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2202202341
 *****************************************************************
 Pressure drop: 22.58833583 Pa
-Total pressure drop: 22.58881796 Pa
+Total pressure drop: 22.58857689 Pa
 Mass Source: -3.418205029e-07 s^-1
 Max Local Mass Source: 8.059580086e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -45,7 +45,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2184692079
 *****************************************************************
 Pressure drop: 22.985392 Pa
-Total pressure drop: 22.98490727 Pa
+Total pressure drop: 22.98514963 Pa
 Mass Source: 3.418021278e-07 s^-1
 Max Local Mass Source: 8.147154214e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -54,7 +54,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2205193199
 *****************************************************************
 Pressure drop: 22.58843372 Pa
-Total pressure drop: 22.58891569 Pa
+Total pressure drop: 22.5886747 Pa
 Mass Source: -3.418528666e-07 s^-1
 Max Local Mass Source: 8.051431165e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -63,7 +63,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2184403571
 *****************************************************************
 Pressure drop: 22.98537495 Pa
-Total pressure drop: 22.98489011 Pa
+Total pressure drop: 22.98513253 Pa
 Mass Source: 3.417123637e-07 s^-1
 Max Local Mass Source: 8.144237316e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -72,7 +72,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.220533219
 *****************************************************************
 Pressure drop: 22.58845741 Pa
-Total pressure drop: 22.58893904 Pa
+Total pressure drop: 22.58869823 Pa
 Mass Source: -3.417981189e-07 s^-1
 Max Local Mass Source: 8.049765272e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -81,7 +81,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2184468029
 *****************************************************************
 Pressure drop: 22.98538419 Pa
-Total pressure drop: 22.98489903 Pa
+Total pressure drop: 22.98514161 Pa
 Mass Source: 3.417371267e-07 s^-1
 Max Local Mass Source: 8.143277931e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -90,7 +90,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2205391217
 *****************************************************************
 Pressure drop: 22.58846768 Pa
-Total pressure drop: 22.58894899 Pa
+Total pressure drop: 22.58870833 Pa
 Mass Source: -3.417695971e-07 s^-1
 Max Local Mass Source: 8.049148701e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559

--- a/applications_tests/gls_vans_3d/spm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/spm_packed_bed.output
@@ -3,12 +3,12 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
-Total pressure drop: -0 Pa
+Total pressure drop: 0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
-Pressure drop: 31.6264129 Pa
+Pressure drop: 32.1004576 Pa
 Total pressure drop: 32.10045739 Pa
 Mass Source: 2.467101038e-11 s^-1
 Max Local Mass Source: 8.133708646e-08 s^-1
@@ -17,7 +17,7 @@ Average Void Fraction in Bed: 0.7930781246
 *****************************************************************
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2170897896
 *****************************************************************
-Pressure drop: 22.64252595 Pa
+Pressure drop: 22.64155772 Pa
 Total pressure drop: 22.6420399 Pa
 Mass Source: -3.417876932e-07 s^-1
 Max Local Mass Source: 8.193898459e-08 s^-1
@@ -26,7 +26,7 @@ Average Void Fraction in Bed: 0.7931050559
 *****************************************************************
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2216487497
 *****************************************************************
-Pressure drop: 22.98208504 Pa
+Pressure drop: 22.98606814 Pa
 Total pressure drop: 22.98558359 Pa
 Mass Source: 3.41770236e-07 s^-1
 Max Local Mass Source: 8.154302746e-08 s^-1
@@ -35,7 +35,7 @@ Average Void Fraction in Bed: 0.7930781246
 *****************************************************************
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2202202341
 *****************************************************************
-Pressure drop: 22.59217056 Pa
+Pressure drop: 22.58833583 Pa
 Total pressure drop: 22.58881796 Pa
 Mass Source: -3.418205029e-07 s^-1
 Max Local Mass Source: 8.059580086e-08 s^-1
@@ -44,7 +44,7 @@ Average Void Fraction in Bed: 0.7931050559
 *****************************************************************
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2184692079
 *****************************************************************
-Pressure drop: 22.98141453 Pa
+Pressure drop: 22.985392 Pa
 Total pressure drop: 22.98490727 Pa
 Mass Source: 3.418021278e-07 s^-1
 Max Local Mass Source: 8.147154214e-08 s^-1
@@ -53,7 +53,7 @@ Average Void Fraction in Bed: 0.7930781246
 *****************************************************************
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2205193199
 *****************************************************************
-Pressure drop: 22.59226835 Pa
+Pressure drop: 22.58843372 Pa
 Total pressure drop: 22.58891569 Pa
 Mass Source: -3.418528666e-07 s^-1
 Max Local Mass Source: 8.051431165e-08 s^-1
@@ -62,7 +62,7 @@ Average Void Fraction in Bed: 0.7931050559
 *****************************************************************
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2184403571
 *****************************************************************
-Pressure drop: 22.98139733 Pa
+Pressure drop: 22.98537495 Pa
 Total pressure drop: 22.98489011 Pa
 Mass Source: 3.417123637e-07 s^-1
 Max Local Mass Source: 8.144237316e-08 s^-1
@@ -71,7 +71,7 @@ Average Void Fraction in Bed: 0.7930781246
 *****************************************************************
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.220533219
 *****************************************************************
-Pressure drop: 22.59229081 Pa
+Pressure drop: 22.58845741 Pa
 Total pressure drop: 22.58893904 Pa
 Mass Source: -3.417981189e-07 s^-1
 Max Local Mass Source: 8.049765272e-08 s^-1
@@ -80,7 +80,7 @@ Average Void Fraction in Bed: 0.7931050559
 *****************************************************************
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2184468029
 *****************************************************************
-Pressure drop: 22.98140638 Pa
+Pressure drop: 22.98538419 Pa
 Total pressure drop: 22.98489903 Pa
 Mass Source: 3.417371267e-07 s^-1
 Max Local Mass Source: 8.143277931e-08 s^-1
@@ -89,7 +89,7 @@ Average Void Fraction in Bed: 0.7930781246
 *****************************************************************
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2205391217
 *****************************************************************
-Pressure drop: 22.59230079 Pa
+Pressure drop: 22.58846768 Pa
 Total pressure drop: 22.58894899 Pa
 Mass Source: -3.417695971e-07 s^-1
 Max Local Mass Source: 8.049148701e-08 s^-1

--- a/applications_tests/gls_vans_3d/spm_packed_bed.output
+++ b/applications_tests/gls_vans_3d/spm_packed_bed.output
@@ -3,11 +3,13 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3300
    Volume of triangulation:      5.656854249e-05
 Pressure drop: 0 Pa
+Total pressure drop: -0 Pa
 
 *****************************************************************
 Transient iteration : 1        Time : 0.002    Time step : 0.002    CFL : 0.06743077177
 *****************************************************************
 Pressure drop: 31.6264129 Pa
+Total pressure drop: 32.10045739 Pa
 Mass Source: 2.467101038e-11 s^-1
 Max Local Mass Source: 8.133708646e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -16,6 +18,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 2        Time : 0.004    Time step : 0.002    CFL : 0.2170897896
 *****************************************************************
 Pressure drop: 22.64252595 Pa
+Total pressure drop: 22.6420399 Pa
 Mass Source: -3.417876932e-07 s^-1
 Max Local Mass Source: 8.193898459e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -24,6 +27,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 3        Time : 0.006    Time step : 0.002    CFL : 0.2216487497
 *****************************************************************
 Pressure drop: 22.98208504 Pa
+Total pressure drop: 22.98558359 Pa
 Mass Source: 3.41770236e-07 s^-1
 Max Local Mass Source: 8.154302746e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -32,6 +36,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 4        Time : 0.008    Time step : 0.002    CFL : 0.2202202341
 *****************************************************************
 Pressure drop: 22.59217056 Pa
+Total pressure drop: 22.58881796 Pa
 Mass Source: -3.418205029e-07 s^-1
 Max Local Mass Source: 8.059580086e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -40,6 +45,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 5        Time : 0.01     Time step : 0.002    CFL : 0.2184692079
 *****************************************************************
 Pressure drop: 22.98141453 Pa
+Total pressure drop: 22.98490727 Pa
 Mass Source: 3.418021278e-07 s^-1
 Max Local Mass Source: 8.147154214e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -48,6 +54,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 6        Time : 0.012    Time step : 0.002    CFL : 0.2205193199
 *****************************************************************
 Pressure drop: 22.59226835 Pa
+Total pressure drop: 22.58891569 Pa
 Mass Source: -3.418528666e-07 s^-1
 Max Local Mass Source: 8.051431165e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -56,6 +63,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 7        Time : 0.014    Time step : 0.002    CFL : 0.2184403571
 *****************************************************************
 Pressure drop: 22.98139733 Pa
+Total pressure drop: 22.98489011 Pa
 Mass Source: 3.417123637e-07 s^-1
 Max Local Mass Source: 8.144237316e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -64,6 +72,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 8        Time : 0.016    Time step : 0.002    CFL : 0.220533219
 *****************************************************************
 Pressure drop: 22.59229081 Pa
+Total pressure drop: 22.58893904 Pa
 Mass Source: -3.417981189e-07 s^-1
 Max Local Mass Source: 8.049765272e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559
@@ -72,6 +81,7 @@ Average Void Fraction in Bed: 0.7931050559
 Transient iteration : 9        Time : 0.018    Time step : 0.002    CFL : 0.2184468029
 *****************************************************************
 Pressure drop: 22.98140638 Pa
+Total pressure drop: 22.98489903 Pa
 Mass Source: 3.417371267e-07 s^-1
 Max Local Mass Source: 8.143277931e-08 s^-1
 Average Void Fraction in Bed: 0.7930781246
@@ -80,6 +90,7 @@ Average Void Fraction in Bed: 0.7930781246
 Transient iteration : 10       Time : 0.02     Time step : 0.002    CFL : 0.2205391217
 *****************************************************************
 Pressure drop: 22.59230079 Pa
+Total pressure drop: 22.58894899 Pa
 Mass Source: -3.417695971e-07 s^-1
 Max Local Mass Source: 8.049148701e-08 s^-1
 Average Void Fraction in Bed: 0.7931050559

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -83,7 +83,7 @@ This subsection controls the post-processing other than the forces and torque on
     \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P d \Gamma}{\int_{\Gamma_\text{inlet}} 1 d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P d \Gamma}{\int_{\Gamma_\text{outlet}} 1 d \Gamma}
 
 .. math::
-    \Delta P_\text{total} =  \frac{ \int_{\Gamma_\text{inlet}} (P + \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} (P + \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
+    \Delta P_\text{total} =  \frac{ \int_{\Gamma_\text{inlet}} (P + \frac{1}{2} \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} (P + \frac{1}{2} \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
 
 * ``calculate flow rate``: controls if calculation of the volumetric flow rates at every boundary is enabled.
     * ``flow rate name``: output filename for flow rate calculations.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -23,8 +23,6 @@ This subsection controls the post-processing other than the forces and torque on
     # Pressure and momentum drop calculations
     set calculate pressure drop     = false
     set pressure drop name          = pressure_drop
-    set calculate momentum drop     = false
-    set momentum drop name          = momentum_drop
     set inlet boundary id           = 0
     set outlet boundary id          = 1
 
@@ -76,9 +74,9 @@ This subsection controls the post-processing other than the forces and torque on
 * ``calculate average velocities``: controls if calculation of time-averaged velocities is enabled.
     * ``initial time``: initial time used for the average velocities calculations.
 
-* ``calculate pressure drop`` and ``calculate momentum drop``: control if calculation of the pressure drop and momentum from the inlet boundary to the outlet boundary are enabled.
+* ``calculate pressure drop``: controls if calculation of the pressure drop from the inlet boundary to the outlet boundary is enabled.
     * ``inlet boundary id`` and ``outlet boundary id``: define the IDs for inlet and outlet boundaries, respectively. 
-    * ``pressure drop name`` and ``momentum drop name``: output filename for pressure drop and momentum calculations.
+    * ``pressure drop name``: output filename for pressure drop calculations.
 
 * ``calculate enstrophy``: controls if calculation of total enstrophy, which corresponds to dissipation effects in the fluid, is enabled. 
     * ``enstrophy name``: output filename for enstrophy calculations.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -78,12 +78,14 @@ This subsection controls the post-processing other than the forces and torque on
     * ``inlet boundary id`` and ``outlet boundary id``: define the IDs for inlet and outlet boundaries, respectively. 
     * ``pressure drop name``: output filename for pressure drop calculations.
     * The pressure drop is calculated as such, with :math:`\Gamma` representing the boundary and :math:`P` the pressure:
+
 .. math::
     \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
 
 * ``calculate flow rate``: controls if calculation of the volumetric flow rates at every boundary is enabled.
     * ``flow rate name``: output filename for flow rate calculations.
     * The flow rate :math:`Q` is calculated as such, with :math:`\Gamma` representing the boundary, :math:`\pmb{u}` the velocity and :math:`\pmb{n}` the vector normal to the surface:
+
 .. math::
     Q =  \int_{\Gamma} \pmb{n} \cdot \pmb{u} d \Gamma
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -77,10 +77,13 @@ This subsection controls the post-processing other than the forces and torque on
 * ``calculate pressure drop``: controls if calculation of the pressure drop from the inlet boundary to the outlet boundary is enabled.
     * ``inlet boundary id`` and ``outlet boundary id``: define the IDs for inlet and outlet boundaries, respectively. 
     * ``pressure drop name``: output filename for pressure drop calculations.
-    * The pressure drop is calculated as such, with :math:`\Gamma` representing the boundary and :math:`P` the pressure:
+    * The pressure drop :math:`\Delta P` and total pressure drop :math:`\Delta P_\text{total}` are calculated as such, with :math:`\Gamma` representing the boundary, :math:`\pmb{u}` the velocity  and :math:`P` the pressure:
 
 .. math::
     \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
+
+.. math::
+    \Delta P_\text{total} =  \frac{ \int_{\Gamma_\text{inlet}} (P + \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} (P + \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
 
 * ``calculate flow rate``: controls if calculation of the volumetric flow rates at every boundary is enabled.
     * ``flow rate name``: output filename for flow rate calculations.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -77,6 +77,15 @@ This subsection controls the post-processing other than the forces and torque on
 * ``calculate pressure drop``: controls if calculation of the pressure drop from the inlet boundary to the outlet boundary is enabled.
     * ``inlet boundary id`` and ``outlet boundary id``: define the IDs for inlet and outlet boundaries, respectively. 
     * ``pressure drop name``: output filename for pressure drop calculations.
+    * The pressure drop is calculated as such, with :math:`\Gamma` representing the boundary and :math:`P` the pressure:
+.. math::
+    \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
+
+* ``calculate flow rate``: controls if calculation of the volumetric flow rates at every boundary is enabled.
+    * ``flow rate name``: output filename for flow rate calculations.
+    * The flow rate :math:`Q` is calculated as such, with :math:`\Gamma` representing the boundary, :math:`\pmb{u}` the velocity and :math:`\pmb{n}` the vector normal to the surface:
+.. math::
+    Q =  \int_{\Gamma} \pmb{n} \cdot \pmb{u} d \Gamma
 
 * ``calculate enstrophy``: controls if calculation of total enstrophy, which corresponds to dissipation effects in the fluid, is enabled. 
     * ``enstrophy name``: output filename for enstrophy calculations.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -20,11 +20,17 @@ This subsection controls the post-processing other than the forces and torque on
     set calculate average velocities  = false
     set initial time                  = 0.0
 
-    # Pressure drop calculation
+    # Pressure and momentum drop calculations
     set calculate pressure drop     = false
     set pressure drop name          = pressure_drop
+    set calculate momentum drop     = false
+    set momentum drop name          = momentum
     set inlet boundary id           = 0
     set outlet boundary id          = 1
+
+    # Flow rate at boundaries calculation
+    set calculate flow rate         = false
+    set flow rate name              = flow_rate
 
     # Enstrophy calculation
     set calculate enstrophy         = false
@@ -70,9 +76,9 @@ This subsection controls the post-processing other than the forces and torque on
 * ``calculate average velocities``: controls if calculation of time-averaged velocities is enabled.
     * ``initial time``: initial time used for the average velocities calculations.
 
-* ``calculate pressure drop``: controls if calculation of the pressure drop from the inlet boundary to the outlet boundary is enabled. 
+* ``calculate pressure drop`` and ``calculate momentum drop``: control if calculation of the pressure drop and momentum from the inlet boundary to the outlet boundary are enabled.
     * ``inlet boundary id`` and ``outlet boundary id``: define the IDs for inlet and outlet boundaries, respectively. 
-    * ``pressure drop name``: output filename for pressure drop calculations.
+    * ``pressure drop name`` and ``momentum drop name``: output filename for pressure drop and momentum calculations.
 
 * ``calculate enstrophy``: controls if calculation of total enstrophy, which corresponds to dissipation effects in the fluid, is enabled. 
     * ``enstrophy name``: output filename for enstrophy calculations.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -20,7 +20,7 @@ This subsection controls the post-processing other than the forces and torque on
     set calculate average velocities  = false
     set initial time                  = 0.0
 
-    # Pressure and momentum drop calculations
+    # Pressure drop calculation
     set calculate pressure drop     = false
     set pressure drop name          = pressure_drop
     set inlet boundary id           = 0

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -24,7 +24,7 @@ This subsection controls the post-processing other than the forces and torque on
     set calculate pressure drop     = false
     set pressure drop name          = pressure_drop
     set calculate momentum drop     = false
-    set momentum drop name          = momentum
+    set momentum drop name          = momentum_drop
     set inlet boundary id           = 0
     set outlet boundary id          = 1
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -80,7 +80,7 @@ This subsection controls the post-processing other than the forces and torque on
     * The pressure drop :math:`\Delta P` and total pressure drop :math:`\Delta P_\text{total}` are calculated as such, with :math:`\Gamma` representing the boundary, :math:`\pmb{u}` the velocity  and :math:`P` the pressure:
 
 .. math::
-    \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}
+    \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P d \Gamma}{\int_{\Gamma_\text{inlet}} 1 d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P d \Gamma}{\int_{\Gamma_\text{outlet}} 1 d \Gamma}
 
 .. math::
     \Delta P_\text{total} =  \frac{ \int_{\Gamma_\text{inlet}} (P + \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{inlet}} d \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} (P + \pmb{u} \cdot \pmb{u}) d \Gamma}{\int_{\Gamma_\text{outlet}} d \Gamma}

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -606,6 +606,12 @@ namespace Parameters
     // The outlet boundary ID for pressure drop calculation
     unsigned int outlet_boundary_id;
 
+    // Enable flow rate post-processing
+    bool calculate_flow_rate;
+
+    // Enable momentum flux post-processing
+    bool calculate_momentum_flux;
+
     // Set initial time to start calculations for velocities
     double initial_time;
 
@@ -620,6 +626,12 @@ namespace Parameters
 
     // Prefix for pressure drop output
     std::string pressure_drop_output_name;
+
+    // Prefix for flow rate output
+    std::string flow_rate_output_name;
+
+    // Prefix for momentum flux output
+    std::string momentum_flux_output_name;
 
     // Prefix for the enstrophy output
     std::string enstrophy_output_name;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -600,9 +600,6 @@ namespace Parameters
     // Enable pressure drop post-processing
     bool calculate_pressure_drop;
 
-    // Enable momentum drop post-processing
-    bool calculate_momentum_drop;
-
     // The outlet boundary ID for pressure drop calculation
     unsigned int inlet_boundary_id;
 
@@ -626,9 +623,6 @@ namespace Parameters
 
     // Prefix for pressure drop output
     std::string pressure_drop_output_name;
-
-    // Prefix for momentum drop output
-    std::string momentum_drop_output_name;
 
     // Prefix for flow rate output
     std::string flow_rate_output_name;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -609,8 +609,8 @@ namespace Parameters
     // Enable flow rate post-processing
     bool calculate_flow_rate;
 
-    // Enable momentum flux post-processing
-    bool calculate_momentum_flux;
+    // Enable momentum post-processing
+    bool calculate_momentum;
 
     // Set initial time to start calculations for velocities
     double initial_time;
@@ -630,8 +630,8 @@ namespace Parameters
     // Prefix for flow rate output
     std::string flow_rate_output_name;
 
-    // Prefix for momentum flux output
-    std::string momentum_flux_output_name;
+    // Prefix for momentum output
+    std::string momentum_output_name;
 
     // Prefix for the enstrophy output
     std::string enstrophy_output_name;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -600,6 +600,9 @@ namespace Parameters
     // Enable pressure drop post-processing
     bool calculate_pressure_drop;
 
+    // Enable momentum drop post-processing
+    bool calculate_momentum_drop;
+
     // The outlet boundary ID for pressure drop calculation
     unsigned int inlet_boundary_id;
 
@@ -608,9 +611,6 @@ namespace Parameters
 
     // Enable flow rate post-processing
     bool calculate_flow_rate;
-
-    // Enable momentum post-processing
-    bool calculate_momentum;
 
     // Set initial time to start calculations for velocities
     double initial_time;
@@ -627,11 +627,11 @@ namespace Parameters
     // Prefix for pressure drop output
     std::string pressure_drop_output_name;
 
+    // Prefix for momentum drop output
+    std::string momentum_drop_output_name;
+
     // Prefix for flow rate output
     std::string flow_rate_output_name;
-
-    // Prefix for momentum output
-    std::string momentum_output_name;
 
     // Prefix for the enstrophy output
     std::string enstrophy_output_name;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -474,8 +474,8 @@ protected:
   TableHandler kinetic_energy_table;
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;
+  TableHandler momentum_drop_table;
   TableHandler flow_rate_table;
-  TableHandler momentum_table;
   std::shared_ptr<AverageVelocities<dim, VectorType, DofsType>>
              average_velocities;
   VectorType average_solution;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -474,7 +474,6 @@ protected:
   TableHandler kinetic_energy_table;
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;
-  TableHandler momentum_drop_table;
   TableHandler flow_rate_table;
   std::shared_ptr<AverageVelocities<dim, VectorType, DofsType>>
              average_velocities;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -474,6 +474,7 @@ protected:
   TableHandler kinetic_energy_table;
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;
+  TableHandler flow_rate_table;
   std::shared_ptr<AverageVelocities<dim, VectorType, DofsType>>
              average_velocities;
   VectorType average_solution;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -475,7 +475,7 @@ protected:
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;
   TableHandler flow_rate_table;
-  TableHandler momentum_flux_table;
+  TableHandler momentum_table;
   std::shared_ptr<AverageVelocities<dim, VectorType, DofsType>>
              average_velocities;
   VectorType average_solution;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -475,6 +475,7 @@ protected:
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;
   TableHandler flow_rate_table;
+  TableHandler momentum_flux_table;
   std::shared_ptr<AverageVelocities<dim, VectorType, DofsType>>
              average_velocities;
   VectorType average_solution;

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -71,12 +71,14 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         const unsigned int            outlet_boundary_id);
 
 /**
- * @brief Calculate the momentum flux at a given boundary. The volumetric flux thus calculated has units of Length^3/Time.
- * @return Volumetric flux at the boundary
+ * @brief Calculate the momentum and the area at a given boundary.
+ * The momentum thus calculated has units of Mass/(Length*Time^2).
+ *
+ * @return Momentum and area at the boundary
  *
  * @param dof_handler The dof_handler used for the calculation
  *
- * @param evaluation_point The solution for which the pressure drop is calculated. The velocity field is assumed to be the "dim" field
+ * @param evaluation_point The solution for which the momentum is calculated. The velocity field is assumed to be the "dim" field
  *
  * @param face_quadrature_formula The face quadrature formula for the calculation
  *
@@ -88,12 +90,12 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
  */
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
-                        std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType &            evaluation_point,
-                        const Quadrature<dim - 1> &   face_quadrature_formula,
-                        const unsigned int            boundary_id,
-                        PhysicalPropertiesManager &   properties_manager);
+calculate_momentum(const DoFHandler<dim> &       dof_handler,
+                   std::shared_ptr<Mapping<dim>> mapping,
+                   const VectorType &            evaluation_point,
+                   const Quadrature<dim - 1> &   face_quadrature_formula,
+                   const unsigned int            boundary_id,
+                   PhysicalPropertiesManager &   properties_manager);
 
 /**
  * @brief Calculate the CFL condition on the simulation domain

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -43,7 +43,7 @@
 #  include <solvers/physical_properties_manager.h>
 
 /**
- * @brief Calculate the pressure drop between two boundaries.
+ * @brief Calculate the pressure drop and total pressure drop between two boundaries.
  * The pressure drop thus calculated has units of Length^2/Time^2.
  *
  * @return Pressure drop of the flow between two boundaries of the domain
@@ -63,7 +63,7 @@
  * @param outlet_boundary_id The id of the outlet boundary
  */
 template <int dim, typename VectorType>
-double
+std::pair<double, double>
 calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         std::shared_ptr<Mapping<dim>> mapping,
                         const VectorType &            evaluation_point,
@@ -71,34 +71,6 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         const Quadrature<dim - 1> &   face_quadrature_formula,
                         const unsigned int            inlet_boundary_id,
                         const unsigned int            outlet_boundary_id);
-
-/**
- * @brief Calculate the total pressure drop for a given inlet and outlet.
- * The total pressure drop thus calculated has units of Length^2/Time^2.
- *
- * @return surface-averaged total pressure drop between the boundaries
- *
- * @param dof_handler The dof_handler used for the calculation
- *
- * @param evaluation_point The solution for which the total pressure drop is calculated. The velocity field is assumed to be the "dim" field
- *
- * @param face_quadrature_formula The face quadrature formula for the calculation
- *
- * @param mapping The mapping of the simulation
- *
- * @param inlet_boundary_id The id of the inlet boundary
- *
- * @param outlet_boundary_id The id of the outlet boundary
- */
-template <int dim, typename VectorType>
-double
-calculate_total_pressure_drop(
-  const DoFHandler<dim> &       dof_handler,
-  std::shared_ptr<Mapping<dim>> mapping,
-  const VectorType &            evaluation_point,
-  const Quadrature<dim - 1> &   face_quadrature_formula,
-  const unsigned int            inlet_boundary_id,
-  const unsigned int            outlet_boundary_id);
 
 /**
  * @brief Calculate the CFL condition on the simulation domain

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -43,7 +43,9 @@
 #  include <solvers/physical_properties_manager.h>
 
 /**
- * @brief Calculate the pressure drop between two boundaries. The pressure drop thus calculated has units of Length^2/Time^2.
+ * @brief Calculate the pressure drop between two boundaries.
+ * The pressure drop thus calculated has units of Length^2/Time^2.
+ *
  * @return Pressure drop of the flow between two boundaries of the domain
  *
  * @param dof_handler The dof_handler used for the calculation
@@ -71,14 +73,14 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         const unsigned int            outlet_boundary_id);
 
 /**
- * @brief Calculate the momentum drop for a given inlet and outlet.
- * The momentum thus calculated has units of Mass/(Length*Time^2).
+ * @brief Calculate the total pressure drop for a given inlet and outlet.
+ * The total pressure drop thus calculated has units of Length^2/Time^2.
  *
- * @return surface-averaged momentum drop between the boundaries
+ * @return surface-averaged total pressure drop between the boundaries
  *
  * @param dof_handler The dof_handler used for the calculation
  *
- * @param evaluation_point The solution for which the momentum is calculated. The velocity field is assumed to be the "dim" field
+ * @param evaluation_point The solution for which the total pressure drop is calculated. The velocity field is assumed to be the "dim" field
  *
  * @param face_quadrature_formula The face quadrature formula for the calculation
  *
@@ -87,18 +89,16 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
  * @param inlet_boundary_id The id of the inlet boundary
  *
  * @param outlet_boundary_id The id of the outlet boundary
- *
- * @param physical_properties The parameters containing the required physical properties
  */
 template <int dim, typename VectorType>
 double
-calculate_momentum_drop(const DoFHandler<dim> &       dof_handler,
-                        std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType &            evaluation_point,
-                        const Quadrature<dim - 1> &   face_quadrature_formula,
-                        const unsigned int            inlet_boundary_id,
-                        const unsigned int            outlet_boundary_id,
-                        PhysicalPropertiesManager &   properties_manager);
+calculate_total_pressure_drop(
+  const DoFHandler<dim> &       dof_handler,
+  std::shared_ptr<Mapping<dim>> mapping,
+  const VectorType &            evaluation_point,
+  const Quadrature<dim - 1> &   face_quadrature_formula,
+  const unsigned int            inlet_boundary_id,
+  const unsigned int            outlet_boundary_id);
 
 /**
  * @brief Calculate the CFL condition on the simulation domain

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -71,6 +71,31 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         const unsigned int            outlet_boundary_id);
 
 /**
+ * @brief Calculate the momentum flux at a given boundary. The volumetric flux thus calculated has units of Length^3/Time.
+ * @return Volumetric flux at the boundary
+ *
+ * @param dof_handler The dof_handler used for the calculation
+ *
+ * @param evaluation_point The solution for which the pressure drop is calculated. The velocity field is assumed to be the "dim" field
+ *
+ * @param cell_quadrature_formula The cell quadrature formula for the calculation
+ *
+ * @param face_quadrature_formula The face quadrature formula for the calculation
+ *
+ * @param mapping The mapping of the simulation
+ *
+ * @param boundary_id The id of the inlet boundary
+ */
+template <int dim, typename VectorType>
+double
+calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
+                        std::shared_ptr<Mapping<dim>> mapping,
+                        const VectorType &            evaluation_point,
+                        const Quadrature<dim> &       cell_quadrature_formula,
+                        const Quadrature<dim - 1> &   face_quadrature_formula,
+                        const unsigned int            boundary_id);
+
+/**
  * @brief Calculate the CFL condition on the simulation domain
  * @return CFL maximal value in the domain
  * Post-processing function

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -78,22 +78,22 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
  *
  * @param evaluation_point The solution for which the pressure drop is calculated. The velocity field is assumed to be the "dim" field
  *
- * @param cell_quadrature_formula The cell quadrature formula for the calculation
- *
  * @param face_quadrature_formula The face quadrature formula for the calculation
  *
  * @param mapping The mapping of the simulation
  *
  * @param boundary_id The id of the inlet boundary
+ *
+ * @param physical_properties The parameters containing the required physical properties
  */
 template <int dim, typename VectorType>
-double
+std::pair<double, double>
 calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
                         std::shared_ptr<Mapping<dim>> mapping,
                         const VectorType &            evaluation_point,
-                        const Quadrature<dim> &       cell_quadrature_formula,
                         const Quadrature<dim - 1> &   face_quadrature_formula,
-                        const unsigned int            boundary_id);
+                        const unsigned int            boundary_id,
+                        PhysicalPropertiesManager &   properties_manager);
 
 /**
  * @brief Calculate the CFL condition on the simulation domain

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -71,10 +71,10 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                         const unsigned int            outlet_boundary_id);
 
 /**
- * @brief Calculate the momentum and the area at a given boundary.
+ * @brief Calculate the momentum drop for a given inlet and outlet.
  * The momentum thus calculated has units of Mass/(Length*Time^2).
  *
- * @return Momentum and area at the boundary
+ * @return surface-averaged momentum drop between the boundaries
  *
  * @param dof_handler The dof_handler used for the calculation
  *
@@ -84,18 +84,21 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
  *
  * @param mapping The mapping of the simulation
  *
- * @param boundary_id The id of the inlet boundary
+ * @param inlet_boundary_id The id of the inlet boundary
+ *
+ * @param outlet_boundary_id The id of the outlet boundary
  *
  * @param physical_properties The parameters containing the required physical properties
  */
 template <int dim, typename VectorType>
-std::pair<double, double>
-calculate_momentum(const DoFHandler<dim> &       dof_handler,
-                   std::shared_ptr<Mapping<dim>> mapping,
-                   const VectorType &            evaluation_point,
-                   const Quadrature<dim - 1> &   face_quadrature_formula,
-                   const unsigned int            boundary_id,
-                   PhysicalPropertiesManager &   properties_manager);
+double
+calculate_momentum_drop(const DoFHandler<dim> &       dof_handler,
+                        std::shared_ptr<Mapping<dim>> mapping,
+                        const VectorType &            evaluation_point,
+                        const Quadrature<dim - 1> &   face_quadrature_formula,
+                        const unsigned int            inlet_boundary_id,
+                        const unsigned int            outlet_boundary_id,
+                        PhysicalPropertiesManager &   properties_manager);
 
 /**
  * @brief Calculate the CFL condition on the simulation domain

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1144,10 +1144,10 @@ namespace Parameters
                         Patterns::Bool(),
                         "Enable calculation of flow rate at boundaries.");
 
-      prm.declare_entry("calculate momentum flux",
+      prm.declare_entry("calculate momentum",
                         "false",
                         Patterns::Bool(),
-                        "Enable calculation of momentum flux at boundaries.");
+                        "Enable calculation of momentum at boundaries.");
 
       prm.declare_entry(
         "initial time",
@@ -1170,10 +1170,10 @@ namespace Parameters
                         Patterns::FileName(),
                         "File output volumetric flux");
 
-      prm.declare_entry("momentum flux name",
-                        "momentum_flux",
+      prm.declare_entry("momentum name",
+                        "momentum",
                         Patterns::FileName(),
-                        "File output momentum flux");
+                        "File output momentum");
 
       prm.declare_entry("enstrophy name",
                         "enstrophy",
@@ -1277,12 +1277,12 @@ namespace Parameters
       inlet_boundary_id              = prm.get_integer("inlet boundary id");
       outlet_boundary_id             = prm.get_integer("outlet boundary id");
       calculate_flow_rate            = prm.get_bool("calculate flow rate");
-      calculate_momentum_flux        = prm.get_bool("calculate momentum flux");
+      calculate_momentum             = prm.get_bool("calculate momentum");
       initial_time                   = prm.get_double("initial time");
       kinetic_energy_output_name     = prm.get("kinetic energy name");
       pressure_drop_output_name      = prm.get("pressure drop name");
       flow_rate_output_name          = prm.get("flow rate name");
-      momentum_flux_output_name      = prm.get("momentum flux name");
+      momentum_output_name           = prm.get("momentum name");
       enstrophy_output_name          = prm.get("enstrophy name");
       apparent_viscosity_output_name = prm.get("apparent viscosity name");
       output_frequency               = prm.get_integer("output frequency");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1124,10 +1124,17 @@ namespace Parameters
                         Patterns::Bool(),
                         "Enable calculation of average velocities.");
 
-      prm.declare_entry("calculate pressure drop",
-                        "false",
-                        Patterns::Bool(),
-                        "Enable calculation of between two boundaries.");
+      prm.declare_entry(
+        "calculate pressure drop",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of pressure drop between two boundaries.");
+
+      prm.declare_entry(
+        "calculate momentum drop",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of momentum drop between two boundaries.");
 
       prm.declare_entry("inlet boundary id",
                         "0",
@@ -1143,11 +1150,6 @@ namespace Parameters
                         "false",
                         Patterns::Bool(),
                         "Enable calculation of flow rate at boundaries.");
-
-      prm.declare_entry("calculate momentum",
-                        "false",
-                        Patterns::Bool(),
-                        "Enable calculation of momentum at boundaries.");
 
       prm.declare_entry(
         "initial time",
@@ -1165,15 +1167,15 @@ namespace Parameters
                         Patterns::FileName(),
                         "File output pressure drop");
 
+      prm.declare_entry("momentum drop name",
+                        "momentum_drop",
+                        Patterns::FileName(),
+                        "File output momentum");
+
       prm.declare_entry("flow rate name",
                         "flow_rate",
                         Patterns::FileName(),
                         "File output volumetric flux");
-
-      prm.declare_entry("momentum name",
-                        "momentum",
-                        Patterns::FileName(),
-                        "File output momentum");
 
       prm.declare_entry("enstrophy name",
                         "enstrophy",
@@ -1274,15 +1276,15 @@ namespace Parameters
       calculate_average_velocities =
         prm.get_bool("calculate average velocities");
       calculate_pressure_drop        = prm.get_bool("calculate pressure drop");
+      calculate_momentum_drop        = prm.get_bool("calculate momentum drop");
       inlet_boundary_id              = prm.get_integer("inlet boundary id");
       outlet_boundary_id             = prm.get_integer("outlet boundary id");
       calculate_flow_rate            = prm.get_bool("calculate flow rate");
-      calculate_momentum             = prm.get_bool("calculate momentum");
       initial_time                   = prm.get_double("initial time");
       kinetic_energy_output_name     = prm.get("kinetic energy name");
       pressure_drop_output_name      = prm.get("pressure drop name");
+      momentum_drop_output_name      = prm.get("momentum drop name");
       flow_rate_output_name          = prm.get("flow rate name");
-      momentum_output_name           = prm.get("momentum name");
       enstrophy_output_name          = prm.get("enstrophy name");
       apparent_viscosity_output_name = prm.get("apparent viscosity name");
       output_frequency               = prm.get_integer("output frequency");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1130,12 +1130,6 @@ namespace Parameters
         Patterns::Bool(),
         "Enable calculation of pressure drop between two boundaries.");
 
-      prm.declare_entry(
-        "calculate momentum drop",
-        "false",
-        Patterns::Bool(),
-        "Enable calculation of momentum drop between two boundaries.");
-
       prm.declare_entry("inlet boundary id",
                         "0",
                         Patterns::Integer(),
@@ -1166,11 +1160,6 @@ namespace Parameters
                         "pressure_drop",
                         Patterns::FileName(),
                         "File output pressure drop");
-
-      prm.declare_entry("momentum drop name",
-                        "momentum_drop",
-                        Patterns::FileName(),
-                        "File output momentum");
 
       prm.declare_entry("flow rate name",
                         "flow_rate",
@@ -1276,14 +1265,12 @@ namespace Parameters
       calculate_average_velocities =
         prm.get_bool("calculate average velocities");
       calculate_pressure_drop        = prm.get_bool("calculate pressure drop");
-      calculate_momentum_drop        = prm.get_bool("calculate momentum drop");
       inlet_boundary_id              = prm.get_integer("inlet boundary id");
       outlet_boundary_id             = prm.get_integer("outlet boundary id");
       calculate_flow_rate            = prm.get_bool("calculate flow rate");
       initial_time                   = prm.get_double("initial time");
       kinetic_energy_output_name     = prm.get("kinetic energy name");
       pressure_drop_output_name      = prm.get("pressure drop name");
-      momentum_drop_output_name      = prm.get("momentum drop name");
       flow_rate_output_name          = prm.get("flow rate name");
       enstrophy_output_name          = prm.get("enstrophy name");
       apparent_viscosity_output_name = prm.get("apparent viscosity name");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1139,6 +1139,16 @@ namespace Parameters
                         Patterns::Integer(),
                         "Outlet boundary ID for pressure drop calculation");
 
+      prm.declare_entry("calculate flow rate",
+                        "false",
+                        Patterns::Bool(),
+                        "Enable calculation of flow rate at boundaries.");
+
+      prm.declare_entry("calculate momentum flux",
+                        "false",
+                        Patterns::Bool(),
+                        "Enable calculation of momentum flux at boundaries.");
+
       prm.declare_entry(
         "initial time",
         "0.0",
@@ -1154,6 +1164,16 @@ namespace Parameters
                         "pressure_drop",
                         Patterns::FileName(),
                         "File output pressure drop");
+
+      prm.declare_entry("flow rate name",
+                        "flow_rate",
+                        Patterns::FileName(),
+                        "File output volumetric flux");
+
+      prm.declare_entry("momentum flux name",
+                        "momentum_flux",
+                        Patterns::FileName(),
+                        "File output momentum flux");
 
       prm.declare_entry("enstrophy name",
                         "enstrophy",
@@ -1256,9 +1276,13 @@ namespace Parameters
       calculate_pressure_drop        = prm.get_bool("calculate pressure drop");
       inlet_boundary_id              = prm.get_integer("inlet boundary id");
       outlet_boundary_id             = prm.get_integer("outlet boundary id");
+      calculate_flow_rate            = prm.get_bool("calculate flow rate");
+      calculate_momentum_flux        = prm.get_bool("calculate momentum flux");
       initial_time                   = prm.get_double("initial time");
       kinetic_energy_output_name     = prm.get("kinetic energy name");
       pressure_drop_output_name      = prm.get("pressure drop name");
+      flow_rate_output_name          = prm.get("flow rate name");
+      momentum_flux_output_name      = prm.get("momentum flux name");
       enstrophy_output_name          = prm.get("enstrophy name");
       apparent_viscosity_output_name = prm.get("apparent viscosity name");
       output_frequency               = prm.get_integer("output frequency");

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1657,17 +1657,16 @@ GLSVANSSolver<dim>::post_processing()
   Assert(this->cfd_dem_simulation_parameters.cfd_parameters
            .physical_properties_manager.density_is_constant(),
          RequiresConstantDensity("Pressure drop calculation"));
-  pressure_drop =
-    calculate_pressure_drop(
-      this->dof_handler,
-      this->mapping,
-      this->evaluation_point,
-      cell_quadrature_formula,
-      face_quadrature_formula,
-      this->cfd_dem_simulation_parameters.cfd_dem.inlet_boundary_id,
-      this->cfd_dem_simulation_parameters.cfd_dem.outlet_boundary_id) *
-    this->cfd_dem_simulation_parameters.cfd_parameters
-      .physical_properties_manager.get_density_scale();
+  std::tie(pressure_drop, std::ignore) = calculate_pressure_drop(
+    this->dof_handler,
+    this->mapping,
+    this->evaluation_point,
+    cell_quadrature_formula,
+    face_quadrature_formula,
+    this->cfd_dem_simulation_parameters.cfd_dem.inlet_boundary_id,
+    this->cfd_dem_simulation_parameters.cfd_dem.outlet_boundary_id);
+  pressure_drop *= this->cfd_dem_simulation_parameters.cfd_parameters
+                     .physical_properties_manager.get_density_scale();
 
   this->pcout << "Mass Source: " << mass_source << " s^-1" << std::endl;
   this->pcout << "Max Local Mass Source: " << max_local_mass_source << " s^-1"

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1273,18 +1273,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
   if (this->simulation_parameters.post_processing.calculate_pressure_drop)
     {
       TimerOutput::Scope t(this->computing_timer, "pressure_drop_calculation");
-      double             pressure_drop = calculate_pressure_drop(
+      double             pressure_drop, total_pressure_drop;
+      std::tie(pressure_drop, total_pressure_drop) = calculate_pressure_drop(
         this->dof_handler,
         this->mapping,
         this->evaluation_point,
         *this->cell_quadrature,
-        *this->face_quadrature,
-        this->simulation_parameters.post_processing.inlet_boundary_id,
-        this->simulation_parameters.post_processing.outlet_boundary_id);
-      double total_pressure_drop = calculate_total_pressure_drop(
-        this->dof_handler,
-        this->mapping,
-        this->evaluation_point,
         *this->face_quadrature,
         this->simulation_parameters.post_processing.inlet_boundary_id,
         this->simulation_parameters.post_processing.outlet_boundary_id);

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -161,12 +161,12 @@ calculate_pressure_drop<3, TrilinosWrappers::MPI::BlockVector>(
 
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
-                        std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType &            evaluation_point,
-                        const Quadrature<dim - 1> &   face_quadrature_formula,
-                        const unsigned int            boundary_id,
-                        PhysicalPropertiesManager &   properties_manager)
+calculate_momentum(const DoFHandler<dim> &       dof_handler,
+                   std::shared_ptr<Mapping<dim>> mapping,
+                   const VectorType &            evaluation_point,
+                   const Quadrature<dim - 1> &   face_quadrature_formula,
+                   const unsigned int            boundary_id,
+                   PhysicalPropertiesManager &   properties_manager)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -212,10 +212,9 @@ calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
                             evaluation_point, velocity_values);
                           fe_face_values[pressure].get_function_values(
                             evaluation_point, pressure_values);
-                          // Integration of density*velocity^3 +
-                          // pressure*velocity
-                          momentum += velocity_values[q] * normal_vector *
-                                      fe_face_values.JxW(q) *
+                          // Integration of density*velocity^2 +
+                          // pressure
+                          momentum += fe_face_values.JxW(q) *
                                       (velocity_values[q] * velocity_values[q] *
                                          fluid_density +
                                        pressure_values[q]);
@@ -234,7 +233,7 @@ calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
 }
 
 template std::pair<double, double>
-calculate_momentum_flux<2, TrilinosWrappers::MPI::Vector>(
+calculate_momentum<2, TrilinosWrappers::MPI::Vector>(
   const DoFHandler<2> &                dof_handler,
   std::shared_ptr<Mapping<2>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
@@ -243,7 +242,7 @@ calculate_momentum_flux<2, TrilinosWrappers::MPI::Vector>(
   PhysicalPropertiesManager &          properties_manager);
 
 template std::pair<double, double>
-calculate_momentum_flux<3, TrilinosWrappers::MPI::Vector>(
+calculate_momentum<3, TrilinosWrappers::MPI::Vector>(
   const DoFHandler<3> &                dof_handler,
   std::shared_ptr<Mapping<3>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
@@ -252,7 +251,7 @@ calculate_momentum_flux<3, TrilinosWrappers::MPI::Vector>(
   PhysicalPropertiesManager &          properties_manager);
 
 template std::pair<double, double>
-calculate_momentum_flux<2, TrilinosWrappers::MPI::BlockVector>(
+calculate_momentum<2, TrilinosWrappers::MPI::BlockVector>(
   const DoFHandler<2> &                     dof_handler,
   std::shared_ptr<Mapping<2>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
@@ -261,7 +260,7 @@ calculate_momentum_flux<2, TrilinosWrappers::MPI::BlockVector>(
   PhysicalPropertiesManager &               properties_manager);
 
 template std::pair<double, double>
-calculate_momentum_flux<3, TrilinosWrappers::MPI::BlockVector>(
+calculate_momentum<3, TrilinosWrappers::MPI::BlockVector>(
   const DoFHandler<3> &                     dof_handler,
   std::shared_ptr<Mapping<3>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -62,19 +62,19 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
   std::vector<Tensor<1, dim>> velocity_values(face_n_q_points);
   std::vector<double>         pressure_values(face_n_q_points);
 
-  double static_pressure_outlet_boundary  = 0.;
-  double static_pressure_inlet_boundary   = 0.;
-  double static_pressure_drop             = 0.;
+  double static_pressure_outlet_boundary = 0.;
+  double static_pressure_inlet_boundary  = 0.;
+  double static_pressure_drop            = 0.;
 
-  double dynamic_pressure_outlet_boundary  = 0.;
-  double dynamic_pressure_inlet_boundary   = 0.;
-  double dynamic_pressure_drop             = 0.;
+  double dynamic_pressure_outlet_boundary = 0.;
+  double dynamic_pressure_inlet_boundary  = 0.;
+  double dynamic_pressure_drop            = 0.;
 
   double outlet_surface = 0.;
   double inlet_surface  = 0.;
 
-  double temp_surface   = 0.;
-  double temp_static_pressure_at_boundary = 0.;
+  double temp_surface                      = 0.;
+  double temp_static_pressure_at_boundary  = 0.;
   double temp_dynamic_pressure_at_boundary = 0.;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
@@ -139,7 +139,7 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
   dynamic_pressure_outlet_boundary =
     Utilities::MPI::sum(dynamic_pressure_outlet_boundary, mpi_communicator);
 
-  inlet_surface = Utilities::MPI::sum(inlet_surface, mpi_communicator);
+  inlet_surface  = Utilities::MPI::sum(inlet_surface, mpi_communicator);
   outlet_surface = Utilities::MPI::sum(outlet_surface, mpi_communicator);
 
   static_pressure_outlet_boundary =

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -161,6 +161,54 @@ calculate_pressure_drop<3, TrilinosWrappers::MPI::BlockVector>(
 
 template <int dim, typename VectorType>
 double
+calculate_momentum_flux(const DoFHandler<dim> &       dof_handler,
+                        std::shared_ptr<Mapping<dim>> mapping,
+                        const VectorType &            evaluation_point,
+                        const Quadrature<dim> &       cell_quadrature_formula,
+                        const Quadrature<dim - 1> &   face_quadrature_formula,
+                        const unsigned int            boundary_id)
+{
+  return 1.;
+}
+
+template double
+calculate_momentum_flux<2, TrilinosWrappers::MPI::Vector>(
+  const DoFHandler<2> &                dof_handler,
+  std::shared_ptr<Mapping<2>>          mapping,
+  const TrilinosWrappers::MPI::Vector &evaluation_point,
+  const Quadrature<2> &                cell_quadrature_formula,
+  const Quadrature<1> &                face_quadrature_formula,
+  const unsigned int                   boundary_id);
+
+template double
+calculate_momentum_flux<3, TrilinosWrappers::MPI::Vector>(
+  const DoFHandler<3> &                dof_handler,
+  std::shared_ptr<Mapping<3>>          mapping,
+  const TrilinosWrappers::MPI::Vector &evaluation_point,
+  const Quadrature<3> &                cell_quadrature_formula,
+  const Quadrature<2> &                face_quadrature_formula,
+  const unsigned int                   boundary_id);
+
+template double
+calculate_momentum_flux<2, TrilinosWrappers::MPI::BlockVector>(
+  const DoFHandler<2> &                     dof_handler,
+  std::shared_ptr<Mapping<2>>               mapping,
+  const TrilinosWrappers::MPI::BlockVector &evaluation_point,
+  const Quadrature<2> &                     cell_quadrature_formula,
+  const Quadrature<1> &                     face_quadrature_formula,
+  const unsigned int                        boundary_id);
+
+template double
+calculate_momentum_flux<3, TrilinosWrappers::MPI::BlockVector>(
+  const DoFHandler<3> &                     dof_handler,
+  std::shared_ptr<Mapping<3>>               mapping,
+  const TrilinosWrappers::MPI::BlockVector &evaluation_point,
+  const Quadrature<3> &                     cell_quadrature_formula,
+  const Quadrature<2> &                     face_quadrature_formula,
+  const unsigned int                        boundary_id);
+
+template <int dim, typename VectorType>
+double
 calculate_CFL(const DoFHandler<dim> &dof_handler,
               const VectorType &     evaluation_point,
               const double           time_step,

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -108,7 +108,7 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
                       temp_static_pressure_at_boundary +=
                         fe_face_values.JxW(q) * pressure_values[q];
                       temp_dynamic_pressure_at_boundary +=
-                        fe_face_values.JxW(q) * velocity_values[q] *
+                        0.5 * fe_face_values.JxW(q) * velocity_values[q] *
                         velocity_values[q];
                     }
                   if (boundary_id == inlet_boundary_id)


### PR DESCRIPTION
# Description of the problem

- Momentum drop was needed in some situations were the inlet and outlet velocity profiles were different
- Flow rate output was needed as a debugging tool to ensure mass conservation

# Description of the solution

- Two CFD post-processing tools were added, with their documentation

# How Has This Been Tested?

- A few simulations were run to make sure they work properly

# Documentation

- [/parameters/cfd/post_processing.rst] 