### PR TITLE
Add material interaction class and surface tension model

### DIFF
--- a/applications_tests/gls_navier_stokes_2d/gls_droplet_marangoni_effect.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_droplet_marangoni_effect.prm
@@ -28,7 +28,6 @@ end
 subsection VOF
   subsection surface tension force
     set enable                                   = true
-    set surface tension coefficient              = 0.023
     set phase fraction gradient diffusion factor = 4
     set curvature diffusion factor               = 1
     set output auxiliary fields                  = true
@@ -92,6 +91,17 @@ subsection physical properties
     set kinematic viscosity  = 0.01
     set thermal conductivity = 60
     set thermal expansion    = 1
+  end
+
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 0.023
+    end
   end
 end
 

--- a/applications_tests/gls_navier_stokes_2d/gls_static_droplet_surface_tension_force.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_static_droplet_surface_tension_force.prm
@@ -25,7 +25,6 @@ end
 subsection VOF
   subsection surface tension force
     set enable                                   = true
-    set surface tension coefficient              = 0.023
     set phase fraction gradient diffusion factor = 4
     set curvature diffusion factor               = 1
     set output auxiliary fields                  = true
@@ -87,6 +86,17 @@ subsection physical properties
   subsection fluid 1
     set density             = 1000
     set kinematic viscosity = 0.01
+  end
+
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 0.023
+    end
   end
 end
 

--- a/applications_tests/gls_navier_stokes_2d/gls_vof_static_droplet_surface_tension_force_with_tanh_filter.prm
+++ b/applications_tests/gls_navier_stokes_2d/gls_vof_static_droplet_surface_tension_force_with_tanh_filter.prm
@@ -25,7 +25,6 @@ end
 subsection VOF
   subsection surface tension force
     set enable                                   = true
-    set surface tension coefficient              = 0.023
     set phase fraction gradient diffusion factor = 4
     set curvature diffusion factor               = 1
     set output auxiliary fields                  = true
@@ -92,6 +91,17 @@ subsection physical properties
   subsection fluid 1
     set density             = 1000
     set kinematic viscosity = 0.01
+  end
+
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 0.023
+    end
   end
 end
 

--- a/doc/source/examples/multiphysics/rising-bubble/rising-bubble.rst
+++ b/doc/source/examples/multiphysics/rising-bubble/rising-bubble.rst
@@ -21,6 +21,7 @@ Features
 --------------------------
 Files Used in This Example
 --------------------------
+
 - Parameter file: ``examples/multiphysics/rising-bubble/rising_bubble.prm``
 - Python file to generate plot: ``examples/multiphysics/rising-bubble/rising_bubble.py``
 
@@ -123,7 +124,6 @@ The interface sharpening method and its parameters are explained in the :doc:`..
 
     subsection surface tension force
       set enable                                = true
-      set surface tension coefficient           = 24.5
       set phase fraction gradient filter factor = 4
       set curvature filter factor               = 1
       set output auxiliary fields               = true
@@ -160,7 +160,7 @@ Physical Properties
 ~~~~~~~~~~~~~~~~~~~~
 We define two fluids here simply by setting the number of fluids to be :math:`2`.
 In ``subsection fluid 0``, we set the density and the kinematic viscosity for the phase associated with a VOF indicator of 0. 
-A similar procedure is done for the phase associated with a VOF indicator of 1 in ``subsection fluid 1``:
+A similar procedure is done for the phase associated with a VOF indicator of 1 in ``subsection fluid 1``. And, a ``fluid-fluid`` type of material interaction is added to specify the ``surface tension model``. In this case, it is set to ``constant`` with the ``surface tension coefficient`` :math:`\sigma` set to :math:`24.5`.
 
 
 .. code-block:: text
@@ -174,6 +174,16 @@ A similar procedure is done for the phase associated with a VOF indicator of 1 i
       subsection fluid 1
         set density             = 100
         set kinematic viscosity = 0.01
+      end
+      set number of material interactions = 1
+      subsection material interaction 0
+        set type = fluid-fluid
+        subsection fluid-fluid interaction
+          set first fluid id              = 0
+          set second fluid id             = 1
+          set surface tension model       = constant
+          set surface tension coefficient = 24.5
+        end
       end
     end
 

--- a/doc/source/examples/multiphysics/rising-bubble/rising-bubble.rst
+++ b/doc/source/examples/multiphysics/rising-bubble/rising-bubble.rst
@@ -160,7 +160,7 @@ Physical Properties
 ~~~~~~~~~~~~~~~~~~~~
 We define two fluids here simply by setting the number of fluids to be :math:`2`.
 In ``subsection fluid 0``, we set the density and the kinematic viscosity for the phase associated with a VOF indicator of 0. 
-A similar procedure is done for the phase associated with a VOF indicator of 1 in ``subsection fluid 1``. And, a ``fluid-fluid`` type of material interaction is added to specify the ``surface tension model``. In this case, it is set to ``constant`` with the ``surface tension coefficient`` :math:`\sigma` set to :math:`24.5`.
+A similar procedure is done for the phase associated with a VOF indicator of 1 in ``subsection fluid 1``. Then a ``fluid-fluid`` type of material interaction is added to specify the ``surface tension model``. In this case, it is set to ``constant`` with the ``surface tension coefficient`` :math:`\sigma` set to :math:`24.5`.
 
 
 .. code-block:: text

--- a/doc/source/examples/multiphysics/static-bubble/static-bubble.rst
+++ b/doc/source/examples/multiphysics/static-bubble/static-bubble.rst
@@ -127,14 +127,13 @@ defined as a circle with a radius :math:`R= 0.5` in the center of the defined co
 VOF
 ~~~
 
-The surface tension force computation is enabled in the ``VOF`` subsection. The surface tension coefficient :math:`\sigma` is set to :math:`1.0` with the parameter ``surface tension coefficient``. The value of the filter factors :math:`\alpha` and :math:`\beta` described in section :ref:`Normal and curvature computations` are controlled respectively by the parameters ``phase fraction gradient filter factor`` and ``curvature filter factor``. Finally, the parameter ``output auxiliary fields`` set at ``true`` enables the output of the filtered phase fraction gradient and filtered curvature fields.
+The surface tension force computation is enabled in the ``VOF`` subsection. The value of the filter factors :math:`\alpha` and :math:`\beta` described in section :ref:`Normal and curvature computations` are controlled respectively by the parameters ``phase fraction gradient filter factor`` and ``curvature filter factor``. Finally, the parameter ``output auxiliary fields`` set at ``true`` enables the output of the filtered phase fraction gradient and filtered curvature fields.
 
 .. code-block:: text
 
     subsection VOF
       subsection surface tension force
         set enable                                = true
-        set surface tension coefficient           = 1
         set phase fraction gradient filter factor = 4
         set curvature filter factor               = 1
         set output auxiliary fields               = true
@@ -154,7 +153,7 @@ The surface tension force computation is enabled in the ``VOF`` subsection. The 
 Physical Properties
 ~~~~~~~~~~~~~~~~~~~
 
-The density and the kinematic viscosity of the two fluids involved in this example are set in the subsection ``physical properties``. To neglect buoyancy, the density of both fluids is set to :math:`10.0`. Finally, the kinematic viscosity is set to :math:`0.1` in both cases.
+The ``density`` and the ``kinematic viscosity`` of the two fluids involved in this example are set in the subsection ``physical properties``. To neglect buoyancy, the density of both fluids is set to :math:`10.0`. And, the kinematic viscosity is set to :math:`0.1` in both cases. Finally, a ``fluid-fluid`` type of material interaction is added to specify the ``surface tension model``. In this case, it is set to ``constant`` with the ``surface tension coefficient`` :math:`\sigma` set to :math:`1.0`.
 
 .. code-block:: text
 
@@ -167,6 +166,16 @@ The density and the kinematic viscosity of the two fluids involved in this examp
       subsection fluid 0
         set density             = 10
         set kinematic viscosity = 0.1
+      end
+      set number of material interactions = 1
+      subsection material interaction 0
+        set type = fluid-fluid
+        subsection fluid-fluid interaction
+          set first fluid id              = 0
+          set second fluid id             = 1
+          set surface tension model       = constant
+          set surface tension coefficient = 1
+        end
       end
     end
 

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -81,7 +81,7 @@ Physical Properties
 
   * The ``thermal expansion model`` specifies the model used to calculate the thermal expansion coefficient. At the moment, only a constant thermal expansion is supported.
 
-  * The ``thermal expansion`` parameter is the thermal expansion coefficient of the fluid with dimension of :math:`\text{Temperature}^{-1}`. Thermal expansion coefficient is used to define the buoyancy-driven flow (natural convection) using the Boussinesq approximation. Using the Boussinesq approximation, the following source term is added to the Navier-Stokes equation.
+  * The ``thermal expansion`` parameter is the thermal expansion coefficient of the fluid with dimension of :math:`\text{Temperature}^{-1}`. It is used to define the buoyancy-driven flow (natural convection) using the Boussinesq approximation, which leads to the definition of the following source term that is added to the Navier-Stokes equation:
 
     .. math::
 

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -95,7 +95,7 @@ Physical Properties
 
 * The ``number of solids`` parameter controls the number of solid regions. Solid regions are currently only implemented for `Conjugate Heat Transfer`_.
 
-* The ``number of material interactions`` parameter controls the number of physical properties that are due to the interaction between two materials. At the moment, only the surface tension between 2 fluids is implemented in `Two Phase Simulations`_.
+* The ``number of material interactions`` parameter controls the number of physical properties that are due to the interaction between two materials. At the moment, only the surface tension between two fluids is implemented in `Two Phase Simulations`_.
 
   * The material interaction ``type`` can either be ``fluid-fluid`` (default) or ``fluid-solid``.
 
@@ -169,7 +169,7 @@ For two phases, the properties are defined for each fluid. Default values are:
 Conjugate Heat Transfer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Conjugate heat transfer enables the addition of solid regions in which the fluid dynamics is not solved for. To enable the presence of a solid region, ``number of solids`` must be put to 1. By default, the region with the ``material_id=0`` will be the fluid region whereas the region with ``material_id=1`` will be the solid region. The physical properties of the solid region are set in an identical fashion as those of the fluid.
+Conjugate heat transfer enables the addition of solid regions in which the fluid dynamics is not solved for. To enable the presence of a solid region, ``number of solids`` must be set to 1. By default, the region with the ``material_id=0`` will be the fluid region whereas the region with ``material_id=1`` will be the solid region. The physical properties of the solid region are set in an identical fashion as those of the fluid.
 
 .. warning::
   This is an experimental feature. It has not been tested on a large range of application cases. 

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -34,43 +34,96 @@ Physical Properties
       set tracer diffusivity model   = constant
       set tracer diffusivity         = 0
     end
+
     set number of solids = 0
+
+    set number of material interactions = 1
+    subsection material interaction 0
+      set type = fluid-fluid
+      subsection fluid-fluid interaction
+        set first fluid id              = 0
+        set second fluid id             = 1
+
+        # Surface tension
+        set surface tension model       = constant
+        set surface tension coefficient = 0
+      end
+
+      # if fluid-solid interaction
+      subsection fluid-solid interaction
+        set fluid id                    = 0
+        set solid id                    = 0
+
+        # Surface tension
+        set surface tension model       = constant
+        set surface tension coefficient = 0
+      end
+    end
   end
  
 * The ``number of fluids`` parameter controls the number of fluids in the simulation. This parameter is set to ``1`` except in `Two Phase Simulations`_ .
 
-* The ``rheological model`` parameter sets the choice of rheological model. The choices are between ``newtonian``, ``power-law``, ``carreau`` and ``phase_change``. For more details on the rheological models, see  `Rheological Models`_ .
+  * The ``rheological model`` parameter sets the choice of rheological model. The choices are between ``newtonian``, ``power-law``, ``carreau`` and ``phase_change``. For more details on the rheological models, see  `Rheological Models`_ .
 
-* The ``kinematic viscosity`` parameter is the kinematic viscosity of the newtonain fluid in units of :math:`\text{Length}^{2} \cdot \text{Time}^{-1}`. In SI this is :math:`\text{m}^{2} \cdot \text{s}^{-1}`. This viscosity is only used when ``rheological model = newtonian``.
+  * The ``kinematic viscosity`` parameter is the kinematic viscosity of the newtonian fluid in units of :math:`\text{Length}^{2} \cdot \text{Time}^{-1}`. In SI, this is :math:`\text{m}^{2} \cdot \text{s}^{-1}`. This viscosity is only used when ``rheological model = newtonian``.
 
-* The ``density model`` specifies the model used to calculate the density. At the moment, a ``constant`` density and an ``isothermal_ideal_gas`` model are supported. For more details on the density models, see `Density Models`_.
+  * The ``density model`` specifies the model used to calculate the density. At the moment, a ``constant`` density and an ``isothermal_ideal_gas`` model are supported. For more details on the density models, see `Density Models`_.
 
-* The ``density`` parameter is the constant density of the fluid in units of :math:`\text{Mass} \cdot \text{Length}^{-3}`
+  * The ``density`` parameter is the constant density of the fluid in units of :math:`\text{Mass} \cdot \text{Length}^{-3}`
 
-* The ``specific heat model`` specifies the model used to calculate the specific heat. At the moment, only a constant specific heat is supported.
+  * The ``specific heat model`` specifies the model used to calculate the specific heat. At the moment, only a constant specific heat is supported.
 
-* The ``specific heat`` parameter is the constant specific heat of the fluid in units of :math:`\text{Energy} \cdot \text{Temperature}^{-1} \cdot \text{Mass}^{-1}` .
+  * The ``specific heat`` parameter is the constant specific heat of the fluid in units of :math:`\text{Energy} \cdot \text{Temperature}^{-1} \cdot \text{Mass}^{-1}` .
 
-* The ``thermal conductivity model`` specifies the model used to calculate the thermal conductivity. At the moment, ``constant`` and ``linear`` thermal conductivity are available. For more details on the thermal conductivity models, see `Thermal Conductivity Models`_.
+  * The ``thermal conductivity model`` specifies the model used to calculate the thermal conductivity. At the moment, ``constant`` and ``linear`` thermal conductivity are available. For more details on the thermal conductivity models, see `Thermal Conductivity Models`_.
 
-* The ``thermal conductivity`` parameter is the thermal conductivity coefficient of the fluid with units of :math:`\text{Power} \cdot \text{Temperature}^{-1} \cdot \text{Length}^{-1}`.
+  * The ``thermal conductivity`` parameter is the thermal conductivity coefficient of the fluid with units of :math:`\text{Power} \cdot \text{Temperature}^{-1} \cdot \text{Length}^{-1}`.
 
-* The ``thermal expansion model`` specifies the model used to calculate the thermal expansion coefficient. At the moment, only a constant thermal expansion is supported.
+  * The ``thermal expansion model`` specifies the model used to calculate the thermal expansion coefficient. At the moment, only a constant thermal expansion is supported.
 
-* The ``thermal expansion`` parameter is the thermal expansion coefficient of the fluid with dimension of :math:`\text{Temperature}^{-1}`. Thermal expansion coefficient is used to define the buoyancy-driven flow (natural convection) using the Boussinesq approximation. Using the Boussinesq approximation, the following source term is added to the Navier-Stokes equation.
+  * The ``thermal expansion`` parameter is the thermal expansion coefficient of the fluid with dimension of :math:`\text{Temperature}^{-1}`. Thermal expansion coefficient is used to define the buoyancy-driven flow (natural convection) using the Boussinesq approximation. Using the Boussinesq approximation, the following source term is added to the Navier-Stokes equation.
 
-.. math::
+    .. math::
 
-  {\bf{F_{B}}} = -\beta {\bf{g}} (T-T_0) 
+      {\bf{F_{B}}} = -\beta {\bf{g}} (T-T_0)
 
-where :math:`F_B` denotes the buoyant force source term, :math:`\beta` is the thermal expansion coefficient, :math:`T` is temperature, and :math:`T_0` is the base temperature.
+    where :math:`F_B` denotes the buoyant force source term, :math:`\beta` is the thermal expansion coefficient, :math:`T` is temperature, and :math:`T_0` is the base temperature.
 
-* The ``tracer diffusivity model`` specifies the model used to calculate the tracer diffusivity. At the moment, only a constant tracer diffusivity is supported.
+  * The ``tracer diffusivity model`` specifies the model used to calculate the tracer diffusivity. At the moment, only a constant tracer diffusivity is supported.
 
-* The ``tracer diffusivity`` parameter is the diffusivity coefficient of the tracer in units of :math:`\text{Length}^{2} \cdot \text{Time}^{-1}` . In SI this is :math:`\text{m}^{2} \cdot \text{s}^{-1}` .
+  * The ``tracer diffusivity`` parameter is the diffusivity coefficient of the tracer in units of :math:`\text{Length}^{2} \cdot \text{Time}^{-1}` . In SI, this is :math:`\text{m}^{2} \cdot \text{s}^{-1}`.
 
 * The ``number of solids`` parameter controls the number of solid regions. Solid regions are currently only implemented for `Conjugate Heat Transfer`_.
 
+* The ``number of material interactions`` parameter controls the number of physical properties that are due to the interaction between two materials. At the moment, only the surface tension between 2 fluids is implemented in `Two Phase Simulations`_.
+
+  * The material interaction ``type`` can either be ``fluid-fluid`` (default) or ``fluid-solid``.
+
+  * In the ``fluid-fluid`` subsection we define the pair of fluids and their physical properties.
+
+    * The ``first fluid id`` is the id of the first fluid.
+
+    * The ``second fluid id`` is the id of the second fluid.
+
+      .. attention::
+          The ``second fluid id`` should be greater than the ``first fluid id``.
+
+    * The ``surface tension model`` specifies the model used to calculate the surface tension coefficient of the fluid-fluid pair. At the moment, only the ``constant`` model is supported.
+
+    * The ``surface tension coefficient`` parameter is the constant surface tension coefficient of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1}`. The surface tension coefficient is used to define the Weber number (:math:`We`):
+
+      .. math::
+          We = Re \cdot \frac{\mu_\text{ref} \; u_\text{ref}}{\sigma}
+
+      where :math:`Re` is the Reynolds number, :math:`\mu_\text{ref}` and :math:`u_\text{ref}` are some reference viscosity and velocity characterizing the flow problem, and :math:`\sigma` is the surface tension coefficient.
+
+  * In the ``fluid-solid`` subsection we define the fluid-solid pair and their physical properties.
+
+    * The ``fluid id`` is the id of the fluid.
+
+    * The ``solid id`` is the id of the solid.
+
+    * The ``surface tension model``  and ``surface tension coefficient`` are the same as described in the ``fluid-fluid`` subsection above.
 
 .. note:: 
   The default values for all physical properties models in Lethe is ``constant``. Consequently, it is not necessary (and not recommended) to specify the physical property model unless this model is not constant. This generates parameter files that are easier to read.
@@ -116,7 +169,7 @@ For two phases, the properties are defined for each fluid. Default values are:
 Conjugate Heat Transfer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Conjugate heat transfer enables the addition of solid regions in which the fluid dynamics is not solved for. To enable the presence of a solid region, ``number of solids`` must be put to 1. By default, the region with the ``material_id=0`` will be the fluid region whereas the region with ``material_id=1`` will be the solid region. The physcal properties of the solid region are set in an identical fashion as those of the fluid. 
+Conjugate heat transfer enables the addition of solid regions in which the fluid dynamics is not solved for. To enable the presence of a solid region, ``number of solids`` must be put to 1. By default, the region with the ``material_id=0`` will be the fluid region whereas the region with ``material_id=1`` will be the solid region. The physical properties of the solid region are set in an identical fashion as those of the fluid.
 
 .. warning::
   This is an experimental feature. It has not been tested on a large range of application cases. 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -44,7 +44,6 @@ The default values of the VOF parameters are given in the text box below.
       set enable                                = false
       set verbosity                             = quiet
       set output auxiliary fields               = false
-      set surface tension coefficient           = 0.0
       set phase fraction gradient filter factor = 4
       set curvature filter factor               = 1
 
@@ -124,14 +123,13 @@ The default values of the VOF parameters are given in the text box below.
 * ``subsection surface tension force``: Surface tension is the tendency of a liquid to maintain the minimum possible surface area. This subsection defines parameters to ensure an accurate interface between the two phases, used when at least one phase is liquid. 
 
   * ``enable``: controls if ``surface tension force`` is considered.
+
+    .. attention::
+
+      When the surface tension force is enabled, a ``fluid-fluid`` material interaction and a ``surface tension model`` with its parameters must be specified in the :doc:`physical_properties` subsection.
+
   * ``verbosity``: enables the display of the output from the surface tension force calculations. Choices are: ``quiet`` (default, no output) and ``verbose``.
   * ``output auxiliary fields``: enables the display of the filtered ``phase fraction gradient`` and filtered ``curvature``. Used for debugging purposes.
-  * ``surface tension coefficient``: surface tension coefficient in :math:`Nm^{-1}`, as used to define the Weber number (:math:`We`):
-
-    .. math::
-        We = Re \cdot \frac{\mu_\text{ref} \; u_\text{ref}}{\sigma} 
-
-    where :math:`Re` is the Reynolds number, :math:`\mu_\text{ref}` and :math:`u_\text{ref}` are some reference viscosity and velocity characterizing the flow problem, and :math:`\sigma` is the surface tension coefficient.
 
   * ``phase fraction gradient filter factor``: value of the factor :math:`\alpha` applied in the filter :math:`\eta_n = \alpha h^2`, where :math:`h` is the cell size. This filter is used to apply a `projection step <https://onlinelibrary.wiley.com/doi/full/10.1002/fld.2643>`_ to damp high frequency errors, that are magnified by differentiation, in the phase fraction gradient (:math:`\bf{\psi}`), following the equation:
 

--- a/examples/multiphysics/rising-bubble/rising-bubble.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble.prm
@@ -42,7 +42,6 @@ subsection VOF
 
   subsection surface tension force
     set enable                                   = true
-    set surface tension coefficient              = 24.5
     set phase fraction gradient diffusion factor = 4
     set curvature diffusion factor               = 1
     set output auxiliary fields                  = true
@@ -92,6 +91,16 @@ subsection physical properties
   subsection fluid 1
     set density             = 100
     set kinematic viscosity = 0.01
+  end
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 24.5
+    end
   end
 end
 

--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -57,7 +57,6 @@ end
 subsection VOF
   subsection surface tension force
     set enable                                   = true
-    set surface tension coefficient              = 1
     set phase fraction gradient diffusion factor = 4
     set curvature diffusion factor               = 1
     set output auxiliary fields                  = true
@@ -77,6 +76,16 @@ subsection physical properties
   subsection fluid 0
     set density             = 10
     set kinematic viscosity = 0.1
+  end
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 1
+    end
   end
 end
 

--- a/include/core/interface_property_model.h
+++ b/include/core/interface_property_model.h
@@ -1,0 +1,170 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef lethe_interface_property_model_h
+#define lethe_interface_property_model_h
+
+#include <core/parameters.h>
+#include <core/physical_property_model.h>
+
+using namespace dealii;
+
+/**
+ * @brief InterfacePropertyModel. Abstract class that defines the interface for a interface property model
+ * Interface property model provides an abstract interface to calculate the
+ * value of an interface property or a vector of interface property value for
+ * given field value. By default, the interface does not require that all (or
+ * any) fields be specified. This is why a map is used to pass the dependent
+ * variable. To allow for the calculation of the appropriate jacobian matrix
+ * (when that is necessary) the interface also provides a jacobian function,
+ * which must provide the derivative with respect to the field specified as an
+ * argument.
+ */
+class InterfacePropertyModel
+{
+public:
+  /**
+   * @brief class InterfacePropertyModel Default constructor. Set the model_depends_on to false for all variables.
+   */
+  InterfacePropertyModel()
+  {
+    model_depends_on[shear_rate]           = false;
+    model_depends_on[temperature]          = false;
+    model_depends_on[previous_temperature] = false;
+    model_depends_on[pressure]             = false;
+  }
+
+  /**
+   * @brief Returns true if the InterfacePropertyModel depends on a field, false if not.
+   */
+
+  inline bool
+  depends_on(const field &id)
+  {
+    return model_depends_on[id];
+  }
+
+
+  /**
+   * @brief value Calculates the value of an interface property.
+   * @param fields_value Value of the various field on which the property may depend.
+   * @return value of the interface property calculated with the fields_value
+   */
+  virtual double
+  value(const std::map<field, double> &fields_value) = 0;
+
+  /**
+   * @brief vector_value Calculates the values of an interface property for multiple points
+   * @param field_vectors
+   */
+  virtual void
+  vector_value(const std::map<field, std::vector<double>> &field_vectors,
+               std::vector<double> &                       property_vector) = 0;
+
+  /**
+   * @brief jacobian Calcualtes the jacobian (the partial derivative) of the interface
+   * property with respect to a field
+   * @param field_values Value of the various fields on which the property may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated
+   * @return value of the partial derivative of the property with respect to the field.
+   */
+
+  virtual double
+  jacobian(const std::map<field, double> &field_values, const field id) = 0;
+
+  /**
+   * @brief vector_jacobian Calculate the derivative of the property with respect to a field
+   * @param field_vectors Vector for the values of the fields used to evaluate the property
+   * @param id Identifier of the field with respect to which a derivative should be calculated
+   * @param jacobian Vector of the value of the derivative of the property with respect to the field id
+   */
+
+  virtual void
+  vector_jacobian(const std::map<field, std::vector<double>> &field_vectors,
+                  const field                                 id,
+                  std::vector<double> &jacobian_vector) = 0;
+
+
+  /**
+   * @brief numerical_jacobian Calculates the jacobian through a forward finite difference (Euler) approximation.
+   * This approach, although not preferable, is meant as a fall-back when
+   * calculating the jacobian manually is too difficult.
+   * @param fields_values The values of the various fields
+   * @param id Field id of the field with respect to which the jacobian should be calculated
+   * @return
+   */
+  inline double
+  numerical_jacobian(const std::map<field, double> &field_values,
+                     const field                    id)
+  {
+    double f_x   = this->value(field_values);
+    auto   x_dx  = field_values;
+    double dx    = std::max(1e-6 * x_dx[id], 1e-8);
+    x_dx[id]     = x_dx[id] + dx;
+    double f_xdx = this->value(x_dx);
+    return (f_xdx - f_x) / dx;
+  }
+
+  /**
+   * @brief vector_numerical_jacobian Calculates the vector of jacobian through forward finite difference (Euler) approximation.
+   * This approach, although not preferable, is meant as a fall-back when
+   * calculating the jacobian manually is too difficult.
+   * @param field_vectors
+   * @param field_id
+   * @param jacobian_vector
+   * @return
+   */
+  inline void
+  vector_numerical_jacobian(
+    const std::map<field, std::vector<double>> &field_vectors,
+    const field                                 id,
+    std::vector<double> &                       jacobian_vector)
+  {
+    const unsigned int n_pts = jacobian_vector.size();
+
+    // Evaluate the properties using the values of the field vector
+    std::vector<double> f_x(n_pts);
+    vector_value(field_vectors, f_x);
+
+    // Make a copy of the field vector for the field we wil perturbate
+    std::map<field, std::vector<double>> perturbed_field_vectors =
+      field_vectors;
+    std::vector<double> &x = perturbed_field_vectors.at(id);
+    std::vector<double>  dx(n_pts);
+
+    // Perturb the field by dx
+    for (unsigned int i = 0; i < n_pts; ++i)
+      {
+        dx[i] = std::max(1e-6 * x[i], 1e-8);
+        x[i] += dx[i];
+      }
+
+    // Evaluate the properties using the perturbed value of the field vector
+    std::vector<double> f_xdx(n_pts);
+    vector_value(perturbed_field_vectors, f_xdx);
+
+    // Fill jacobian
+    for (unsigned int i = 0; i < n_pts; ++i)
+      jacobian_vector[i] = (f_xdx[i] - f_x[i]) / dx[i];
+  }
+
+protected:
+  // Map to indicate on which variables the model depends on
+  std::map<field, bool> model_depends_on;
+};
+
+#endif

--- a/include/core/interface_property_model.h
+++ b/include/core/interface_property_model.h
@@ -140,7 +140,7 @@ public:
     std::vector<double> f_x(n_pts);
     vector_value(field_vectors, f_x);
 
-    // Make a copy of the field vector for the field we wil perturbate
+    // Make a copy of the field vector for the field we will perturbate
     std::map<field, std::vector<double>> perturbed_field_vectors =
       field_vectors;
     std::vector<double> &x = perturbed_field_vectors.at(id);

--- a/include/core/interface_property_model.h
+++ b/include/core/interface_property_model.h
@@ -75,7 +75,7 @@ public:
                std::vector<double> &                       property_vector) = 0;
 
   /**
-   * @brief jacobian Calcualtes the jacobian (the partial derivative) of the interface
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the interface
    * property with respect to a field
    * @param field_values Value of the various fields on which the property may depend.
    * @param id Indicator of the field with respect to which the jacobian

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -411,7 +411,6 @@ namespace Parameters
     } surface_tension_model;
     SurfaceTensionParameters surface_tension_parameters;
 
-
     std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
       fluid_fluid_interaction_with_material_interaction_id;
     std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
@@ -420,7 +419,6 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm, unsigned int id);
 
-    // TODO ask about scaling/dimensionality
     void
     parse_parameters(ParameterHandler &prm, const unsigned int id);
   };

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -297,6 +297,19 @@ namespace Parameters
     parse_parameters(ParameterHandler &prm, const Dimensionality dimensions);
   };
 
+  /**
+   * @brief SurfaceTensionParameters - Defines parameters for surface tension models
+   */
+  struct SurfaceTensionParameters
+  {
+    // Surface tension coefficient (sigma) in N/m
+    double surface_tension_coefficient;
+
+    void
+    declare_parameters(ParameterHandler &prm);
+    void
+    parse_parameters(ParameterHandler &prm);
+  };
 
   /**
    * @brief Material - Class that defines the physical property of a material.
@@ -376,7 +389,41 @@ namespace Parameters
     double k_A1;
   };
 
+  /**
+   * @brief MaterialInteractions - Class that defines physical properties due to interactions between two different materials (either fluid-fluid or fluid-solid).
+   */
+  class MaterialInteractions
+  {
+  public:
+    MaterialInteractions()
+    {}
 
+    enum class MaterialInteractionsType
+    {
+      fluid_fluid,
+      fluid_solid
+    } material_interaction_type;
+
+    // Surface tension models
+    enum class SurfaceTensionModel
+    {
+      constant
+    } surface_tension_model;
+    SurfaceTensionParameters surface_tension_parameters;
+
+
+    std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
+      fluid_fluid_interaction_with_material_interaction_id;
+    std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
+      fluid_solid_interaction_with_material_interaction_id;
+
+    void
+    declare_parameters(ParameterHandler &prm, unsigned int id);
+
+    // TODO ask about scaling/dimensionality
+    void
+    parse_parameters(ParameterHandler &prm, const unsigned int id);
+  };
 
   /**
    * @brief PhysicalProperties - Define the possible physical properties.
@@ -400,6 +447,15 @@ namespace Parameters
     std::vector<Material>     solids;
     unsigned int              number_of_solids;
     static const unsigned int max_solids = 1;
+
+    // Fluid-fluid or fluid-solid interactions
+    std::vector<MaterialInteractions> material_interactions;
+    unsigned int                      number_of_material_interactions;
+    static const unsigned int         max_material_interactions = 5;
+    std::map<std::pair<unsigned int, unsigned int>, unsigned int>
+      fluid_fluid_interactions_with_material_interaction_ids;
+    std::map<std::pair<unsigned int, unsigned int>, unsigned int>
+      fluid_solid_interactions_with_material_interaction_ids;
 
     void
     declare_parameters(ParameterHandler &prm);

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -449,7 +449,7 @@ namespace Parameters
     // Fluid-fluid or fluid-solid interactions
     std::vector<MaterialInteractions> material_interactions;
     unsigned int                      number_of_material_interactions;
-    static const unsigned int         max_material_interactions = 5;
+    static const unsigned int         max_material_interactions = 3;
     std::map<std::pair<unsigned int, unsigned int>, unsigned int>
       fluid_fluid_interactions_with_material_interaction_ids;
     std::map<std::pair<unsigned int, unsigned int>, unsigned int>

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -167,9 +167,6 @@ namespace Parameters
   struct VOF_SurfaceTensionForce
   {
     bool enable;
-    // Surface tension coefficient.
-    // This will be moved to the property manager in another PR.
-    double surface_tension_coef;
 
     double phase_fraction_gradient_diffusion_factor;
     double curvature_diffusion_factor;

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -1,0 +1,115 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef lethe_surface_tension_model_h
+#define lethe_surface_tension_model_h
+
+#include <core/physical_property_model.h>
+
+/**
+ * @brief SurfaceTensionModel. Abstract class that allows to calculate the
+ * surface tension.
+ */
+class SurfaceTensionModel : public PhysicalPropertyModel
+{
+public:
+  /**
+   * @brief Instantiates and returns a pointer to a SurfaceTensionModel object by casting it to
+   * the proper child class
+   *
+   * @param material_properties Parameters for a single fluid
+   */
+  static std::shared_ptr<SurfaceTensionModel>
+  model_cast(
+    const Parameters::SurfaceTensionParameters &surface_tension_parameters);
+};
+
+
+
+/**
+ * @brief Constant surface tension.
+ */
+class SurfaceTensionConstant : public SurfaceTensionModel
+{
+public:
+  /**
+   * @brief Default constructor
+   */
+  SurfaceTensionConstant(const double p_surface_tension_coefficient)
+    : surface_tension_coefficient(p_surface_tension_coefficient)
+  {}
+
+  /**
+   * @brief value Calculates the surface tension coefficient
+   * @param fields_value Value of the various field on which the property may depend.
+   * @return value of the physical property calculated with the fields_value
+   */
+  double
+  value(const std::map<field, double> & /*fields_value*/) override
+  {
+    return surface_tension_coefficient;
+  }
+
+  /**
+   * @brief vector_value Calculates the vector of surface tension coefficient.
+   * @param field_vectors Vectors of the fields on which the surface tension coefficient may depend.
+   * @param property_vector Vectors of the surface tension coefficient values
+   */
+  void
+  vector_value(const std::map<field, std::vector<double>> & /*field_vectors*/,
+               std::vector<double> &property_vector) override
+  {
+    std::fill(property_vector.begin(),
+              property_vector.end(),
+              surface_tension_coefficient);
+  }
+
+  /**
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the surface tension coefficient with respect to a field
+   * @param field_values Value of the various fields on which the property may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated.
+   * @return value of the partial derivative of the surface tension coefficient with respect to the field.
+   */
+
+  double
+  jacobian(const std::map<field, double> & /*field_values*/,
+           field /*id*/) override
+  {
+    return 0;
+  }
+
+  /**
+   * @brief vector_jacobian Calculates the derivative of the surface tension coefficient with respect to a field.
+   * @param field_vectors Vector for the values of the fields used to evaluate the property.
+   * @param id Identifier of the field with respect to which a derivative should be calculated.
+   * @param jacobian vector of the value of the derivative of the surface tension coefficient with respect to the field id.
+   */
+
+  void
+  vector_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field /*id*/,
+    std::vector<double> &jacobian_vector) override
+  {
+    std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+  }
+
+private:
+  const double surface_tension_coefficient;
+};
+
+#endif

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -38,7 +38,6 @@ public:
 };
 
 
-
 /**
  * @brief Constant surface tension.
  */
@@ -84,7 +83,6 @@ public:
    * should be calculated.
    * @return value of the partial derivative of the surface tension coefficient with respect to the field.
    */
-
   double
   jacobian(const std::map<field, double> & /*field_values*/,
            field /*id*/) override
@@ -98,7 +96,6 @@ public:
    * @param id Identifier of the field with respect to which a derivative should be calculated.
    * @param jacobian vector of the value of the derivative of the surface tension coefficient with respect to the field id.
    */
-
   void
   vector_jacobian(
     const std::map<field, std::vector<double>> & /*field_vectors*/,

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -17,13 +17,13 @@
 #ifndef lethe_surface_tension_model_h
 #define lethe_surface_tension_model_h
 
-#include <core/physical_property_model.h>
+#include <core/interface_property_model.h>
 
 /**
  * @brief SurfaceTensionModel. Abstract class that allows to calculate the
  * surface tension coefficient.
  */
-class SurfaceTensionModel : public PhysicalPropertyModel
+class SurfaceTensionModel : public InterfacePropertyModel
 {
 public:
   /**

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -21,7 +21,7 @@
 
 /**
  * @brief SurfaceTensionModel. Abstract class that allows to calculate the
- * surface tension.
+ * surface tension coefficient.
  */
 class SurfaceTensionModel : public PhysicalPropertyModel
 {
@@ -30,7 +30,7 @@ public:
    * @brief Instantiates and returns a pointer to a SurfaceTensionModel object by casting it to
    * the proper child class
    *
-   * @param material_properties Parameters for a single fluid
+   * @param surface_tension_parameters Parameters for the surface tension coefficient calculation
    */
   static std::shared_ptr<SurfaceTensionModel>
   model_cast(

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -936,7 +936,7 @@ public:
   std::vector<double> viscosity_1;
   std::vector<double> thermal_expansion_0;
   std::vector<double> thermal_expansion_1;
-
+  std::vector<double> surface_tension;
 
   // FEValues for the Navier-Stokes problem
   FEValues<dim>              fe_values;

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -48,6 +48,12 @@ DeclException1(
        "Modifications to Lethe are required to take this into account.");
 
 
+enum material_interactions_type
+{
+  fluid_fluid,
+  fluid_solid
+};
+
 
 /** @class The PhysicalPropertiesManager class manages the physical properties
  * model which are required to calculate the various physical properties
@@ -87,8 +93,6 @@ public:
 
   void
   initialize(Parameters::PhysicalProperties physical_properties);
-
-
 
   inline unsigned int
   get_number_of_fluids() const
@@ -238,11 +242,12 @@ public:
   }
 
   unsigned int
-  get_material_interaction_id(const std::string  material_interaction_type,
-                              const unsigned int material_0_id,
-                              const unsigned int material_1_id) const
+  get_material_interaction_id(
+    const material_interactions_type material_interaction_type,
+    const unsigned int               material_0_id,
+    const unsigned int               material_1_id) const
   {
-    if (material_interaction_type == "fluid-fluid")
+    if (material_interaction_type == material_interactions_type::fluid_fluid)
       {
         std::pair<unsigned int, unsigned int> fluid_fluid_material_interaction(
           material_0_id, material_1_id);
@@ -250,7 +255,8 @@ public:
           .find(fluid_fluid_material_interaction)
           ->second;
       }
-    else if (material_interaction_type == "fluid-solid")
+    else if (material_interaction_type ==
+             material_interactions_type::fluid_solid)
       {
         std::pair<unsigned int, unsigned int> fluid_solid_material_interaction(
           material_0_id, material_1_id);
@@ -266,6 +272,9 @@ public:
 private:
   void
   establish_fields_required_by_model(PhysicalPropertyModel &model);
+
+  void
+  establish_fields_required_by_model(InterfacePropertyModel &model);
 
   /** @brief Calculates the global id of the physical property. By default. Lethe stores all
    *  the properties of the fluids, then the properties of the solid. Fluids
@@ -286,7 +295,6 @@ private:
         return number_of_fluids + material_id - 1;
       }
   }
-
 
 public:
   bool is_initialized;

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -260,7 +260,7 @@ public:
       }
     else
       throw(std::runtime_error(
-        "Invalid type of material interaction. At the moment, the only choice is <fluid-fluid|fluid-solid>"));
+        "Invalid type of material interaction. The choices are <fluid-fluid|fluid-solid>"));
   }
 
 private:

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -180,6 +180,23 @@ public:
           "Inconsistency in .prm!\n in subsection VOF, with sharpening type = adaptative\n "
           "use: monitoring = true");
       }
+    if (multiphysics.vof_parameters.surface_tension_force.enable &&
+        physical_properties.number_of_material_interactions == 0)
+      {
+        throw std::logic_error(
+          "Inconsistency in .prm!\n in subsection VOF, with surface tension force enabled,\n but no material interactions specified in\n subsection physical properties\n"
+          "use:\n"
+          "  set number of material interactions = 1\n"
+          "  subsection material interaction 0\n"
+          "    set type = fluid-fluid\n"
+          "    subsection fluid-fluid interaction\n"
+          "      set first fluid id              = 0\n"
+          "      set second fluid id             = 1\n"
+          "      set surface tension model       = constant\n"
+          "      set surface tension coefficient = $value_of_coefficient\n"
+          "    end\n"
+          "  end");
+      }
   }
 
 private:

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -197,6 +197,35 @@ public:
           "    end\n"
           "  end");
       }
+    if (multiphysics.vof_parameters.surface_tension_force.enable)
+      {
+        bool error = true;
+        for (unsigned int i = 0;
+             i < physical_properties.number_of_material_interactions;
+             ++i)
+          {
+            if (physical_properties.material_interactions[i]
+                  .material_interaction_type ==
+                Parameters::MaterialInteractions::MaterialInteractionsType::
+                  fluid_fluid)
+              error = false;
+          }
+        if (error)
+          {
+            throw std::logic_error(
+              "Inconsistency in .prm!\n in subsection VOF, with surface tension force enabled,\n but no fluid-fluid material interactions specified in\n subsection physical properties\n"
+              "use:\n"
+              "  subsection material interaction $material_interaction_id\n"
+              "    set type = fluid-fluid\n"
+              "    subsection fluid-fluid interaction\n"
+              "      set first fluid id              = 0\n"
+              "      set second fluid id             = 1\n"
+              "      set surface tension model       = constant\n"
+              "      set surface tension coefficient = $value_of_coefficient\n"
+              "    end\n"
+              "  end");
+          }
+      }
   }
 
 private:

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -73,7 +73,7 @@ add_library(lethe-core
   ../../include/core/thermal_expansion_model.h
   ../../include/core/time_integration_utilities.h
   ../../include/core/tracer_diffusivity_model.h
-  ../../include/core/utilities.h)
+  ../../include/core/utilities.h ../../include/core/interface_property_model.h)
 
 deal_ii_setup_target(lethe-core)
 target_include_directories(lethe-core PUBLIC ../../include)

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(lethe-core
   solid_objects_parameters.cc
   solutions_output.cc
   specific_heat_model.cc
+  surface_tension_model.cc
   thermal_conductivity_model.cc
   thermal_expansion_model.cc
   tracer_diffusivity_model.cc
@@ -66,6 +67,7 @@ add_library(lethe-core
   ../../include/core/solid_objects_parameters.h
   ../../include/core/solutions_output.h
   ../../include/core/specific_heat_model.h
+  ../../include/core/surface_tension_model.h
   ../../include/core/tensors_and_points_dimension_manipulation.h
   ../../include/core/thermal_conductivity_model.h
   ../../include/core/thermal_expansion_model.h

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(lethe-core
   ../../include/core/ib_particle.h
   ../../include/core/ib_stencil.h
   ../../include/core/inexact_newton_non_linear_solver.h
+  ../../include/core/interface_property_model.h
   ../../include/core/kinsol_newton_non_linear_solver.h
   ../../include/core/lethe_grid_tools.h
   ../../include/core/manifolds.h
@@ -73,7 +74,7 @@ add_library(lethe-core
   ../../include/core/thermal_expansion_model.h
   ../../include/core/time_integration_utilities.h
   ../../include/core/tracer_diffusivity_model.h
-  ../../include/core/utilities.h ../../include/core/interface_property_model.h)
+  ../../include/core/utilities.h)
 
 deal_ii_setup_target(lethe-core)
 target_include_directories(lethe-core PUBLIC ../../include)

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -937,7 +937,7 @@ namespace Parameters
                          Utilities::int_to_string(id, 1));
     {
       prm.declare_entry(
-        "material interaction type",
+        "type",
         "fluid-fluid",
         Patterns::Selection("fluid-fluid|fluid-solid"),
         "Type of materials interacting. Choices <fluid-fluid|fluid-solid>");
@@ -949,12 +949,12 @@ namespace Parameters
           "first fluid id",
           "0",
           Patterns::Integer(),
-          "ID of the first fluid interacting with the second fluid");
+          "ID of the first fluid interacting with the second fluid. This value should be lower than the second fluid's id.");
         prm.declare_entry(
           "second fluid id",
           "1",
           Patterns::Integer(),
-          "ID of the second fluid interacting with the first fluid");
+          "ID of the second fluid interacting with the first fluid. This value should be greater than the first fluid's id.");
 
         // Surface tension interactions
         prm.declare_entry(
@@ -1011,10 +1011,11 @@ namespace Parameters
 
       if (material_interaction_type == MaterialInteractionsType::fluid_fluid)
         {
+          prm.enter_subsection("fluid-fluid interaction");
           std::pair<unsigned int, unsigned int> fluid_fluid_interaction;
           fluid_fluid_interaction.first  = prm.get_integer("first fluid id");
           fluid_fluid_interaction.second = prm.get_integer("second fluid id");
-          AssertThrow(fluid_fluid_interaction.first <
+          AssertThrow(fluid_fluid_interaction.first <=
                         fluid_fluid_interaction.second,
                       OrderOfFluidIDsError(fluid_fluid_interaction.first,
                                            fluid_fluid_interaction.second));
@@ -1032,9 +1033,12 @@ namespace Parameters
           else
             throw(std::runtime_error(
               "Invalid surface tension model. At the moment, the only choice is <constant>"));
+
+          prm.leave_subsection();
         }
       else // Solid-fluid interactions
         {
+          prm.enter_subsection("fluid-solid interaction");
           std::pair<unsigned int, unsigned int> fluid_solid_interaction;
           fluid_solid_interaction.first  = prm.get_integer("fluid id");
           fluid_solid_interaction.second = prm.get_integer("solid id");
@@ -1055,6 +1059,7 @@ namespace Parameters
           std::pair<std::pair<unsigned int, unsigned int>, SurfaceTensionModel>
             fluid_solid_surface_tension_interaction(fluid_solid_interaction,
                                                     surface_tension_model);
+          prm.leave_subsection();
         }
     }
     prm.leave_subsection();

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -15,7 +15,7 @@ DeclException1(
   NumberOfFluidsError,
   int,
   << "Number of fluids: " << arg1
-  << " is not 1 (single phase simulation) or 2 (VOF simulation).This is currently not supported.");
+  << " is not 1 (single phase simulation) or 2 (VOF simulation). This is currently not supported.");
 
 DeclException1(NumberOfSolidsError,
                int,
@@ -940,7 +940,7 @@ namespace Parameters
         "type",
         "fluid-fluid",
         Patterns::Selection("fluid-fluid|fluid-solid"),
-        "Type of materials interacting. Choices <fluid-fluid|fluid-solid>");
+        "Type of materials interacting. Choices are <fluid-fluid|fluid-solid>");
 
       // Fluid-fluid interactions
       prm.enter_subsection("fluid-fluid interaction");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -11,15 +11,28 @@ DeclException2(
   << " The liquidus temperature specific is below or equal to the solidus temperature."
   << " The phase change specific heat model requires that T_liquidus>T_solidus.");
 
-DeclException1(NumberOfFluidsError,
-               int,
-               << "Number of fluids: " << arg1
-               << " is not 1 (single phase simulation) or 2 (VOF simulation)");
+DeclException1(
+  NumberOfFluidsError,
+  int,
+  << "Number of fluids: " << arg1
+  << " is not 1 (single phase simulation) or 2 (VOF simulation).This is currently not supported.");
 
 DeclException1(NumberOfSolidsError,
                int,
                << "Number of solids: " << arg1
                << " is larger than 1. This is currently not supported.");
+
+DeclException1(NumberOfMaterialInteractionsError,
+               int,
+               << "Number of material interactions: " << arg1
+               << " is larger than 3. This is currently not supported.");
+
+DeclException2(
+  OrderOfFluidIDsError,
+  int,
+  int,
+  << "The first fluid's id is " << arg1 << " and the id of the second fluid is "
+  << arg2 << ". The first fluid's id should be lower than the second fluid's.");
 
 DeclException1(
   TwoDimensionalLaserError,
@@ -408,6 +421,22 @@ namespace Parameters
   }
 
   void
+  SurfaceTensionParameters::declare_parameters(dealii::ParameterHandler &prm)
+  {
+    prm.declare_entry(
+      "surface tension coefficient",
+      "0",
+      Patterns::Double(),
+      "Surface tension coefficient for the corresponding pair of fluids or fluid-solid pair");
+  }
+
+  void
+  SurfaceTensionParameters::parse_parameters(ParameterHandler &prm)
+  {
+    surface_tension_coefficient = prm.get_double("surface tension coefficient");
+  }
+
+  void
   Stabilization::declare_parameters(ParameterHandler &prm)
   {
     prm.enter_subsection("stabilization");
@@ -577,6 +606,8 @@ namespace Parameters
     number_of_fluids = 1;
     solids.resize(max_solids);
     number_of_solids = 0;
+    material_interactions.resize(max_material_interactions);
+    number_of_material_interactions = 0;
 
     prm.enter_subsection("physical properties");
     {
@@ -602,6 +633,21 @@ namespace Parameters
           solids[i_solid].declare_parameters(prm, "solid", i_solid);
         }
     }
+
+    // Definition of interactions between materials
+    prm.declare_entry(
+      "number of material interactions",
+      "0",
+      Patterns::Integer(),
+      "Number of material interactions (either fluid-fluid or fluid-solid)");
+
+    for (unsigned int i_material_interaction = 0;
+         i_material_interaction < max_material_interactions;
+         ++i_material_interaction)
+      {
+        material_interactions[i_material_interaction].declare_parameters(
+          prm, i_material_interaction);
+      }
 
     prm.leave_subsection();
   }
@@ -629,7 +675,31 @@ namespace Parameters
           solids[i_solid].parse_parameters(prm, "solid", i_solid, dimensions);
         }
       AssertThrow(number_of_solids <= max_solids,
-                  NumberOfSolidsError(number_of_fluids));
+                  NumberOfSolidsError(number_of_solids));
+
+      // Definition of interactions between materials
+      number_of_material_interactions =
+        prm.get_integer("number of material interactions");
+      AssertThrow(number_of_material_interactions <= max_material_interactions,
+                  NumberOfMaterialInteractionsError(
+                    number_of_material_interactions));
+      for (unsigned int i_material_interaction = 0;
+           i_material_interaction < number_of_material_interactions;
+           ++i_material_interaction)
+        {
+          material_interactions[i_material_interaction].parse_parameters(
+            prm, i_material_interaction);
+          if (material_interactions[i_material_interaction]
+                .material_interaction_type ==
+              MaterialInteractions::MaterialInteractionsType::fluid_fluid)
+            fluid_fluid_interactions_with_material_interaction_ids.insert(
+              material_interactions[i_material_interaction]
+                .fluid_fluid_interaction_with_material_interaction_id);
+          else // fluid-solid interaction
+            fluid_solid_interactions_with_material_interaction_ids.insert(
+              material_interactions[i_material_interaction]
+                .fluid_solid_interaction_with_material_interaction_id);
+        }
     }
     prm.leave_subsection();
   }
@@ -855,6 +925,137 @@ namespace Parameters
       // Phase change properties
       //--------------------------------
       phase_change_parameters.parse_parameters(prm, dimensions);
+    }
+    prm.leave_subsection();
+  }
+
+  void
+  MaterialInteractions::declare_parameters(ParameterHandler &prm,
+                                           unsigned int      id)
+  {
+    prm.enter_subsection("material interaction " +
+                         Utilities::int_to_string(id, 1));
+    {
+      prm.declare_entry(
+        "material interaction type",
+        "fluid-fluid",
+        Patterns::Selection("fluid-fluid|fluid-solid"),
+        "Type of materials interacting. Choices <fluid-fluid|fluid-solid>");
+
+      // Fluid-fluid interactions
+      prm.enter_subsection("fluid-fluid interaction");
+      {
+        prm.declare_entry(
+          "first fluid id",
+          "0",
+          Patterns::Integer(),
+          "ID of the first fluid interacting with the second fluid");
+        prm.declare_entry(
+          "second fluid id",
+          "1",
+          Patterns::Integer(),
+          "ID of the second fluid interacting with the first fluid");
+
+        // Surface tension interactions
+        prm.declare_entry(
+          "surface tension model",
+          "constant",
+          Patterns::Selection("constant"),
+          "Model used for the calculation of the surface tension coefficient"
+          "At the moment, the only choice is <constant>");
+        surface_tension_parameters.declare_parameters(prm);
+      }
+      prm.leave_subsection();
+
+      // Fluid-solid interactions
+      prm.enter_subsection("fluid-solid interaction");
+      {
+        prm.declare_entry("fluid id",
+                          "0",
+                          Patterns::Integer(),
+                          "ID of the fluid interacting with the solid");
+        prm.declare_entry("solid id",
+                          "0",
+                          Patterns::Integer(),
+                          "ID of the solid interacting with the fluid");
+
+        // Surface tension interactions
+        prm.declare_entry(
+          "surface tension model",
+          "constant",
+          Patterns::Selection("constant"),
+          "Model used for the calculation of the surface tension coefficient"
+          "At the moment, the only choice is <constant>");
+        surface_tension_parameters.declare_parameters(prm);
+      }
+      prm.leave_subsection();
+    }
+    prm.leave_subsection();
+  }
+
+  void
+  MaterialInteractions::parse_parameters(ParameterHandler &prm, unsigned int id)
+  {
+    prm.enter_subsection("material interaction " +
+                         Utilities::int_to_string(id, 1));
+    {
+      std::string op;
+      op = prm.get("type");
+      if (op == "fluid-fluid")
+        material_interaction_type = MaterialInteractionsType::fluid_fluid;
+      else if (op == "fluid-solid")
+        material_interaction_type = MaterialInteractionsType::fluid_solid;
+      else
+        throw(std::runtime_error(
+          "Invalid material interaction type. Choices are <fluid-fluid|fluid-solid>"));
+
+      if (material_interaction_type == MaterialInteractionsType::fluid_fluid)
+        {
+          std::pair<unsigned int, unsigned int> fluid_fluid_interaction;
+          fluid_fluid_interaction.first  = prm.get_integer("first fluid id");
+          fluid_fluid_interaction.second = prm.get_integer("second fluid id");
+          AssertThrow(fluid_fluid_interaction.first <
+                        fluid_fluid_interaction.second,
+                      OrderOfFluidIDsError(fluid_fluid_interaction.first,
+                                           fluid_fluid_interaction.second));
+          fluid_fluid_interaction_with_material_interaction_id.first =
+            fluid_fluid_interaction;
+          fluid_fluid_interaction_with_material_interaction_id.second = id;
+
+          // Surface tension
+          op = prm.get("surface tension model");
+          if (op == "constant")
+            {
+              surface_tension_model = SurfaceTensionModel::constant;
+              surface_tension_parameters.parse_parameters(prm);
+            }
+          else
+            throw(std::runtime_error(
+              "Invalid surface tension model. At the moment, the only choice is <constant>"));
+        }
+      else // Solid-fluid interactions
+        {
+          std::pair<unsigned int, unsigned int> fluid_solid_interaction;
+          fluid_solid_interaction.first  = prm.get_integer("fluid id");
+          fluid_solid_interaction.second = prm.get_integer("solid id");
+          fluid_solid_interaction_with_material_interaction_id.first =
+            fluid_solid_interaction;
+          fluid_solid_interaction_with_material_interaction_id.second = id;
+
+          // Surface tension
+          op = prm.get("surface tension model");
+          if (op == "constant")
+            {
+              surface_tension_model = SurfaceTensionModel::constant;
+              surface_tension_parameters.parse_parameters(prm);
+            }
+          else
+            throw(std::runtime_error(
+              "Invalid surface tension model. At the moment, the only choice is <constant>"));
+          std::pair<std::pair<unsigned int, unsigned int>, SurfaceTensionModel>
+            fluid_solid_surface_tension_interaction(fluid_solid_interaction,
+                                                    surface_tension_model);
+        }
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -438,11 +438,6 @@ Parameters::VOF_SurfaceTensionForce::declare_parameters(ParameterHandler &prm)
                       Patterns::Bool(),
                       "Enable surface tension force calculation <true|false>");
 
-    prm.declare_entry("surface tension coefficient",
-                      "0.0",
-                      Patterns::Double(),
-                      "Surface tension coefficient");
-
     prm.declare_entry("output auxiliary fields",
                       "false",
                       Patterns::Bool(),
@@ -490,8 +485,6 @@ Parameters::VOF_SurfaceTensionForce::parse_parameters(ParameterHandler &prm)
   prm.enter_subsection("surface tension force");
   {
     enable = prm.get_bool("enable");
-    // Surface tension coefficient
-    surface_tension_coef = prm.get_double("surface tension coefficient");
     phase_fraction_gradient_diffusion_factor =
       prm.get_double("phase fraction gradient diffusion factor");
     curvature_diffusion_factor = prm.get_double("curvature diffusion factor");

--- a/source/core/surface_tension_model.cc
+++ b/source/core/surface_tension_model.cc
@@ -1,0 +1,25 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/surface_tension_model.h>
+
+std::shared_ptr<SurfaceTensionModel>
+SurfaceTensionModel::model_cast(
+  const Parameters::SurfaceTensionParameters &surface_tension_parameters)
+{
+  return std::make_shared<SurfaceTensionConstant>(
+    surface_tension_parameters.surface_tension_coefficient);
+}

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -117,7 +117,7 @@ NavierStokesScratchData<dim>::enable_vof(
   viscosity_1         = std::vector<double>(n_q_points);
   thermal_expansion_0 = std::vector<double>(n_q_points);
   thermal_expansion_1 = std::vector<double>(n_q_points);
-  //  surface_tension     = std::vector<double>(n_q_points);
+  surface_tension     = std::vector<double>(n_q_points);
 
   // Create filter
   filter = VolumeOfFluidFilterBase::model_cast(phase_filter_parameters);
@@ -152,7 +152,7 @@ NavierStokesScratchData<dim>::enable_vof(
   viscosity_1         = std::vector<double>(n_q_points);
   thermal_expansion_0 = std::vector<double>(n_q_points);
   thermal_expansion_1 = std::vector<double>(n_q_points);
-  //  surface_tension     = std::vector<double>(n_q_points);
+  surface_tension     = std::vector<double>(n_q_points);
 
   // Create filter
   this->filter = filter;
@@ -316,25 +316,19 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
           const auto rheology_model_0 = properties_manager.get_rheology(0);
           const auto density_model_1  = properties_manager.get_density(1);
           const auto rheology_model_1 = properties_manager.get_rheology(1);
+
+          // Gather properties from material interactions if necessary
           if (properties_manager.get_number_of_material_interactions() >
-              0) // left for debugging
-                 // purposes since prm files don't contain the material
-                 // interactions yet
+              0)
             {
               const auto material_interaction_id =
                 properties_manager.get_material_interaction_id("fluid-fluid",
                                                                0,
                                                                1);
+              // Gather surface tension
               const auto surface_tension_model =
                 properties_manager.get_surface_tension(material_interaction_id);
               surface_tension_model->vector_value(fields, surface_tension);
-            }
-          else
-            {
-              for (double &surface_tension_coeff : surface_tension)
-                {
-                  surface_tension_coeff = 10;
-                }
             }
 
 

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -117,6 +117,7 @@ NavierStokesScratchData<dim>::enable_vof(
   viscosity_1         = std::vector<double>(n_q_points);
   thermal_expansion_0 = std::vector<double>(n_q_points);
   thermal_expansion_1 = std::vector<double>(n_q_points);
+  //  surface_tension     = std::vector<double>(n_q_points);
 
   // Create filter
   filter = VolumeOfFluidFilterBase::model_cast(phase_filter_parameters);
@@ -151,6 +152,7 @@ NavierStokesScratchData<dim>::enable_vof(
   viscosity_1         = std::vector<double>(n_q_points);
   thermal_expansion_0 = std::vector<double>(n_q_points);
   thermal_expansion_1 = std::vector<double>(n_q_points);
+  //  surface_tension     = std::vector<double>(n_q_points);
 
   // Create filter
   this->filter = filter;
@@ -314,6 +316,19 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
           const auto rheology_model_0 = properties_manager.get_rheology(0);
           const auto density_model_1  = properties_manager.get_density(1);
           const auto rheology_model_1 = properties_manager.get_rheology(1);
+          if (properties_manager.get_number_of_material_interactions() >
+              0) // left for debugging
+                 // purposes since prm files don't contain the material interactions yet
+            {
+              const auto material_interaction_id =
+                properties_manager.get_material_interaction_id("fluid-fluid",
+                                                               0,
+                                                               1);
+              const auto surface_tension_model =
+                properties_manager.get_surface_tension(material_interaction_id);
+              surface_tension_model->vector_value(fields, surface_tension);
+            }
+
 
           density_model_0->vector_value(fields, density_0);
           rheology_model_0->vector_value(fields, viscosity_0);

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -318,7 +318,8 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
           const auto rheology_model_1 = properties_manager.get_rheology(1);
           if (properties_manager.get_number_of_material_interactions() >
               0) // left for debugging
-                 // purposes since prm files don't contain the material interactions yet
+                 // purposes since prm files don't contain the material
+                 // interactions yet
             {
               const auto material_interaction_id =
                 properties_manager.get_material_interaction_id("fluid-fluid",
@@ -327,6 +328,13 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
               const auto surface_tension_model =
                 properties_manager.get_surface_tension(material_interaction_id);
               surface_tension_model->vector_value(fields, surface_tension);
+            }
+          else
+            {
+              for (double &surface_tension_coeff : surface_tension)
+                {
+                  surface_tension_coeff = 10;
+                }
             }
 
 

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -318,8 +318,7 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
           const auto rheology_model_1 = properties_manager.get_rheology(1);
 
           // Gather properties from material interactions if necessary
-          if (properties_manager.get_number_of_material_interactions() >
-              0)
+          if (properties_manager.get_number_of_material_interactions() > 0)
             {
               const auto material_interaction_id =
                 properties_manager.get_material_interaction_id("fluid-fluid",

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -321,9 +321,8 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
           if (properties_manager.get_number_of_material_interactions() > 0)
             {
               const auto material_interaction_id =
-                properties_manager.get_material_interaction_id("fluid-fluid",
-                                                               0,
-                                                               1);
+                properties_manager.get_material_interaction_id(
+                  material_interactions_type::fluid_fluid, 0, 1);
               // Gather surface tension
               const auto surface_tension_model =
                 properties_manager.get_surface_tension(material_interaction_id);

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -13,7 +13,7 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -220,7 +220,7 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -391,7 +391,7 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -453,7 +453,7 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -519,15 +519,12 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Surface tension coefficient
-  const double surface_tension_coef = STF_parameters.surface_tension_coef;
-
   // Densities of phases
   Assert(scratch_data.properties_manager.density_is_constant(),
          RequiresConstantDensity(
            "GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix"));
 
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -539,6 +536,9 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
+      // Surface tension coefficient
+      const double surface_tension_coef = scratch_data.surface_tension[q];
+
       // Gather pfg and curvature values
       const double &        curvature_value = scratch_data.curvature_values[q];
       const Tensor<1, dim> &phase_gradient_value =
@@ -578,9 +578,6 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Surface tension coefficient
-  const double surface_tension_coef = STF_properties.surface_tension_coef;
-
   // Surface tension gradient
   const double surface_tension_gradient =
     STF_properties.surface_tension_gradient;
@@ -590,7 +587,7 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
          RequiresConstantDensity(
            "GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix"));
 
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -602,6 +599,9 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
+      // Surface tension coefficient
+      const double surface_tension_coef = scratch_data.surface_tension[q];
+
       const double &curvature_value = scratch_data.curvature_values[q];
 
       // Gather phase fraction gradient
@@ -657,7 +657,7 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -890,7 +890,7 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_rhs(
   NavierStokesScratchData<dim> &        scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-  // Loop and quadrature informations
+  // Loop and quadrature information
   const auto &       JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -29,6 +29,18 @@ PhysicalPropertiesManager::establish_fields_required_by_model(
 }
 
 void
+PhysicalPropertiesManager::establish_fields_required_by_model(
+  InterfacePropertyModel &model)
+{
+  // Loop through the map. The use of or (||) is there to ensure
+  // that if a field is already required, it won't be erased.
+  for (auto &f : required_fields)
+    {
+      f.second = f.second || model.depends_on(f.first);
+    }
+}
+
+void
 PhysicalPropertiesManager::initialize(
   Parameters::PhysicalProperties physical_properties)
 {

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -36,6 +36,12 @@ PhysicalPropertiesManager::initialize(
 
   number_of_fluids = physical_properties.number_of_fluids;
   number_of_solids = physical_properties.number_of_solids;
+  number_of_material_interactions =
+    physical_properties.number_of_material_interactions;
+  fluid_fluid_interactions_with_material_interaction_ids =
+    physical_properties.fluid_fluid_interactions_with_material_interaction_ids;
+  fluid_solid_interactions_with_material_interaction_ids =
+    physical_properties.fluid_solid_interactions_with_material_interaction_ids;
 
   viscosity_scale = physical_properties.fluids[0].viscosity;
   density_scale   = physical_properties.fluids[0].density;
@@ -122,5 +128,15 @@ PhysicalPropertiesManager::initialize(
       thermal_expansion.push_back(
         ThermalExpansionModel::model_cast(physical_properties.solids[s]));
       establish_fields_required_by_model(*thermal_expansion[s]);
+    }
+
+  // For each pair of interacting materials (fluid-fluid or fluid-solid), append
+  // physical properties
+  for (unsigned int i = 0; i < number_of_material_interactions; ++i)
+    {
+      surface_tension.push_back(SurfaceTensionModel::model_cast(
+        physical_properties.material_interactions[i]
+          .surface_tension_parameters));
+      establish_fields_required_by_model(*surface_tension[i]);
     }
 }

--- a/tests/core/surface_tension_constant.cc
+++ b/tests/core/surface_tension_constant.cc
@@ -1,0 +1,66 @@
+/**
+ * @brief Tests the constant surface tension model. This model should always return a constant.
+ */
+
+// Lethe
+#include <core/surface_tension_model.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beginning" << std::endl;
+
+
+  SurfaceTensionConstant surface_tension_model(72.86);
+
+  deallog << "Testing surface tension" << std::endl;
+
+  // field values can remain empty since the surface tension density does
+  // not depend on any fields
+  std::map<field, double> field_values;
+
+  deallog << "Test 1, surface tension = "
+          << surface_tension_model.value(field_values) << std::endl;
+  deallog << "Test 2, surface tension = "
+          << surface_tension_model.value(field_values) << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/surface_tension_constant.output
+++ b/tests/core/surface_tension_constant.output
@@ -1,0 +1,6 @@
+
+DEAL::Beginning
+DEAL::Testing surface tension
+DEAL::Test 1, surface tension = 72.86
+DEAL::Test 2, surface tension = 72.86
+DEAL::OK

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -34,8 +34,8 @@ test()
   // Create a physical property manager
 
   Parameters::PhysicalProperties physical_properties;
-  physical_properties.number_of_fluids = 1;
-  physical_properties.number_of_solids = 0;
+  physical_properties.number_of_fluids                = 1;
+  physical_properties.number_of_solids                = 0;
   physical_properties.number_of_material_interactions = 0;
   physical_properties.fluids.resize(1);
   physical_properties.fluids[0].density_model =

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -36,6 +36,7 @@ test()
   Parameters::PhysicalProperties physical_properties;
   physical_properties.number_of_fluids = 1;
   physical_properties.number_of_solids = 0;
+  physical_properties.number_of_material_interactions = 0;
   physical_properties.fluids.resize(1);
   physical_properties.fluids[0].density_model =
     Parameters::Material::DensityModel::constant;

--- a/tests/solvers/physical_properties_manager_02.cc
+++ b/tests/solvers/physical_properties_manager_02.cc
@@ -35,9 +35,9 @@ test()
   // Create a physical property manager
 
   Parameters::PhysicalProperties physical_properties;
-  physical_properties.number_of_fluids = 1;
-  physical_properties.number_of_solids = 1;
-  physical_properties.number_of_material_interactions = 0; // for now
+  physical_properties.number_of_fluids                = 1;
+  physical_properties.number_of_solids                = 1;
+  physical_properties.number_of_material_interactions = 1;
 
 
   // Generate fluid properties
@@ -60,7 +60,8 @@ test()
 
   // Generate fluid-solid interaction properties
   physical_properties.material_interactions.resize(1);
-  physical_properties.material_interactions[0].surface_tension_model = Parameters::MaterialInteractions::SurfaceTensionModel::constant;
+  physical_properties.material_interactions[0].surface_tension_model =
+    Parameters::MaterialInteractions::SurfaceTensionModel::constant;
 
   // Fix fluid properties
   physical_properties.fluids[0].density              = 1;
@@ -73,7 +74,8 @@ test()
   physical_properties.solids[0].specific_heat        = 20;
 
   // Fix fluid-solid interaction properties
-  physical_properties.material_interactions[0].surface_tension_parameters.surface_tension_coefficient=70;
+  physical_properties.material_interactions[0]
+    .surface_tension_parameters.surface_tension_coefficient = 70;
 
   PhysicalPropertiesManager physical_properties_manager;
   physical_properties_manager.initialize(physical_properties);
@@ -105,7 +107,13 @@ test()
           << physical_properties_manager.get_thermal_conductivity(0, 1)->value(
                dummy_fields)
           << std::endl;
-  // add output for solid-fluid interactions
+
+  deallog << "Testing PhysicalPropertiesManager - Material interaction 0 "
+          << std::endl;
+  deallog << "Surface tension      : "
+          << physical_properties_manager.get_surface_tension(0)->value(
+               dummy_fields)
+          << std::endl;
 }
 
 int

--- a/tests/solvers/physical_properties_manager_02.cc
+++ b/tests/solvers/physical_properties_manager_02.cc
@@ -37,6 +37,7 @@ test()
   Parameters::PhysicalProperties physical_properties;
   physical_properties.number_of_fluids = 1;
   physical_properties.number_of_solids = 1;
+  physical_properties.number_of_material_interactions = 0; // for now
 
 
   // Generate fluid properties
@@ -57,6 +58,10 @@ test()
   physical_properties.solids[0].thermal_conductivity_model =
     Parameters::Material::ThermalConductivityModel::constant;
 
+  // Generate fluid-solid interaction properties
+  physical_properties.material_interactions.resize(1);
+  physical_properties.material_interactions[0].surface_tension_model = Parameters::MaterialInteractions::SurfaceTensionModel::constant;
+
   // Fix fluid properties
   physical_properties.fluids[0].density              = 1;
   physical_properties.fluids[0].thermal_conductivity = 3;
@@ -66,6 +71,9 @@ test()
   physical_properties.solids[0].density              = 10;
   physical_properties.solids[0].thermal_conductivity = 30;
   physical_properties.solids[0].specific_heat        = 20;
+
+  // Fix fluid-solid interaction properties
+  physical_properties.material_interactions[0].surface_tension_parameters.surface_tension_coefficient=70;
 
   PhysicalPropertiesManager physical_properties_manager;
   physical_properties_manager.initialize(physical_properties);
@@ -97,6 +105,7 @@ test()
           << physical_properties_manager.get_thermal_conductivity(0, 1)->value(
                dummy_fields)
           << std::endl;
+  // add output for solid-fluid interactions
 }
 
 int

--- a/tests/solvers/physical_properties_manager_02.output
+++ b/tests/solvers/physical_properties_manager_02.output
@@ -7,3 +7,5 @@ DEAL::Testing PhysicalPropertiesManager - Solid 0
 DEAL::Density              : 10.0000
 DEAL::Specific heat        : 20.0000
 DEAL::Thermal conductivity : 30.0000
+DEAL::Testing PhysicalPropertiesManager - Material interaction 0
+DEAL::Surface tension      : 70.0000

--- a/tests/solvers/physical_properties_manager_03.cc
+++ b/tests/solvers/physical_properties_manager_03.cc
@@ -34,13 +34,14 @@ test()
 {
   // Create a physical property manager
   Parameters::PhysicalProperties physical_properties;
-  physical_properties.number_of_fluids = 2;
-  physical_properties.number_of_solids = 2;
-  physical_properties.number_of_material_interactions = 0; // for now
+  physical_properties.number_of_fluids                = 2;
+  physical_properties.number_of_solids                = 2;
+  physical_properties.number_of_material_interactions = 5;
 
 
   physical_properties.fluids.resize(2);
   physical_properties.solids.resize(2);
+  physical_properties.material_interactions.resize(5);
 
   for (int i = 0; i < 2; ++i)
     {
@@ -70,7 +71,14 @@ test()
       physical_properties.solids[i].specific_heat        = 20 + 100 * i;
     }
 
-
+  for (int i = 0; i < 5; ++i)
+    {
+      // Generate fluid-fluid and fluid-solid interaction properties
+      physical_properties.material_interactions[i].surface_tension_model =
+        Parameters::MaterialInteractions::SurfaceTensionModel::constant;
+      physical_properties.material_interactions[i]
+        .surface_tension_parameters.surface_tension_coefficient = 10 * (i + 1);
+    }
 
   PhysicalPropertiesManager physical_properties_manager;
   physical_properties_manager.initialize(physical_properties);
@@ -105,6 +113,15 @@ test()
       deallog << "Thermal conductivity : "
               << physical_properties_manager.get_thermal_conductivity(0, i + 1)
                    ->value(dummy_fields)
+              << std::endl;
+    }
+  for (int i = 0; i < 5; ++i)
+    {
+      deallog << "Testing PhysicalPropertiesManager - Material interaction "
+              << i << std::endl;
+      deallog << "Surface tension      : "
+              << physical_properties_manager.get_surface_tension(i)->value(
+                   dummy_fields)
               << std::endl;
     }
 }

--- a/tests/solvers/physical_properties_manager_03.cc
+++ b/tests/solvers/physical_properties_manager_03.cc
@@ -38,7 +38,6 @@ test()
   physical_properties.number_of_solids                = 2;
   physical_properties.number_of_material_interactions = 5;
 
-
   physical_properties.fluids.resize(2);
   physical_properties.solids.resize(2);
   physical_properties.material_interactions.resize(5);

--- a/tests/solvers/physical_properties_manager_03.cc
+++ b/tests/solvers/physical_properties_manager_03.cc
@@ -36,6 +36,7 @@ test()
   Parameters::PhysicalProperties physical_properties;
   physical_properties.number_of_fluids = 2;
   physical_properties.number_of_solids = 2;
+  physical_properties.number_of_material_interactions = 0; // for now
 
 
   physical_properties.fluids.resize(2);

--- a/tests/solvers/physical_properties_manager_03.cc
+++ b/tests/solvers/physical_properties_manager_03.cc
@@ -17,7 +17,7 @@
 
 /**
  * @brief This code tests the PhysicalPropertiesManager class and its capacity to instantiate the various models for physical properties
- * for the case when there are 2 fluids and 2 solids.
+ * for the case when there are 2 fluids and 2 solids. This test exceeds the actual capacity of the solver (2 fluids, 1 solid).
  */
 
 // Lethe

--- a/tests/solvers/physical_properties_manager_03.output
+++ b/tests/solvers/physical_properties_manager_03.output
@@ -15,3 +15,13 @@ DEAL::Testing PhysicalPropertiesManager - Solid 1
 DEAL::Density              : 110.000
 DEAL::Specific heat        : 120.000
 DEAL::Thermal conductivity : 130.000
+DEAL::Testing PhysicalPropertiesManager - Material interaction 0
+DEAL::Surface tension      : 10.0000
+DEAL::Testing PhysicalPropertiesManager - Material interaction 1
+DEAL::Surface tension      : 20.0000
+DEAL::Testing PhysicalPropertiesManager - Material interaction 2
+DEAL::Surface tension      : 30.0000
+DEAL::Testing PhysicalPropertiesManager - Material interaction 3
+DEAL::Surface tension      : 40.0000
+DEAL::Testing PhysicalPropertiesManager - Material interaction 4
+DEAL::Surface tension      : 50.0000

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -105,8 +105,9 @@ RestartNavierStokes<dim>::run()
   physical_properties.number_of_fluids = 1;
   physical_properties.fluids[0].rheological_model =
     Parameters::Material::RheologicalModel::newtonian;
-  physical_properties.fluids[0].viscosity = 1;
-  physical_properties.number_of_solids    = 0;
+  physical_properties.fluids[0].viscosity             = 1;
+  physical_properties.number_of_solids                = 0;
+  physical_properties.number_of_material_interactions = 0;
 
 
   this->simulation_parameters.physical_properties_manager.initialize(


### PR DESCRIPTION
# Description of the problem

- The surface tension coefficient is a physical property that is due the interaction between two materials (fluid-fluid or fluid-solid). This property was previously directly implemented in the ``surface tension force`` subsection of the VOF model. However, as it is also a property used in the Cahn-Hilliard (CH) phase-field model and it may also be a temperature dependent property, it had to be refactored so that it goes through the physical properties manager.

# Description of the solution

- As the surface tension is a consequence of interaction between two fluids or a fluid with a solid, a new class MaterialInteractions was made with two types of material interactions: ``fluid-fluid`` and ``fluid-solid``. The surface tension is a property that belongs to both of these types. Other properties may eventually belong to only one of these class, such as the ``mobility`` in the CH model.
- The new surface tension has been fully implemented for VOF and concerned examples were updated (doc and .prm):

  - [x]  Static Bubble
  - [x]  Rising Bubble

- Assertion conditions were added to minimize errors and debug easily when using the new parameters.

# How Has This Been Tested?

- A new unit test was added:

  - [x] /tests/core/surface_tension_constant.cc (.output)

- Physical properties manager unit tests were updated:

  - [x] /tests/solvers/physical_properties_manager_01.cc (.output)
  - [x] /tests/solvers/physical_properties_manager_02.cc (.output)
  - [x] /tests/solvers/physical_properties_manager_03.cc (.output)

- Application tests with VOF and surface tension were updated:

  - [x] /applications_tests/gls_navier_stokes_2d/gls_static_droplet_surface_tension_force.prm (.output)
  - [x] /applications_tests/gls_navier_stokes_2d/gls_vof_static_droplet_surface_tension_force_with_tanh_filter.prm (.output)
  - [x] /applications_tests/gls_navier_stokes_2d/gls_droplet_marangoni_effect.prm (.output)

# Documentation

- The Physical Properties and Volume of Fluid (Multiphase Flow) pages in the Parameters Guide were updated:

  - [x] /doc/source/parameters/cfd/physical_properties.rst
  - [x] /doc/source/parameters/cfd/volume_of_fluid.rst

# Future changes

- The ``surface tension gradient`` appearing in the Marangoni will have to be added to the material interactions class in a future implementation.
- The ``mobility`` appearing the CH equations will also have to be added to the material interactions class in a future implementation.
