### PR TITLE
Fix Rayleigh critical time step equation

### DIFF
--- a/applications_tests/dem_2d/circle_restart.output
+++ b/applications_tests/dem_2d/circle_restart.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.32182% of Rayleigh time step
+DEM time-step is 2.58386% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/circle_with_floating_walls.mpirun=1.output
+++ b/applications_tests/dem_2d/circle_with_floating_walls.mpirun=1.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/insert_list_2d.mpirun=2.output
+++ b/applications_tests/dem_2d/insert_list_2d.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/insert_list_2d.output
+++ b/applications_tests/dem_2d/insert_list_2d.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/packing_in_circle.mpirun=1.output
+++ b/applications_tests/dem_2d/packing_in_circle.mpirun=1.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/packing_in_circle.mpirun=2.output
+++ b/applications_tests/dem_2d/packing_in_circle.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/packing_in_square.mpirun=1.output
+++ b/applications_tests/dem_2d/packing_in_square.mpirun=1.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/packing_in_square.mpirun=2.output
+++ b/applications_tests/dem_2d/packing_in_square.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/rotating_in_circle.output
+++ b/applications_tests/dem_2d/rotating_in_circle.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_2d/two_types_packing_in_circle.output
+++ b/applications_tests/dem_2d/two_types_packing_in_circle.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.19898% of Rayleigh time step
+DEM time-step is 1.3343% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/ball_with_floating_walls.output
+++ b/applications_tests/dem_3d/ball_with_floating_walls.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/box_grid_rotation.output
+++ b/applications_tests/dem_3d/box_grid_rotation.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/box_grid_slide.output
+++ b/applications_tests/dem_3d/box_grid_slide.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/floating_mesh.output
+++ b/applications_tests/dem_3d/floating_mesh.output
@@ -2,8 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 15.7495% of Rayleigh time step
-Warning: It is recommended to decrease the time-step
+DEM time-step is 14.3773% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/force_boundary_box.output
+++ b/applications_tests/dem_3d/force_boundary_box.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 4.64363% of Rayleigh time step
+DEM time-step is 5.16772% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/initial_value_insertion.output
+++ b/applications_tests/dem_3d/initial_value_insertion.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 13.1342% of Rayleigh time step
+DEM time-step is 14.6165% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/insert_list_3d.output
+++ b/applications_tests/dem_3d/insert_list_3d.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/insert_periodic_boundary_gmsh.output
+++ b/applications_tests/dem_3d/insert_periodic_boundary_gmsh.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 7.71088% of Rayleigh time step
+DEM time-step is 8.58114% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/insert_z-x-y.output
+++ b/applications_tests/dem_3d/insert_z-x-y.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 6.56709% of Rayleigh time step
+DEM time-step is 7.30826% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/load_balancing_mobility_status.mpirun=2.output
+++ b/applications_tests/dem_3d/load_balancing_mobility_status.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 16.4177% of Rayleigh time step
+DEM time-step is 18.2706% of Rayleigh time step
 Warning: It is recommended to decrease the time-step
 Reading triangulation
 

--- a/applications_tests/dem_3d/load_balancing_solid_object.mpirun=2.output
+++ b/applications_tests/dem_3d/load_balancing_solid_object.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 2.29954% of Rayleigh time step
+DEM time-step is 2.78488% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/mobility_status.output
+++ b/applications_tests/dem_3d/mobility_status.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 16.4177% of Rayleigh time step
+DEM time-step is 18.2706% of Rayleigh time step
 Warning: It is recommended to decrease the time-step
 Reading triangulation
 

--- a/applications_tests/dem_3d/moving_float.output
+++ b/applications_tests/dem_3d/moving_float.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 4.82056% of Rayleigh time step
+DEM time-step is 5.83799% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/outlet_boundary.output
+++ b/applications_tests/dem_3d/outlet_boundary.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_ball.mpirun=1.output
+++ b/applications_tests/dem_3d/packing_in_ball.mpirun=1.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_ball.mpirun=2.output
+++ b/applications_tests/dem_3d/packing_in_ball.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_ball_dynamic_contact.output
+++ b/applications_tests/dem_3d/packing_in_ball_dynamic_contact.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_ball_dynamic_load_balance.mpirun=2.output
+++ b/applications_tests/dem_3d/packing_in_ball_dynamic_load_balance.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_box.mpirun=1.output
+++ b/applications_tests/dem_3d/packing_in_box.mpirun=1.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_box.mpirun=2.output
+++ b/applications_tests/dem_3d/packing_in_box.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 2.07669% of Rayleigh time step
+DEM time-step is 2.31107% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/packing_in_cylinder.output
+++ b/applications_tests/dem_3d/packing_in_cylinder.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/periodic_boundary_box.output
+++ b/applications_tests/dem_3d/periodic_boundary_box.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.31342% of Rayleigh time step
+DEM time-step is 1.46165% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/periodic_boundary_collisions.mpirun=1.output
+++ b/applications_tests/dem_3d/periodic_boundary_collisions.mpirun=1.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 2.57029% of Rayleigh time step
+DEM time-step is 2.86038% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/periodic_boundary_collisions.mpirun=2.output
+++ b/applications_tests/dem_3d/periodic_boundary_collisions.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 2.57029% of Rayleigh time step
+DEM time-step is 2.86038% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/periodic_boundary_load_balancing.mpirun=2.output
+++ b/applications_tests/dem_3d/periodic_boundary_load_balancing.mpirun=2.output
@@ -2,7 +2,7 @@
 *********************
 Running on 2 rank(s)
 *********************
-DEM time-step is 1.31342% of Rayleigh time step
+DEM time-step is 1.46165% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/sliding_in_box.output
+++ b/applications_tests/dem_3d/sliding_in_box.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/sliding_restart.output
+++ b/applications_tests/dem_3d/sliding_restart.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.46845% of Rayleigh time step
+DEM time-step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/applications_tests/dem_3d/torque_boundary_box.output
+++ b/applications_tests/dem_3d/torque_boundary_box.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 4.64363% of Rayleigh time step
+DEM time-step is 5.16772% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/source/dem/input_parameter_inspection.cc
+++ b/source/dem/input_parameter_inspection.cc
@@ -15,15 +15,16 @@ input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
   double rayleigh_time_step  = 0;
 
   for (unsigned int i = 0; i < physical_properties.particle_type_number; ++i)
-    rayleigh_time_step =
-      std::max(M_PI_2 * physical_properties.particle_average_diameter[i] *
-                 sqrt(2 * physical_properties.density_particle[i] *
-                      (2 + physical_properties.poisson_ratio_particle[i]) *
-                      (1 - physical_properties.poisson_ratio_particle[i]) /
-                      physical_properties.youngs_modulus_particle[i]) /
-                 (0.1631 * physical_properties.poisson_ratio_particle[i] +
-                  0.8766),
-               rayleigh_time_step);
+    {
+      double shear_modulus =
+        physical_properties.youngs_modulus_particle[i] /
+        (2.0 * (1.0 + physical_properties.poisson_ratio_particle[i]));
+      rayleigh_time_step = std::max(
+        M_PI_2 * physical_properties.particle_average_diameter[i] *
+          sqrt(physical_properties.density_particle[i] / shear_modulus) /
+          (0.1631 * physical_properties.poisson_ratio_particle[i] + 0.8766),
+        rayleigh_time_step);
+    }
 
   const double time_step_rayleigh_ratio =
     parameters.simulation_control.dt / rayleigh_time_step;


### PR DESCRIPTION
# Description of the problem

- The critical time step was implemented as:
$$\Delta t_c =\frac{\pi d_i}{2(0.8766 + 0.1631\nu)} \sqrt{\frac{2\rho(2+\nu)(1-\nu)}{E}}$$

Where the shear modulus $G$ definition is wrong.

# Description of the solution

- New implementation fixes the issue and is expressed as followed:
$$\Delta t_c =\frac{\pi d_i}{2(0.8766 + 0.1631\nu)} \sqrt{\frac{\rho}{G}} = \frac{\pi d_i}{2(0.8766 + 0.1631\nu)} \sqrt{\frac{2\rho(1+\nu)}{E}}$$

# How Has This Been Tested?

- All the Rayleigh time step outputs in test are changed.

