### PR TITLE
Enable Lagrangian post-processing PVD restart

### DIFF
--- a/include/dem/read_checkpoint.h
+++ b/include/dem/read_checkpoint.h
@@ -46,6 +46,7 @@ using namespace std;
  * @param dem_parameters Input DEM parameters in the parameter handler file
  * @param simulation_control Simulation control
  * @param particles_pvdhandler PVD handler
+ * @param grid_pvdhandler PVD handler for post-processing
  * @param triangulation Triangulation
  * @param particle_handler Particle handler
  */
@@ -55,6 +56,7 @@ read_checkpoint(TimerOutput &                              computing_timer,
                 const DEMSolverParameters<dim> &           dem_parameters,
                 std::shared_ptr<SimulationControl> &       simulation_control,
                 PVDHandler &                               particles_pvdhandler,
+                PVDHandler &                               grid_pvdhandler,
                 parallel::distributed::Triangulation<dim> &triangulation,
                 Particles::ParticleHandler<dim> &          particle_handler);
 

--- a/include/dem/write_checkpoint.h
+++ b/include/dem/write_checkpoint.h
@@ -46,6 +46,7 @@ using namespace std;
  * @param dem_parameters Input DEM parameters in the parameter handler file
  * @param simulation_control Simulation control
  * @param particles_pvdhandler PVD handler
+ * @param grid_pvdhandler PVD handler for post-processing
  * @param triangulation Triangulation
  * @param particle_handler Particle handler
  * @param pcout Printing in parallel
@@ -58,6 +59,7 @@ write_checkpoint(TimerOutput &                       computing_timer,
                  const DEMSolverParameters<dim> &    dem_parameters,
                  std::shared_ptr<SimulationControl> &simulation_control,
                  PVDHandler &                        particles_pvdhandler,
+                 PVDHandler &                        grid_pvdhandler,
                  parallel::distributed::Triangulation<dim> &triangulation,
                  Particles::ParticleHandler<dim> &          particle_handler,
                  const ConditionalOStream &                 pcout,

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -1017,6 +1017,7 @@ DEMSolver<dim>::solve()
                       parameters,
                       simulation_control,
                       particles_pvdhandler,
+                      grid_pvdhandler,
                       triangulation,
                       particle_handler);
 
@@ -1347,6 +1348,7 @@ DEMSolver<dim>::solve()
                            parameters,
                            simulation_control,
                            particles_pvdhandler,
+                           grid_pvdhandler,
                            triangulation,
                            particle_handler,
                            pcout,

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -8,6 +8,7 @@ read_checkpoint(TimerOutput &                              computing_timer,
                 const DEMSolverParameters<dim> &           parameters,
                 std::shared_ptr<SimulationControl> &       simulation_control,
                 PVDHandler &                               particles_pvdhandler,
+                PVDHandler &                               grid_pvdhandler,
                 parallel::distributed::Triangulation<dim> &triangulation,
                 Particles::ParticleHandler<dim> &          particle_handler)
 {
@@ -15,6 +16,11 @@ read_checkpoint(TimerOutput &                              computing_timer,
   std::string        prefix = parameters.restart.filename;
   simulation_control->read(prefix);
   particles_pvdhandler.read(prefix);
+
+  if (parameters.post_processing.Lagrangian_post_processing)
+    {
+      grid_pvdhandler.read(prefix + "_postprocess_data");
+    }
 
   // Gather particle serialization information
   std::string   particle_filename = prefix + ".particles";
@@ -59,6 +65,7 @@ read_checkpoint(TimerOutput &                            computing_timer,
                 const DEMSolverParameters<2> &           parameters,
                 std::shared_ptr<SimulationControl> &     simulation_control,
                 PVDHandler &                             particles_pvdhandler,
+                PVDHandler &                             grid_pvdhandler,
                 parallel::distributed::Triangulation<2> &triangulation,
                 Particles::ParticleHandler<2> &          particle_handler);
 
@@ -67,5 +74,6 @@ read_checkpoint(TimerOutput &                            computing_timer,
                 const DEMSolverParameters<3> &           parameters,
                 std::shared_ptr<SimulationControl> &     simulation_control,
                 PVDHandler &                             particles_pvdhandler,
+                PVDHandler &                             grid_pvdhandler,
                 parallel::distributed::Triangulation<3> &triangulation,
                 Particles::ParticleHandler<3> &          particle_handler);

--- a/source/dem/write_checkpoint.cc
+++ b/source/dem/write_checkpoint.cc
@@ -8,6 +8,7 @@ write_checkpoint(TimerOutput &                       computing_timer,
                  const DEMSolverParameters<dim> &    parameters,
                  std::shared_ptr<SimulationControl> &simulation_control,
                  PVDHandler &                        particles_pvdhandler,
+                 PVDHandler &                        grid_pvdhandler,
                  parallel::distributed::Triangulation<dim> &triangulation,
                  Particles::ParticleHandler<dim> &          particle_handler,
                  const ConditionalOStream &                 pcout,
@@ -22,6 +23,11 @@ write_checkpoint(TimerOutput &                       computing_timer,
     {
       simulation_control->save(prefix);
       particles_pvdhandler.save(prefix);
+
+      if (parameters.post_processing.Lagrangian_post_processing)
+        {
+          grid_pvdhandler.save(prefix + "_postprocess_data");
+        }
     }
 
   // Prepare the particle handler for checkpointing
@@ -44,6 +50,7 @@ write_checkpoint(TimerOutput &                            computing_timer,
                  const DEMSolverParameters<2> &           parameters,
                  std::shared_ptr<SimulationControl> &     simulation_control,
                  PVDHandler &                             particles_pvdhandler,
+                 PVDHandler &                             grid_pvdhandler,
                  parallel::distributed::Triangulation<2> &triangulation,
                  Particles::ParticleHandler<2> &          particle_handler,
                  const ConditionalOStream &               pcout,
@@ -54,6 +61,7 @@ write_checkpoint(TimerOutput &                            computing_timer,
                  const DEMSolverParameters<3> &           parameters,
                  std::shared_ptr<SimulationControl> &     simulation_control,
                  PVDHandler &                             particles_pvdhandler,
+                 PVDHandler &                             grid_pvdhandler,
                  parallel::distributed::Triangulation<3> &triangulation,
                  Particles::ParticleHandler<3> &          particle_handler,
                  const ConditionalOStream &               pcout,

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -212,11 +212,17 @@ CFDDEMSolver<dim>::write_checkpoint()
 
   std::string prefix = this->simulation_parameters.restart_parameters.filename;
   std::string prefix_particles = prefix + "_particles";
+  std::string prefix_grid      = prefix + "_postprocess_data";
   if (Utilities::MPI::this_mpi_process(this->mpi_communicator) == 0)
     {
       this->simulation_control->save(prefix);
       this->pvdhandler.save(prefix);
       particles_pvdhandler.save(prefix_particles);
+
+      if (this->dem_parameters.post_processing.Lagrangian_post_processing)
+        {
+          grid_pvdhandler.save(prefix_grid);
+        }
 
       if (this->simulation_parameters.flow_control.enable_flow_control)
         this->flow_control.save(prefix);
@@ -288,10 +294,16 @@ CFDDEMSolver<dim>::read_checkpoint()
   TimerOutput::Scope timer(this->computing_timer, "read_checkpoint");
   std::string prefix = this->simulation_parameters.restart_parameters.filename;
   std::string prefix_particles = prefix + "_particles";
+  std::string prefix_grid      = prefix + "_postprocess_data";
 
   this->simulation_control->read(prefix);
   this->pvdhandler.read(prefix);
   particles_pvdhandler.read(prefix_particles);
+
+  if (this->dem_parameters.post_processing.Lagrangian_post_processing)
+    {
+      grid_pvdhandler.read(prefix_grid);
+    }
 
   // Gather particle serialization information
   std::string   particle_filename = prefix + ".particles";


### PR DESCRIPTION
# Description of the problem

- There's currently no restart checkpoints for grid PVD that is used for Lagrangian post-processing results
- When running restart simulations, the PVD file for post-processing results outputs was not updated and it was not possible to visualize results in the previous simulations with the PVD

# Description of the solution

- Handle the checkpoints for grid PVD as it is for fluid or particles in DEM and CFD-DEM

# How Has This Been Tested?

- Restart has been tested for DEM and CFD-DEM and it's now possible to visualize all the simulation outputs with the PVD file

# Comments

- I don't know if I should handle the grid PVD reading as with other PVD. For instance, if we run a restart of a simulation that didn't have Lagrangian post-processing enabled in the previous restart. I don't know if this is really relevant.
- @blaisb do you think I need another reviewer for that since it's kinda copy and paste.
