### PR TITLE
utilities: copy debug outputs in update-golden.tl

### DIFF
--- a/contrib/utilities/update-golden.tl
+++ b/contrib/utilities/update-golden.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env txr
-;;; SPDX-FileCopyrightText: Copyright (C) 2021 The Lethe Authors
+;;; SPDX-FileCopyrightText: Copyright (C) 2021, 2023 The Lethe Authors
 ;;; SPDX-License-Identifier: LGPL-2.1-or-later
 
 (define-option-struct opts nil
@@ -14,9 +14,9 @@
 
 (defun get-dest (path build-dir lethe-dir)
   (match-case path
-    (`@{build-dir}/applications_tests/@app/@test.release/@mpirun/output`
+    (`@{build-dir}/applications_tests/@app/@test.@{nil #/release|debug/}/@mpirun/output`
      `@{lethe-dir}/applications_tests/@app/@test.@mpirun.output`)
-    (`@{build-dir}/applications_tests/@app/@test.release/output`
+    (`@{build-dir}/applications_tests/@app/@test.@{nil #/release|debug/}/output`
      `@{lethe-dir}/applications_tests/@app/@test.output`)
     (@otherwise nil)))
 

--- a/contrib/utilities/update-golden.tl
+++ b/contrib/utilities/update-golden.tl
@@ -1,7 +1,6 @@
 #!/usr/bin/env txr
-;;; Copyright (C) 2021 The Lethe Authors
-;;;
-;;; SPDX-License-Identifier: LGPL-3.0-only
+;;; SPDX-FileCopyrightText: Copyright (C) 2021 The Lethe Authors
+;;; SPDX-License-Identifier: LGPL-2.1-or-later
 
 (define-option-struct opts nil
   (n dry-run :bool "Don't copy any files, just show what would be done.")

--- a/doc/source/tools/tools.rst
+++ b/doc/source/tools/tools.rst
@@ -7,5 +7,6 @@ Tools
     :glob:
     :titlesonly:
 
+    updating-test-results
     gmsh/gmsh
     automatic_launch/automatic_launch

--- a/doc/source/tools/updating-test-results.rst
+++ b/doc/source/tools/updating-test-results.rst
@@ -1,0 +1,49 @@
+=====================
+Updating test results
+=====================
+Lethe's test suite compares individual test results against reference
+results, stored in so-called golden files, which are known, to some
+extent, to be good.
+However, these golden files can turn out to be wrong, or can change
+slightly, either in format or numerical precision.
+
+Updating the golden files manually is tedious, and so the
+`update-golden` build target exists to automate this process.
+The `update-golden` target launches the
+file:`contrib/utilities/update-golden.tl` script with appropriate
+arguments.
+
+The file:`contrib/utilities/update-golden.tl` script's only dependency
+is TXR_.
+
+.. _TXR: https://www.nongnu.org/txr/
+
+-----
+Setup
+-----
+TXR can be installed to file:`/usr/local/bin` as follows:
+
+.. code-block:: shell
+   curl 'https://www.kylheku.com/cgit/txr/snapshot/txr-285.tar.gz' | tar -xzf -
+   cd txr-285
+   make
+   sudo make install
+
+If Lethe's build was configured before TXR was installed, then the
+`update-golden` target will not exist.
+In this situation, the build has to be reconfigured, for example with:
+
+.. code-block:: shell
+   cmake -S. -Bbuild
+
+assuming the current directory is Lethe's root directory, and the build
+directory file:`build`.
+
+-----
+Usage
+-----
+Assuming the build directory is file:`build`, the following command
+updates the golden files:
+
+.. code-block:: shell
+   cmake --build build --target update-golden


### PR DESCRIPTION
The `TEST.debug` directories, and by extension the output files therein, were being ignored by `update-golden.tl`, as @voferreira discovered.

Also added some documentation on how to update the golden files with `update-golden.tl`, as requested by @voferreira.