### PR TITLE
Add high-order output for the boundaries

### DIFF
--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -884,7 +884,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto                            &present_solution = this->present_solution;
+  auto &                           present_solution = this->present_solution;
 
   // Global flags
   // Their dimension is consistent with the dimension returned by
@@ -1902,7 +1902,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
             1, DataComponentInterpretation::component_is_scalar);
 
         std::vector<std::string> qcriterion_name = {"qcriterion"};
-        const DoFHandler<dim>   &dof_handler_qcriterion =
+        const DoFHandler<dim> &  dof_handler_qcriterion =
           qcriterion_smoothing.get_dof_handler();
         data_out.add_data_vector(dof_handler_qcriterion,
                                  qcriterion_field,
@@ -1921,7 +1921,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
             1, DataComponentInterpretation::component_is_scalar);
 
         std::vector<std::string> continuity_name = {"velocity_divergence"};
-        const DoFHandler<dim>   &dof_handler_qcriterion =
+        const DoFHandler<dim> &  dof_handler_qcriterion =
           continuity_smoothing.get_dof_handler();
         data_out.add_data_vector(dof_handler_qcriterion,
                                  continuity_field,


### PR DESCRIPTION
# Description of the problem

- High-order boundary mesh was not correctly exported when "output boundaries = true". This was an annoyance in some simulations as noted by @acdaigneault  (damn I want to find an alternative name like Chad, but google tells me I should use Stacy. So Stacy Audrey)

# Description of the solution

- Fixed it and this closes #727 

# How Has This Been Tested?

- Tested it on a dummy Poiseuille case. The results are convincing. Before and after pictures are below.
![Screenshot_20230517_230150](https://github.com/lethe-cfd/lethe/assets/7850307/99950b07-f710-492a-8b7f-b2d58049bd6e)

![Screenshot_20230517_230156](https://github.com/lethe-cfd/lethe/assets/7850307/08648d4d-8ca6-4a9e-8941-b1aff9db87d7)


