### PR TITLE
Use box refinement in GLS and GD Navier-Stokes solvers

### DIFF
--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -1207,6 +1207,7 @@ GDNavierStokesSolver<dim>::solve()
     this->simulation_parameters.boundary_conditions);
 
   this->setup_dofs();
+  this->box_refine_mesh();
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1589,6 +1589,7 @@ GLSNavierStokesSolver<dim>::solve()
     this->simulation_parameters.boundary_conditions);
 
   this->setup_dofs();
+  this->box_refine_mesh();
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);


### PR DESCRIPTION
# Description of the problem

- Using box refinement was impossible for these solvers.

# Description of the solution

- The usage of the appropriate function was added.

# How Has This Been Tested?

- All tests still pass.

# Documentation

- No applicable. The documentation already said that it was possible to use box refinement in all solvers.
