### PR TITLE
Allow more particles sharp and add cache to composite shapes

### DIFF
--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -856,7 +856,6 @@ public:
     std::map<unsigned int, double>         constituent_shapes_values,
     std::map<unsigned int, Tensor<1, dim>> constituent_shapes_gradients) const;
 
-
   /**
    * @brief
    * Clear the cache of the shape

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -856,6 +856,15 @@ public:
     std::map<unsigned int, double>         constituent_shapes_values,
     std::map<unsigned int, Tensor<1, dim>> constituent_shapes_gradients) const;
 
+
+  /**
+   * @brief
+   * Clear the cache of the shape
+   *
+   */
+  virtual void
+  clear_cache() override;
+
 private:
   // The members of this class are all the constituent and operations that are
   // to be performed to construct the composite shape

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2195,7 +2195,7 @@ namespace Parameters
         "number of particles",
         "1",
         Patterns::Integer(),
-        "Number of particles reprensented by IB max number of particles = 10 ");
+        "Number of particles reprensented by IB max number of particles = 10000 ");
       prm.declare_entry(
         "initial refinement",
         "0",
@@ -2205,7 +2205,7 @@ namespace Parameters
         "stencil order",
         "2",
         Patterns::Integer(),
-        "Number of particles reprensented by IB max number of particles = 10 ");
+        "Order of the stencil used for extrapolation to the boundary.");
       prm.declare_entry(
         "levels not precalculated",
         "0",
@@ -2349,7 +2349,7 @@ namespace Parameters
         prm.set("Function expression", "0; 0; 0");
       prm.leave_subsection();
 
-      unsigned int max_ib_particles = 10;
+      unsigned int max_ib_particles = 10000;
       particles.resize(max_ib_particles);
       for (unsigned int i = 0; i < max_ib_particles; ++i)
         {

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2195,7 +2195,7 @@ namespace Parameters
         "number of particles",
         "1",
         Patterns::Integer(),
-        "Number of particles reprensented by IB max number of particles = 10000 ");
+        "Number of particles represented by IB (max number of particles = 10000)");
       prm.declare_entry(
         "initial refinement",
         "0",

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1181,6 +1181,18 @@ CompositeShape<dim>::apply_boolean_operations(
 }
 
 template <int dim>
+void
+CompositeShape<dim>::clear_cache()
+{
+  this->value_cache.clear();
+  this->gradient_cache.clear();
+  for (auto const &[component_id, component] : constituents)
+    {
+      component->clear_cache();
+    }
+}
+
+template <int dim>
 RBFShape<dim>::RBFShape(const std::vector<double> &          support_radii,
                         const std::vector<RBFBasisFunction> &basis_functions,
                         const std::vector<double> &          weights,

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -950,9 +950,7 @@ CompositeShape<dim>::value(const Point<dim> &evaluation_point,
       return levelset;
     }
   else
-    {
-      return iterator->second;
-    }
+    return iterator->second;
 }
 
 template <int dim>
@@ -992,9 +990,7 @@ CompositeShape<dim>::value_with_cell_guess(
       return levelset;
     }
   else
-    {
-      return this->value_cache[point_in_string];
-    }
+    return this->value_cache[point_in_string];
 }
 
 template <int dim>
@@ -1027,9 +1023,7 @@ CompositeShape<dim>::gradient(const Point<dim> &evaluation_point,
       return gradient;
     }
   else
-    {
-      return iterator->second;
-    }
+    return iterator->second;
 }
 
 template <int dim>
@@ -1065,9 +1059,7 @@ CompositeShape<dim>::gradient_with_cell_guess(
       return gradient;
     }
   else
-    {
-      return this->gradient_cache[point_in_string];
-    }
+    return this->gradient_cache[point_in_string];
 }
 
 template <int dim>
@@ -1086,20 +1078,12 @@ CompositeShape<dim>::update_precalculations(
   const unsigned int levels_not_precalculated)
 {
   for (auto const &[component_id, component] : constituents)
-    {
-      if (typeid(*component) == typeid(RBFShape<dim>))
-        {
-          std::static_pointer_cast<RBFShape<dim>>(component)
-            ->update_precalculations(updated_dof_handler,
-                                     levels_not_precalculated);
-        }
-      else if (typeid(*component) == typeid(CompositeShape<dim>))
-        {
-          std::static_pointer_cast<CompositeShape<dim>>(component)
-            ->update_precalculations(updated_dof_handler,
-                                     levels_not_precalculated);
-        }
-    }
+    if (typeid(*component) == typeid(RBFShape<dim>))
+      std::static_pointer_cast<RBFShape<dim>>(component)
+        ->update_precalculations(updated_dof_handler, levels_not_precalculated);
+    else if (typeid(*component) == typeid(CompositeShape<dim>))
+      std::static_pointer_cast<CompositeShape<dim>>(component)
+        ->update_precalculations(updated_dof_handler, levels_not_precalculated);
 }
 
 template <int dim>

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -921,29 +921,38 @@ double
 CompositeShape<dim>::value(const Point<dim> &evaluation_point,
                            const unsigned int /*component*/) const
 {
-  // We align and center the evaluation point according to the shape referential
-  Point<dim> centered_point = this->align_and_center(evaluation_point);
-
-  // The levelset value of all constituent shapes is computed.
-  std::map<unsigned int, double>         constituent_shapes_values;
-  std::map<unsigned int, Tensor<1, dim>> constituent_shapes_gradients;
-  for (auto const &[component_id, component] : constituents)
+  auto point_in_string = this->point_to_string(evaluation_point);
+  auto iterator        = this->value_cache.find(point_in_string);
+  if (iterator == this->value_cache.end())
     {
-      constituent_shapes_values[component_id] =
-        component->value(centered_point);
-      // A dummy gradient is used here because apply_boolean_operations
-      // requires a gradient map as an argument.
-      // This design choice of not duplicating apply_boolean_operations
-      // was made for brevity of the code, at a negligible
-      // additional computing cost.
-      constituent_shapes_gradients[component_id] = Tensor<1, dim>{};
-    }
+      // We align and center the evaluation point according to the shape
+      // referential
+      Point<dim> centered_point = this->align_and_center(evaluation_point);
 
-  double levelset;
-  std::tie(levelset, std::ignore) =
-    apply_boolean_operations(constituent_shapes_values,
-                             constituent_shapes_gradients);
-  return levelset;
+      // The levelset value of all component shapes is computed
+      std::map<unsigned int, double>         constituent_shapes_values;
+      std::map<unsigned int, Tensor<1, dim>> constituent_shapes_gradients;
+      for (auto const &[component_id, component] : constituents)
+        {
+          constituent_shapes_values[component_id] =
+            component->value(centered_point);
+          // A dummy gradient is used here because apply_boolean_operations
+          // requires a gradient map as an argument. This design choice of not
+          // duplicating apply_boolean_operations was made for brevity of the
+          // code, at a negligible additional computing cost.
+          constituent_shapes_gradients[component_id] = Tensor<1, dim>{};
+        }
+
+      double levelset;
+      std::tie(levelset, std::ignore) =
+        apply_boolean_operations(constituent_shapes_values,
+                                 constituent_shapes_gradients);
+      return levelset;
+    }
+  else
+    {
+      return iterator->second;
+    }
 }
 
 template <int dim>
@@ -993,24 +1002,34 @@ Tensor<1, dim>
 CompositeShape<dim>::gradient(const Point<dim> &evaluation_point,
                               const unsigned int /*component*/) const
 {
-  // We align and center the evaluation point according to the shape referential
-  Point<dim> centered_point = this->align_and_center(evaluation_point);
-  // The levelset value and gradient of all component shapes is computed
-  std::map<unsigned int, double>         constituent_shapes_values;
-  std::map<unsigned int, Tensor<1, dim>> constituent_shapes_gradients;
-  for (auto const &[component_id, component] : constituents)
+  auto point_in_string = this->point_to_string(evaluation_point);
+  auto iterator        = this->gradient_cache.find(point_in_string);
+  if (iterator == this->gradient_cache.end())
     {
-      constituent_shapes_values[component_id] =
-        component->value(centered_point);
-      constituent_shapes_gradients[component_id] =
-        component->gradient(centered_point);
-    }
+      // We align and center the evaluation point according to the shape
+      // referential
+      Point<dim> centered_point = this->align_and_center(evaluation_point);
+      // The levelset value and gradient of all component shapes is computed
+      std::map<unsigned int, double>         constituent_shapes_values;
+      std::map<unsigned int, Tensor<1, dim>> constituent_shapes_gradients;
+      for (auto const &[component_id, component] : constituents)
+        {
+          constituent_shapes_values[component_id] =
+            component->value(centered_point);
+          constituent_shapes_gradients[component_id] =
+            component->gradient(centered_point);
+        }
 
-  Tensor<1, dim> gradient;
-  std::tie(std::ignore, gradient) =
-    apply_boolean_operations(constituent_shapes_values,
-                             constituent_shapes_gradients);
-  return gradient;
+      Tensor<1, dim> gradient;
+      std::tie(std::ignore, gradient) =
+        apply_boolean_operations(constituent_shapes_values,
+                                 constituent_shapes_gradients);
+      return gradient;
+    }
+  else
+    {
+      return iterator->second;
+    }
 }
 
 template <int dim>


### PR DESCRIPTION
# Description of the problem

- When solving the flow around multiple particles with the Sharp solver, there was a too low limit on the number of particles (10)
- The alternative of using composite shapes to define the packing was costly because of the multiple boolean operations

# Description of the solution

- The limit on the number of particles was increased (10 000)
- The cache functionality was added for composite shapes

# How Has This Been Tested?

No test was added, but all of them still pass.

# Documentation

No change was required.