### PR TITLE
Fix links in example diagrams in documentation

### DIFF
--- a/doc/source/examples/incompressible-flow/incompressible-flow.rst
+++ b/doc/source/examples/incompressible-flow/incompressible-flow.rst
@@ -24,7 +24,7 @@ Incompressible flow
 
     digraph incompressible_diagram {
       graph [bgcolor="transparent", align=true, ranksep=1.5];
-      node [fontname=Arial, fontsize=18, shape=box, fontcolor=royalblue, color=royalblue];
+      node [fontname=Arial, fontsize=20, shape=box, fontcolor=royalblue, color=royalblue,height=1];
       edge [color=royalblue];
       rankdir="LR";
       size = "9,9";

--- a/doc/source/examples/multiphysics/multiphysics.rst
+++ b/doc/source/examples/multiphysics/multiphysics.rst
@@ -15,7 +15,7 @@ Multiphysics
 
     digraph multiphysics_diagram {
       graph [bgcolor="transparent", align=true, ranksep=1.5];
-      node [fontname=Arial, fontsize=18, shape=box, fontcolor=royalblue, color=royalblue];
+      node [fontname=Arial, fontsize=20, shape=box, fontcolor=royalblue, color=royalblue, height=1];
       edge [color=royalblue];
       rankdir="LR";
       size = "9,9";

--- a/doc/source/examples/rpt/rpt.rst
+++ b/doc/source/examples/rpt/rpt.rst
@@ -14,7 +14,7 @@ Radioactive Particle Tracking (RPT)
 
     digraph rpt_diagram {
       graph [bgcolor="transparent", align=true, ranksep=1.5];
-      node [fontname=Arial, fontsize=18, shape=box, fontcolor=royalblue, color=royalblue];
+      node [fontname=Arial, fontsize=20, shape=box, fontcolor=royalblue, color=royalblue, height=1];
       edge [color=royalblue];
       rankdir="LR";
       size = "9,9";

--- a/doc/source/examples/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/examples/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -13,7 +13,7 @@ Sharp immersed boundary solver
 .. graphviz:: 
 
     digraph sharp_diagram {
-      graph [bgcolor="transparent", align=true, ranksep=1.5];
+      graph [bgcolor="transparent", align=true];
       node [fontname=Arial, fontsize=20, shape=box, fontcolor=royalblue, color=royalblue, height=1];
       edge [color=royalblue];
       rankdir="LR";

--- a/doc/source/examples/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/examples/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -14,7 +14,7 @@ Sharp immersed boundary solver
 
     digraph sharp_diagram {
       graph [bgcolor="transparent", align=true, ranksep=1.5];
-      node [fontname=Arial, fontsize=18, shape=box, fontcolor=royalblue, color=royalblue];
+      node [fontname=Arial, fontsize=20, shape=box, fontcolor=royalblue, color=royalblue, height=1];
       edge [color=royalblue];
       rankdir="LR";
       size = "9,9";

--- a/doc/source/examples/unresolved-cfd-dem/unresolved-cfd-dem.rst
+++ b/doc/source/examples/unresolved-cfd-dem/unresolved-cfd-dem.rst
@@ -18,7 +18,7 @@ This section includes examples related to multiphase fluid-solid flows. We organ
 
     digraph unresolved_cfd_dem_diagram {
       graph [bgcolor="transparent", align=true, ranksep=1.5];
-      node [fontname=Arial, fontsize=18, shape=box, fontcolor=royalblue, color=royalblue];
+      node [fontname=Arial, fontsize=20, shape=box, fontcolor=royalblue, color=royalblue, height=1];
       edge [color=royalblue];
       rankdir="LR";
       size = "9,9";


### PR DESCRIPTION
# Description of the problem

Some of the links were overlapping with other ones which resulted in unexpected behavior.

# Description of the solution

The height of the nodes was fixed to avoid overlapping nodes.
