### PR TITLE
Fix refine mesh issues for deal.ii distributed vector

### DIFF
--- a/applications_tests/mf_gls_navier_stokes_2d/mms2d_full_mf_gls.mpirun=2.output
+++ b/applications_tests/mf_gls_navier_stokes_2d/mms2d_full_mf_gls.mpirun=2.output
@@ -1,0 +1,26 @@
+Running on 2 MPI rank(s)...
+   Number of active cells:       64
+   Number of degrees of freedom: 867
+   Volume of triangulation:      4
+
+*****************************
+Steady iteration:        1/3
+*****************************
+
+*****************************
+Steady iteration:        2/3
+*****************************
+   Number of active cells:       256
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      4
+
+*****************************
+Steady iteration:        3/3
+*****************************
+   Number of active cells:       1024
+   Number of degrees of freedom: 12675
+   Volume of triangulation:      4
+cells   error_velocity     error_pressure   
+   64 6.123724e-01     - 2.000000e+00     - 
+  256 6.123724e-01 -0.00 2.000000e+00 -0.00 
+ 1024 6.123724e-01  0.00 2.000000e+00  0.00 

--- a/applications_tests/mf_gls_navier_stokes_3d/mms3d_mf_gls.mpirun=2.output
+++ b/applications_tests/mf_gls_navier_stokes_3d/mms3d_mf_gls.mpirun=2.output
@@ -1,0 +1,18 @@
+Running on 2 MPI rank(s)...
+   Number of active cells:       64
+   Number of degrees of freedom: 500
+   Volume of triangulation:      8
+
+*****************************
+Steady iteration:        1/2
+*****************************
+
+*****************************
+Steady iteration:        2/2
+*****************************
+   Number of active cells:       512
+   Number of degrees of freedom: 2916
+   Volume of triangulation:      8
+cells   error_velocity    error_pressure  
+   64 4.185618e-01     - 0.000000e+00   - 
+  512 5.303301e-01 -0.34 0.000000e+00 nan 

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -401,6 +401,14 @@ protected:
   void
   rescale_pressure_dofs_in_newton_update();
 
+  /**
+   * @brief init_temporary_vector
+   * This function initializes correctly a temporary vector depending on the
+   * vector type
+   */
+  inline VectorType
+  init_temporary_vector();
+
   // Member variables
 protected:
   DofsType locally_owned_dofs;


### PR DESCRIPTION
# Description of the problem

There were two issues when refining the mesh and using the `LinearAlgebra::distributed::Vector<double>`. 1) The solution vectors needed to update ghosts before calling the `prepare_for_coarsening_and_refinement` function. 2) The temporary vector used before the interpolation by the solution transfer object needs to be a ghosted vector.

# Description of the solution

The update_ghost_values call was added before all `prepare_for_coarsening_and_refinement` calls. A new inline function `init_temporary_vector` was added to the NavierStokesBase class. This function reinits the temporary vector according to vector type to solve the second issue.

# How Has This Been Tested?

- The parallel output for the two existing tests of the mf_gls_navier_stokes applications in 2D and 3D was added.

# Comments

- This fixes an issue mentioned in #755.
