### PR TITLE
Fix Pcout initialization and constant modes

### DIFF
--- a/include/core/physics_solver.h
+++ b/include/core/physics_solver.h
@@ -127,7 +127,7 @@ private:
 template <typename VectorType>
 PhysicsSolver<VectorType>::PhysicsSolver(
   const Parameters::NonLinearSolver non_linear_solver_parameters)
-  : pcout({std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0})
+  : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
 {
   switch (non_linear_solver_parameters.solver)
     {

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -51,7 +51,7 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
   : mpi_communicator(MPI_COMM_WORLD)
   , n_mpi_processes(Utilities::MPI::n_mpi_processes(mpi_communicator))
   , this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator))
-  , pcout({std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0})
+  , pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   , parameters(dem_parameters)
   , triangulation(this->mpi_communicator)
   , mapping(1)
@@ -264,7 +264,7 @@ DEMSolver<dim>::cell_weight(
   switch (status)
     {
       case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
-        // If CELL_PERSIST, do as CELL_REFINE
+      // If CELL_PERSIST, do as CELL_REFINE
       case parallel::distributed::Triangulation<dim>::CELL_REFINE:
         {
           const unsigned int n_particles_in_cell =
@@ -331,7 +331,7 @@ DEMSolver<dim>::cell_weight_with_mobility_status(
   switch (status)
     {
       case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
-        // If CELL_PERSIST, do as CELL_REFINE
+      // If CELL_PERSIST, do as CELL_REFINE
       case parallel::distributed::Triangulation<dim>::CELL_REFINE:
         {
           const unsigned int n_particles_in_cell =

--- a/source/dem/list_insertion.cc
+++ b/source/dem/list_insertion.cc
@@ -114,8 +114,8 @@ ListInsertion<dim>::insert(
       remaining_particles_of_each_type -= n_total_particles_to_insert;
 
 
-      ConditionalOStream pcout = {
-        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0};
+      ConditionalOStream pcout(
+        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
       this->print_insertion_info(n_total_particles_to_insert,
                                  remaining_particles_of_each_type,
                                  current_inserting_particle_type,

--- a/source/dem/non_uniform_insertion.cc
+++ b/source/dem/non_uniform_insertion.cc
@@ -44,8 +44,8 @@ NonUniformInsertion<dim>::insert(
   if (remained_particles_of_each_type != 0)
     {
       MPI_Comm           communicator = triangulation.get_communicator();
-      ConditionalOStream pcout        = {
-        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0};
+      ConditionalOStream pcout(
+        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
 
       auto this_mpi_process = Utilities::MPI::this_mpi_process(communicator);
       auto n_mpi_process    = Utilities::MPI::n_mpi_processes(communicator);

--- a/source/dem/uniform_insertion.cc
+++ b/source/dem/uniform_insertion.cc
@@ -44,8 +44,8 @@ UniformInsertion<dim>::insert(
   if (remained_particles_of_each_type != 0)
     {
       MPI_Comm           communicator = triangulation.get_communicator();
-      ConditionalOStream pcout        = {
-        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0};
+      ConditionalOStream pcout(
+        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
 
       auto this_mpi_process = Utilities::MPI::this_mpi_process(communicator);
       auto n_mpi_process    = Utilities::MPI::n_mpi_processes(communicator);

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -33,6 +33,8 @@
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/component_mask.h>
+
 #include <deal.II/grid/grid_tools.h>
 
 #include <deal.II/lac/full_matrix.h>
@@ -908,16 +910,21 @@ GDNavierStokesSolver<dim>::setup_AMG()
 
   // Constant modes for velocity
   std::vector<std::vector<bool>> velocity_constant_modes;
-  std::vector<bool>              velocity_components(dim + 1, true);
-  velocity_components[dim] = false;
+  FEValuesExtractors::Vector     velocities(0);
+
+  ComponentMask velocity_components = this->fe->component_mask(velocities);
+  // std::vector<bool> velocity_components(dim + 1, true);
+  // velocity_components[dim] = false;
   DoFTools::extract_constant_modes(this->dof_handler,
                                    velocity_components,
                                    velocity_constant_modes);
 
   // Constant modes for pressure
   std::vector<std::vector<bool>> pressure_constant_modes;
-  std::vector<bool>              pressure_components(dim + 1, false);
-  pressure_components[dim] = true;
+  FEValuesExtractors::Scalar     pressure(dim);
+  ComponentMask pressure_components = this->fe->component_mask(pressure);
+  // std::vector<bool> pressure_components(dim + 1, false);
+  // pressure_components[dim] = true;
   DoFTools::extract_constant_modes(this->dof_handler,
                                    pressure_components,
                                    pressure_constant_modes);

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1212,12 +1212,13 @@ GLSNavierStokesSolver<dim>::setup_AMG()
 {
   TimerOutput::Scope t(this->computing_timer, "setup_AMG");
 
+  // Constant modes for velocity
   std::vector<std::vector<bool>> constant_modes;
+
   // Constant modes include pressure since everything is in the same matrix
-  std::vector<bool> velocity_components(dim + 1, true);
-  velocity_components[dim] = true;
+  ComponentMask components(dim + 1, true);
   DoFTools::extract_constant_modes(this->dof_handler,
-                                   velocity_components,
+                                   components,
                                    constant_modes);
 
   TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;

--- a/tests/dem/boundary_cells_and_faces.cc
+++ b/tests/dem/boundary_cells_and_faces.cc
@@ -55,10 +55,12 @@ test()
 
   // Fining boundary cellds information
   BoundaryCellsInformation<dim> boundary_cells_object;
-  boundary_cells_object.build(triangulation,
-                              outlet_boundaries,
-                              false,
-                              std::cout);
+  boundary_cells_object.build(
+    triangulation,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // Reporting the information of boundary cells
   for (auto boundary_cells_information_iterator =

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -146,7 +146,12 @@ test()
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
 
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // P-W broad search
   ParticleWallBroadSearch<dim> particle_wall_broad_search_object;

--- a/tests/dem/particle_point_contact.cc
+++ b/tests/dem/particle_point_contact.cc
@@ -118,7 +118,12 @@ test()
   // Construct boundary cells object and build it
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // Particle-point broad search
   std::unordered_map<unsigned int,
@@ -139,16 +144,7 @@ test()
   std::vector<double>       MOI;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
   for (unsigned i = 0; i < MOI.size(); ++i)

--- a/tests/dem/particle_wall_contact_force_linear.cc
+++ b/tests/dem/particle_wall_contact_force_linear.cc
@@ -135,16 +135,7 @@ test()
   std::vector<double>       MOI;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
   for (unsigned i = 0; i < MOI.size(); ++i)
@@ -153,7 +144,12 @@ test()
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // Calling broad search
   ParticleWallBroadSearch<dim> broad_search_object;

--- a/tests/dem/particle_wall_contact_force_nonlinear.cc
+++ b/tests/dem/particle_wall_contact_force_nonlinear.cc
@@ -145,7 +145,12 @@ test()
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // Calling broad search
   ParticleWallBroadSearch<dim> broad_search_object;

--- a/tests/dem/particle_wall_contact_pairs.cc
+++ b/tests/dem/particle_wall_contact_pairs.cc
@@ -95,7 +95,12 @@ test()
   // boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // Calling particle-wall broad search
   ParticleWallBroadSearch<dim> broad_search_object;

--- a/tests/dem/particle_wall_fine_search.cc
+++ b/tests/dem/particle_wall_fine_search.cc
@@ -90,7 +90,12 @@ test()
   // boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // Calling particle-wall broad search
   ParticleWallBroadSearch<dim> broad_search_object;

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -149,7 +149,12 @@ test(double coefficient_of_restitution)
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
   std::vector<unsigned int>     outlet_boundaries;
-  boundary_cells_object.build(tr, outlet_boundaries, false, std::cout);
+  boundary_cells_object.build(
+    tr,
+    outlet_boundaries,
+    false,
+    ConditionalOStream(std::cout,
+                       Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
   // P-W broad search
   ParticleWallBroadSearch<dim> particle_wall_broad_search_object;

--- a/tests/solvers/multiphysics_interface_01.cc
+++ b/tests/solvers/multiphysics_interface_01.cc
@@ -65,8 +65,9 @@ test()
     std::make_shared<SimulationControlTransient>(
       solver_parameters.simulation_control);
 
-  ConditionalOStream pcout(
-    {std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0});
+  ConditionalOStream pcout(std::cout,
+                           Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) ==
+                             0);
 
   {
     MultiphysicsInterface<dim> multiphysics(solver_parameters,


### PR DESCRIPTION
# Description of the problem

- Lethe currently does not compile with deal.II master because of some syntax changes related to PCout and constant mode extraction

# Description of the solution

- Adapt syntax to deal.II master. Remove some deprecated lines at the same time.