### PR TITLE
WIP: Add home made gcr solver *experimental*

### DIFF
--- a/applications_tests/gls_sharp_navier_stokes_3d/static_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes_3d/static_stokes.prm
@@ -297,7 +297,7 @@ end
 # Linear Solver Control
 #---------------------------------------------------
 subsection linear solver
-  set method                                 = gmres
+  set method                                 = gcr
   set max iters                              = 1000
   set relative residual                      = 1e-3
   set minimum residual                       = 1e-12

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -79,6 +79,7 @@ In this subsection, the control options of linear solvers are specified. These c
 	* ``gmres`` (default parameter value), a GMRES iterative solver with ILU preconditioning.
 	* ``amg``, a GMRES iterative solver with AMG preconditioning and an ILU coarsener and smoother.
 	* ``bicgstab``, a BICGSTAB iterative solver with ILU preconditioning.
+	* ``gcr``, a General conjugate residual iterative solver with ILU preconditioning. This solver is directly implemented in Lethe. It is experimental and should only be used for development purposes
 	* ``direct``, a direct solver using `TrilinosWrappers::SolverDirect <https://www.dealii.org/current/doxygen/deal.II/classTrilinosWrappers_1_1SolverDirect.html>`_.
 
 	.. hint::
@@ -143,7 +144,7 @@ In this subsection, the control options of linear solvers are specified. These c
 .. warning::
 	With this mode on, errors on the linear solver convergence are not thrown. Forcing the solver to continue can be useful for debugging purposes if a given iteration is hard to pass, but use with caution!
 
-* ``max krylov vectors`` sets the maximum number of krylov vectors for ``GMRES`` and ``AMG`` solvers.
+* ``max krylov vectors`` sets the maximum number of krylov vectors for ``GMRES``, ``GCR`` and ``AMG`` solvers.
 
 .. tip::
 	Consider using ``set max krylov vectors = 200`` for complex simulations with convergence issues. 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -150,9 +150,9 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 0: Calculate the residual  :math:`r_0=b - \mathcal{A} x_0`.
 
-* Step 1: Define a correction vector with a preconditioner :math:`d_i=\mathcal{M}^{-1} r_0`.
+* Step 1: Define a correction vector with a preconditioner :math:`d_i=\mathcal{M}^{-1} r_i`.
 
-* Step 1.1 (optional): Orthogonalized :math:`d_i=\mathcal{M}^{-1} r_0` with the set of correction directions :math:`D` and normalized the orthogonalized vector. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the projected components of :math:`d_i`.
+* Step 1.1 (optional): Orthogonalized :math:`d_i=\mathcal{M}^{-1} r_i` with the set of correction directions :math:`D` and normalized the orthogonalized vector. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the projected components of :math:`d_i`.
 
 * Step 2: Store the vector :math:`d_i` in the set of correction directions :math:`D`.
 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -152,7 +152,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 1: Define a correction vector with a preconditioner :math:`d_i=\mathcal{M}^{-1} r_i`.
 
-* Step 1.1 (optional): Orthogonalized :math:`d_i` with the set of correction directions :math:`D` and normalized it. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise since the subspace defined by the set of vector :math:`D` is unchanged. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the projected components of :math:`d_i`.
+* Step 1.1 (optional): Orthogonalized :math:`d_i` with the set of correction directions :math:`D` and normalized it. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise since the subspace defined by the set of vector :math:`D` (including  :math:`d_i`) is unchanged. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the resulting projected components from :math:`d_i`.
 
 * Step 2: Store the vector :math:`d_i` in the set of correction directions :math:`D`.
 
@@ -160,7 +160,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 4: Store the vector :math:`s_i` in the set of residual variation in a given direction :math:`S`.
 
-* Step 5: Calculate the vecotr of weights :math:`\alpha` of the optimal linear combination of all correction vectors stored in :math:`D` that minimize :math:`r_{i+1}`.
+* Step 5: Calculate the vector of weights :math:`\alpha` of the optimal linear combination of all correction vectors stored in :math:`D` that minimize :math:`r_{i+1}`.
 
 * Step 5.1: Assemble the matrix and right-hand side of the following form:
 
@@ -182,7 +182,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
    r_{i+1}=r_{i}-\alpha_0 s_0-\alpha_1 s_1-...-\alpha_i s_i
    
 .. note:: 
-   The matrix used to find :math:`\alpha` of the optimal linear combination is obtained by taking the partial derivative of the Euclidean norm squared of the vector :math:`r_{i+1}` with respect to each weight of :math:`\alpha` and setting it equal to 0. This generates the :math:`i` linear equations with :math:`i` unknown that is solved in step 5.1.
+   The matrix used to find the vector :math:`\alpha` is obtained by taking the partial derivative of the Euclidean norm squared of the vector :math:`r_{i+1}` with respect to each weight of :math:`\alpha` and setting it equal to 0. This generates the :math:`i` linear equations with :math:`i` unknown that is solved in step 5.1.
    
 * Step 7: Check if the residual is sufficiently small; otherwise, go back to step 1.
 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -166,7 +166,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 .. math::
 
-    \left[ \begin{matrix} 	s_0 \cdot s_0 & s_0 \cdot s_1 & ... & s_0 \cdot s_i  \\[0.3em]	s_1 \cdot s_0 & s_1 \cdot s_1 & ... & s_1 \cdot s_i \\ ... & ...& ...& ... \\ s_i \cdot s_0 & s_i \cdot s_1 & ... & s_i \cdot s_i  \end{matrix} \right] \left[ \begin{matrix} \alpha_0 \\[0.3em] \alpha_1 \\ ...\\  \alpha_i  \end{matrix} \right]  &= \left[ \begin{matrix} s_0 \cdot r_i    \\[0.3em]		s_1 \cdot r_i    \\ ... \\ s_i \cdot r_i    \\ \end{matrix} \right]
+    \left[ \begin{matrix} 	s_0 \cdot s_0 & s_0 \cdot s_1 & ... & s_0 \cdot s_i  \\[0.3em]	s_1 \cdot s_0 & s_1 \cdot s_1 & ... & s_1 \cdot s_i \\[0.3em] ... & ...& ...& ... \\[0.3em] s_i \cdot s_0 & s_i \cdot s_1 & ... & s_i \cdot s_i  \end{matrix} \right] \left[ \begin{matrix} \alpha_0 \\[0.3em] \alpha_1 \\[0.3em] ...\\[0.3em]  \alpha_i  \end{matrix} \right]  &= \left[ \begin{matrix} s_0 \cdot r_i    \\[0.3em]		s_1 \cdot r_i    \\[0.3em] ... \\[0.3em] s_i \cdot r_i   \end{matrix} \right]
 
 
 * Step 5.2: Solve this system using a direct solver to find the :math:`\alpha_i`.
@@ -180,6 +180,9 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 .. math::
 
    r_{i+1}=r_{i}-\alpha_0 s_0-\alpha_1 s_1-...-\alpha_i s_i
+   
+.. note:: 
+   The matrix used to find the weight :math:`\alpha_i` of the optimal linear combination is obtained by taking the partial derivative of the Euclidean norm squared of the vector :math:`r_{i+1}` with respect to the :math:`\alpha_i` and setting it equal to 0. This generates the :math:`i` linear equations with :math:`i` unknown that is solved in step 5.1.
    
 * Step 7: Check if the residual is sufficiently small; otherwise, go back to step 1.
 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -160,7 +160,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 4: Store the vector :math:`s_i` in the set of residual variation in a given direction :math:`S`.
 
-* Step 5: Calculate the weight  :math:`\alpha_i` of the optimal linear combination of all correction vectors stored in :math:`D` that minimize :math:`r_{i+1}`.
+* Step 5: Calculate the vecotr of weights :math:`\alpha` of the optimal linear combination of all correction vectors stored in :math:`D` that minimize :math:`r_{i+1}`.
 
 * Step 5.1: Assemble the matrix and right-hand side of the following form:
 
@@ -169,7 +169,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
     \left[ \begin{matrix} 	s_0 \cdot s_0 & s_0 \cdot s_1 & ... & s_0 \cdot s_i  \\[0.3em]	s_1 \cdot s_0 & s_1 \cdot s_1 & ... & s_1 \cdot s_i \\[0.3em] ... & ...& ...& ... \\[0.3em] s_i \cdot s_0 & s_i \cdot s_1 & ... & s_i \cdot s_i  \end{matrix} \right] \left[ \begin{matrix} \alpha_0 \\[0.3em] \alpha_1 \\[0.3em] ...\\[0.3em]  \alpha_i  \end{matrix} \right]  &= \left[ \begin{matrix} s_0 \cdot r_i    \\[0.3em]		s_1 \cdot r_i    \\[0.3em] ... \\[0.3em] s_i \cdot r_i   \end{matrix} \right]
 
 
-* Step 5.2: Solve this system using a direct solver to find the :math:`\alpha_i`.
+* Step 5.2: Solve this system using a direct solver to find :math:`\alpha`.
 
 * Step 6: Update the solution and the residual with the optimal linear combination of the set of vectors :math:`D`.
 
@@ -182,7 +182,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
    r_{i+1}=r_{i}-\alpha_0 s_0-\alpha_1 s_1-...-\alpha_i s_i
    
 .. note:: 
-   The matrix used to find the weight :math:`\alpha_i` of the optimal linear combination is obtained by taking the partial derivative of the Euclidean norm squared of the vector :math:`r_{i+1}` with respect to the :math:`\alpha_i` and setting it equal to 0. This generates the :math:`i` linear equations with :math:`i` unknown that is solved in step 5.1.
+   The matrix used to find :math:`\alpha` of the optimal linear combination is obtained by taking the partial derivative of the Euclidean norm squared of the vector :math:`r_{i+1}` with respect to each weight of :math:`\alpha` and setting it equal to 0. This generates the :math:`i` linear equations with :math:`i` unknown that is solved in step 5.1.
    
 * Step 7: Check if the residual is sufficiently small; otherwise, go back to step 1.
 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -143,16 +143,16 @@ Some remarks:
 
 * In Lethe we use the Trilinos implementation of the AMG method through `deal.II <https://www.dealii.org/>`_: `TrilinosWrappers::PreconditionAMG <https://dealii.org/developer/doxygen/deal.II/classTrilinosWrappers_1_1PreconditionAMG.html>`_. One must specify several parameters related to the number of cycles, the type of cycle and smoother parameters.
 
-Generale Conjugate Residual
+General Conjugate Residual
 ___________________________
 
 In Lethe we have implemented an experimental iterative solver to test possible modifications to the iterative resolution process. The solver is based on the General Conjugate Residual method (GCR). This section presents the current implementation of the solver.
 
-* Step 0: Calculate the residual  :math:`r_0=b - \mathcal{A} x_0`.
+* Step 0: Calculate the residual  :math:`r_0=\mathcal{A} x_0-b`.
 
 * Step 1: Define a correction vector with a preconditioner :math:`d_i=\mathcal{M}^{-1} r_i`.
 
-* Step 1.1 (optional): Orthogonalized :math:`d_i=\mathcal{M}^{-1} r_i` with the set of correction directions :math:`D` and normalized the orthogonalized vector. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the projected components of :math:`d_i`.
+* Step 1.1 (optional): Orthogonalized :math:`d_i` with the set of correction directions :math:`D` and normalized it. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise since the subspace defined by the set of vector :math:`D` is unchanged. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the projected components of :math:`d_i`.
 
 * Step 2: Store the vector :math:`d_i` in the set of correction directions :math:`D`.
 
@@ -171,7 +171,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 5.2: Solve this system using a direct solver to find :math:`\alpha`.
 
-* Step 6: Update the solution and the residual with the optimal linear combination of the set of vectors :math:`D`.
+* Step 6: Update the solution with the optimal linear combination of the set of vectors :math:`D` and the residual with the set of residual variation  :math:`S`.
 
 .. math::
 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -152,24 +152,26 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 1: Define a correction vector with a preconditioner :math:`d_i=\mathcal{M}^{-1} r_0`.
 
-* Step 2: Store the vector :math:`d_i` in the list of correction directions :math:`D`.
+* Step 1.1 (optional): Orthogonalized :math:`d_i=\mathcal{M}^{-1} r_0` with the set of correction directions :math:`D` and normalized the orthogonalized vector. This helps the conditioning of the matrix used in step 5.
+
+* Step 2: Store the vector :math:`d_i` in the set of correction directions :math:`D`.
 
 * Step 3: Calculate the variation vector in the direction of :math:`d_i`, :math:`s_i=\mathcal{A} d_i`.
 
-* Step 4: Store the vector :math:`s_i` in the list of residual variation in a given direction :math:`S`.
+* Step 4: Store the vector :math:`s_i` in the set of residual variation in a given direction :math:`S`.
 
-* Step 4: Calculate the weight  :math:`\alpha_i` of the optimal linear combination of all correction vectors stored in :math:`D` that minimize :math:`r_{i+1}`.
+* Step 5: Calculate the weight  :math:`\alpha_i` of the optimal linear combination of all correction vectors stored in :math:`D` that minimize :math:`r_{i+1}`.
 
-* Step 4.1: Assemble the matrix and right-hand side of the following form:
+* Step 5.1: Assemble the matrix and right-hand side of the following form:
 
 .. math::
 
     \left[ \begin{matrix} 	s_0 \cdot s_0 & s_0 \cdot s_1 & ... & s_0 \cdot s_i  \\[0.3em]	s_1 \cdot s_0 & s_1 \cdot s_1 & ... & s_1 \cdot s_i \\ ... & ...& ...& ... \\ s_i \cdot s_0 & s_i \cdot s_1 & ... & s_i \cdot s_i  \end{matrix} \right] \left[ \begin{matrix} \alpha_0 \\[0.3em] \alpha_1 \\ ...\\  \alpha_i  \end{matrix} \right]  &= \left[ \begin{matrix} s_0 \cdot r_i    \\[0.3em]		s_1 \cdot r_i    \\ ... \\ s_i \cdot r_i    \\ \end{matrix} \right]
 
 
-* Step 4.2: Solve this system using a direct solver to find the :math:`\alpha_i`.
+* Step 5.2: Solve this system using a direct solver to find the :math:`\alpha_i`.
 
-* Step 5: Update the solution and the residual with the optimal linear combination of the set of vectors :math:`D`.
+* Step 6: Update the solution and the residual with the optimal linear combination of the set of vectors :math:`D`.
 
 .. math::
 
@@ -179,7 +181,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
    r_{i+1}=r_{i}-\alpha_0 s_0-\alpha_1 s_1-...-\alpha_i s_i
    
-* Step 6: Check if the residual is sufficiently small; otherwise, go back to step 1.
+* Step 7: Check if the residual is sufficiently small; otherwise, go back to step 1.
 
 
 

--- a/doc/source/theory/fluid_dynamics/linear_solvers.rst
+++ b/doc/source/theory/fluid_dynamics/linear_solvers.rst
@@ -152,7 +152,7 @@ In Lethe we have implemented an experimental iterative solver to test possible m
 
 * Step 1: Define a correction vector with a preconditioner :math:`d_i=\mathcal{M}^{-1} r_0`.
 
-* Step 1.1 (optional): Orthogonalized :math:`d_i=\mathcal{M}^{-1} r_0` with the set of correction directions :math:`D` and normalized the orthogonalized vector. This helps the conditioning of the matrix used in step 5.
+* Step 1.1 (optional): Orthogonalized :math:`d_i=\mathcal{M}^{-1} r_0` with the set of correction directions :math:`D` and normalized the orthogonalized vector. This helps the conditioning of the matrix used in step 5 but does not affect the convergence otherwise. To orthogonalized :math:`d_i` with the set of correction directions :math:`D`, we project :math:`d_i` over all the vectors in :math:`D` and remove the projected components of :math:`d_i`.
 
 * Step 2: Store the vector :math:`d_i` in the set of correction directions :math:`D`.
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -787,7 +787,8 @@ namespace Parameters
       gmres,
       bicgstab,
       amg,
-      direct
+      direct,
+      gcr
     };
     SolverType solver;
 

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -259,7 +259,10 @@ private:
                       const double relative_residual);
 
   /**
-   * @brief Generalized Conjugate Residual (GCR) iterative solver with optimal alpha calculation. This implementation aims to have an open iterative solver for debugging and learning purposes. This scheme solves matrices in a similar number of iterations and time as GMRES.
+   * @brief Generalized Conjugate Residual (GCR) iterative solver with optimal alpha
+   * calculation. This implementation aims to have an open iterative solver for
+   * debugging and learning purposes. This scheme solves matrices in a similar number
+   * of iterations and time as GMRES.
    */
   void
   solve_system_gcr_iterative(const bool   initial_step,

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -261,8 +261,8 @@ private:
   /**
    * @brief Generalized Conjugate Residual (GCR) iterative solver with optimal alpha
    * calculation. This implementation aims to have an open iterative solver for
-   * debugging and learning purposes. This scheme solves matrices in a similar number
-   * of iterations and time as GMRES.
+   * debugging and learning purposes. This scheme solves matrices in a similar
+   * number of iterations and time as GMRES.
    */
   void
   solve_system_gcr_iterative(const bool   initial_step,

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -263,8 +263,8 @@ private:
    */
   void
   solve_system_gcr_iterative(const bool   initial_step,
-                      const double absolute_residual,
-                      const double relative_residual);
+                             const double absolute_residual,
+                             const double relative_residual);
 
   /**
    * @brief  Set-up AMG preconditioner

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -259,6 +259,14 @@ private:
                       const double relative_residual);
 
   /**
+   * @brief Generalized Conjugate Residual (GCR) iterative solver with optimal alpha calculation. This implementation aims to have an open iterative solver for debugging and learning purposes. This scheme solves matrices in a similar number of iterations and time as GMRES.
+   */
+  void
+  solve_system_gcr_iterative(const bool   initial_step,
+                      const double absolute_residual,
+                      const double relative_residual);
+
+  /**
    * @brief  Set-up AMG preconditioner
    */
   void

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1636,7 +1636,7 @@ namespace Parameters
       prm.declare_entry(
         "method",
         "gmres",
-        Patterns::Selection("gmres|bicgstab|amg|direct"),
+        Patterns::Selection("gmres|bicgstab|amg|direct|gcr"),
         "The iterative solver for the linear system of equations. "
         "Choices are <gmres|bicgstab|amg|tfqmr|direct>. gmres is a GMRES iterative "
         "solver "
@@ -1752,6 +1752,8 @@ namespace Parameters
         solver = SolverType::bicgstab;
       else if (sv == "direct")
         solver = SolverType::direct;
+      else if (sv == "gcr")
+        solver = SolverType::gcr;
       else
         throw std::logic_error(
           "Error, invalid iterative solver type. Choices are amg, gmres, bicgstab or direct");

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1298,7 +1298,7 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
   TrilinosWrappers::MPI::Vector variation_in_direction(this->locally_owned_dofs,
                                                        this->mpi_communicator);
 
-  // tol of solution
+  // Tol of solution
   const AffineConstraints<double> &constraints_used =
     initial_step ? this->nonzero_constraints : this->zero_constraints;
   const double linear_solver_tolerance =
@@ -1311,7 +1311,7 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
                   << linear_solver_tolerance << std::endl;
     }
 
-  // Define initial solution guess assuming diagonal matrix.
+  // Define initial solution guess.
   solution = 0;
 
   // Initialize residual
@@ -1361,7 +1361,7 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
       previous_direction_matrix_prod.push_back(variation_in_direction);
 
       // Initialized matrix used to find the optimal combination of alphas with
-      // the set of direction.
+      // the set of directions.
       FullMatrix<double> variation_vector_dot_product(
         previous_direction.size(), previous_direction.size());
       FullMatrix<double> inv_variation_vector_dot_product(
@@ -1394,7 +1394,7 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
                   variation_vector_residue_dot[vect_id_i] =
                     previous_direction_matrix_prod[vect_id_i] * residual;
                   variation_vector_dot_product[vect_id_i][vect_id_j] = alpha;
-                  // The matrix is symetric, so we only do the calculation once
+                  // The matrix is symmetric, so we only do the calculation once
                   // and stores both matrix entries.
                   if (vect_id_i != vect_id_j)
                     {
@@ -1436,7 +1436,8 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
       inv_variation_vector_dot_product.vmult(alphas,
                                              variation_vector_residue_dot);
 
-      // Applied the optimal alpha with the previous direction.
+      // Applied the optimal alpha with the previous direction. to update the
+      // solution and the residual.
       for (unsigned int vect_id = 0; vect_id < previous_direction.size();
            ++vect_id)
         {
@@ -1450,7 +1451,7 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
             {
               // At least one of the alpha is a Nan, which means that at least
               // two correction vectors are almost collinear, and the matrix
-              // inversion has a very high condition number. This means that
+              // inversion as failed. This means that
               // either the preconditioner or the matrix is close to being
               // singular.
               if (this->simulation_parameters.linear_solver

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1160,7 +1160,9 @@ GLSNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
     solve_system_direct(initial_step, absolute_residual, relative_residual);
   else if (this->simulation_parameters.linear_solver.solver ==
            Parameters::LinearSolver::SolverType::gcr)
-    solve_system_gcr_iterative(initial_step, absolute_residual, relative_residual);
+    solve_system_gcr_iterative(initial_step,
+                               absolute_residual,
+                               relative_residual);
   else
     throw(std::runtime_error("This solver is not allowed"));
 }
@@ -1172,9 +1174,9 @@ GLSNavierStokesSolver<dim>::setup_preconditioner()
   if (this->simulation_parameters.linear_solver.solver ==
         Parameters::LinearSolver::SolverType::gmres ||
       this->simulation_parameters.linear_solver.solver ==
-        Parameters::LinearSolver::SolverType::bicgstab||
+        Parameters::LinearSolver::SolverType::bicgstab ||
       this->simulation_parameters.linear_solver.solver ==
-        Parameters::LinearSolver::SolverType::gcr )
+        Parameters::LinearSolver::SolverType::gcr)
     setup_ILU();
   else if (this->simulation_parameters.linear_solver.solver ==
            Parameters::LinearSolver::SolverType::amg)
@@ -1270,9 +1272,10 @@ GLSNavierStokesSolver<dim>::setup_AMG()
 
 template <int dim>
 void
-GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(const bool   initial_step,
-                                               const double absolute_residual,
-                                               const double relative_residual)
+GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(
+  const bool   initial_step,
+  const double absolute_residual,
+  const double relative_residual)
 {
   // This function implementation of a (Generalized Conjugate Residual) GCR
   // iterative solver with optimal alpha calculation. This implementation aims
@@ -1315,10 +1318,10 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(const bool   initial_step
   this->system_matrix.vmult(residual, solution);
   residual.add(-1, this->system_rhs);
 
-  int iter                               = 0;
-  bool         abort_resolution_and_keep_solution = false;
-  double       current_residual                   = residual.l2_norm();
-  double       previous_residual                  = DBL_MAX;
+  int    iter                               = 0;
+  bool   abort_resolution_and_keep_solution = false;
+  double current_residual                   = residual.l2_norm();
+  double previous_residual                  = DBL_MAX;
   while (current_residual > linear_solver_tolerance &&
          iter < this->simulation_parameters.linear_solver.max_iterations)
     {
@@ -1329,7 +1332,8 @@ GLSNavierStokesSolver<dim>::solve_system_gcr_iterative(const bool   initial_step
         {
           // Define the direction with the ILU preconditioner
           ilu_preconditioner->vmult(direction, residual);
-          // Orthogonalalized direction with previous direction for numerical stability.
+          // Orthogonalalized direction with previous direction for numerical
+          // stability.
           for (unsigned int vect_id_i = 0;
                vect_id_i < previous_direction.size();
                ++vect_id_i)


### PR DESCRIPTION
# Description of the problem

- The sharp solver is unstable with certain parameters with an ilu precondition but not with an identity preconditioner. Since the preconditioner and the iterative process are very opaque when using Trillinos vector, we implemented a variation on a homemade basic GCR  iterative solver. 
- Note : there are some modifications from the classic GCR implementation to reuse more information from the previous correction vector. I it is still named it GCR since alpha is defined in the same way as in the GCR algorithm if you store 0 previous correction vector

# Description of the solution

- The GCR solver was implemented to enable future debugging and modification to the iterative solver process for sharp IB and understand why it is unstable with ILU preconditioning in some specific cases.

# How Has This Been Tested?

- The static stokes case is now solved using the GCR solver.
- The periodic hill case benchmarked the solver compares to GMRES. A similar number of iterations and time per iteration was observed. 

# Documentation

 Still missing. 
- Update parameter.
- Theory guide of the solver.

