### PR TITLE
Fix issue when particles cross PBC

### DIFF
--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -1133,6 +1133,11 @@ DEMSolver<dim>::solve()
       if (particles_insertion_step || load_balance_step ||
           contact_detection_step || checkpoint_step)
         {
+          // Particles displacement if passing through a periodic boundary
+          periodic_boundaries_object.execute_particles_displacement(
+            particle_handler,
+            container_manager.periodic_boundaries_cells_information);
+
           particle_handler.sort_particles_into_subdomains_and_cells();
 
           if (has_disabled_contacts && !simulation_control->is_at_start())
@@ -1309,11 +1314,6 @@ DEMSolver<dim>::solve()
                 disable_contacts_object.get_mobility_status());
             }
         }
-
-      // Particles displacement if passing through a periodic boundary
-      periodic_boundaries_object.execute_particles_displacement(
-        particle_handler,
-        container_manager.periodic_boundaries_cells_information);
 
       // Visualization
       if (simulation_control->is_output_iteration())

--- a/source/dem/find_contact_detection_step.cc
+++ b/source/dem/find_contact_detection_step.cc
@@ -16,8 +16,8 @@ find_particle_contact_detection_step(
     for (auto &d : displacement)
       d = 0.;
 
-  double       max_displacement       = 0;
-  unsigned int contact_detection_step = 0;
+  double max_displacement       = 0.;
+  bool   contact_detection_step = false;
 
   // Updating displacement
   for (auto &particle : particle_handler)
@@ -38,18 +38,16 @@ find_particle_contact_detection_step(
       max_displacement = std::max(max_displacement, particle_displacement);
     }
 
+  // If the maximum displacement of particles exceeds criterion, this step
+  // is a contact detection step
   if (max_displacement > smallest_contact_search_criterion)
     {
-      // If the maximum displacement of particles exceeds criterion, the
-      // function returns true and the displcament of all particles are reset to
-      // zero
-
-      contact_detection_step = 1;
+      contact_detection_step = true;
     }
 
-  // Broadcasting updating_step value to other processors
+  // Broadcasting contact detection step value to other processors
   contact_detection_step =
-    Utilities::MPI::max(contact_detection_step, mpi_communicator);
+    Utilities::MPI::logical_or(contact_detection_step, mpi_communicator);
 
   return contact_detection_step;
 }


### PR DESCRIPTION
# Description of the problem

- When particles cross PBC, their location is updated but not the cell in which they are. No issues was encountered in the pass, bugs seem to happen when diameter is very small.

# Description of the solution

- Move the execution of the particle displacement at the same step as the sorting of particles in cells. This means the particles won't have their location updated as soon as the position > the location of the periodic wall. The particle displacement is already executed as is for CFD-DEM.

# How Has This Been Tested?

- Tested with hopper case and tests are good

