### PR TITLE
Refactor the contact manager in DEM

### DIFF
--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -19,7 +19,7 @@
 #include <core/serial_solid.h>
 
 #include <dem/data_containers.h>
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/disable_contacts.h>
 #include <dem/find_boundary_cells_information.h>
@@ -339,14 +339,13 @@ private:
   const unsigned int insertion_frequency;
 
   // Initilization of classes and building objects
-  DEMContainerManager<dim>           container_manager;
+  DEMContactManager<dim>             contact_manager;
   std::shared_ptr<SimulationControl> simulation_control;
   BoundaryCellsInformation<dim>      boundary_cell_object;
   std::shared_ptr<GridMotion<dim>>   grid_motion_object;
   ParticlePointLineForce<dim>        particle_point_line_contact_force_object;
   std::shared_ptr<Integrator<dim>>   integrator_object;
   std::shared_ptr<Insertion<dim>>    insertion_object;
-  PeriodicBoundariesManipulator<dim> periodic_boundaries_object;
   std::shared_ptr<ParticleParticleContactForceBase<dim>>
     particle_particle_contact_force_object;
   std::shared_ptr<ParticleWallContactForce<dim>>
@@ -360,8 +359,23 @@ private:
   std::vector<Tensor<1, 3>> force;
   std::vector<double>       displacement;
   std::vector<double>       MOI;
-  Tensor<1, dim>            periodic_offset;
-  bool                      has_periodic_boundaries;
+
+  // Mesh and boundary information
+  typename dem_data_structures<dim>::floating_mesh_information
+    floating_mesh_info;
+  typename dem_data_structures<dim>::boundary_points_and_normal_vectors
+    updated_boundary_points_and_normal_vectors;
+  typename dem_data_structures<dim>::vector_on_boundary
+    forces_boundary_information;
+  typename dem_data_structures<dim>::vector_on_boundary
+    torques_boundary_information;
+  typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
+    periodic_boundaries_cells_information;
+
+  // Information for periodic boundaries
+  PeriodicBoundariesManipulator<dim> periodic_boundaries_object;
+  Tensor<1, dim>                     periodic_offset;
+  bool                               has_periodic_boundaries;
 
   // Information for parallel grid processing
   DoFHandler<dim> background_dh;

--- a/include/dem/dem_contact_manager.h
+++ b/include/dem/dem_contact_manager.h
@@ -242,21 +242,6 @@ public:
     const double                                      neighborhood_threshold,
     const bool has_floating_mesh = false);
 
-  /**
-   * Carries out the storing of the floating mesh informations for background
-   * and solid cells
-   *
-   * @param triangulation The triangulation to access the information of the cells
-   * @param solids An object which manages a serial triangulation that represents a solid object.
-   */
-
-  void
-  store_floating_mesh_info(
-    const parallel::distributed::Triangulation<dim> &triangulation,
-    typename dem_data_structures<dim>::floating_mesh_information
-                                                            floating_mesh_info,
-    std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> solids);
-
 
   // Container with the iterators to all local and ghost particles
   typename dem_data_structures<dim>::particle_index_iterator_map

--- a/include/dem/dem_contact_manager.h
+++ b/include/dem/dem_contact_manager.h
@@ -36,11 +36,11 @@
 
 using namespace DEM;
 
-#ifndef lethe_dem_container_manager_h
-#  define lethe_dem_container_manager_h
+#ifndef lethe_dem_contact_manager_h
+#  define lethe_dem_contact_manager_h
 
 template <int dim>
-class DEMContainerManager
+class DEMContactManager
 {
 public:
   /**
@@ -48,6 +48,7 @@ public:
    * triangulation.
    *
    * @param triangulation The triangulation to access the information of the cells
+   * @param periodic_boundaries_cells_information Information of periodic cells used if periodic boundaries are used
    * @param has_periodic_boundaries A boolean to allow periodic container manipulations
    * @param has_floating_mesh A boolean to allow dealing with floating mesh neighbors
    *
@@ -56,6 +57,8 @@ public:
   void
   execute_cell_neighbors_search(
     const parallel::distributed::Triangulation<dim> &triangulation,
+    const typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
+               periodic_boundaries_cells_information,
     const bool has_periodic_boundaries = false,
     const bool has_floating_mesh       = false);
 
@@ -64,6 +67,7 @@ public:
    * triangulation while clearing containers before the update.
    *
    * @param triangulation The triangulation to access the information of the cells
+   * @param periodic_boundaries_cells_information Information of periodic cells used if periodic boundaries are used
    * @param has_periodic_boundaries A boolean to allow periodic container manipulations
    * @param has_floating_mesh A boolean to allow dealing with floating mesh neighbors
    *
@@ -72,6 +76,8 @@ public:
   void
   update_cell_neighbors(
     const parallel::distributed::Triangulation<dim> &triangulation,
+    const typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
+               periodic_boundaries_cells_information,
     const bool has_periodic_boundaries = false,
     const bool has_floating_mesh       = false)
   {
@@ -83,6 +89,7 @@ public:
     total_neighbor_list.clear();
 
     execute_cell_neighbors_search(triangulation,
+                                  periodic_boundaries_cells_information,
                                   has_periodic_boundaries,
                                   has_floating_mesh);
   }
@@ -161,8 +168,9 @@ public:
    *
    * @param particle_handler Particle handler of particles located in boundary
    * cells
-   * @param boundary_cells_information Information of the boundary cells and
-   * faces. This is the output of the FindBoundaryCellsInformation class
+   * @param boundary_cells_object Information of the boundary cells and
+   * faces. This is the output of the BoundaryCellsInformation class
+   *    * @param floating_mesh_info Container of all of floating meshes
    * @param floating_wall Properties of the floating walls specified in the parameter handler file
    * @param simulation_time Simulation time
    * @param has_floating_mesh A boolean to allow dealing with floating mesh neighbors
@@ -170,8 +178,10 @@ public:
 
   void
   execute_particle_wall_broad_search(
-    const Particles::ParticleHandler<dim> &           particle_handler,
-    BoundaryCellsInformation<dim> &                   boundary_cell_object,
+    const Particles::ParticleHandler<dim> &particle_handler,
+    BoundaryCellsInformation<dim> &        boundary_cell_object,
+    const typename dem_data_structures<dim>::floating_mesh_information
+                                                      floating_mesh_info,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
     const double                                      simulation_time,
     const bool has_floating_mesh = false);
@@ -184,6 +194,7 @@ public:
    * cells
    * @param boundary_cells_information Information of the boundary cells and
    * faces. This is the output of the FindBoundaryCellsInformation class
+   * @param floating_mesh_info Container of all of floating meshes
    * @param floating_wall Properties of the floating walls specified in the parameter handler file
    * @param simulation_time Simulation time
    * @param has_floating_mesh A boolean to allow dealing with floating mesh neighbors
@@ -191,8 +202,10 @@ public:
 
   void
   execute_particle_wall_broad_search(
-    const Particles::ParticleHandler<dim> &           particle_handler,
-    BoundaryCellsInformation<dim> &                   boundary_cell_object,
+    const Particles::ParticleHandler<dim> &particle_handler,
+    BoundaryCellsInformation<dim> &        boundary_cell_object,
+    const typename dem_data_structures<dim>::floating_mesh_information
+                                                      floating_mesh_info,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
     const double                                      simulation_time,
     const DisableContacts<dim> &disable_particle_contact_object,
@@ -239,7 +252,9 @@ public:
 
   void
   store_floating_mesh_info(
-    const parallel::distributed::Triangulation<dim> &       triangulation,
+    const parallel::distributed::Triangulation<dim> &triangulation,
+    typename dem_data_structures<dim>::floating_mesh_information
+                                                            floating_mesh_info,
     std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> solids);
 
 
@@ -313,16 +328,6 @@ public:
     ghost_local_periodic_adjacent_particles;
 
   // Containers with other information
-  typename dem_data_structures<dim>::floating_mesh_information
-    floating_mesh_info;
-  typename dem_data_structures<dim>::boundary_points_and_normal_vectors
-    updated_boundary_points_and_normal_vectors;
-  typename dem_data_structures<dim>::vector_on_boundary
-    forces_boundary_information;
-  typename dem_data_structures<dim>::vector_on_boundary
-    torques_boundary_information;
-  typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
-    periodic_boundaries_cells_information;
   typename DEM::dem_data_structures<dim>::cell_vector periodic_cells_container;
 
 private:
@@ -340,4 +345,4 @@ private:
   FindCellNeighbors<dim> cell_neighbors_object;
 };
 
-#endif // lethe_dem_container_manager_h
+#endif // lethe_dem_contact_manager_h

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -269,7 +269,7 @@ private:
 
   // Structure that contains the boundary cells with floating walls
   std::unordered_map<
-    types::particle_index,
+    unsigned int,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
     boundary_cells_for_floating_walls;
 

--- a/include/dem/find_contact_detection_step.h
+++ b/include/dem/find_contact_detection_step.h
@@ -61,7 +61,6 @@ find_particle_contact_detection_step(
  * @brief Carries out finding steps for dynamic contact search in particle-floating
  * mesh contacts
  *
- * @param particle_handler
  * @param smallest_contact_search_criterion A criterion which defines the maximal displacement that a solid face may have displaced
  * @param solids All solid objects used in the simulation
  * @return Returns true if the maximum cumulative

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -28,7 +28,7 @@
 #include <deal.II/particles/particle_iterator.h>
 
 template <int dim>
-class DEMContainerManager;
+class DEMContactManager;
 
 using namespace dealii;
 
@@ -65,7 +65,7 @@ public:
   void
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContainerManager<dim> &               container_manager);
+    DEMContactManager<dim> &                 container_manager);
 
   /**
    * @brief Finds a vector of pairs (particle_particle_candidates) which shows the
@@ -86,7 +86,7 @@ public:
   void
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContainerManager<dim> &               container_manager,
+    DEMContactManager<dim> &                 container_manager,
     const DisableContacts<dim> &             disable_contacts_object);
 
   /**
@@ -104,7 +104,7 @@ public:
   void
   find_particle_particle_periodic_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContainerManager<dim> &               container_manager);
+    DEMContactManager<dim> &                 container_manager);
 
   /**
    * @brief Finds a vector of pairs (particle_particle_candidates) which contains the
@@ -125,7 +125,7 @@ public:
   void
   find_particle_particle_periodic_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContainerManager<dim> &               container_manager,
+    DEMContactManager<dim> &                 container_manager,
     const DisableContacts<dim> &             disable_contacts_object);
 
 private:

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -21,7 +21,7 @@
 #include <core/dem_properties.h>
 
 #include <dem/data_containers.h>
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/particle_particle_contact_info.h>
 #include <dem/rolling_resistance_torque_models.h>
@@ -71,7 +71,7 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    DEMContainerManager<dim> & container_manager,
+    DEMContactManager<dim> &   container_manager,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -167,7 +167,7 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    DEMContainerManager<dim> & container_manager,
+    DEMContactManager<dim> &   container_manager,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,

--- a/include/dem/particle_particle_fine_search.h
+++ b/include/dem/particle_particle_fine_search.h
@@ -30,7 +30,7 @@
 #include <boost/range/adaptor/map.hpp>
 
 template <int dim>
-class DEMContainerManager;
+class DEMContactManager;
 
 using namespace dealii;
 

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -108,7 +108,7 @@ public:
   void
   find_particle_floating_wall_contact_pairs(
     const std::unordered_map<
-      types::particle_index,
+      unsigned int,
       std::set<typename Triangulation<dim>::active_cell_iterator>>
       &                                    boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,
@@ -120,7 +120,7 @@ public:
   void
   find_particle_floating_wall_contact_pairs(
     const std::unordered_map<
-      types::particle_index,
+      unsigned int,
       std::set<typename Triangulation<dim>::active_cell_iterator>>
       &                                    boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -15,7 +15,7 @@
  */
 #include <dem/boundary_cells_info_struct.h>
 #include <dem/data_containers.h>
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 
 #include <deal.II/distributed/tria.h>

--- a/include/fem-dem/cfd_dem_coupling.h
+++ b/include/fem-dem/cfd_dem_coupling.h
@@ -21,7 +21,7 @@
 #include <solvers/navier_stokes_scratch_data.h>
 
 #include <dem/data_containers.h>
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/disable_contacts.h>
 #include <dem/find_contact_detection_step.h>
@@ -260,20 +260,34 @@ private:
   double                    standard_deviation_multiplier;
   double                    smallest_contact_search_criterion;
   double                    triangulation_cell_diameter;
-  Tensor<1, dim>            periodic_offset;
-  bool                      has_periodic_boundaries;
 
-  DEMContainerManager<dim>           container_manager;
-  ParticlePointLineForce<dim>        particle_point_line_contact_force_object;
-  PeriodicBoundariesManipulator<dim> periodic_boundaries_object;
-  std::shared_ptr<Integrator<dim>>   integrator_object;
-  std::shared_ptr<Insertion<dim>>    insertion_object;
+  DEMContactManager<dim>           contact_manager;
+  ParticlePointLineForce<dim>      particle_point_line_contact_force_object;
+  std::shared_ptr<Integrator<dim>> integrator_object;
+  std::shared_ptr<Insertion<dim>>  insertion_object;
   std::shared_ptr<ParticleParticleContactForceBase<dim>>
     particle_particle_contact_force_object;
   std::shared_ptr<ParticleWallContactForce<dim>>
                                 particle_wall_contact_force_object;
   Visualization<dim>            visualization_object;
   BoundaryCellsInformation<dim> boundary_cell_object;
+
+  // Mesh and boundary information
+  typename dem_data_structures<dim>::floating_mesh_information
+    floating_mesh_info;
+  typename dem_data_structures<dim>::boundary_points_and_normal_vectors
+    updated_boundary_points_and_normal_vectors;
+  typename dem_data_structures<dim>::vector_on_boundary
+    forces_boundary_information;
+  typename dem_data_structures<dim>::vector_on_boundary
+    torques_boundary_information;
+  typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
+    periodic_boundaries_cells_information;
+
+  // Information for periodic boundaries
+  PeriodicBoundariesManipulator<dim> periodic_boundaries_object;
+  Tensor<1, dim>                     periodic_offset;
+  bool                               has_periodic_boundaries;
 
   DisableContacts<dim> disable_contacts_object;
   bool                 has_disabled_contacts;

--- a/source/dem/CMakeLists.txt
+++ b/source/dem/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(lethe-dem
   # Sources
   data_containers.cc
   dem.cc
-        dem_contact_manager.cc
+  dem_contact_manager.cc
   dem_solver_parameters.cc
   explicit_euler_integrator.cc
   disable_contacts.cc

--- a/source/dem/CMakeLists.txt
+++ b/source/dem/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(lethe-dem
   # Sources
   data_containers.cc
   dem.cc
-  dem_container_manager.cc
+        dem_contact_manager.cc
   dem_solver_parameters.cc
   explicit_euler_integrator.cc
   disable_contacts.cc

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -449,9 +449,11 @@ DEMSolver<dim>::load_balance()
 
   // Update the container with all the combinations of background and
   // solid cells
-  contact_manager.store_floating_mesh_info(triangulation,
-                                           floating_mesh_info,
-                                           solids);
+  for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
+    {
+      floating_mesh_info[i_solid] =
+        solids[i_solid]->map_solid_in_background_triangulation(triangulation);
+    }
 
   if (has_periodic_boundaries)
     {
@@ -1082,9 +1084,11 @@ DEMSolver<dim>::solve()
             parameters.boundary_conditions);
 
   // Store information about floating mesh/background mesh intersection
-  contact_manager.store_floating_mesh_info(triangulation,
-                                           floating_mesh_info,
-                                           solids);
+  for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
+    {
+      floating_mesh_info[i_solid] =
+        solids[i_solid]->map_solid_in_background_triangulation(triangulation);
+    }
 
   if (parameters.restart.restart == true)
     {
@@ -1249,9 +1253,12 @@ DEMSolver<dim>::solve()
           if (floating_mesh_map_step)
             {
               // Update floating mesh information in the container manager
-              contact_manager.store_floating_mesh_info(triangulation,
-                                                       floating_mesh_info,
-                                                       solids);
+              for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
+                {
+                  floating_mesh_info[i_solid] =
+                    solids[i_solid]->map_solid_in_background_triangulation(
+                      triangulation);
+                }
             }
         }
 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -232,13 +232,13 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
     }
 
   // Generate solid objects
-  container_manager.floating_mesh_info.resize(solids.size());
+  floating_mesh_info.resize(solids.size());
 
   // Resize particle_floating_mesh_in_contact
   if (solids.size() > 0)
     {
       has_floating_mesh = true;
-      container_manager.particle_floating_mesh_in_contact.resize(solids.size());
+      contact_manager.particle_floating_mesh_in_contact.resize(solids.size());
     }
 
   // Check if there's periodic boundaries
@@ -449,21 +449,24 @@ DEMSolver<dim>::load_balance()
 
   // Update the container with all the combinations of background and
   // solid cells
-  container_manager.store_floating_mesh_info(triangulation, solids);
+  contact_manager.store_floating_mesh_info(triangulation,
+                                           floating_mesh_info,
+                                           solids);
 
   if (has_periodic_boundaries)
     {
       periodic_boundaries_object.map_periodic_cells(
-        triangulation, container_manager.periodic_boundaries_cells_information);
+        triangulation, periodic_boundaries_cells_information);
 
       periodic_offset =
         periodic_boundaries_object.get_periodic_offset_distance();
     }
 
   // Update neighbors of cells after load balance
-  container_manager.update_cell_neighbors(triangulation,
-                                          has_periodic_boundaries,
-                                          has_floating_mesh);
+  contact_manager.update_cell_neighbors(triangulation,
+                                        periodic_boundaries_cells_information,
+                                        has_periodic_boundaries,
+                                        has_floating_mesh);
 
   boundary_cell_object.build(
     triangulation,
@@ -476,7 +479,7 @@ DEMSolver<dim>::load_balance()
   if (parameters.grid_motion.motion_type !=
       Parameters::Lagrangian::GridMotion<dim>::MotionType::none)
     boundary_cell_object.update_boundary_info_after_grid_motion(
-      container_manager.updated_boundary_points_and_normal_vectors);
+      updated_boundary_points_and_normal_vectors);
 
   const auto average_minimum_maximum_cells =
     Utilities::MPI::min_max_avg(triangulation.n_active_cells(),
@@ -761,18 +764,16 @@ DEMSolver<dim>::particle_wall_contact_force()
 {
   // Particle-wall contact force
   particle_wall_contact_force_object->calculate_particle_wall_contact_force(
-    container_manager.particle_wall_in_contact,
+    contact_manager.particle_wall_in_contact,
     simulation_control->get_time_step(),
     torque,
     force);
 
   if (parameters.forces_torques.calculate_force_torque)
     {
-      container_manager
-        .forces_boundary_information[simulation_control->get_step_number()] =
+      forces_boundary_information[simulation_control->get_step_number()] =
         particle_wall_contact_force_object->get_force();
-      container_manager
-        .torques_boundary_information[simulation_control->get_step_number()] =
+      torques_boundary_information[simulation_control->get_step_number()] =
         particle_wall_contact_force_object->get_torque();
     }
 
@@ -780,7 +781,7 @@ DEMSolver<dim>::particle_wall_contact_force()
   if (parameters.floating_walls.floating_walls_number > 0)
     {
       particle_wall_contact_force_object->calculate_particle_wall_contact_force(
-        container_manager.particle_floating_wall_in_contact,
+        contact_manager.particle_floating_wall_in_contact,
         simulation_control->get_time_step(),
         torque,
         force);
@@ -791,7 +792,7 @@ DEMSolver<dim>::particle_wall_contact_force()
     {
       particle_wall_contact_force_object
         ->calculate_particle_floating_wall_contact_force(
-          container_manager.particle_floating_mesh_in_contact,
+          contact_manager.particle_floating_mesh_in_contact,
           simulation_control->get_time_step(),
           torque,
           force,
@@ -800,7 +801,7 @@ DEMSolver<dim>::particle_wall_contact_force()
 
   particle_point_line_contact_force_object
     .calculate_particle_point_contact_force(
-      &container_manager.particle_points_in_contact,
+      &contact_manager.particle_points_in_contact,
       parameters.lagrangian_physical_properties,
       force);
 
@@ -808,7 +809,7 @@ DEMSolver<dim>::particle_wall_contact_force()
     {
       particle_point_line_contact_force_object
         .calculate_particle_line_contact_force(
-          &container_manager.particle_lines_in_contact,
+          &contact_manager.particle_lines_in_contact,
           parameters.lagrangian_physical_properties,
           force);
     }
@@ -870,8 +871,8 @@ DEMSolver<dim>::finish_simulation()
         parameters.forces_torques.output_frequency,
         triangulation.get_boundary_ids(),
         simulation_control->get_time_step(),
-        container_manager.forces_boundary_information,
-        container_manager.torques_boundary_information);
+        forces_boundary_information,
+        torques_boundary_information);
     }
 }
 
@@ -957,7 +958,6 @@ DEMSolver<dim>::write_output_results()
                             iter,
                             group_files,
                             mpi_communicator);
-
 
   if (simulation_control->get_output_boundaries())
     {
@@ -1082,7 +1082,9 @@ DEMSolver<dim>::solve()
             parameters.boundary_conditions);
 
   // Store information about floating mesh/background mesh intersection
-  container_manager.store_floating_mesh_info(triangulation, solids);
+  contact_manager.store_floating_mesh_info(triangulation,
+                                           floating_mesh_info,
+                                           solids);
 
   if (parameters.restart.restart == true)
     {
@@ -1127,7 +1129,7 @@ DEMSolver<dim>::solve()
         parameters.boundary_conditions.periodic_direction);
 
       periodic_boundaries_object.map_periodic_cells(
-        triangulation, container_manager.periodic_boundaries_cells_information);
+        triangulation, periodic_boundaries_cells_information);
 
       // Temporary offset calculation : works only for one set of periodic
       // boundary on an axis.
@@ -1136,9 +1138,11 @@ DEMSolver<dim>::solve()
     }
 
   // Find cell neighbors
-  container_manager.execute_cell_neighbors_search(triangulation,
-                                                  has_periodic_boundaries,
-                                                  has_floating_mesh);
+  contact_manager.execute_cell_neighbors_search(
+    triangulation,
+    periodic_boundaries_cells_information,
+    has_periodic_boundaries,
+    has_floating_mesh);
 
   // Finding boundary cells with faces
   boundary_cell_object.build(
@@ -1175,7 +1179,7 @@ DEMSolver<dim>::solve()
         {
           grid_motion_object->move_grid(triangulation);
           boundary_cell_object.update_boundary_info_after_grid_motion(
-            container_manager.updated_boundary_points_and_normal_vectors);
+            updated_boundary_points_and_normal_vectors);
         }
 
       // Keep track if particles were inserted this step
@@ -1207,8 +1211,7 @@ DEMSolver<dim>::solve()
         {
           // Particles displacement if passing through a periodic boundary
           periodic_boundaries_object.execute_particles_displacement(
-            particle_handler,
-            container_manager.periodic_boundaries_cells_information);
+            particle_handler, periodic_boundaries_cells_information);
 
           particle_handler.sort_particles_into_subdomains_and_cells();
 
@@ -1246,7 +1249,9 @@ DEMSolver<dim>::solve()
           if (floating_mesh_map_step)
             {
               // Update floating mesh information in the container manager
-              container_manager.store_floating_mesh_info(triangulation, solids);
+              contact_manager.store_floating_mesh_info(triangulation,
+                                                       floating_mesh_info,
+                                                       solids);
             }
         }
 
@@ -1262,26 +1267,28 @@ DEMSolver<dim>::solve()
           // contact pair candidates
           if (!contacts_are_disabled())
             {
-              container_manager.execute_particle_particle_broad_search(
+              contact_manager.execute_particle_particle_broad_search(
                 particle_handler, has_periodic_boundaries);
 
-              container_manager.execute_particle_wall_broad_search(
+              contact_manager.execute_particle_wall_broad_search(
                 particle_handler,
                 boundary_cell_object,
+                floating_mesh_info,
                 parameters.floating_walls,
                 simulation_control->get_current_time(),
                 has_floating_mesh);
             }
           else // has_disabled_contacts && contact_build_number > 1
             {
-              container_manager.execute_particle_particle_broad_search(
+              contact_manager.execute_particle_particle_broad_search(
                 particle_handler,
                 disable_contacts_object,
                 has_periodic_boundaries);
 
-              container_manager.execute_particle_wall_broad_search(
+              contact_manager.execute_particle_wall_broad_search(
                 particle_handler,
                 boundary_cell_object,
+                floating_mesh_info,
                 parameters.floating_walls,
                 simulation_control->get_current_time(),
                 disable_contacts_object,
@@ -1294,23 +1301,23 @@ DEMSolver<dim>::solve()
           // Update contacts, remove replicates and add new contact pairs
           // to the contact containers when particles are exchanged between
           // processors
-          container_manager.update_contacts(has_periodic_boundaries);
+          contact_manager.update_contacts(has_periodic_boundaries);
 
           // Updates the iterators to particles in local-local contact
           // containers
-          container_manager.update_local_particles_in_cells(
+          contact_manager.update_local_particles_in_cells(
             particle_handler, load_balance_step, has_periodic_boundaries);
 
           // Execute fine search by updating particle-particle contact
           // containers according to the neighborhood threshold
-          container_manager.execute_particle_particle_fine_search(
+          contact_manager.execute_particle_particle_fine_search(
             neighborhood_threshold_squared,
             has_periodic_boundaries,
             periodic_offset);
 
           // Execute fine search by updating particle-wall contact containers
           // according to the neighborhood threshold
-          container_manager.execute_particle_wall_fine_search(
+          contact_manager.execute_particle_wall_fine_search(
             parameters.floating_walls,
             simulation_control->get_current_time(),
             neighborhood_threshold_squared,
@@ -1320,7 +1327,7 @@ DEMSolver<dim>::solve()
       // Particle-particle contact force
       particle_particle_contact_force_object
         ->calculate_particle_particle_contact_force(
-          container_manager,
+          contact_manager,
           simulation_control->get_time_step(),
           torque,
           force,
@@ -1336,8 +1343,8 @@ DEMSolver<dim>::solve()
           Parameters::Lagrangian::GridMotion<dim>::MotionType::none)
         grid_motion_object
           ->update_boundary_points_and_normal_vectors_in_contact_list(
-            container_manager.particle_wall_in_contact,
-            container_manager.updated_boundary_points_and_normal_vectors);
+            contact_manager.particle_wall_in_contact,
+            updated_boundary_points_and_normal_vectors);
 
       // Move the solid triangulations, previous time must be used here instead
       // of current time.
@@ -1401,10 +1408,8 @@ DEMSolver<dim>::solve()
           (parameters.forces_torques.force_torque_verbosity ==
            Parameters::Verbosity::verbose))
         write_forces_torques_output_locally(
-          container_manager
-            .forces_boundary_information[simulation_control->get_step_number()],
-          container_manager.torques_boundary_information
-            [simulation_control->get_step_number()]);
+          forces_boundary_information[simulation_control->get_step_number()],
+          torques_boundary_information[simulation_control->get_step_number()]);
 
       // Post-processing
       if (parameters.post_processing.Lagrangian_post_processing &&

--- a/source/dem/dem_contact_manager.cc
+++ b/source/dem/dem_contact_manager.cc
@@ -483,22 +483,5 @@ DEMContactManager<dim>::execute_particle_wall_fine_search(
     }
 }
 
-template <int dim>
-void
-DEMContactManager<dim>::store_floating_mesh_info(
-  const parallel::distributed::Triangulation<dim> &triangulation,
-  typename dem_data_structures<dim>::floating_mesh_information
-                                                          floating_mesh_info,
-  std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> solids)
-{
-  for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
-    {
-      // Create/update a container that contains all the combinations of
-      // background and solid cells
-      floating_mesh_info[i_solid] =
-        solids[i_solid]->map_solid_in_background_triangulation(triangulation);
-    }
-}
-
 template class DEMContactManager<2>;
 template class DEMContactManager<3>;

--- a/source/dem/dem_contact_manager.cc
+++ b/source/dem/dem_contact_manager.cc
@@ -16,14 +16,16 @@
  *
  */
 
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_cell_neighbors_search(
+DEMContactManager<dim>::execute_cell_neighbors_search(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const bool                                       has_periodic_boundaries,
-  const bool                                       has_floating_mesh)
+  const typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
+             periodic_boundaries_cells_information,
+  const bool has_periodic_boundaries,
+  const bool has_floating_mesh)
 {
   // Find cell neighbors
   cell_neighbors_object.find_cell_neighbors(triangulation,
@@ -51,7 +53,7 @@ DEMContainerManager<dim>::execute_cell_neighbors_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::update_contacts(const bool has_periodic_boundaries)
+DEMContactManager<dim>::update_contacts(const bool has_periodic_boundaries)
 {
   // Update particle-particle contacts in local_adjacent_particles of fine
   // search step with local_contact_pair_candidates
@@ -145,7 +147,7 @@ DEMContainerManager<dim>::update_contacts(const bool has_periodic_boundaries)
 
 template <int dim>
 void
-DEMContainerManager<dim>::update_local_particles_in_cells(
+DEMContactManager<dim>::update_local_particles_in_cells(
   const Particles::ParticleHandler<dim> &particle_handler,
   const bool                             clear_contact_structures,
   const bool                             has_periodic_boundaries)
@@ -245,7 +247,7 @@ DEMContainerManager<dim>::update_local_particles_in_cells(
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_particle_particle_broad_search(
+DEMContactManager<dim>::execute_particle_particle_broad_search(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
   const bool                               has_periodic_boundaries)
 {
@@ -261,7 +263,7 @@ DEMContainerManager<dim>::execute_particle_particle_broad_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_particle_particle_broad_search(
+DEMContactManager<dim>::execute_particle_particle_broad_search(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
   const DisableContacts<dim> &             disable_contacts_object,
   const bool                               has_periodic_boundaries)
@@ -280,9 +282,11 @@ DEMContainerManager<dim>::execute_particle_particle_broad_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_particle_wall_broad_search(
-  const Particles::ParticleHandler<dim> &           particle_handler,
-  BoundaryCellsInformation<dim> &                   boundary_cell_object,
+DEMContactManager<dim>::execute_particle_wall_broad_search(
+  const Particles::ParticleHandler<dim> &particle_handler,
+  BoundaryCellsInformation<dim> &        boundary_cell_object,
+  const typename dem_data_structures<dim>::floating_mesh_information
+                                                    floating_mesh_info,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
   const double                                      simulation_time,
   const bool                                        has_floating_mesh)
@@ -331,9 +335,11 @@ DEMContainerManager<dim>::execute_particle_wall_broad_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_particle_wall_broad_search(
-  const Particles::ParticleHandler<dim> &           particle_handler,
-  BoundaryCellsInformation<dim> &                   boundary_cell_object,
+DEMContactManager<dim>::execute_particle_wall_broad_search(
+  const Particles::ParticleHandler<dim> &particle_handler,
+  BoundaryCellsInformation<dim> &        boundary_cell_object,
+  const typename dem_data_structures<dim>::floating_mesh_information
+                                                    floating_mesh_info,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
   const double                                      simulation_time,
   const DisableContacts<dim> &                      disable_contacts_object,
@@ -389,7 +395,7 @@ DEMContainerManager<dim>::execute_particle_wall_broad_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_particle_particle_fine_search(
+DEMContactManager<dim>::execute_particle_particle_fine_search(
   const double         neighborhood_threshold,
   const bool           has_periodic_boundaries,
   const Tensor<1, dim> periodic_offset)
@@ -438,7 +444,7 @@ DEMContainerManager<dim>::execute_particle_particle_fine_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::execute_particle_wall_fine_search(
+DEMContactManager<dim>::execute_particle_wall_fine_search(
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
   const double                                      simulation_time,
   const double                                      neighborhood_threshold,
@@ -479,8 +485,10 @@ DEMContainerManager<dim>::execute_particle_wall_fine_search(
 
 template <int dim>
 void
-DEMContainerManager<dim>::store_floating_mesh_info(
-  const parallel::distributed::Triangulation<dim> &       triangulation,
+DEMContactManager<dim>::store_floating_mesh_info(
+  const parallel::distributed::Triangulation<dim> &triangulation,
+  typename dem_data_structures<dim>::floating_mesh_information
+                                                          floating_mesh_info,
   std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> solids)
 {
   for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
@@ -492,5 +500,5 @@ DEMContainerManager<dim>::store_floating_mesh_info(
     }
 }
 
-template class DEMContainerManager<2>;
-template class DEMContainerManager<3>;
+template class DEMContactManager<2>;
+template class DEMContactManager<3>;

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -1,4 +1,4 @@
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/particle_particle_broad_search.h>
 
 using namespace dealii;
@@ -11,7 +11,7 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContainerManager<dim> &               container_manager)
+  DEMContactManager<dim> &                 container_manager)
 {
   // Pre-fetch and clear containers
   auto &local_contact_pair_candidates =
@@ -136,7 +136,7 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContainerManager<dim> &               container_manager,
+  DEMContactManager<dim> &                 container_manager,
   const DisableContacts<dim> &             disable_contacts_object)
 {
   // Pre-fetch and clear containers
@@ -295,7 +295,7 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_periodic_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContainerManager<dim> &               container_manager)
+  DEMContactManager<dim> &                 container_manager)
 {
   // Pre-fetch and clear containers
   auto &local_contact_pair_periodic_candidates =
@@ -471,7 +471,7 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_periodic_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContainerManager<dim> &               container_manager,
+  DEMContactManager<dim> &                 container_manager,
   const DisableContacts<dim> &             disable_contacts_object)
 {
   // Pre-fetch and clear containers

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -112,7 +112,7 @@ template <
 void
 ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
   calculate_particle_particle_contact_force(
-    DEMContainerManager<dim> & container_manager,
+    DEMContactManager<dim> &   container_manager,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -1,4 +1,4 @@
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/particle_particle_fine_search.h>
 
 using namespace dealii;

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -67,7 +67,7 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
-    types::particle_index,
+    unsigned int,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
     &                                    boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,
@@ -278,7 +278,7 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
-    types::particle_index,
+    unsigned int,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
     &                                    boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -550,15 +550,15 @@ CFDDEMSolver<dim>::load_balance()
   if (has_periodic_boundaries)
     {
       periodic_boundaries_object.map_periodic_cells(
-        *parallel_triangulation,
-        container_manager.periodic_boundaries_cells_information);
+        *parallel_triangulation, periodic_boundaries_cells_information);
 
       periodic_offset =
         periodic_boundaries_object.get_periodic_offset_distance();
     }
 
-  container_manager.update_cell_neighbors(*parallel_triangulation,
-                                          has_periodic_boundaries);
+  contact_manager.update_cell_neighbors(*parallel_triangulation,
+                                        periodic_boundaries_cells_information,
+                                        has_periodic_boundaries);
 
 
   boundary_cell_object.build(
@@ -680,8 +680,7 @@ CFDDEMSolver<dim>::initialize_dem_parameters()
         dem_parameters.boundary_conditions.periodic_direction);
 
       periodic_boundaries_object.map_periodic_cells(
-        *parallel_triangulation,
-        container_manager.periodic_boundaries_cells_information);
+        *parallel_triangulation, periodic_boundaries_cells_information);
 
       // Temporary offset calculation : works only for one set of periodic
       // boundary on an axis.
@@ -698,8 +697,10 @@ CFDDEMSolver<dim>::initialize_dem_parameters()
     }
 
   // Finding cell neighbors
-  container_manager.execute_cell_neighbors_search(*parallel_triangulation,
-                                                  has_periodic_boundaries);
+  contact_manager.execute_cell_neighbors_search(
+    *parallel_triangulation,
+    periodic_boundaries_cells_information,
+    has_periodic_boundaries);
 
   // Finding boundary cells with faces
   boundary_cell_object.build(
@@ -838,7 +839,7 @@ CFDDEMSolver<dim>::dem_iterator(unsigned int counter)
   // Particle-particle contact force
   particle_particle_contact_force_object
     ->calculate_particle_particle_contact_force(
-      container_manager, dem_time_step, torque, force, periodic_offset);
+      contact_manager, dem_time_step, torque, force, periodic_offset);
 
   // Particles-walls contact force:
   particle_wall_contact_force();
@@ -915,8 +916,7 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
       // Particles displacement if passing through a periodic boundary
       if (has_periodic_boundaries)
         periodic_boundaries_object.execute_particles_displacement(
-          this->particle_handler,
-          container_manager.periodic_boundaries_cells_information);
+          this->particle_handler, periodic_boundaries_cells_information);
 
       this->particle_handler.sort_particles_into_subdomains_and_cells();
 
@@ -959,25 +959,27 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
       // contact pair candidates
       if (!contacts_are_disabled(counter))
         {
-          container_manager.execute_particle_particle_broad_search(
+          contact_manager.execute_particle_particle_broad_search(
             this->particle_handler, has_periodic_boundaries);
 
-          container_manager.execute_particle_wall_broad_search(
+          contact_manager.execute_particle_wall_broad_search(
             this->particle_handler,
             boundary_cell_object,
+            floating_mesh_info,
             dem_parameters.floating_walls,
             this->simulation_control->get_current_time());
         }
       else // disabling particle contacts are enabled & counter > 1
         {
-          container_manager.execute_particle_particle_broad_search(
+          contact_manager.execute_particle_particle_broad_search(
             this->particle_handler,
             disable_contacts_object,
             has_periodic_boundaries);
 
-          container_manager.execute_particle_wall_broad_search(
+          contact_manager.execute_particle_wall_broad_search(
             this->particle_handler,
             boundary_cell_object,
+            floating_mesh_info,
             dem_parameters.floating_walls,
             this->simulation_control->get_current_time(),
             disable_contacts_object);
@@ -986,23 +988,23 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
       // Update contacts, remove replicates and add new contact pairs
       // to the contact containers when particles are exchanged between
       // processors
-      container_manager.update_contacts(has_periodic_boundaries);
+      contact_manager.update_contacts(has_periodic_boundaries);
 
       // Updates the iterators to particles in local-local contact
       // containers
-      container_manager.update_local_particles_in_cells(
+      contact_manager.update_local_particles_in_cells(
         this->particle_handler, load_balance_step, has_periodic_boundaries);
 
       // Execute fine search by updating particle-particle contact
       // containers regards the neighborhood threshold
-      container_manager.execute_particle_particle_fine_search(
+      contact_manager.execute_particle_particle_fine_search(
         neighborhood_threshold_squared,
         has_periodic_boundaries,
         periodic_offset);
 
       // Execute fine search by updating particle-wall contact containers
       // regards the neighborhood threshold
-      container_manager.execute_particle_wall_fine_search(
+      contact_manager.execute_particle_wall_fine_search(
         dem_parameters.floating_walls,
         this->simulation_control->get_current_time(),
         neighborhood_threshold_squared);
@@ -1054,16 +1056,15 @@ CFDDEMSolver<dim>::particle_wall_contact_force()
 {
   // Particle-wall contact force
   particle_wall_contact_force_object->calculate_particle_wall_contact_force(
-    container_manager.particle_wall_in_contact, dem_time_step, torque, force);
+    contact_manager.particle_wall_in_contact, dem_time_step, torque, force);
 
   if (this->cfd_dem_simulation_parameters.dem_parameters.forces_torques
         .calculate_force_torque)
     {
-      container_manager.forces_boundary_information[this->simulation_control
-                                                      ->get_step_number()] =
+      forces_boundary_information[this->simulation_control->get_step_number()] =
         particle_wall_contact_force_object->get_force();
-      container_manager.torques_boundary_information[this->simulation_control
-                                                       ->get_step_number()] =
+      torques_boundary_information[this->simulation_control
+                                     ->get_step_number()] =
         particle_wall_contact_force_object->get_torque();
     }
 
@@ -1071,7 +1072,7 @@ CFDDEMSolver<dim>::particle_wall_contact_force()
   if (dem_parameters.floating_walls.floating_walls_number > 0)
     {
       particle_wall_contact_force_object->calculate_particle_wall_contact_force(
-        container_manager.particle_floating_wall_in_contact,
+        contact_manager.particle_floating_wall_in_contact,
         dem_time_step,
         torque,
         force);
@@ -1079,7 +1080,7 @@ CFDDEMSolver<dim>::particle_wall_contact_force()
 
   particle_point_line_contact_force_object
     .calculate_particle_point_contact_force(
-      &container_manager.particle_points_in_contact,
+      &contact_manager.particle_points_in_contact,
       dem_parameters.lagrangian_physical_properties,
       force);
 
@@ -1087,7 +1088,7 @@ CFDDEMSolver<dim>::particle_wall_contact_force()
     {
       particle_point_line_contact_force_object
         .calculate_particle_line_contact_force(
-          &container_manager.particle_lines_in_contact,
+          &contact_manager.particle_lines_in_contact,
           dem_parameters.lagrangian_physical_properties,
           force);
     }

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -992,8 +992,9 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
 
       // Updates the iterators to particles in local-local contact
       // containers
-      contact_manager.update_local_particles_in_cells(
-        this->particle_handler, load_balance_step, has_periodic_boundaries);
+      contact_manager.update_local_particles_in_cells(this->particle_handler,
+                                                      load_balance_step,
+                                                      has_periodic_boundaries);
 
       // Execute fine search by updating particle-particle contact
       // containers regards the neighborhood threshold

--- a/tests/dem/find_contact_pairs.cc
+++ b/tests/dem/find_contact_pairs.cc
@@ -37,7 +37,7 @@
 
 
 // Lethe
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/find_cell_neighbors.h>
 
 // Tests (with common definitions)
@@ -61,7 +61,7 @@ test()
 
   MappingQ1<dim> mapping;
 
-  DEMContainerManager<dim>        container_manager;
+  DEMContactManager<dim>          container_manager;
   Particles::ParticleHandler<dim> particle_handler(triangulation, mapping);
 
   // Finding cell neighbors list, it is required for finding the broad search

--- a/tests/dem/particle_particle_contact_force_linear.cc
+++ b/tests/dem/particle_particle_contact_force_linear.cc
@@ -38,7 +38,7 @@
 // Lethe
 #include <core/dem_properties.h>
 
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/find_cell_neighbors.h>
 #include <dem/particle_particle_broad_search.h>
@@ -92,7 +92,7 @@ test()
 
   // Creating containers manager for finding cell neighbor and also broad and
   // fine particle-particle search objects
-  DEMContainerManager<dim> container_manager;
+  DEMContactManager<dim> container_manager;
 
   // Finding cell neighbors
   FindCellNeighbors<dim> cell_neighbor_object;

--- a/tests/dem/particle_particle_contact_force_nonlinear.cc
+++ b/tests/dem/particle_particle_contact_force_nonlinear.cc
@@ -38,7 +38,7 @@
 // Lethe
 #include <core/dem_properties.h>
 
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/find_cell_neighbors.h>
 #include <dem/particle_particle_broad_search.h>
@@ -91,7 +91,7 @@ test()
 
   // Creating containers manager for finding cell neighbor and also broad and
   // fine particle-particle search objects
-  DEMContainerManager<dim> container_manager;
+  DEMContactManager<dim> container_manager;
 
   // Finding cell neighbors
   FindCellNeighbors<dim> cell_neighbor_object;

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -39,7 +39,7 @@
 #include <core/dem_properties.h>
 
 #include <dem/data_containers.h>
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/find_cell_neighbors.h>
 #include <dem/particle_particle_broad_search.h>
@@ -122,7 +122,7 @@ test()
   typename dem_data_structures<2>::adjacent_particle_pairs
     cleared_ghost_adjacent_particles;
 
-  DEMContainerManager<dim> container_manager;
+  DEMContactManager<dim> container_manager;
 
   // Finding cell neighbors
   FindCellNeighbors<dim> cell_neighbor_object;

--- a/tests/dem/particle_particle_fine_search.cc
+++ b/tests/dem/particle_particle_fine_search.cc
@@ -36,7 +36,7 @@
 #include <deal.II/particles/particle_iterator.h>
 
 // Lethe
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/find_cell_neighbors.h>
 #include <dem/particle_particle_broad_search.h>
 #include <dem/particle_particle_contact_info.h>
@@ -66,7 +66,7 @@ test()
   Particles::ParticleHandler<dim> particle_handler(
     triangulation, mapping, DEM::get_number_properties());
 
-  DEMContainerManager<dim> container_manager;
+  DEMContactManager<dim> container_manager;
 
   // Finding cell neighbors
   FindCellNeighbors<dim> cell_neighbor_object;

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -13,7 +13,7 @@
 // Lethe
 #include <core/dem_properties.h>
 
-#include <dem/dem_container_manager.h>
+#include <dem/dem_contact_manager.h>
 #include <dem/dem_solver_parameters.h>
 #include <dem/find_cell_neighbors.h>
 #include <dem/particle_particle_broad_search.h>
@@ -97,7 +97,7 @@ test()
   typename dem_data_structures<2>::adjacent_particle_pairs
     cleared_ghost_adjacent_particles;
 
-  DEMContainerManager<dim> container_manager;
+  DEMContactManager<dim> container_manager;
 
   // Finding cell neighbors
   FindCellNeighbors<dim> cell_neighbor_object;


### PR DESCRIPTION
# Description of the problem

- The container manager class was more a contact manager with extra random containers and it was a bit weird.

# Description of the solution

- Replace the DEMContainerManager class to DEMContactManager class
- Move some containers back to DEM or CFD-DEM coupling
- Fix a small error in the map of floating walls since it used particle_id type for floating walls

# How Has This Been Tested?

- Tests are good

