### PR TITLE
Dangling refs gls nitsche

### DIFF
--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -138,10 +138,12 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_nitsche_restriction()
           Assert(pic.begin() == particle, ExcInternalError());
           for (const auto &p : pic)
             {
+              const ArrayView<const double> properties = p.get_properties();
+
               velocity           = 0;
               const auto &ref_q  = p.get_reference_location();
               const auto &real_q = p.get_location();
-              const auto &JxW    = p.get_properties()[0];
+              const auto &JxW    = properties[0];
 
               for (unsigned int k = 0; k < dofs_per_cell; ++k)
                 {
@@ -302,13 +304,15 @@ GLSNitscheNavierStokesSolver<2, 3>::calculate_forces_on_solid(
 
       for (const auto &p : pic)
         {
+          const ArrayView<const double> properties = p.get_properties();
+
           velocity_gradient = 0;
           pressure          = 0;
           const auto &q     = p.get_location();
-          const auto &JxW   = p.get_properties()[0];
-          normal_vector[0]  = -p.get_properties()[1];
-          normal_vector[1]  = -p.get_properties()[2];
-          normal_vector[2]  = -p.get_properties()[3];
+          const auto &JxW   = properties[0];
+          normal_vector[0]  = -properties[1];
+          normal_vector[1]  = -properties[2];
+          normal_vector[2]  = -properties[3];
 
           for (int k = 0; k < 3; ++k)
             {
@@ -381,10 +385,12 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::calculate_forces_on_solid(
       Assert(pic.begin() == particle, ExcInternalError());
       for (const auto &p : pic)
         {
+          const ArrayView<const double> properties = p.get_properties();
+
           velocity           = 0;
           const auto &ref_q  = p.get_reference_location();
           const auto &real_q = p.get_location();
-          const auto &JxW    = p.get_properties()[0];
+          const auto &JxW    = properties[0];
 
           for (unsigned int k = 0; k < dofs_per_cell; ++k)
             {
@@ -468,12 +474,14 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::calculate_torque_on_solid(
       Assert(pic.begin() == particle, ExcInternalError());
       for (const auto &p : pic)
         {
+          const ArrayView<const double> properties = p.get_properties();
+
           Tensor<1, spacedim> force;
           force              = 0;
           velocity           = 0;
           const auto &ref_q  = p.get_reference_location();
           const auto &real_q = p.get_location();
-          const auto &JxW    = p.get_properties()[0];
+          const auto &JxW    = properties[0];
 
           for (unsigned int k = 0; k < dofs_per_cell; ++k)
             {

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -126,10 +126,12 @@ HeatTransfer<dim>::assemble_nitsche_heat_restriction(bool assemble_matrix)
               Assert(pic.begin() == particle, ExcInternalError());
               for (const auto &p : pic)
                 {
+                  const ArrayView<const double> properties = p.get_properties();
+
                   double      fluid_temperature = 0;
                   const auto &ref_q             = p.get_reference_location();
                   const auto &real_q            = p.get_location();
-                  const auto &JxW               = p.get_properties()[0];
+                  const auto &JxW               = properties[0];
 
                   for (unsigned int k = 0; k < dofs_per_cell; ++k)
                     {
@@ -230,10 +232,12 @@ HeatTransfer<dim>::postprocess_heat_flux_on_nitsche_ib()
               Assert(pic.begin() == particle, ExcInternalError());
               for (const auto &p : pic)
                 {
+                  const ArrayView<const double> properties = p.get_properties();
+
                   double      fluid_temperature = 0;
                   const auto &ref_q             = p.get_reference_location();
                   const auto &real_q            = p.get_location();
-                  const auto &JxW               = p.get_properties()[0];
+                  const auto &JxW               = properties[0];
 
                   for (unsigned int k = 0; k < dofs_per_cell; ++k)
                     {


### PR DESCRIPTION
# Description of the problem

- There were a few compilation warning caused by dangling references creating warnings.

# Description of the solution

- Fixed them by using an explicit ArrayView
