### PR TITLE
Make workflow verbose on failure

### DIFF
--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -64,7 +64,7 @@ jobs:
           # Print the tests to be executed
           ctest -N --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
           # Run in parallel
-          ctest -V -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          ctest --output-on-failure -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
 
       # These tests require two cores each so we will run them sequencially
       - name: Run multi-core Lethe tests (Debug-deal.ii:${{ matrix.dealii_version }})
@@ -76,4 +76,4 @@ jobs:
           # Print the tests to be executed
           ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
           # Run sequencially
-          ctest -V --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          ctest --output-on-failure --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -64,7 +64,7 @@ jobs:
           # Print the tests to be executed
           ctest -N --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
           # Run in parallel
-          ctest -V -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          ctest --output-on-failure -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
       
       # These tests require two cores each so we will run them sequencially
       - name: Run multi-core Lethe tests (Release-deal.ii:${{ matrix.dealii_version }})
@@ -76,4 +76,4 @@ jobs:
           # Print the tests to be executed
           ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
           # Run sequencially
-          ctest -V --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          ctest --output-on-failure --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}


### PR DESCRIPTION
# Description of the problem

- The current CI is verbose for all unit test. This makes it difficult to identify why it crashed

# Description of the solution

- Fix the ctest command to only output on failure.

