### PR TITLE
Initial position and rotation for solid object

### DIFF
--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -21,7 +21,7 @@ This subsection explains the solid objects (floating meshes) information. First 
             set file name              = none
             set simplex                = true
             set initial refinement     = 0
-            set initial rotation axis  = 0, 0, 0
+            set initial rotation axis  = 1, 0, 0
             set initial rotation angle = 0
             set initial translation    = 0, 0, 0
 
@@ -48,7 +48,7 @@ This subsection explains the solid objects (floating meshes) information. First 
 
 * The ``number of solids`` parameter defines the total number of floating meshes we wish to use during the simulation.
 
-* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``, ``initial rotation axis``, ``initial rotation angle``  ) is defined. Each component of the ``initial translation`` and of the ``initial rotation axis`` parameters represent the ``x``, ``y`` and ``z`` directions respectively. The rotation is apply before the translation.
+* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``, ``initial rotation axis``, ``initial rotation angle``  ) is defined. Each component of the ``initial translation`` and of the ``initial rotation axis`` parameters represent the ``x``, ``y`` and ``z`` axis. The rotation is apply before the translation.
 
 * In the subsection ``translational velocity``, we define the translational velocity of the floating mesh.
 

--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -21,6 +21,7 @@ This subsection explains the solid objects (floating meshes) information. First 
             set file name           = none
             set simplex             = true
             set initial refinement  = 0
+            set initial translation = 0, 0, 0
         end
     
         subsection translational velocity
@@ -44,7 +45,7 @@ This subsection explains the solid objects (floating meshes) information. First 
 
 * The ``number of solids`` parameter defines the total number of floating meshes we wish to use during the simulation.
 
-* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``) is defined.
+* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``,) is defined. Each component of the ``initial translation`` parameter represent the ``x``, ``y`` and ``z`` directions respectively.
 
 * In the subsection ``translational velocity``, we define the translational velocity of the floating mesh.
 

--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -21,9 +21,9 @@ This subsection explains the solid objects (floating meshes) information. First 
             set file name              = none
             set simplex                = true
             set initial refinement     = 0
-            set initial translation    = 0, 0, 0
             set initial rotation axis  = 0, 0, 0
             set initial rotation angle = 0
+            set initial translation    = 0, 0, 0
 
         end
     
@@ -48,7 +48,7 @@ This subsection explains the solid objects (floating meshes) information. First 
 
 * The ``number of solids`` parameter defines the total number of floating meshes we wish to use during the simulation.
 
-* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``, ``initial rotation axis``, ``initial rotation angle``  ) is defined. Each component of the ``initial translation`` and of the ``initial rotation axis`` parameters represent the ``x``, ``y`` and ``z`` directions respectively.
+* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``, ``initial rotation axis``, ``initial rotation angle``  ) is defined. Each component of the ``initial translation`` and of the ``initial rotation axis`` parameters represent the ``x``, ``y`` and ``z`` directions respectively. The rotation is apply before the translation.
 
 * In the subsection ``translational velocity``, we define the translational velocity of the floating mesh.
 

--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -17,11 +17,14 @@ This subsection explains the solid objects (floating meshes) information. First 
     set number of solids  = 1
       subsection  solid object 0
         subsection mesh
-            set type                = gmsh
-            set file name           = none
-            set simplex             = true
-            set initial refinement  = 0
-            set initial translation = 0, 0, 0
+            set type                   = gmsh
+            set file name              = none
+            set simplex                = true
+            set initial refinement     = 0
+            set initial translation    = 0, 0, 0
+            set initial rotation axis  = 0, 0, 0
+            set initial rotation angle = 0
+
         end
     
         subsection translational velocity
@@ -45,7 +48,7 @@ This subsection explains the solid objects (floating meshes) information. First 
 
 * The ``number of solids`` parameter defines the total number of floating meshes we wish to use during the simulation.
 
-* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``,) is defined. Each component of the ``initial translation`` parameter represent the ``x``, ``y`` and ``z`` directions respectively.
+* For each floating mesh, we need a separate subsection (for instance 	``subsection solid object 0``) in which the information of the floating mesh (``type``, ``file name``, ``initial refinement``, ``initial translation``, ``initial rotation axis``, ``initial rotation angle``  ) is defined. Each component of the ``initial translation`` and of the ``initial rotation axis`` parameters represent the ``x``, ``y`` and ``z`` directions respectively.
 
 * In the subsection ``translational velocity``, we define the translational velocity of the floating mesh.
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -923,11 +923,11 @@ namespace Parameters
     bool expand_particle_wall_contact_search;
 
     // Grid displacement at initiation
-    std::vector<double> translate;
+    std::vector<double> translation;
 
     // Grid rotation at initiation
-    Tensor<1, 3> axis;
-    double       angle;
+    Tensor<1, 3> rotation_axis;
+    double       rotation_angle;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -926,8 +926,8 @@ namespace Parameters
     std::vector<double> translate;
 
     // Grid rotation at initiation
-    Tensor<1,3>  axis;
-    double angle;
+    Tensor<1, 3> axis;
+    double       angle;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -926,8 +926,7 @@ namespace Parameters
     std::vector<double> translate;
 
     // Grid rotation at initiation
-    bool   rotate;
-    int    axis;
+    Tensor<1,3>  axis;
     double angle;
 
     static void

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -923,10 +923,7 @@ namespace Parameters
     bool expand_particle_wall_contact_search;
 
     // Grid displacement at initiation
-    bool   translate;
-    double delta_x;
-    double delta_y;
-    double delta_z;
+    std::vector<double> translate;
 
     // Grid rotation at initiation
     bool   rotate;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -923,7 +923,7 @@ namespace Parameters
     bool expand_particle_wall_contact_search;
 
     // Grid displacement at initiation
-    std::vector<double> translation;
+    Tensor<1, 3> translation;
 
     // Grid rotation at initiation
     Tensor<1, 3> rotation_axis;

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -251,7 +251,7 @@ private:
    *
    */
   void
-  rotate_grid(const double angle, Tensor<1, 3> axis);
+  rotate_grid(const double angle, const Tensor<1, 3> axis);
 
   // Member variables
 

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -251,7 +251,7 @@ private:
    *
    */
   void
-  rotate_grid(const double angle, const int axis);
+  rotate_grid(const double angle, Tensor<1,3> axis);
 
   // Member variables
 

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -251,7 +251,7 @@ private:
    *
    */
   void
-  rotate_grid(const double angle, Tensor<1,3> axis);
+  rotate_grid(const double angle, Tensor<1, 3> axis);
 
   // Member variables
 

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -247,11 +247,19 @@ private:
    *
    * @param angle The angle (in rad) with which the solid is rotated
    *
-   * @param axis The axis over which the solid is rotated. Currently, only (x=0, y=1, z=2) are supported
+   * @param axis The axis over which the solid is rotated.
    *
    */
   void
   rotate_grid(const double angle, const Tensor<1, 3> axis);
+
+  /**
+   * @brief Translate the grid. In spacedim=2, the third component is ignore
+   *
+   * @param translate The vector with which the solid is translated.
+   */
+  void
+  translate_grid(const Tensor<1, 3> translate);
 
   // Member variables
 

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -195,7 +195,7 @@ public:
   print_particle_positions();
 
   void
-  rotate_grid(double angle, Tensor<1, 3> axis);
+  rotate_grid(const double angle, const Tensor<1, 3> axis);
 
   /**
    * @brief Updates the time in the function used to describe the solid temperature

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -194,8 +194,24 @@ public:
   void
   print_particle_positions();
 
+  /**
+   * @brief Rotates the grid by a given angle around an axis
+   *
+   * @param angle The angle (in rad) with which the grid is rotated
+   *
+   * @param axis The axis over which the grid is rotated.
+   *
+   */
   void
   rotate_grid(const double angle, const Tensor<1, 3> axis);
+
+  /**
+   * @brief Translate the grid. In spacedim=2, the third component is ignore
+   *
+   * @param translate The vector with which the solid is translated.
+   */
+  void
+  translate_grid(const Tensor<1, 3> translate);
 
   /**
    * @brief Updates the time in the function used to describe the solid temperature

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -195,7 +195,7 @@ public:
   print_particle_positions();
 
   void
-  rotate_grid(double angle, int axis);
+  rotate_grid(double angle, Tensor<1,3> axis);
 
   /**
    * @brief Updates the time in the function used to describe the solid temperature

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -195,7 +195,7 @@ public:
   print_particle_positions();
 
   void
-  rotate_grid(double angle, Tensor<1,3> axis);
+  rotate_grid(double angle, Tensor<1, 3> axis);
 
   /**
    * @brief Updates the time in the function used to describe the solid temperature

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -267,10 +267,6 @@ attach_grid_to_triangulation(
     throw std::runtime_error(
       "Unsupported mesh type - mesh will not be created");
 
-  // Rotate the mesh
-  if (mesh_parameters.rotate)
-    throw std::runtime_error(
-      "Main grid cannot be rotated: the solid mesh must be rotated instead. The grid will not be rotated.");
 }
 
 

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -266,7 +266,6 @@ attach_grid_to_triangulation(
   else
     throw std::runtime_error(
       "Unsupported mesh type - mesh will not be created");
-
 }
 
 

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -267,10 +267,6 @@ attach_grid_to_triangulation(
     throw std::runtime_error(
       "Unsupported mesh type - mesh will not be created");
 
-  // Translate the mesh
-  if (mesh_parameters.translate)
-    throw std::runtime_error(
-      "Main grid can't be moved: the solid mesh must be moved instead. Grid will not be moved.");
   // Rotate the mesh
   if (mesh_parameters.rotate)
     throw std::runtime_error(

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1640,16 +1640,20 @@ namespace Parameters
       std::string              translation_str = prm.get("initial translation");
       std::vector<std::string> translate_str_list =
         Utilities::split_string_list(translation_str);
-      translate = Utilities::string_to_double(translate_str_list);
+      translation = Utilities::string_to_double(translate_str_list);
 
       // Initial rotation
+      // Create a string from the input file, split the string into smaller
+      // strings and store them in a vector, transform the strings into doubles
+      // and stores those in a tensor
       std::string              axis_str = prm.get("initial rotation axis");
       std::vector<std::string> axis_str_list =
         Utilities::split_string_list(axis_str);
-      axis  = Tensor<1, 3>({Utilities::string_to_double(axis_str_list[0]),
-                           Utilities::string_to_double(axis_str_list[1]),
-                           Utilities::string_to_double(axis_str_list[2])});
-      angle = prm.get_double("initial rotation angle");
+      rotation_axis =
+        Tensor<1, 3>({Utilities::string_to_double(axis_str_list[0]),
+                      Utilities::string_to_double(axis_str_list[1]),
+                      Utilities::string_to_double(axis_str_list[2])});
+      rotation_angle = prm.get_double("initial rotation angle");
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1640,7 +1640,10 @@ namespace Parameters
       std::string              translation_str = prm.get("initial translation");
       std::vector<std::string> translate_str_list =
         Utilities::split_string_list(translation_str);
-      translation = Utilities::string_to_double(translate_str_list);
+      translation =
+        Tensor<1, 3>({Utilities::string_to_double(translate_str_list[0]),
+                      Utilities::string_to_double(translate_str_list[1]),
+                      Utilities::string_to_double(translate_str_list[2])});
 
       // Initial rotation
       // Create a string from the input file, split the string into smaller

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1643,9 +1643,9 @@ namespace Parameters
       std::string              axis_str = prm.get("initial rotation axis");
       std::vector<std::string> axis_str_list =
         Utilities::split_string_list(axis_str);
-      axis  = (Utilities::string_to_double(axis_str_list)[0],
-               Utilities::string_to_double(axis_str_list)[1],
-               Utilities::string_to_double(axis_str_list)[2]);
+      axis  = Tensor<1,3>({Utilities::string_to_double(axis_str_list[0]),
+               Utilities::string_to_double(axis_str_list[1]),
+               Utilities::string_to_double(axis_str_list[2])});
       angle = prm.get_double("initial rotation angle");
     }
     prm.leave_subsection();

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1513,7 +1513,6 @@ namespace Parameters
     }
     prm.leave_subsection();
   }
-
   void
   Mesh::declare_parameters(ParameterHandler &prm)
   {
@@ -1582,6 +1581,10 @@ namespace Parameters
       prm.declare_entry("grid type", "hyper_cube");
       prm.declare_entry("grid arguments", "-1 : 1 : false");
 
+      prm.declare_entry("initial translation",
+                        "0, 0, 0",
+                        Patterns::List(Patterns::Double()),
+                        "Component of the desired translation of the mesh");
 
       prm.declare_entry(
         "translate",
@@ -1661,11 +1664,10 @@ namespace Parameters
         prm.get_bool("expand particle-wall contact search");
       target_size = prm.get_double("target size");
 
-
-      translate = prm.get_bool("translate");
-      delta_x   = prm.get_double("delta_x");
-      delta_y   = prm.get_double("delta_y");
-      delta_z   = prm.get_double("delta_z");
+      std::string              translation_str = prm.get("initial translation");
+      std::vector<std::string> translate_str_list =
+        Utilities::split_string_list(translation_str);
+      translate = Utilities::string_to_double(translate_str_list);
 
       rotate = prm.get_bool("rotate");
       axis   = prm.get_integer("axis");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1584,48 +1584,17 @@ namespace Parameters
       prm.declare_entry("initial translation",
                         "0, 0, 0",
                         Patterns::List(Patterns::Double()),
-                        "Component of the desired translation of the mesh");
+                        "Component of the desired translation of the mesh at initialization");
 
-      prm.declare_entry(
-        "translate",
-        "false",
-        Patterns::Bool(),
-        "Indicates that the mesh should be translated. To be "
-        "used to reposition solid grids relative to the fluid grid.");
+      prm.declare_entry("initial rotation axis",
+                        "1, 0, 0",
+                        Patterns::List(Patterns::Double()),
+                        "Component of the desired rotation of the mesh at initialization");
 
-      prm.declare_entry("delta_x",
-                        "0 ",
+      prm.declare_entry("initial rotation angle",
+                        "0",
                         Patterns::Double(),
-                        "X component of the desired translation of the mesh");
-
-      prm.declare_entry("delta_y",
-                        "0 ",
-                        Patterns::Double(),
-                        "Y component of the desired translation of the mesh");
-
-      prm.declare_entry("delta_z",
-                        "0 ",
-                        Patterns::Double(),
-                        "Z component of the desired translation of the mesh");
-
-      // Grid rotation at initiation
-      prm.declare_entry(
-        "rotate",
-        "false",
-        Patterns::Bool(),
-        "Indicates that the mesh should be rotated. To be "
-        "used to reposition solid grids relative to the fluid grid.");
-
-      prm.declare_entry(
-        "axis",
-        "0",
-        Patterns::Integer(),
-        "Axis around which the rotation should occur (0 for x, 1 for y, 2 for z)");
-
-      prm.declare_entry("angle",
-                        "0 ",
-                        Patterns::Double(),
-                        "Angle of rotation around the axis in radian");
+                        "Angle of rotation of the mesh at initialization around the axis in radian");
     }
     prm.leave_subsection();
   }
@@ -1664,14 +1633,20 @@ namespace Parameters
         prm.get_bool("expand particle-wall contact search");
       target_size = prm.get_double("target size");
 
+      // Initial translation
       std::string              translation_str = prm.get("initial translation");
       std::vector<std::string> translate_str_list =
         Utilities::split_string_list(translation_str);
       translate = Utilities::string_to_double(translate_str_list);
 
-      rotate = prm.get_bool("rotate");
-      axis   = prm.get_integer("axis");
-      angle  = prm.get_double("angle");
+      // Initial rotation
+      std::string              axis_str = prm.get("initial rotation axis");
+      std::vector<std::string> axis_str_list =
+        Utilities::split_string_list(axis_str);
+      axis  = (Utilities::string_to_double(axis_str_list)[0],
+               Utilities::string_to_double(axis_str_list)[1],
+               Utilities::string_to_double(axis_str_list)[2]);
+      angle = prm.get_double("initial rotation angle");
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1581,20 +1581,23 @@ namespace Parameters
       prm.declare_entry("grid type", "hyper_cube");
       prm.declare_entry("grid arguments", "-1 : 1 : false");
 
-      prm.declare_entry("initial translation",
-                        "0, 0, 0",
-                        Patterns::List(Patterns::Double()),
-                        "Component of the desired translation of the mesh at initialization");
+      prm.declare_entry(
+        "initial translation",
+        "0, 0, 0",
+        Patterns::List(Patterns::Double()),
+        "Component of the desired translation of the mesh at initialization");
 
-      prm.declare_entry("initial rotation axis",
-                        "1, 0, 0",
-                        Patterns::List(Patterns::Double()),
-                        "Component of the desired rotation of the mesh at initialization");
+      prm.declare_entry(
+        "initial rotation axis",
+        "1, 0, 0",
+        Patterns::List(Patterns::Double()),
+        "Component of the desired rotation of the mesh at initialization");
 
-      prm.declare_entry("initial rotation angle",
-                        "0",
-                        Patterns::Double(),
-                        "Angle of rotation of the mesh at initialization around the axis in radian");
+      prm.declare_entry(
+        "initial rotation angle",
+        "0",
+        Patterns::Double(),
+        "Angle of rotation of the mesh at initialization around the axis in radian");
     }
     prm.leave_subsection();
   }
@@ -1643,9 +1646,9 @@ namespace Parameters
       std::string              axis_str = prm.get("initial rotation axis");
       std::vector<std::string> axis_str_list =
         Utilities::split_string_list(axis_str);
-      axis  = Tensor<1,3>({Utilities::string_to_double(axis_str_list[0]),
-               Utilities::string_to_double(axis_str_list[1]),
-               Utilities::string_to_double(axis_str_list[2])});
+      axis  = Tensor<1, 3>({Utilities::string_to_double(axis_str_list[0]),
+                           Utilities::string_to_double(axis_str_list[1]),
+                           Utilities::string_to_double(axis_str_list[2])});
       angle = prm.get_double("initial rotation angle");
     }
     prm.leave_subsection();

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -165,8 +165,7 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
 {
   if (param->solid_mesh.type == Parameters::Mesh::Type::gmsh)
     {
-      if (param->solid_mesh.simplex)
-        {
+
           // Grid creation
           GridIn<dim, spacedim> grid_in;
           // Attach triangulation
@@ -175,13 +174,7 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
           std::ifstream input_file(param->solid_mesh.file_name);
 
           grid_in.read_msh(input_file);
-        }
-      else
-        {
-          // Not implemented
-          throw(
-            std::runtime_error("DEM only supports simplex for solid object"));
-        }
+
     }
   else if (param->solid_mesh.type == Parameters::Mesh::Type::dealii)
     {
@@ -272,19 +265,24 @@ SerialSolid<dim, spacedim>::get_triangulation()
 
 template <>
 void
-SerialSolid<1, 2>::rotate_grid(const double /*angle*/,
+SerialSolid<1, 2>::rotate_grid(const double angle,
                                const Tensor<1, 3> /*axis*/)
 {
-  // Not implemented right now
-  throw(std::runtime_error("This is currently not implemented"));
+  GridTools::rotate(angle, *solid_tria);
 }
 
 template <>
 void
-SerialSolid<2, 2>::rotate_grid(double /*angle*/, const Tensor<1, 3> /*axis*/)
+SerialSolid<2, 2>::rotate_grid(double angle, const Tensor<1, 3> /*axis*/)
 {
-  // Not implemented right now
-  throw(std::runtime_error("This is currently not implemented"));
+  GridTools::rotate(angle, *solid_tria);
+}
+
+template <>
+void
+SerialSolid<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> axis)
+{
+  GridTools::rotate(axis, angle, *solid_tria);
 }
 template <>
 void
@@ -295,9 +293,9 @@ SerialSolid<3, 3>::rotate_grid(double angle, const Tensor<1, 3> axis)
 
 template <>
 void
-SerialSolid<2, 3>::translate_grid(const Tensor<1, 3> translation)
+SerialSolid<1, 2>::translate_grid(const Tensor<1, 3> translation)
 {
-  GridTools::shift(translation, *solid_tria);
+  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
 }
 
 template <>
@@ -309,16 +307,16 @@ SerialSolid<2, 2>::translate_grid(const Tensor<1, 3> translation)
 
 template <>
 void
-SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> translation)
+SerialSolid<2, 3>::translate_grid(const Tensor<1, 3> translation)
 {
   GridTools::shift(translation, *solid_tria);
 }
 
 template <>
 void
-SerialSolid<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> axis)
+SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> translation)
 {
-  GridTools::rotate(axis, angle, *solid_tria);
+  GridTools::shift(translation, *solid_tria);
 }
 
 template <int dim, int spacedim>

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -165,16 +165,14 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
 {
   if (param->solid_mesh.type == Parameters::Mesh::Type::gmsh)
     {
+      // Grid creation
+      GridIn<dim, spacedim> grid_in;
+      // Attach triangulation
+      grid_in.attach_triangulation(*solid_tria);
+      // Read input gmsh file
+      std::ifstream input_file(param->solid_mesh.file_name);
 
-          // Grid creation
-          GridIn<dim, spacedim> grid_in;
-          // Attach triangulation
-          grid_in.attach_triangulation(*solid_tria);
-          // Read input gmsh file
-          std::ifstream input_file(param->solid_mesh.file_name);
-
-          grid_in.read_msh(input_file);
-
+      grid_in.read_msh(input_file);
     }
   else if (param->solid_mesh.type == Parameters::Mesh::Type::dealii)
     {
@@ -265,8 +263,7 @@ SerialSolid<dim, spacedim>::get_triangulation()
 
 template <>
 void
-SerialSolid<1, 2>::rotate_grid(const double angle,
-                               const Tensor<1, 3> /*axis*/)
+SerialSolid<1, 2>::rotate_grid(const double angle, const Tensor<1, 3> /*axis*/)
 {
   GridTools::rotate(angle, *solid_tria);
 }

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -224,10 +224,7 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
                                    param->solid_mesh.translate[1],
                                    param->solid_mesh.translate[2]),
                    *solid_tria);
-  if (param->solid_mesh.rotate)
-    {
-      rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
-    }
+  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
 
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file
@@ -277,7 +274,7 @@ SerialSolid<dim, spacedim>::get_triangulation()
 
 template <>
 void
-SerialSolid<1, 2>::rotate_grid(double /*angle*/, int /*axis*/)
+SerialSolid<1, 2>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
 {
   // Not implemented right now
   throw(std::runtime_error("This is currently not implemented"));
@@ -285,14 +282,14 @@ SerialSolid<1, 2>::rotate_grid(double /*angle*/, int /*axis*/)
 
 template <>
 void
-SerialSolid<2, 2>::rotate_grid(double /*angle*/, int /*axis*/)
+SerialSolid<2, 2>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
 {
   // Not implemented right now
   throw(std::runtime_error("This is currently not implemented"));
 }
 template <>
 void
-SerialSolid<3, 3>::rotate_grid(double /*angle*/, int /*axis*/)
+SerialSolid<3, 3>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
 {
   // Not implemented right now
   throw(std::runtime_error("This is currently not implemented"));
@@ -300,11 +297,9 @@ SerialSolid<3, 3>::rotate_grid(double /*angle*/, int /*axis*/)
 
 template <>
 void
-SerialSolid<2, 3>::rotate_grid(const double angle, const int axis)
+SerialSolid<2, 3>::rotate_grid(const double angle, Tensor<1,3> axis)
 {
-  Tensor<1, 3> t_axis;
-  t_axis[axis] = 1;
-  GridTools::rotate(t_axis, angle, *solid_tria);
+  GridTools::rotate(axis, angle, *solid_tria);
 }
 
 template <int dim, int spacedim>

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -221,7 +221,7 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
 
   // Rotate the triangulation
   rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
-  
+
   // Translate the triangulation
   GridTools::shift(Point<spacedim>(param->solid_mesh.translate[0],
                                    param->solid_mesh.translate[1],
@@ -276,7 +276,7 @@ SerialSolid<dim, spacedim>::get_triangulation()
 
 template <>
 void
-SerialSolid<1, 2>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
+SerialSolid<1, 2>::rotate_grid(double /*angle*/, Tensor<1, 3> /*axis*/)
 {
   // Not implemented right now
   throw(std::runtime_error("This is currently not implemented"));
@@ -284,14 +284,14 @@ SerialSolid<1, 2>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
 
 template <>
 void
-SerialSolid<2, 2>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
+SerialSolid<2, 2>::rotate_grid(double /*angle*/, Tensor<1, 3> /*axis*/)
 {
   // Not implemented right now
   throw(std::runtime_error("This is currently not implemented"));
 }
 template <>
 void
-SerialSolid<3, 3>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
+SerialSolid<3, 3>::rotate_grid(double /*angle*/, Tensor<1, 3> /*axis*/)
 {
   // Not implemented right now
   throw(std::runtime_error("This is currently not implemented"));
@@ -299,7 +299,7 @@ SerialSolid<3, 3>::rotate_grid(double /*angle*/, Tensor<1,3> /*axis*/)
 
 template <>
 void
-SerialSolid<2, 3>::rotate_grid(const double angle, Tensor<1,3> axis)
+SerialSolid<2, 3>::rotate_grid(const double angle, Tensor<1, 3> axis)
 {
   GridTools::rotate(axis, angle, *solid_tria);
 }

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -222,10 +222,7 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
               param->solid_mesh.rotation_axis);
 
   // Translate the triangulation
-  GridTools::shift(Point<spacedim>(param->solid_mesh.translation[0],
-                                   param->solid_mesh.translation[1],
-                                   param->solid_mesh.translation[2]),
-                   *solid_tria);
+  translate_grid(param->solid_mesh.translation);
 
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file
@@ -294,6 +291,27 @@ void
 SerialSolid<3, 3>::rotate_grid(double angle, const Tensor<1, 3> axis)
 {
   GridTools::rotate(axis, angle, *solid_tria);
+}
+
+template <>
+void
+SerialSolid<2, 3>::translate_grid(const Tensor<1, 3> translation)
+{
+  GridTools::shift(translation, *solid_tria);
+}
+
+template <>
+void
+SerialSolid<2, 2>::translate_grid(const Tensor<1, 3> translation)
+{
+  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
+}
+
+template <>
+void
+SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> translation)
+{
+  GridTools::shift(translation, *solid_tria);
 }
 
 template <>

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -166,9 +166,11 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
   if (param->solid_mesh.type == Parameters::Mesh::Type::gmsh)
     {
       if (param->solid_mesh.simplex)
-        {
+        { // Grid creation
           GridIn<dim, spacedim> grid_in;
+          // Attach triangulation
           grid_in.attach_triangulation(*solid_tria);
+          // Read input gmsh file
           std::ifstream input_file(param->solid_mesh.file_name);
 
           grid_in.read_msh(input_file);
@@ -218,11 +220,10 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
       "Unsupported mesh type - solid mesh will not be created");
 
   // Translate the triangulation
-  if (param->solid_mesh.translate)
-    GridTools::shift(Point<spacedim>(param->solid_mesh.delta_x,
-                                     param->solid_mesh.delta_y,
-                                     param->solid_mesh.delta_z),
-                     *solid_tria);
+  GridTools::shift(Point<spacedim>(param->solid_mesh.translate[0],
+                                   param->solid_mesh.translate[1],
+                                   param->solid_mesh.translate[2]),
+                   *solid_tria);
   if (param->solid_mesh.rotate)
     {
       rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -219,12 +219,14 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
 
       "Unsupported mesh type - solid mesh will not be created");
 
+  // Rotate the triangulation
+  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
+  
   // Translate the triangulation
   GridTools::shift(Point<spacedim>(param->solid_mesh.translate[0],
                                    param->solid_mesh.translate[1],
                                    param->solid_mesh.translate[2]),
                    *solid_tria);
-  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
 
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -214,12 +214,13 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
       "Unsupported mesh type - solid mesh will not be created");
 
   // Rotate the triangulation
-  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
+  rotate_grid(param->solid_mesh.rotation_angle,
+              param->solid_mesh.rotation_axis);
 
   // Translate the triangulation
-  GridTools::shift(Point<spacedim>(param->solid_mesh.translate[0],
-                                   param->solid_mesh.translate[1],
-                                   param->solid_mesh.translate[2]),
+  GridTools::shift(Point<spacedim>(param->solid_mesh.translation[0],
+                                   param->solid_mesh.translation[1],
+                                   param->solid_mesh.translation[2]),
                    *solid_tria);
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file
@@ -240,19 +241,19 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
 
 template <>
 void
-SolidBase<2, 2>::rotate_grid(double angle, Tensor<1, 3> /*axis*/)
+SolidBase<2, 2>::rotate_grid(const double angle, const Tensor<1, 3> /*axis*/)
 {
   GridTools::rotate(angle, *solid_tria);
 }
 template <>
 void
-SolidBase<2, 3>::rotate_grid(double angle, Tensor<1, 3> axis)
+SolidBase<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> axis)
 {
   GridTools::rotate(axis, angle, *solid_tria);
 }
 template <>
 void
-SolidBase<3, 3>::rotate_grid(const double angle, Tensor<1, 3> axis)
+SolidBase<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> axis)
 {
   GridTools::rotate(axis, angle, *solid_tria);
 }

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -214,11 +214,10 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
       "Unsupported mesh type - solid mesh will not be created");
 
   // Translate the triangulation
-  if (param->solid_mesh.translate)
-    GridTools::shift(Point<spacedim>(param->solid_mesh.delta_x,
-                                     param->solid_mesh.delta_y,
-                                     param->solid_mesh.delta_z),
-                     *solid_tria);
+  GridTools::shift(Point<spacedim>(param->solid_mesh.translate[0],
+                                   param->solid_mesh.translate[1],
+                                   param->solid_mesh.translate[2]),
+                   *solid_tria);
   // Rotate the triangulation
   if (param->solid_mesh.rotate)
     {

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -218,10 +218,7 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
               param->solid_mesh.rotation_axis);
 
   // Translate the triangulation
-  GridTools::shift(Point<spacedim>(param->solid_mesh.translation[0],
-                                   param->solid_mesh.translation[1],
-                                   param->solid_mesh.translation[2]),
-                   *solid_tria);
+  translate_grid(param->solid_mesh.translation);
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file
   // afterwards
@@ -256,6 +253,27 @@ void
 SolidBase<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> axis)
 {
   GridTools::rotate(axis, angle, *solid_tria);
+}
+
+template <>
+void
+SolidBase<2, 3>::translate_grid(const Tensor<1, 3> translation)
+{
+  GridTools::shift(translation, *solid_tria);
+}
+
+template <>
+void
+SolidBase<2, 2>::translate_grid(const Tensor<1, 3> translation)
+{
+  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
+}
+
+template <>
+void
+SolidBase<3, 3>::translate_grid(const Tensor<1, 3> translation)
+{
+  GridTools::shift(translation, *solid_tria);
 }
 
 

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -219,10 +219,7 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
                                    param->solid_mesh.translate[2]),
                    *solid_tria);
   // Rotate the triangulation
-  if (param->solid_mesh.rotate)
-    {
-      rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
-    }
+  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
 
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file
@@ -243,25 +240,21 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
 
 template <>
 void
-SolidBase<2, 2>::rotate_grid(double angle, int /*axis*/)
+SolidBase<2, 2>::rotate_grid(double angle, Tensor<1,3> /*axis*/)
 {
   GridTools::rotate(angle, *solid_tria);
 }
 template <>
 void
-SolidBase<2, 3>::rotate_grid(double angle, int axis)
+SolidBase<2, 3>::rotate_grid(double angle, Tensor<1,3> axis)
 {
-  Tensor<1, 3> t_axis;
-  t_axis[axis] = 1;
-  GridTools::rotate(t_axis, angle, *solid_tria);
+  GridTools::rotate(axis, angle, *solid_tria);
 }
 template <>
 void
-SolidBase<3, 3>::rotate_grid(double angle, int axis)
+SolidBase<3, 3>::rotate_grid(const double angle, Tensor<1,3> axis)
 {
-  Tensor<1, 3> t_axis;
-  t_axis[axis] = 1;
-  GridTools::rotate(t_axis, angle, *solid_tria);
+    GridTools::rotate(axis, angle, *solid_tria);
 }
 
 

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -240,21 +240,21 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
 
 template <>
 void
-SolidBase<2, 2>::rotate_grid(double angle, Tensor<1,3> /*axis*/)
+SolidBase<2, 2>::rotate_grid(double angle, Tensor<1, 3> /*axis*/)
 {
   GridTools::rotate(angle, *solid_tria);
 }
 template <>
 void
-SolidBase<2, 3>::rotate_grid(double angle, Tensor<1,3> axis)
+SolidBase<2, 3>::rotate_grid(double angle, Tensor<1, 3> axis)
 {
   GridTools::rotate(axis, angle, *solid_tria);
 }
 template <>
 void
-SolidBase<3, 3>::rotate_grid(const double angle, Tensor<1,3> axis)
+SolidBase<3, 3>::rotate_grid(const double angle, Tensor<1, 3> axis)
 {
-    GridTools::rotate(axis, angle, *solid_tria);
+  GridTools::rotate(axis, angle, *solid_tria);
 }
 
 

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -257,16 +257,16 @@ SolidBase<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> axis)
 
 template <>
 void
-SolidBase<2, 3>::translate_grid(const Tensor<1, 3> translation)
+SolidBase<2, 2>::translate_grid(const Tensor<1, 3> translation)
 {
-  GridTools::shift(translation, *solid_tria);
+  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
 }
 
 template <>
 void
-SolidBase<2, 2>::translate_grid(const Tensor<1, 3> translation)
+SolidBase<2, 3>::translate_grid(const Tensor<1, 3> translation)
 {
-  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
+  GridTools::shift(translation, *solid_tria);
 }
 
 template <>

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -213,14 +213,14 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
     throw std::runtime_error(
       "Unsupported mesh type - solid mesh will not be created");
 
+  // Rotate the triangulation
+  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
+
   // Translate the triangulation
   GridTools::shift(Point<spacedim>(param->solid_mesh.translate[0],
                                    param->solid_mesh.translate[1],
                                    param->solid_mesh.translate[2]),
                    *solid_tria);
-  // Rotate the triangulation
-  rotate_grid(param->solid_mesh.angle, param->solid_mesh.axis);
-
   // Refine the solid triangulation to its initial size
   // NB: solid_tria should not be refined if loaded from a restart file
   // afterwards

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -59,8 +59,8 @@ test()
   param->solid_mesh.grid_arguments     = "-2, -1 : 2, 1 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = true;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.translate          = {0., 0., 0.};
+  param->solid_mesh.axis               = (1., 0., 0.);
   param->solid_mesh.angle              = 0.;
 
   SerialSolid<2, 3> solid(param, 0);

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -59,7 +59,7 @@ test()
   param->solid_mesh.grid_arguments     = "-2, -1 : 2, 1 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = true;
-  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;
 

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -60,7 +60,8 @@ test()
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = true;
   param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.rotate             = false;
+  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.angle              = 0.;
 
   SerialSolid<2, 3> solid(param, 0);
 

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -59,9 +59,9 @@ test()
   param->solid_mesh.grid_arguments     = "-2, -1 : 2, 1 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = true;
-  param->solid_mesh.translate          = {0., 0., 0.};
-  param->solid_mesh.axis               = (1., 0., 0.);
-  param->solid_mesh.angle              = 0.;
+  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.rotation_angle     = 0.;
 
   SerialSolid<2, 3> solid(param, 0);
 

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -59,7 +59,7 @@ test()
   param->solid_mesh.grid_arguments     = "-2, -1 : 2, 1 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = true;
-  param->solid_mesh.translate          = false;
+  param->solid_mesh.translate          = {0., 0. ,0.};
   param->solid_mesh.rotate             = false;
 
   SerialSolid<2, 3> solid(param, 0);

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -62,7 +62,7 @@ test()
   param->solid_mesh.initial_refinement = 4;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;
 

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -60,7 +60,7 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 4;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = false;
+  param->solid_mesh.translate          = {0., 0. ,0.};
   param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
 

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -26,6 +26,7 @@
 
 #include <deal.II/particles/data_out.h>
 
+
 // Lethe
 #include <core/parameters.h>
 #include <core/solid_base.h>
@@ -61,9 +62,9 @@ test()
   param->solid_mesh.initial_refinement = 4;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translate          = {0., 0., 0.};
-  param->solid_mesh.axis               = (1., 0., 0.);
-  param->solid_mesh.angle              = 0.;
+  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.rotation_angle     = 0.;
 
   // Mesh of the fluid
   GridGenerator::hyper_cube(*fluid_tria, -1, 1);

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -60,9 +60,10 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 4;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
+  param->solid_mesh.translate          = {0., 0. ,0.};
+  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.angle              = 0.;
 
   // Mesh of the fluid
   GridGenerator::hyper_cube(*fluid_tria, -1, 1);

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -61,8 +61,8 @@ test()
   param->solid_mesh.initial_refinement = 4;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.translate          = {0., 0., 0.};
+  param->solid_mesh.axis               = (1., 0., 0.);
   param->solid_mesh.angle              = 0.;
 
   // Mesh of the fluid

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -60,9 +60,8 @@ test()
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75";
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
+  param->solid_mesh.translate          = {0., 0. ,0.};
 
 
   // Mesh of the fluid

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -61,7 +61,9 @@ test()
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translate          = {0., 0., 0.};
+  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.rotation_angle     = 0.;
 
 
   // Mesh of the fluid

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -61,7 +61,7 @@ test()
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translate          = {0., 0. ,0.};
+  param->solid_mesh.translate          = {0., 0., 0.};
 
 
   // Mesh of the fluid

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -61,7 +61,7 @@ test()
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;
 

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -60,7 +60,7 @@ test()
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75";
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = false;
+  param->solid_mesh.translate          = {0., 0. ,0.};
   param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
 

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -60,8 +60,8 @@ test()
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75 : false";
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.translate          = {0., 0., 0.};
+  param->solid_mesh.axis               = (1., 0., 0.);
   param->solid_mesh.angle              = 0.;
   param->number_quadrature_points      = 2;
 

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -60,7 +60,7 @@ test()
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75 : false";
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = false;
+  param->solid_mesh.translate          = {0., 0. ,0.};
   param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
 

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -60,9 +60,9 @@ test()
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75 : false";
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = {0., 0., 0.};
-  param->solid_mesh.axis               = (1., 0., 0.);
-  param->solid_mesh.angle              = 0.;
+  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.rotation_angle     = 0.;
   param->number_quadrature_points      = 2;
 
 

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -60,7 +60,7 @@ test()
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75 : false";
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;
   param->number_quadrature_points      = 2;

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -61,7 +61,8 @@ test()
   param->solid_mesh.initial_refinement = 1;
   param->solid_mesh.simplex            = false;
   param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.rotate             = false;
+  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.angle              = 0.;
   param->number_quadrature_points      = 2;
 
 

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -74,7 +74,7 @@ test()
   param->solid_mesh.simplex            = false;
   param->particles_sub_iterations      = 1;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;
 

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -73,9 +73,10 @@ test()
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
   param->particles_sub_iterations      = 1;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
+  param->solid_mesh.translate          = {0., 0. ,0.};
+  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.angle              = 0.;
 
 
   double time_step = 0.01;

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -74,8 +74,8 @@ test()
   param->solid_mesh.simplex            = false;
   param->particles_sub_iterations      = 1;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.translate          = {0., 0., 0.};
+  param->solid_mesh.axis               = (1., 0., 0.);
   param->solid_mesh.angle              = 0.;
 
 

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -74,9 +74,9 @@ test()
   param->solid_mesh.simplex            = false;
   param->particles_sub_iterations      = 1;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translate          = {0., 0., 0.};
-  param->solid_mesh.axis               = (1., 0., 0.);
-  param->solid_mesh.angle              = 0.;
+  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.rotation_angle     = 0.;
 
 
   double time_step = 0.01;

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -73,7 +73,7 @@ test()
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
   param->particles_sub_iterations      = 1;
-  param->solid_mesh.translate          = false;
+  param->solid_mesh.translate          = {0., 0. ,0.};
   param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
 

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -64,7 +64,7 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;
 

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -64,7 +64,7 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = false;
+  param->solid_mesh.translate          = {0., 0. ,0.};
   param->solid_mesh.rotate             = false;
   param->number_quadrature_points      = 2;
 

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -64,9 +64,9 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = {0., 0., 0.};
-  param->solid_mesh.axis               = (1., 0., 0.);
-  param->solid_mesh.angle              = 0.;
+  param->solid_mesh.translation        = {0., 0., 0.};
+  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.rotation_angle     = 0.;
 
   double time_step = 0.01;
   param->solid_velocity.declare_parameters(prm, 3);

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -64,6 +64,7 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
+  param->number_quadrature_points      = 2;
   param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
   param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0.;

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -64,8 +64,8 @@ test()
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.translate          = {0., 0., 0.};
+  param->solid_mesh.axis               = (1., 0., 0.);
   param->solid_mesh.angle              = 0.;
 
   double time_step = 0.01;

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -65,8 +65,8 @@ test()
   param->solid_mesh.initial_refinement = 3;
   param->solid_mesh.simplex            = false;
   param->solid_mesh.translate          = {0., 0. ,0.};
-  param->solid_mesh.rotate             = false;
-  param->number_quadrature_points      = 2;
+  param->solid_mesh.axis               = (1., 0. ,0.);
+  param->solid_mesh.angle              = 0.;
 
   double time_step = 0.01;
   param->solid_velocity.declare_parameters(prm, 3);


### PR DESCRIPTION
# Description of the problems and associated solutions

- Translation and rotation for solid object in DEM were not in documentation.
- Translation was previously define by 4 parameters in the .prm . Now it's by one parameter. 
- Rotation was only possible around one axis (0,1,2) . Now it can be define around any axis in the 3D space.

# How Has This Been Tested?

- Basic translation and rotation with multiple solid object were done.

# Documentation

-doc/parameters/dem/floating_mesh.rst  

