### PR TITLE
Add isothermal ideal gas density model

### DIFF
--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -6,42 +6,42 @@ Physical Properties
 .. code-block:: text
 
   subsection physical properties
-    set number of fluids	= 1
+    set number of fluids = 1
     subsection fluid 0
       # Rheology
-      set rheological model = newtonian
-      set kinematic viscosity 	= 1
+      set rheological model          = newtonian
+      set kinematic viscosity        = 1
       
       # Density
-      set density model = constant
-      set density 		= 1
+      set density model              = constant
+      set density                    = 1
       
       # Specific heat
-      set specific heat model = constant
-      set specific heat 	= 1
+      set specific heat model        = constant
+      set specific heat              = 1
       
       # Thermal conductivity
       set thermal conductivity model = constant
-      set thermal conductivity = 1
+      set thermal conductivity       = 1
       
       # Thermal expansion
-      set thermal expansion model = constant 
-      set thermal expansion = 0
+      set thermal expansion model    = constant
+      set thermal expansion          = 0
       
       # Tracer diffusivity
-      set tracer diffusivity model = constant
-      set tracer diffusivity   = 0
+      set tracer diffusivity model   = constant
+      set tracer diffusivity         = 0
     end
-    set number of solids	= 0
+    set number of solids = 0
   end
  
 * The ``number of fluids`` parameter controls the number of fluids in the simulation. This parameter is set to ``1`` except in `two phase simulations`_ .
 
-* The ``rheological model`` parameter sets the choice of rheological model. The choices are between ``newtonian``, ``power-law``, ``carreau`` and ``phase_change``. For more details on the rheological model, see  `Rheological models`_ .
+* The ``rheological model`` parameter sets the choice of rheological model. The choices are between ``newtonian``, ``power-law``, ``carreau`` and ``phase_change``. For more details on the rheological models, see  `Rheological models`_ .
 
 * The ``kinematic viscosity`` parameter is the kinematic viscosity of the newtonain fluid in units of :math:`\text{Length}^{2} \cdot \text{Time}^{-1}`. In SI this is :math:`\text{m}^{2} \cdot \text{s}^{-1}`. This viscosity is only used when ``rheological model = newtonian``.
 
-* The ``density model`` specifies the model used to calculate the density. At the moment, only a constant density is supported.
+* The ``density model`` specifies the model used to calculate the density. At the moment, a ``constant`` density and an ``isothermal_ideal_gas`` model are supported. For more details on the density models, see `Density models`_.
 
 * The ``density`` parameter is the constant density of the fluid in units of :math:`\text{Mass} \cdot \text{Length}^{-3}`
 
@@ -85,18 +85,18 @@ For two phases, the properties are defined for each fluid. Default values are:
 .. code-block:: text
 
   subsection physical properties
-  set number of fluids		= 2
+  set number of fluids = 2
       subsection fluid 0
-         set density 		= 1
-         set kinematic viscosity 	= 1
-         set specific heat 	= 1
+         set density              = 1
+         set kinematic viscosity  = 1
+         set specific heat        = 1
          set thermal conductivity = 1
          set tracer diffusivity   = 0
       end
       subsection fluid 1
-         set density 		= 1
-         set kinematic viscosity 	= 1
-         set specific heat 	= 1
+         set density              = 1
+         set kinematic viscosity  = 1
+         set specific heat        = 1
          set thermal conductivity = 1
          set tracer diffusivity   = 0
       end
@@ -116,29 +116,29 @@ Conjugate heat transfer
 
 Conjugate heat transfer enables the addition of solid regions in which the fluid dynamics is not solved for. To enable the presence of a solid region, ``number of solids`` must be put to 1. By default, the region with the ``material_id=0`` will be the fluid region whereas the region with ``material_id=1`` will be the solid region. The physcal properties of the solid region are set in an identical fashion as those of the fluid. 
 
- .. warning::
+.. warning::
   This is an experimental feature. It has not been tested on a large range of application cases. 
 
 .. code-block:: text
 
   subsection physical properties
-    set number of fluids	= 1
+    set number of fluids = 1
     subsection fluid 0
       ...
     end
-    set number of solids	= 1
+    set number of solids = 1
     subsection solid 0
       # Density
-      set density model = constant
-      set density 		= 1
+      set density model              = constant
+      set density                    = 1
       
       # Specific heat
-      set specific heat model = constant
-      set specific heat 	= 1
+      set specific heat model        = constant
+      set specific heat              = 1
       
       # Thermal conductivity
       set thermal conductivity model = constant
-      set thermal conductivity = 1
+      set thermal conductivity       = 1
     end
   end
 
@@ -154,7 +154,7 @@ The ``rheological model`` parameter sets which rheological model you are using. 
 .. code-block:: text
 
     subsection physical properties
-      set number of fluids		= 1
+      set number of fluids = 1
       subsection fluid 0
         set rheological model   = newtonian
         set kinematic viscosity = 1.0
@@ -188,7 +188,7 @@ When using the power-law model, the default values are:
 .. code-block:: text
 
   subsection physical properties
-    set number of fluids		  = 1
+    set number of fluids = 1
     subsection fluid 0
       set rheological model   = power-law
       subsection non newtonian
@@ -227,12 +227,12 @@ The parameters for the Carreau model are defined by the ``carreau`` subsection. 
 .. code-block:: text
 
   subsection physical properties
-    set number of fluids		  = 1
+    set number of fluids = 1
     subsection fluid 0
       set rheological model   = carreau
       subsection non newtonian
         subsection carreau
-          set viscosity_0	   = 1.0
+          set viscosity_0     = 1.0
           set viscosity_inf   = 1.0
           set a               = 2.0
           set lambda          = 1.0
@@ -281,10 +281,10 @@ This model is parameterized using the ``phase change`` subsection
     set solidus temperature  = 0
 
     # Specific heat of the liquid phase
-    set viscosity liquid = 1
+    set viscosity liquid     = 1
   
     # viscosity of the solid phase
-    set viscosity solid  = 1
+    set viscosity solid      = 1
   end
 
 
@@ -299,6 +299,49 @@ This model is parameterized using the ``phase change`` subsection
 .. note::
   The phase change subsection is used to parametrize *both* ``rheological model = phase_change`` *and* ``specific heat model = phase_change``. This prevents parameter duplication.
 
+.. _density_models:
+
+Density models
+~~~~~~~~~~~~~~
+
+Lethe supports both ``constant`` and ``isothermal_ideal_gas`` density models. Constant density assumes a constant density value. Isothermal ideal gas density assumes that the fluid's density varies according the following state equation (ideal gas law):
+
+.. math::
+  \rho = \rho_{ref} + \psi p = \rho_{ref} + \frac{1}{R T} \ p
+
+where :math:`\rho_{ref}` is the density of the fluid at the reference state, :math:`\psi = \frac{1}{R T}` is the compressibility factor derived from the ideal gas law with :math:`R= \frac{R_u}{M}` the specific gas constant (universal gas constant (:math:`R_u`) divided by the molar mass of the gas (:math:`M`)) and :math:`T` the temperature of the gas, finally, :math:`p` is the differential pressure between the reference state and the current state.
+
+This model is parametrized using the ``isothermal_ideal_gas`` subsection:
+
+.. code-block:: text
+
+  subsection physical properties
+    set number of fluids = 1
+    subsection fluid 0
+      set density model = isothermal_ideal_gas
+      subsection isothermal_ideal_gas
+        set density_ref = 1.2
+        set R           = 287.05
+        set T           = 293.15
+      end
+    end
+  end
+
+where:
+
+* ``density_ref`` corresponds to :math:`\rho_{ref}`
+
+* ``R`` corresponds to :math:`R`
+
+* ``T`` corresponds to :math:`T`
+
+By default, parameters are set to the values of dry air evaluated under normal temperature and pressure conditions :math:`(20 \ \text{°C}`, :math:`1 \ \text{atm})`.
+
+.. caution::
+  When defining the initial pressure condition in the ``initial conditions`` subsection (see :doc:`initial_conditions`), make sure to set it to :math:`0`, as it represents the reference state for the calculated pressure. In solving the Navier-Stokes equations, the pressure is defined to within a constant. Therefore, it is more appropriate to interpret it as a differential pressure.
+
+  .. attention::
+    Currently, the ``isothermal_ideal_gas`` density model can only be used in conjunction with the incompressible Navier-Stokes equations. However, it is meant to be used with the isothermal formulation of compressible Navier-Stokes equations to account for weakly compressible flows. In a future update, these equations will be implemented.
 
 .. _thermal_conductivity_models:
 
@@ -319,7 +362,7 @@ In the ``phase_change`` thermal conductivity model, two different values (``ther
   k = \alpha_l k_l + (1 - \alpha_l) k_s
 
 
-where :math:`k_l`, :math:`k_s` and  :math:`alpha_l` denote thermal conductivities of the liquid and solid phases and the liquid fraction.
+where :math:`k_l`, :math:`k_s` and  :math:`\alpha_l` denote thermal conductivities of the liquid and solid phases and the liquid fraction.
 
 Specific heat models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -304,7 +304,7 @@ This model is parameterized using the ``phase change`` subsection
 Density models
 ~~~~~~~~~~~~~~
 
-Lethe supports both ``constant`` and ``isothermal_ideal_gas`` density models. Constant density assumes a constant density value. Isothermal ideal gas density assumes that the fluid's density varies according the following state equation (ideal gas law):
+Lethe supports both ``constant`` and ``isothermal_ideal_gas`` density models. Constant density assumes a constant density value. Isothermal ideal gas density assumes that the fluid's density varies according the following state equation:
 
 .. math::
   \rho = \rho_{ref} + \psi p = \rho_{ref} + \frac{1}{R T} \ p

--- a/include/core/dimensionality.h
+++ b/include/core/dimensionality.h
@@ -95,7 +95,6 @@ namespace Parameters
      * everywhere.
      */
     double density_scaling;
-    double pressure_scaling;
     double specific_gas_constant_scaling;
     double viscosity_scaling;
     double specific_heat_scaling;

--- a/include/core/dimensionality.h
+++ b/include/core/dimensionality.h
@@ -95,6 +95,8 @@ namespace Parameters
      * everywhere.
      */
     double density_scaling;
+    double pressure_scaling;
+    double specific_gas_constant_scaling;
     double viscosity_scaling;
     double specific_heat_scaling;
     double thermal_conductivity_scaling;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -229,7 +229,7 @@ namespace Parameters
     // Flow behavior index"
     double n;
     // Minimal shear rate magnitude for which we calculate viscosity, since
-    // power-law does not allow for minimal visocsity
+    // power-law does not allow for minimal viscosity
     double shear_rate_min;
 
     static void
@@ -266,7 +266,6 @@ namespace Parameters
    * non newtonian flows according to the chosen
    * rheological model.
    */
-
   struct NonNewtonian
   {
     CarreauParameters  carreau_parameters;
@@ -278,6 +277,25 @@ namespace Parameters
     parse_parameters(ParameterHandler &prm, const Dimensionality dimensions);
   };
 
+
+  /**
+   * @brief Isothermal ideal gas model to solve for isothermal weakly compressible fluid
+   * flows.
+   */
+  struct IsothermalIdealGasDensityParameters
+  {
+    // Reference state density of the gas in Pa
+    double density_ref;
+    // Specific gas constant in J/kg/K
+    double R;
+    // Absolute temperature of the ideal gas in K
+    double T;
+
+    static void
+    declare_parameters(ParameterHandler &prm);
+    void
+    parse_parameters(ParameterHandler &prm, const Dimensionality dimensions);
+  };
 
 
   /**
@@ -329,8 +347,10 @@ namespace Parameters
 
     enum class DensityModel
     {
-      constant
+      constant,
+      isothermal_ideal_gas
     } density_model;
+    IsothermalIdealGasDensityParameters isothermal_ideal_gas_density_parameters;
 
     enum class SpecificHeatModel
     {
@@ -351,7 +371,7 @@ namespace Parameters
       phase_change
     } thermal_expansion_model;
 
-    // Linear thermal conductivity parameters : k = k_A0 + k_A1 * T
+    // Linear thermal conductivity parameters: k = k_A0 + k_A1 * T
     double k_A0;
     double k_A1;
   };
@@ -363,7 +383,7 @@ namespace Parameters
    * All continuum equations share the same physical properties object but only
    * take the subset of properties they require
    * Defined as a class with public attributes in order to use a non-static
-   * declare_paremeters methods (useful for multiple fluid simulations).
+   * declare_parameters methods (useful for multiple fluid simulations).
    */
   class PhysicalProperties
   {
@@ -622,7 +642,7 @@ namespace Parameters
     // Frequency of the output
     unsigned int output_frequency;
 
-    // Prefix for kinectic energy output
+    // Prefix for kinetic energy output
     std::string kinetic_energy_output_name;
 
     // Prefix for pressure drop output

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -33,7 +33,8 @@ enum field : int
 {
   shear_rate,
   temperature,
-  previous_temperature
+  previous_temperature,
+  pressure
 };
 
 inline void
@@ -71,6 +72,7 @@ public:
     model_depends_on[shear_rate]           = false;
     model_depends_on[temperature]          = false;
     model_depends_on[previous_temperature] = false;
+    model_depends_on[pressure]             = false;
   }
 
   /**

--- a/include/core/thermal_conductivity_model.h
+++ b/include/core/thermal_conductivity_model.h
@@ -77,7 +77,7 @@ public:
   }
 
   /**
-   * @brief jacobian Calcualtes the jacobian (the partial derivative) of the thermal conductivity with respect to a field
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the thermal conductivity with respect to a field
    * @param field_values Value of the various fields on which the property may depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated
@@ -154,7 +154,7 @@ public:
   }
 
   /**
-   * @brief jacobian Calcualtes the jacobian (the partial derivative) of the thermal conductivity with respect to a field
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the thermal conductivity with respect to a field
    * @param field_values Value of the various fields on which the property may depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated
@@ -268,7 +268,7 @@ public:
   };
 
   /**
-   * @brief jacobian Calcualtes the jacobian (the partial derivative) of the thermal conductivity with respect to a field
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the thermal conductivity with respect to a field
    * @param field_values Value of the various fields on which the property may depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated

--- a/include/solvers/postprocessors.h
+++ b/include/solvers/postprocessors.h
@@ -408,4 +408,37 @@ private:
   std::shared_ptr<Shape<dim>> shape;
 };
 
+
+/**
+ * @class Calculates the density on post-processing points this is used when the
+ * density isn<t considered constant
+ */
+template <int dim>
+class DensityPostprocessor : public DataPostprocessorScalar<dim>
+{
+public:
+  DensityPostprocessor(std::shared_ptr<DensityModel> p_density_model)
+    : DataPostprocessorScalar<dim>("density", update_values)
+    , density_model(p_density_model)
+  {}
+  virtual void
+  evaluate_vector_field(
+    const DataPostprocessorInputs::Vector<dim> &inputs,
+    std::vector<Vector<double>> &computed_quantities) const override
+  {
+    const unsigned int      n_quadrature_points = inputs.solution_values.size();
+    std::map<field, double> field_values;
+
+    for (unsigned int q = 0; q < n_quadrature_points; ++q)
+      {
+        AssertDimension(computed_quantities[q].size(), 1);
+
+        field_values[field::pressure] = inputs.solution_values[q][dim];
+        computed_quantities[q]        = density_model->value(field_values);
+      }
+  }
+
+private:
+  std::shared_ptr<DensityModel> density_model;
+};
 #endif

--- a/source/core/density_model.cc
+++ b/source/core/density_model.cc
@@ -19,5 +19,16 @@
 std::shared_ptr<DensityModel>
 DensityModel::model_cast(const Parameters::Material &material_properties)
 {
-  return std::make_shared<DensityConstant>(material_properties.density);
+  if (material_properties.density_model ==
+      Parameters::Material::DensityModel::isothermal_ideal_gas)
+    {
+      return std::make_shared<DensityIsothermalIdealGas>(
+        material_properties.isothermal_ideal_gas_density_parameters.density_ref,
+        material_properties.isothermal_ideal_gas_density_parameters.R,
+        material_properties.isothermal_ideal_gas_density_parameters.T);
+    }
+  else
+    {
+      return std::make_shared<DensityConstant>(material_properties.density);
+    }
 }

--- a/source/core/dimensionality.cc
+++ b/source/core/dimensionality.cc
@@ -13,13 +13,14 @@ namespace Parameters
     const double theta = temperature;
     const double T     = time;
 
-    density_scaling              = 1. * L * L * L / M;
-    viscosity_scaling            = 1. / L / L * T;
-    specific_heat_scaling        = 1. / L / L * T * T * theta;
-    thermal_conductivity_scaling = 1. / M / L * T * T * T * theta;
-    enthalpy_scaling             = 1. / M / L / L * T * T;
-    diffusivity_scaling          = 1. / L / L * T;
-    thermal_expansion_scaling    = T;
+    density_scaling               = 1. * L * L * L / M;
+    specific_gas_constant_scaling = 1. / L / L * T * T * theta;
+    viscosity_scaling             = 1. / L / L * T;
+    specific_heat_scaling         = 1. / L / L * T * T * theta;
+    thermal_conductivity_scaling  = 1. / M / L * T * T * T * theta;
+    enthalpy_scaling              = 1. / M / L / L * T * T;
+    diffusivity_scaling           = 1. / L / L * T;
+    thermal_expansion_scaling     = T;
   }
 
   void

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1896,6 +1896,14 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
   VorticityPostprocessor<dim>  vorticity;
   data_out.add_data_vector(solution, vorticity);
 
+  DensityPostprocessor<dim> density_postprocessed(
+    this->simulation_parameters.physical_properties_manager.get_density());
+  if (!this->simulation_parameters.physical_properties_manager
+         .density_is_constant()) // Only output when density is not constant
+    {
+      data_out.add_data_vector(solution, density_postprocessed);
+    }
+
   // Trilinos vector for the smoothed output fields
   QcriterionPostProcessorSmoothing<dim, VectorType> qcriterion_smoothing(
     *this->triangulation,

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -74,6 +74,8 @@ NavierStokesScratchData<dim>::allocate()
 
   // Physical properties
   fields.insert(
+    std::pair<field, std::vector<double>>(field::pressure, n_q_points));
+  fields.insert(
     std::pair<field, std::vector<double>>(field::shear_rate, n_q_points));
 
   density                   = std::vector<double>(n_q_points);
@@ -258,6 +260,11 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
       set_field_vector(field::temperature,
                        this->temperature_values,
                        this->fields);
+    }
+
+  if (properties_manager.field_is_required(field::pressure))
+    {
+      set_field_vector(field::pressure, this->pressure_values, this->fields);
     }
 
   if (properties_manager.field_is_required(field::shear_rate))

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -46,6 +46,7 @@ PhysicalPropertiesManager::initialize(
   required_fields[field::temperature]          = false;
   required_fields[field::previous_temperature] = false;
   required_fields[field::shear_rate]           = false;
+  required_fields[field::pressure]             = false;
 
   // For each fluid, declare the physical properties
   for (unsigned int f = 0; f < number_of_fluids; ++f)

--- a/tests/core/carreau_rheology.cc
+++ b/tests/core/carreau_rheology.cc
@@ -16,8 +16,7 @@ test()
   Carreau rheology_model(5, 0, 1, 2, 0.5);
 
 
-  // field values can remain empty since the constant thermal conductivity does
-  // not depend  on any fields
+  // Field values must contain shear rate
   std::map<field, double> field_values;
 
   deallog << "Testing Carreau viscosity - nu" << std::endl;

--- a/tests/core/density_isothermal_ideal_gas.cc
+++ b/tests/core/density_isothermal_ideal_gas.cc
@@ -1,5 +1,5 @@
 /**
- * @brief Tests the isothermal ideal gas density model. This model should always return a constant.
+ * @brief Tests the isothermal ideal gas density model. This model should always return rho_ref + 1/(RT)*p
  */
 
 // Lethe

--- a/tests/core/density_isothermal_ideal_gas.cc
+++ b/tests/core/density_isothermal_ideal_gas.cc
@@ -1,0 +1,66 @@
+/**
+ * @brief Tests the isothermal ideal gas density model. This model should always return a constant.
+ */
+
+// Lethe
+#include <core/density_model.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beginning" << std::endl;
+
+  DensityIsothermalIdealGas density_model(1.2, 287.05, 293.15);
+
+  // Field values must contain pressure
+  std::map<field, double> field_values;
+
+  deallog << "Testing isothermal ideal gas density - rho" << std::endl;
+  field_values[field::pressure] = 0;
+  deallog << " p = 0    , density = " << density_model.value(field_values)
+          << std::endl;
+
+  field_values[field::pressure] = 1000;
+  deallog << " p = 1000 , density = " << density_model.value(field_values)
+          << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/density_isothermal_ideal_gas.output
+++ b/tests/core/density_isothermal_ideal_gas.output
@@ -1,0 +1,6 @@
+
+DEAL::Beginning
+DEAL::Testing isothermal ideal gas density - rho
+DEAL:: p = 0    , density = 1.2
+DEAL:: p = 1000 , density = 1.21188
+DEAL::OK

--- a/tests/core/newtonian_rheology.cc
+++ b/tests/core/newtonian_rheology.cc
@@ -17,8 +17,7 @@ test()
 
   deallog << "Testing constant viscosity - nu" << std::endl;
 
-  // field values can remain empty since the constant thermal conductivity does
-  // not depend  on any fields
+  // Field values must contain shear rate
   std::map<field, double> field_values;
 
   field_values[field::shear_rate] = 1;

--- a/tests/core/power_law_rheology.cc
+++ b/tests/core/power_law_rheology.cc
@@ -16,8 +16,7 @@ test()
   PowerLaw rheology_model(5, 0.5, 1e-3);
 
 
-  // field values can remain empty since the constant thermal conductivity does
-  // not depend  on any fields
+  // Field values must contain shear rate
   std::map<field, double> field_values;
 
   deallog << "Testing power law viscosity - nu" << std::endl;


### PR DESCRIPTION
# Description of the problem

- When experimenting with the dam break with an obstacle example, it was noticed that the software performed poorly in mimicking the wave's natural shape after the impact. It was assumed that this is due to the lack of considering the air's natural compressibility.

# Description of the solution

- In an attempt to solve this issue, an isothermal compressible fluid dynamics model will be implemented. As a first step, an isothermal ideal gas density model is implemented.

# How Has This Been Tested?

- A unit test for the isothermal ideal gas density model was added.

- [x] tests/core/density_isothermal_ideal_gas.cc

# Documentation

- The physical properties page in the documentation was updated by adding the isothermal ideal gas density model.

- [x] doc/source/parameters/cfd/physical_properties.rst

# Future changes

- Currently, the isothermal ideal gas model can only be used in conjunction with the incompressible Navier-Stokes equations. However, it is meant to be used with the isothermal formulation of compressible Navier-Stokes equations to account for weakly compressible fluid flows. In a future PR, an isothermal compressible formulation of the equations will be implemented.

# Comments

- A DataPostprocessor object was implemented for density, and the density field is only outputted when it is not constant.
- Other minor corrections were made to unrelated files (mainly typos in the comments).
