### PR TITLE
Disable DG prototypes

### DIFF
--- a/prototypes/CMakeLists.txt
+++ b/prototypes/CMakeLists.txt
@@ -1,6 +1,4 @@
 add_subdirectory(chorin_navier_stokes)
-add_subdirectory(dg_advection_diffusion_equation)
-add_subdirectory(dg_heat_equation)
 add_subdirectory(direct_gls_navier_stokes)
 add_subdirectory(direct_steady_navier_stokes)
 add_subdirectory(matrix_based_non_linear_poisson)


### PR DESCRIPTION
# Description of the problem

DG prototypes are outdated and no longer compile with the current version of deal.II.

# Description of the solution

The DG prototypes were disabled by removing them from the CMakeLists.txt. 