### PR TITLE
Augment the maximum number of solid object to 10

### DIFF
--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -375,7 +375,7 @@ namespace Parameters
     // DEM solid objects
     std::vector<std::shared_ptr<RigidSolidObject<dim>>> solids;
     unsigned int                                        number_solids;
-    static const unsigned int max_number_of_solids = 5;
+    static const unsigned int max_number_of_solids = 10;
   };
 
   template <int dim>


### PR DESCRIPTION
# Description of the problem

- The number of solid object was limited to 5 which is a bit low for lpbf powder spreading simulation with multiple spreads (

# Description of the solution

- Augment to 10!
