### PR TITLE
Superquadric shapes

### DIFF
--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -211,7 +211,7 @@ The following parameter and subsection are all inside the subsection ``particle 
 
     * Death Star: *sphere radius*, *hole radius*, *distance between centers*; the effective radius is the *sphere radius*;
 
-    * Superquadric: *x half length* (or :math:`a`), *y half length* (or :math:`b`), *z half length* (or :math:`c`), *x exponent* (or :math:`r`), *y exponent* (or :math:`s`), *z exponent* (or :math:`t`); the effective radius is the Euclidian norm of the half lengths. The exponents represent the blockiness in each direction. The surface is implicitly described by :math:`|\frac{x}{a}|^r + |\frac{y}{b}|^s + |\frac{z}{c}|^t - 1 = 0`;
+    * Superquadric: *x half length* (or :math:`a`), *y half length* (or :math:`b`), *z half length* (or :math:`c`), *x exponent* (or :math:`r`), *y exponent* (or :math:`s`), *z exponent* (or :math:`t`); the effective radius is the Euclidian norm of the half lengths. The exponents represent the blockiness in each direction. The surface is implicitly described by :math:`\left|\frac{x}{a}\right|^r + \left|\frac{y}{b}\right|^s + \left|\frac{z}{c}\right|^t - 1 = 0`;
 
     * Composite: *file name*.
    

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -164,7 +164,7 @@ The following properties are used if the particle impact one of the boundaries o
 .. warning::
     Currently this feature works only for spherical particles.
 
-* The ``particles file`` The file from which the particles are defined. Each line corresponds to a particle and all the relevant variables. The file must contain the following information for each particle (the header must be defined accordingly): type shape_argument_0 shape_argument_1 shape_argument_2 p_x p_y p_z v_x v_y v_z omega_x omega_y omega_z orientation_x orientation_y orientation_z density inertia pressure_x pressure_y pressure_z youngs_modulus restitution_coefficient friction_coefficient poisson_ratio rolling_friction_coefficient. The particle type is defined by the shape index. The shape indices are as follows: sphere=0, hyper rectangle=1, ellipsoid=2, torus=3, cone=4, cylinder=5, cylindrical tube=6, cylindrical helix=7, cut hollow sphere=8, death star=9. Currently, the composite, the RBF, and the OpenCascade shapes cannot be loaded from a file.
+* The ``particles file`` The file from which the particles are defined. Each line corresponds to a particle and all the relevant variables. The file must contain the following information for each particle (the header must be defined accordingly): type shape_argument_0 shape_argument_1 shape_argument_2 p_x p_y p_z v_x v_y v_z omega_x omega_y omega_z orientation_x orientation_y orientation_z density inertia pressure_x pressure_y pressure_z youngs_modulus restitution_coefficient friction_coefficient poisson_ratio rolling_friction_coefficient. The particle type is defined by the shape index. The shape indices are as follows: sphere=0, hyper rectangle=1, ellipsoid=2, torus=3, cone=4, cylinder=5, cylindrical tube=6, cylindrical helix=7, cut hollow sphere=8, death star=9, superquadric=10. Currently, the composite, the RBF, and the OpenCascade shapes cannot be loaded from a file.
 
 The following parameter and subsection are all inside the subsection ``particle info 0`` and have to be redefined for all particles separately.
 
@@ -188,7 +188,7 @@ The following parameter and subsection are all inside the subsection ``particle 
 
 * The ``pressure location`` parameter is used to define the X, Y, and Z coordinate offsets of the pressure reference point relative to the center of the particle. These parameters are used when the ``assemble Navier-Stokes inside particles`` parameter is set to ``true`` to define the pressure reference point.
 
-* The ``type`` parameter is used to define the geometry type of the particle. The alternatives in 2D are: ``sphere``, ``ellipsoid``, ``hyper rectangle``. In 3D, in addition to the previous shapes, alternatives include: ``cone``, ``death star``, ``cut hollow sphere``, ``torus``, ``cylinder``, ``cylindrical tube``, ``cylindrical helix``, ``composite``, ``rbf``, ``opencascade``. An ``rbf`` geometry is a flexible object described by a weighted sum of radial basis functions. The RBF data of an object can be generated from an STL file using a `bitpit <https://github.com/optimad/bitpit>`_-based script, namely example `RBF_example_00001 <https://github.com/optimad/bitpit/blob/master/examples/RBF_example_00001.cpp>`_.
+* The ``type`` parameter is used to define the geometry type of the particle. The alternatives in 2D are: ``sphere``, ``ellipsoid``, ``hyper rectangle``. In 3D, in addition to the previous shapes, alternatives include: ``cone``, ``death star``, ``superquadric``, ``cut hollow sphere``, ``torus``, ``cylinder``, ``cylindrical tube``, ``cylindrical helix``, ``composite``, ``rbf``, ``opencascade``. An ``rbf`` geometry is a flexible object described by a weighted sum of radial basis functions. The RBF data of an object can be generated from an STL file using a `bitpit <https://github.com/optimad/bitpit>`_-based script, namely example `RBF_example_00001 <https://github.com/optimad/bitpit/blob/master/examples/RBF_example_00001.cpp>`_.
 
 * The ``shape arguments`` parameter is used to define the parameters of the shape in the form of a list separated by ``;``. The required arguments and the effective radius, used for near-particle refinement, are:
     * Sphere: *radius*; the effective radius is the *radius*;
@@ -210,6 +210,8 @@ The following parameter and subsection are all inside the subsection ``particle 
     * Cut Hollow Sphere: *radius*, *cut height*, *wall thickness*; the effective radius is the *radius*;
 
     * Death Star: *sphere radius*, *hole radius*, *distance between centers*; the effective radius is the *sphere radius*.
+
+    * Superquadric: *x half length*, *y half length*, [*z half length* (if 3D)], *x exponent*, *y exponent*, [*z exponent* (if 3D)]; the effective radius is the Euclidian norm of the half lengths;
 
     * Composite: *file name*.
    

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -211,7 +211,7 @@ The following parameter and subsection are all inside the subsection ``particle 
 
     * Death Star: *sphere radius*, *hole radius*, *distance between centers*; the effective radius is the *sphere radius*;
 
-    * Superquadric: *x half length* (or :math:`a`), *y half length* (or :math:`b`), *z half length* (or :math:`c`), *x exponent* (or :math:`r`), *y exponent* (or :math:`s`), *z exponent* (or :math:`t`); the effective radius is the Euclidian norm of the half lengths. The exponents represent the blockiness in each direction. The surface is implicitly described by :math:`|\frac{x}{a}|^r + |\frac{y}{b}|^s + |\frac{z}{c}|^t - 1`. At the moment, only convex shapes are supported, which means exponents should be kept above 1;
+    * Superquadric: *x half length* (or :math:`a`), *y half length* (or :math:`b`), *z half length* (or :math:`c`), *x exponent* (or :math:`r`), *y exponent* (or :math:`s`), *z exponent* (or :math:`t`); the effective radius is the Euclidian norm of the half lengths. The exponents represent the blockiness in each direction. The surface is implicitly described by :math:`|\frac{x}{a}|^r + |\frac{y}{b}|^s + |\frac{z}{c}|^t - 1 = 0`;
 
     * Composite: *file name*.
    

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -209,9 +209,9 @@ The following parameter and subsection are all inside the subsection ``particle 
 
     * Cut Hollow Sphere: *radius*, *cut height*, *wall thickness*; the effective radius is the *radius*;
 
-    * Death Star: *sphere radius*, *hole radius*, *distance between centers*; the effective radius is the *sphere radius*.
+    * Death Star: *sphere radius*, *hole radius*, *distance between centers*; the effective radius is the *sphere radius*;
 
-    * Superquadric: *x half length*, *y half length*, [*z half length* (if 3D)], *x exponent*, *y exponent*, [*z exponent* (if 3D)]; the effective radius is the Euclidian norm of the half lengths;
+    * Superquadric: *x half length* (or :math:`a`), *y half length* (or :math:`b`), *z half length* (or :math:`c`), *x exponent* (or :math:`r`), *y exponent* (or :math:`s`), *z exponent* (or :math:`t`); the effective radius is the Euclidian norm of the half lengths. The exponents represent the blockiness in each direction. The surface is implicitly described by :math:`|\frac{x}{a}|^r + |\frac{y}{b}|^s + |\frac{z}{c}|^t - 1`. At the moment, only convex shapes are supported, which means exponents should be kept above 1;
 
     * Composite: *file name*.
    

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -381,7 +381,7 @@ private:
 /**
  * @class This class defines superquadric shapes. Their signed distance function
  * is:
- * |\frac{x}{a}|^r  + |\frac{y}{b}|^s + |\frac{z}{c}|^t - 1 = 0
+ * \left|\frac{x}{a}\right|^r + \left|\frac{y}{b}\right|^s + \left|\frac{z}{c}\right|^t - 1 = 0
  * @tparam dim Dimension of the shape
  */
 template <int dim>
@@ -399,11 +399,8 @@ public:
                     const Tensor<1, dim> exponents,
                     const Point<dim> &   position,
                     const Tensor<1, 3> & orientation)
-    : Shape<dim>(half_lengths.norm(), position, orientation)
+    : Shape<dim>(half_lengths.norm(), position, orientation),half_lengths(half_lengths),exponents(exponents),epsilon(1e-12)
   {
-    this->half_lengths = half_lengths;
-    this->exponents    = exponents;
-    this->epsilon      = 1e-12;
   }
 
   /**
@@ -479,7 +476,6 @@ public:
   closest_surface_point(const Point<dim> &p,
                         Point<dim> &      closest_point) const override;
 
-
   /**
    * @brief
    * Clear the cache of the shape
@@ -511,7 +507,7 @@ public:
   {
     return pow(abs(centered_point[0] / half_lengths[0]), exponents[0]) +
            pow(abs(centered_point[1] / half_lengths[1]), exponents[1]) +
-           pow(abs(centered_point[2] / half_lengths[2]), exponents[2]) - 1;
+           pow(abs(centered_point[2] / half_lengths[2]), exponents[2]) - 1.0;
   }
 
   /**

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -381,7 +381,8 @@ private:
 /**
  * @class This class defines superquadric shapes. Their signed distance function
  * is:
- * \left|\frac{x}{a}\right|^r + \left|\frac{y}{b}\right|^s + \left|\frac{z}{c}\right|^t - 1 = 0
+ * \left|\frac{x}{a}\right|^r + \left|\frac{y}{b}\right|^s +
+ * \left|\frac{z}{c}\right|^t - 1 = 0
  * @tparam dim Dimension of the shape
  */
 template <int dim>
@@ -399,9 +400,11 @@ public:
                     const Tensor<1, dim> exponents,
                     const Point<dim> &   position,
                     const Tensor<1, 3> & orientation)
-    : Shape<dim>(half_lengths.norm(), position, orientation),half_lengths(half_lengths),exponents(exponents),epsilon(1e-12)
-  {
-  }
+    : Shape<dim>(half_lengths.norm(), position, orientation)
+    , half_lengths(half_lengths)
+    , exponents(exponents)
+    , epsilon(1e-12)
+  {}
 
   /**
    * @brief Return the evaluation of the signed distance function of this solid

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -493,10 +493,8 @@ public:
   {
     if (prm > 0)
       return 1;
-    else if (prm < 0)
-      return -1;
     else
-      return 0;
+      return -1;
   }
 
   /**

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -22,8 +22,6 @@
 #include <deal.II/grid/manifold.h>
 #include <deal.II/grid/manifold_lib.h>
 
-#include <deal.II/lac/full_matrix.h>
-
 #ifdef DEAL_II_WITH_OPENCASCADE
 #  include <deal.II/opencascade/manifold_lib.h>
 #  include <deal.II/opencascade/utilities.h>
@@ -393,7 +391,7 @@ public:
   /**
    * @brief Constructor for a superquadric shape
    * @param half_lengths The half-lengths of each direction
-   * @param exponents The lengths of each direction
+   * @param exponents The blockiness in each direction
    * @param position The superquadric center
    * @param orientation The superquadric orientation
    */

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -530,6 +530,28 @@ public:
     return gradient / gradient.norm();
   }
 
+  inline double
+  fonc(const Point<dim> &current_point, const Point<dim> &centered_point) const
+  {
+    return 0.1 * sign(superquadric(current_point)) *
+             (current_point - centered_point).norm_square() +
+           abs(superquadric(current_point));
+  }
+
+  inline Point<dim>
+  fonc_grad(const Point<dim> &current_point,
+            const Point<dim> &centered_point) const
+  {
+    Point<dim> gradient{};
+    Point<dim> superquadric_grad = superquadric_gradient(current_point);
+    for (unsigned int d = 0; d < dim; d++)
+      {
+        gradient[d] = 0.1 * (current_point[d] - centered_point[d] + epsilon) +
+                      superquadric_grad[d];
+      }
+    return gradient / gradient.norm();
+  }
+
 private:
   Tensor<1, dim> half_lengths;
   Tensor<1, dim> exponents;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -378,6 +378,90 @@ private:
 #endif
 };
 
+/**
+ * @class This class defines superquadric shapes. Their signed distance function
+ * is:
+ * |\frac{x}{a}|^r  + |\frac{y}{b}|^s + |\frac{z}{c}|^t - 1 = 0
+ * @tparam dim Dimension of the shape
+ */
+template <int dim>
+class Superquadric : public Shape<dim>
+{
+public:
+  /**
+   * @brief Constructor for a superquadric shape
+   * @param half_lengths The half-lengths of each direction
+   * @param exponents The lengths of each direction
+   * @param position The superquadric center
+   * @param orientation The superquadric orientation
+   */
+  Superquadric<dim>(const Tensor<1, dim> half_lengths,
+                    const Tensor<1, dim> exponents,
+                    const Point<dim> &   position,
+                    const Tensor<1, 3> & orientation)
+    : Shape<dim>(half_lengths.norm(), position, orientation)
+  {
+    this->half_lengths = half_lengths;
+    this->exponents    = exponents;
+  }
+
+  /**
+   * @brief Return the evaluation of the signed distance function of this solid
+   * at the given point evaluation point.
+   *
+   * @param evaluation_point The point at which the function will be evaluated
+   * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
+   */
+  double
+  value(const Point<dim> & evaluation_point,
+        const unsigned int component = 0) const override;
+
+  /**
+   * @brief Return the evaluation of the signed distance function of this solid
+   * at the given point evaluation point with a guess for the cell containing
+   * the evaluation point
+   * @param evaluation_point The point at which the function will be evaluated
+   * @param cell The cell that is likely to contain the evaluation point
+   * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
+   */
+  double
+  value_with_cell_guess(
+    const Point<dim> &                                   evaluation_point,
+    const typename DoFHandler<dim>::active_cell_iterator cell,
+    const unsigned int /*component = 0*/) override;
+
+  /**
+   * @brief Return a pointer to a copy of the Shape
+   */
+  std::shared_ptr<Shape<dim>>
+  static_copy() const override;
+
+  /**
+   * @brief Return the analytical gradient of the distance
+   * @param evaluation_point The point at which the function will be evaluated
+   * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
+   */
+  Tensor<1, dim>
+  gradient(const Point<dim> & evaluation_point,
+           const unsigned int component = 0) const override;
+
+  /**
+   * @brief Return the gradient of the distance function
+   * @param evaluation_point The point at which the function will be evaluated
+   * @param cell The cell that is likely to contain the evaluation point
+   * @param component Not applicable
+   */
+  Tensor<1, dim>
+  gradient_with_cell_guess(
+    const Point<dim> &                                   evaluation_point,
+    const typename DoFHandler<dim>::active_cell_iterator cell,
+    const unsigned int component = 0) override;
+
+private:
+  Tensor<1, dim> half_lengths;
+  Tensor<1, dim> exponents;
+};
+
 template <int dim>
 class HyperRectangle : public Shape<dim>
 {

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -403,6 +403,7 @@ public:
   {
     this->half_lengths = half_lengths;
     this->exponents    = exponents;
+    this->epsilon      = 1e-12;
   }
 
   /**
@@ -491,8 +492,10 @@ public:
   {
     if (prm > 0)
       return 1;
-    else
+    else if (prm < 0)
       return -1;
+    else
+      return 0;
   }
 
   /**
@@ -516,15 +519,21 @@ public:
   {
     Point<dim> gradient{};
     for (unsigned int d = 0; d < dim; d++)
-      gradient[d] =
-        sign(centered_point[d]) * exponents[d] * (1 / half_lengths[d]) *
-        pow(abs(centered_point[d] / half_lengths[d]), exponents[d] - 1);
-    return gradient;
+      {
+        if (abs(centered_point[d]) < epsilon)
+          gradient[d] = sign(superquadric(centered_point)) * epsilon;
+        else
+          gradient[d] =
+            sign(centered_point[d]) * exponents[d] * (1 / half_lengths[d]) *
+            pow(abs(centered_point[d] / half_lengths[d]), exponents[d] - 1);
+      }
+    return gradient / gradient.norm();
   }
 
 private:
   Tensor<1, dim> half_lengths;
   Tensor<1, dim> exponents;
+  double         epsilon;
 
   // The cache of the evaluation of the shape. This is used to avoid costly
   // reevaluation of the shape.

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2227,8 +2227,10 @@ namespace Parameters
       "The parameters for a death star are, in order: sphere radius,"
       "smaller sphere radius, distance between centers."
       "The parameters for a superquadric are, in order: "
-      "a, b, c, r, s, t. The first three are half-lengths in x, y, and z."
-      "The last three are the blockiness in the x, y, and z directions."
+      "a, b, c, r, s, t, epsilon. "
+      "The first three are half-lengths in x, y, and z."
+      "The next three are the blockiness in the x, y, and z directions."
+      "The last is the tolerance of the found surface."
       "The parameter for an rbf is the file name."
       "The parameter for a composite is the file name.");
     prm.declare_entry("shape arguments",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2228,7 +2228,7 @@ namespace Parameters
       "smaller sphere radius, distance between centers."
       "The parameters for a superquadric are, in order: "
       "a, b, c, r, s, t. The first three are half-lengths in x, y, and z."
-      "The last three are the exponents applied to each of the x, y, and z fractions."
+      "The last three are the blockiness in the x, y, and z directions."
       "The parameter for an rbf is the file name."
       "The parameter for a composite is the file name.");
     prm.declare_entry("shape arguments",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2203,9 +2203,9 @@ namespace Parameters
       "type",
       "sphere",
       Patterns::Selection(
-        "sphere|hyper rectangle|ellipsoid|torus|cone|cylinder|cylindrical tube|cylindrical helix|cut hollow sphere|death star|rbf|opencascade|composite"),
+        "sphere|hyper rectangle|ellipsoid|torus|cone|cylinder|cylindrical tube|cylindrical helix|cut hollow sphere|death star|superquadric|rbf|opencascade|composite"),
       "The type of shape considered."
-      "Choices are <sphere|hyper rectangle|ellipsoid|torus|cone|cylinder|cylindrical tube|cylindrical helix|cut hollow sphere|death star|rbf|opencascade|composite>."
+      "Choices are <sphere|hyper rectangle|ellipsoid|torus|cone|cylinder|cylindrical tube|cylindrical helix|cut hollow sphere|death star|superquadric|rbf|opencascade|composite>."
       "The parameter for a sphere is: radius. "
       "The parameters for a hyper rectangle are, in order: x half length,"
       "y half length, z half length."
@@ -2226,6 +2226,9 @@ namespace Parameters
       "cut thickness, wall thickness. "
       "The parameters for a death star are, in order: sphere radius,"
       "smaller sphere radius, distance between centers."
+      "The parameters for a superquadric are, in order: "
+      "a, b, c, r, s, t. The first three are half-lengths in x, y, and z."
+      "The last three are the exponents applied to each of the x, y, and z fractions."
       "The parameter for an rbf is the file name."
       "The parameter for a composite is the file name.");
     prm.declare_entry("shape arguments",

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -417,6 +417,22 @@ Superquadric<dim>::closest_surface_point(const Point<dim> &p,
 
           iteration++;
         }
+      iteration                = 0;
+      dx[0]                    = 1;
+      double global_blockiness = exponents.norm();
+      relaxation               = 0.01 / global_blockiness;
+      iteration_max            = 100 * global_blockiness;
+      while (iteration < iteration_max && dx.norm() > epsilon)
+        {
+          distance_gradient = fonc_grad(current_point, centered_point);
+          dx                = -relaxation *
+               (fonc(current_point, centered_point) * distance_gradient) /
+               distance_gradient.norm_square();
+
+          current_point = current_point + dx;
+
+          iteration++;
+        }
 
       closest_point = this->reverse_align_and_center(current_point);
     }

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -405,13 +405,13 @@ Superquadric<dim>::closest_surface_point(const Point<dim> &p,
       double minimal_radius = half_lengths[0];
       minimal_radius        = std::min(minimal_radius, half_lengths[1]);
       minimal_radius        = std::min(minimal_radius, half_lengths[2]);
-      minimal_radius *= 0.1;
+      minimal_radius *= 0.5;
       if (centered_point.norm() < minimal_radius)
         {
-          Point<dim> dummy_point{};
+          Point<dim> safety_point{};
           for (unsigned int d = 0; d < dim; d++)
-            dummy_point[d] = half_lengths[d];
-          closest_point = this->reverse_align_and_center(dummy_point);
+            safety_point[d] = sign(centered_point[d]) * 0.5 * half_lengths[d];
+          closest_point = this->reverse_align_and_center(safety_point);
         }
       else
         {

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -362,7 +362,6 @@ Sphere<dim>::set_position(const Point<dim> &position)
 #endif
 }
 
-
 template <int dim>
 void
 Superquadric<dim>::closest_surface_point(

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -18,8 +18,6 @@
 #include <deal.II/grid/manifold.h>
 #include <deal.II/grid/manifold_lib.h>
 
-#include <deal.II/lac/full_matrix.h>
-
 #ifdef DEAL_II_WITH_OPENCASCADE
 #  include <deal.II/opencascade/manifold_lib.h>
 #  include <deal.II/opencascade/utilities.h>

--- a/source/core/shape_parsing.cc
+++ b/source/core/shape_parsing.cc
@@ -61,6 +61,23 @@ ShapeGenerator::initialize_shape_from_vector(
         }
       shape = std::make_shared<Ellipsoid<dim>>(radii, position, orientation);
     }
+  else if (type == "superquadric")
+    {
+      if constexpr (dim == 3)
+        {
+          Tensor<1, dim> half_lengths{};
+          Tensor<1, dim> exponents{};
+          for (unsigned int d = 0; d < dim; d++)
+            {
+              half_lengths[d] = shape_arguments[d];
+              exponents[d]    = shape_arguments[d + dim];
+            }
+          shape = std::make_shared<Superquadric<dim>>(half_lengths,
+                                                      exponents,
+                                                      position,
+                                                      orientation);
+        }
+    }
   else if (type == "torus")
     {
       if constexpr (dim == 3)

--- a/source/core/shape_parsing.cc
+++ b/source/core/shape_parsing.cc
@@ -72,10 +72,9 @@ ShapeGenerator::initialize_shape_from_vector(
               half_lengths[d] = shape_arguments[d];
               exponents[d]    = shape_arguments[d + dim];
             }
-          shape = std::make_shared<Superquadric<dim>>(half_lengths,
-                                                      exponents,
-                                                      position,
-                                                      orientation);
+          const double epsilon = shape_arguments[3 + dim];
+          shape                = std::make_shared<Superquadric<dim>>(
+            half_lengths, exponents, epsilon, position, orientation);
         }
     }
   else if (type == "torus")

--- a/tests/core/shape_primitives.cc
+++ b/tests/core/shape_primitives.cc
@@ -46,7 +46,7 @@ test()
     std::make_shared<CylindricalHelix<3>>(
       radius, 0.3 * radius, height, pitch, position, orientation);
   std::shared_ptr<Shape<3>> superquadric = std::make_shared<Superquadric<3>>(
-    half_lengths, exponents_superquadric, position, orientation);
+    half_lengths, exponents_superquadric, 1e-12, position, orientation);
 
 
   deallog << "Testing value" << std::endl;

--- a/tests/core/shape_primitives.cc
+++ b/tests/core/shape_primitives.cc
@@ -17,6 +17,7 @@ test()
   double                    radius    = 2;
   double                    thickness = 0.2;
   Tensor<1, 3>              half_lengths({1., 1., 3.});
+  Tensor<1, 3>              exponents_superquadric({1., 1.5, 2.});
   double                    tan_theta = 2.;
   double                    height    = 1.5;
   double                    pitch     = 1;
@@ -44,11 +45,16 @@ test()
   std::shared_ptr<Shape<3>> cylindrical_helix =
     std::make_shared<CylindricalHelix<3>>(
       radius, 0.3 * radius, height, pitch, position, orientation);
+  std::shared_ptr<Shape<3>> superquadric = std::make_shared<Superquadric<3>>(
+    half_lengths, exponents_superquadric, position, orientation);
 
 
   deallog << "Testing value" << std::endl;
   // Testing value of all shape, to confirm proper implementation
   Point<3> p({1., 0.8, 0.75});
+  Point<3> p_superquadric_1({0, 0, 3});
+  Point<3> p_superquadric_2({0, 0, -3});
+  Point<3> p_superquadric_3({1, 1, 3});
   deallog << " Sphere , SD = " << sphere->value(p) << std::endl;
   deallog << " HyperRectangle , SD = " << rectangle->value(p) << std::endl;
   deallog << " Ellipsoid , SD = " << ellipsoid->value(p) << std::endl;
@@ -60,6 +66,12 @@ test()
   deallog << " Cylindrical Tube , SD = " << cylindrical_tube->value(p)
           << std::endl;
   deallog << " Cylindrical Helix , SD = " << cylindrical_helix->value(p)
+          << std::endl;
+  deallog << " Superquadric 1 , SD = " << superquadric->value(p_superquadric_1)
+          << std::endl;
+  deallog << " Superquadric 2 , SD = " << superquadric->value(p_superquadric_2)
+          << std::endl;
+  deallog << " Superquadric 3 , SD = " << superquadric->value(p_superquadric_3)
           << std::endl;
   deallog << "OK" << std::endl;
 
@@ -88,6 +100,12 @@ test()
           << std::endl;
   deallog << " Gradient for ellipsoid at p[2] = " << gradient_ellipsoid[2]
           << std::endl;
+  deallog << " Superquadric 1 , SD = "
+          << superquadric->gradient(p_superquadric_1) << std::endl;
+  deallog << " Superquadric 2 , SD = "
+          << superquadric->gradient(p_superquadric_2) << std::endl;
+  deallog << " Superquadric 3 , SD = "
+          << superquadric->gradient(p_superquadric_3) << std::endl;
   deallog << "OK" << std::endl;
 
   deallog << "Testing copy" << std::endl;

--- a/tests/core/shape_primitives.output
+++ b/tests/core/shape_primitives.output
@@ -11,6 +11,9 @@ DEAL:: Death Star , SD = 1.27344
 DEAL:: Cylinder , SD = 0.00000
 DEAL:: Cylindrical Tube , SD = -0.280625
 DEAL:: Cylindrical Helix , SD = 0.202481
+DEAL:: Superquadric 1 , SD = 0.00000
+DEAL:: Superquadric 2 , SD = 0.00000
+DEAL:: Superquadric 3 , SD = 1.23393
 DEAL::OK
 DEAL::Testing rotation and translation
 DEAL:: New distance for hyper rectangle , SD = 0.141370
@@ -22,6 +25,9 @@ DEAL:: Gradient for sphere at p[2] = 0.505363
 DEAL:: Gradient for ellipsoid at p[0] = 0.773081
 DEAL:: Gradient for ellipsoid at p[1] = 0.618465
 DEAL:: Gradient for ellipsoid at p[2] = 0.0783615
+DEAL:: Superquadric 1 , SD = 0.00000 0.00000 0.00000
+DEAL:: Superquadric 2 , SD = 0.00000 0.00000 0.00000
+DEAL:: Superquadric 3 , SD = 0.628744 0.674896 0.386259
 DEAL::OK
 DEAL::Testing copy
 DEAL:: Position of original cone[0] = 0.00000

--- a/tests/core/shape_primitives.output
+++ b/tests/core/shape_primitives.output
@@ -13,7 +13,7 @@ DEAL:: Cylindrical Tube , SD = -0.280625
 DEAL:: Cylindrical Helix , SD = 0.202481
 DEAL:: Superquadric 1 , SD = 0.00000
 DEAL:: Superquadric 2 , SD = 0.00000
-DEAL:: Superquadric 3 , SD = 1.24112
+DEAL:: Superquadric 3 , SD = 1.24326
 DEAL::OK
 DEAL::Testing rotation and translation
 DEAL:: New distance for hyper rectangle , SD = 0.141370
@@ -27,7 +27,7 @@ DEAL:: Gradient for ellipsoid at p[1] = 0.618465
 DEAL:: Gradient for ellipsoid at p[2] = 0.0783615
 DEAL:: Superquadric 1 , SD = 0.00000 0.00000 0.00000
 DEAL:: Superquadric 2 , SD = 0.00000 0.00000 0.00000
-DEAL:: Superquadric 3 , SD = 0.614758 0.689449 0.383057
+DEAL:: Superquadric 3 , SD = 0.611102 0.693294 0.381966
 DEAL::OK
 DEAL::Testing copy
 DEAL:: Position of original cone[0] = 0.00000

--- a/tests/core/shape_primitives.output
+++ b/tests/core/shape_primitives.output
@@ -13,7 +13,7 @@ DEAL:: Cylindrical Tube , SD = -0.280625
 DEAL:: Cylindrical Helix , SD = 0.202481
 DEAL:: Superquadric 1 , SD = 0.00000
 DEAL:: Superquadric 2 , SD = 0.00000
-DEAL:: Superquadric 3 , SD = 1.23393
+DEAL:: Superquadric 3 , SD = 1.24112
 DEAL::OK
 DEAL::Testing rotation and translation
 DEAL:: New distance for hyper rectangle , SD = 0.141370
@@ -27,7 +27,7 @@ DEAL:: Gradient for ellipsoid at p[1] = 0.618465
 DEAL:: Gradient for ellipsoid at p[2] = 0.0783615
 DEAL:: Superquadric 1 , SD = 0.00000 0.00000 0.00000
 DEAL:: Superquadric 2 , SD = 0.00000 0.00000 0.00000
-DEAL:: Superquadric 3 , SD = 0.628744 0.674896 0.386259
+DEAL:: Superquadric 3 , SD = 0.614758 0.689449 0.383057
 DEAL::OK
 DEAL::Testing copy
 DEAL:: Position of original cone[0] = 0.00000


### PR DESCRIPTION
# Description of the problem

- Superquadric shapes were not implemented.
- Superquadric shapes have a surface function that is distorted (gradient isn't systematically of norm 1), which means it can't be used directly to find the gradient and closest surface points.

# Description of the solution

- An iterative way to find the closest point, and subsequently value and gradient of the distance function, is added.

# How Has This Been Tested?

- A few new lines were added in core/shape_primitives.cc.
- Visual inspections with different parameters were made.

# Documentation

- The new shape was added to the documentation.

# Future changes

- For now, the gradient and values found are a bit wrong: gradient is not perpendicular to the surface by construction, so the values can be a bit overestimated. For the purpose of sharp immersed boundary solver this will not be a problem, but a modified objective function to find the closest point could be used to find the true closest points (and so gradient and value). This will be the subject of another PR.

![image](https://github.com/lethe-cfd/lethe/assets/14217956/e1235dde-7ec4-4350-a3b4-2083fe5fdb86)
