### PR TITLE
Extrapolate ib refinement

### DIFF
--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -14,9 +14,9 @@ This subsection contains the parameters related to the sharp immersed boundary s
         set calculate force                         = true
         set ib force output file                    = ib_force
         set ib particles pvd file                   = ib_particles_data
+        set levels not precalculated                = 0
         set initial refinement                      = 0
         set refinement zone extrapolation	    = false
-        set levels not precalculated                = 0
         set refine mesh inside radius factor        = 0.5
         set refine mesh outside radius factor       = 1.5
         set integrate motion                        = false
@@ -108,7 +108,7 @@ To sharpen the immersed boundary of each particle, a layer of cells around the i
 
 * The ``initial refinement`` parameter controls the number of refinement cycles in the near-particle refinement zone around every particle before the simulation starts.
 
-* * The ``refinement zone extrapolation`` parameter controls how the refinement zone is evaluated. By default, the refinement zone is around the particle's last position (If this parameter is false). If this parameter is set to true, the refinement zone position is extrapolated from the particle's current velocity. It will then apply all the initial refinement steps at the particle's new position. This is used when the particle moves significantly between two time steps.
+* The ``refinement zone extrapolation`` parameter controls how the refinement zone is evaluated. By default, the refinement zone is around the particle's last position (If this parameter is false). If this parameter is set to true, the refinement zone position is extrapolated from the particle's current velocity. It will then apply all the initial refinement steps at the particle's new position. This is used when the particle moves significantly between two time steps.
 
 * The ``levels not precalculated`` parameter controls the number of layers of the hierarchical grid used by Lethe that are ignored by precalculations. It allows to reduce the memory footprint at the cost of an increased computing time. At the moment, this is used only for RBF shapes. The value should be increased when the RBF contains a lot of nodes and/or the grid is extremely fine.
 

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -15,6 +15,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
         set ib force output file                    = ib_force
         set ib particles pvd file                   = ib_particles_data
         set initial refinement                      = 0
+        set refinement zone extrapolation	    = false
         set levels not precalculated                = 0
         set refine mesh inside radius factor        = 0.5
         set refine mesh outside radius factor       = 1.5
@@ -106,6 +107,8 @@ To sharpen the immersed boundary of each particle, a layer of cells around the i
 	This near-particle zone will be systematically refined at each refinement step until reaching the ``max refinement level`` parameter (:doc:`../cfd/mesh_adaptation_control`).
 
 * The ``initial refinement`` parameter controls the number of refinement cycles in the near-particle refinement zone around every particle before the simulation starts.
+
+* * The ``refinement zone extrapolation`` parameter controls how the refinement zone is evaluated. By default, the refinement zone is around the particle's last position (If this parameter is false). If this parameter is set to true, the refinement zone position is extrapolated from the particle's current velocity. It will then apply all the initial refinement steps at the particle's new position. This is used when the particle moves significantly between two time steps.
 
 * The ``levels not precalculated`` parameter controls the number of layers of the hierarchical grid used by Lethe that are ignored by precalculations. It allows to reduce the memory footprint at the cost of an increased computing time. At the moment, this is used only for RBF shapes. The value should be increased when the RBF contains a lot of nodes and/or the grid is extremely fine.
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1086,6 +1086,7 @@ namespace Parameters
     unsigned int                 levels_not_precalculated;
     double                       inside_radius;
     double                       outside_radius;
+    bool                         time_extrapolation_of_refinement_zone;
     std::vector<IBParticle<dim>> particles;
     bool                         calculate_force_ib;
     bool                         assemble_navier_stokes_inside;

--- a/include/fem-dem/gls_sharp_navier_stokes.h
+++ b/include/fem-dem/gls_sharp_navier_stokes.h
@@ -447,6 +447,14 @@ private:
   void
   load_particles_from_file();
 
+  /**
+   * @brief Regroup and organize the refinement process around the IB particle.
+   *
+   * @param initial_refinement, A bool that indicate if this is the initial refinement.
+   */
+  void
+  refinement_control(bool initial_refinement);
+
 
   /**
 * @brief

--- a/include/fem-dem/gls_sharp_navier_stokes.h
+++ b/include/fem-dem/gls_sharp_navier_stokes.h
@@ -453,7 +453,7 @@ private:
    * @param initial_refinement, A bool that indicate if this is the initial refinement.
    */
   void
-  refinement_control(bool initial_refinement);
+  refinement_control(const bool initial_refinement);
 
 
   /**

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2351,6 +2351,11 @@ namespace Parameters
         "false",
         Patterns::Bool(),
         "This parameter enables the output of more information related to the particles in the vtu file.");
+      prm.declare_entry(
+        "refinement zone extrapolation",
+        "false",
+        Patterns::Bool(),
+        "This parameter enables the extrapolation in time of the refinement zone. This means that it will try to refine where the particle will be at the end of the time step instead of the initial position.");
 
 
       prm.enter_subsection("gravity");
@@ -2383,9 +2388,11 @@ namespace Parameters
     using numbers::PI;
     prm.enter_subsection("particles");
     {
-      nb                       = prm.get_integer("number of particles");
-      order                    = prm.get_integer("stencil order");
-      initial_refinement       = prm.get_integer("initial refinement");
+      nb                 = prm.get_integer("number of particles");
+      order              = prm.get_integer("stencil order");
+      initial_refinement = prm.get_integer("initial refinement");
+      time_extrapolation_of_refinement_zone =
+        prm.get_bool("refinement zone extrapolation");
       levels_not_precalculated = prm.get_integer("levels not precalculated");
       inside_radius      = prm.get_double("refine mesh inside radius factor");
       outside_radius     = prm.get_double("refine mesh outside radius factor");

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -369,10 +369,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::refinement_control(bool initial_refinement)
 {
-  // To change once refinement is split into two function
-  // Warning: variables.begin() only takes the first values given (not
-  // generalized for multivariables mesh adaptation)
-
+  //  This function applies the various refinement steps depending on the
+  //  parameters and the state.
   if (initial_refinement)
     {
       // Apply the initial box refinement

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -366,6 +366,67 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
 }
 
 template <int dim>
+void
+GLSSharpNavierStokesSolver<dim>::refinement_control(bool initial_refinement)
+{
+  // To change once refinement is split into two function
+  // Warning: variables.begin() only takes the first values given (not
+  // generalized for multivariables mesh adaptation)
+
+  if (initial_refinement)
+    {
+      // Apply the initial box refinement
+      this->box_refine_mesh();
+      update_precalculations_for_ib();
+    }
+  if (this->simulation_parameters.particlesParameters
+        ->time_extrapolation_of_refinement_zone ||
+      initial_refinement)
+    {
+      // Stores variable for refinement around the particle.
+      double temp_refine =
+        this->simulation_parameters.mesh_adaptation.variables.begin()
+          ->second.refinement_fraction;
+      double temp_coarse =
+        this->simulation_parameters.mesh_adaptation.variables.begin()
+          ->second.coarsening_fraction;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.refinement_fraction = 0;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.coarsening_fraction = 0;
+
+      for (unsigned int i = 0;
+           i <
+           this->simulation_parameters.particlesParameters->initial_refinement;
+           ++i)
+        {
+          this->pcout << "Initial refinement around IB particles - Step : "
+                      << i + 1 << " of "
+                      << this->simulation_parameters.particlesParameters
+                           ->initial_refinement
+                      << std::endl;
+          refine_ib();
+          NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
+            refine_mesh();
+          update_precalculations_for_ib();
+        }
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.refinement_fraction = temp_refine;
+      this->simulation_parameters.mesh_adaptation.variables.begin()
+        ->second.coarsening_fraction = temp_coarse;
+    }
+  if (initial_refinement == false)
+    {
+      refine_ib();
+      NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
+        refine_mesh();
+      update_precalculations_for_ib();
+    }
+}
+
+
+
+template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p_absolute_distance(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
@@ -723,12 +784,14 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
   DoFTools::map_dofs_to_support_points(*this->mapping,
                                        this->dof_handler,
                                        support_points);
-  double dt    = this->simulation_control->get_time_steps_vector()[0];
+  double dt = this->simulation_control->get_time_steps_vector()[0];
 
   const unsigned int                   dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
-  bool extrapolate_particle_position=true;
+  bool extrapolate_particle_position =
+    this->simulation_parameters.particlesParameters
+      ->time_extrapolation_of_refinement_zone;
 
   const auto &cell_iterator = this->dof_handler.active_cell_iterators();
   for (const auto &cell : cell_iterator)
@@ -743,23 +806,23 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
               Tensor<1, dim> r;
               r[0] = particles[p].radius;
 
-              Point<dim> particle_position;
-              Tensor<1,3> particle_orientation;
-              if( extrapolate_particle_position){
-                  particle_position=particles[p].position;
-                  particle_orientation=particles[p].orientation;
+              Point<dim>   particle_position;
+              Tensor<1, 3> particle_orientation;
+              if (extrapolate_particle_position)
+                {
+                  particle_position    = particles[p].position;
+                  particle_orientation = particles[p].orientation;
                   particles[p].orientation =
                     particles[p].orientation + particles[p].omega * dt;
                   particles[p].position[0] =
-                      particles[p].position[0] + particles[p].velocity[0] * dt;
+                    particles[p].position[0] + particles[p].velocity[0] * dt;
                   particles[p].position[1] =
                     particles[p].position[1] + particles[p].velocity[1] * dt;
 
-                  if constexpr (dim==3)
+                  if constexpr (dim == 3)
                     {
-                      particles[p].position[2] =
-                        particles[p].position[2] + particles[p].velocity[2] * dt;
-
+                      particles[p].position[2] = particles[p].position[2] +
+                                                 particles[p].velocity[2] * dt;
                     }
                   particles[p].set_position(particles[p].position);
                   particles[p].set_orientation(particles[p].orientation);
@@ -795,9 +858,10 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                     }
                 }
 
-              if( extrapolate_particle_position){
-                  particles[p].position=particle_position;
-                  particles[p].orientation=particle_orientation;
+              if (extrapolate_particle_position)
+                {
+                  particles[p].position    = particle_position;
+                  particles[p].orientation = particle_orientation;
                   particles[p].set_position(particles[p].position);
                   particles[p].set_orientation(particles[p].orientation);
                 }
@@ -806,8 +870,6 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                   cell->set_refine_flag();
                   break;
                 }
-
-
             }
         }
     }
@@ -4291,46 +4353,10 @@ GLSSharpNavierStokesSolver<dim>::solve()
 
   define_particles();
   this->setup_dofs();
-  this->box_refine_mesh();
 
-  update_precalculations_for_ib();
   if (this->simulation_parameters.restart_parameters.restart == false)
     {
-      // To change once refinement is split into two function
-      // Warning: variables.begin() only takes the first values given (not
-      // generalized for multivariables mesh adaptation)
-      double temp_refine =
-        this->simulation_parameters.mesh_adaptation.variables.begin()
-          ->second.refinement_fraction;
-      double temp_coarse =
-        this->simulation_parameters.mesh_adaptation.variables.begin()
-          ->second.coarsening_fraction;
-      this->simulation_parameters.mesh_adaptation.variables.begin()
-        ->second.refinement_fraction = 0;
-      this->simulation_parameters.mesh_adaptation.variables.begin()
-        ->second.coarsening_fraction = 0;
-
-      for (unsigned int i = 0;
-           i <
-           this->simulation_parameters.particlesParameters->initial_refinement;
-           ++i)
-        {
-          this->pcout << "Initial refinement around IB particles - Step : "
-                      << i + 1 << " of "
-                      << this->simulation_parameters.particlesParameters
-                           ->initial_refinement
-                      << std::endl;
-
-          refine_ib();
-          NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
-            refine_mesh();
-          update_precalculations_for_ib();
-        }
-      this->simulation_parameters.mesh_adaptation.variables.begin()
-        ->second.refinement_fraction = temp_refine;
-      this->simulation_parameters.mesh_adaptation.variables.begin()
-        ->second.coarsening_fraction = temp_coarse;
-
+      refinement_control(true);
       vertices_cell_mapping();
 
       if (all_spheres)
@@ -4384,42 +4410,14 @@ GLSSharpNavierStokesSolver<dim>::solve()
       else
         {
           ib_done.clear();
-          double temp_refine =
-            this->simulation_parameters.mesh_adaptation.variables.begin()
-              ->second.refinement_fraction;
-          double temp_coarse =
-            this->simulation_parameters.mesh_adaptation.variables.begin()
-              ->second.coarsening_fraction;
-          this->simulation_parameters.mesh_adaptation.variables.begin()
-            ->second.refinement_fraction = 0;
-          this->simulation_parameters.mesh_adaptation.variables.begin()
-            ->second.coarsening_fraction = 0;
-
-          for (unsigned int i = 0;
-               i <
-               this->simulation_parameters.particlesParameters->initial_refinement-1;
-               ++i)
-            {
-
-              refine_ib();
-              NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
-                refine_mesh();
-              update_precalculations_for_ib();
-            }
-          this->simulation_parameters.mesh_adaptation.variables.begin()
-            ->second.refinement_fraction = temp_refine;
-          this->simulation_parameters.mesh_adaptation.variables.begin()
-            ->second.coarsening_fraction = temp_coarse;
-          refine_ib();
-          NavierStokesBase<dim, TrilinosWrappers::MPI::Vector, IndexSet>::
-            refine_mesh();
-          update_precalculations_for_ib();
+          refinement_control(false);
           vertices_cell_mapping();
 
           if (all_spheres)
             optimized_generate_cut_cells_map();
           else
             generate_cut_cells_map();
+
           ib_dem.update_particles_boundary_contact(this->particles,
                                                    this->dof_handler,
                                                    *this->face_quadrature,

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -367,7 +367,8 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
 
 template <int dim>
 void
-GLSSharpNavierStokesSolver<dim>::refinement_control(const bool initial_refinement)
+GLSSharpNavierStokesSolver<dim>::refinement_control(
+  const bool initial_refinement)
 {
   //  This function applies the various refinement steps depending on the
   //  parameters and the state.

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -367,7 +367,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
 
 template <int dim>
 void
-GLSSharpNavierStokesSolver<dim>::refinement_control(bool initial_refinement)
+GLSSharpNavierStokesSolver<dim>::refinement_control(const bool initial_refinement)
 {
   //  This function applies the various refinement steps depending on the
   //  parameters and the state.


### PR DESCRIPTION
# Description of the problem

- When particles are moving fast relative to their diameter, the particle was exiting its refinement zone since it was based on its previous position.

# Description of the solution

- Define the refinement zone around the particle based on an extrapolation of its position using its velocity.

# How Has This Been Tested?

- No tests were added. But it was tested on cases with extremely high CFL.

# Documentation

- The sharp documentation was updated.

