### PR TITLE
Optimize fine search to use ankerl maps

### DIFF
--- a/applications_tests/dem_3d/load_balancing_solid_object.mpirun=2.output
+++ b/applications_tests/dem_3d/load_balancing_solid_object.mpirun=2.output
@@ -77,221 +77,221 @@ Transient iteration: 5000     Time: 0.05     Time step: 1e-05
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
 | Contact list generation      | 0.0000e+00 | 1.3000e+01 | 7.4000e+00 | 3.7000e+01 | 
-| Velocity magnitude           | 3.1596e-02 | 4.9040e-01 | 4.1335e-01 | 4.1335e+02 |
-| Angular velocity magnitude   | 0.0000e+00 | 2.0925e+02 | 2.2270e+01 | 2.2270e+04 |
-| Translational kinetic energy | 1.4113e-08 | 3.3999e-06 | 2.5796e-06 | 2.5796e-03 |
-| Rotational kinetic energy    | 0.0000e+00 | 1.1142e-06 | 5.3264e-08 | 5.3264e-05 |
+| Velocity magnitude           | 3.1596e-02 | 4.9040e-01 | 4.1335e-01 | 4.1335e+02 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.0925e+02 | 2.2270e+01 | 2.2270e+04 | 
+| Translational kinetic energy | 1.4113e-08 | 3.3999e-06 | 2.5796e-06 | 2.5796e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 1.1142e-06 | 5.3264e-08 | 5.3264e-05 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 266 and 734
 Minimum and maximum number of cells owned by the processors are 612 and 5085
 
 *****************************************************************
-Transient iteration: 6000     Time: 0.06     Time step: 1e-05
+Transient iteration: 6000     Time: 0.06     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 1.5000e+01 | 8.6667e+00 | 5.2000e+01 |
-| Velocity magnitude           | 6.8992e-02 | 5.8850e-01 | 5.0022e-01 | 5.0022e+02 |
-| Angular velocity magnitude   | 0.0000e+00 | 3.0882e+02 | 2.7901e+01 | 2.7901e+04 |
-| Translational kinetic energy | 6.7292e-08 | 4.8962e-06 | 3.7092e-06 | 3.7092e-03 |
-| Rotational kinetic energy    | 0.0000e+00 | 2.4269e-06 | 6.5656e-08 | 6.5656e-05 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.5000e+01 | 8.6667e+00 | 5.2000e+01 | 
+| Velocity magnitude           | 6.8992e-02 | 5.8850e-01 | 5.0022e-01 | 5.0022e+02 | 
+| Angular velocity magnitude   | 0.0000e+00 | 3.0882e+02 | 2.7901e+01 | 2.7901e+04 | 
+| Translational kinetic energy | 6.7292e-08 | 4.8962e-06 | 3.7092e-06 | 3.7092e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.4269e-06 | 6.5656e-08 | 6.5656e-05 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 277 and 723
 Minimum and maximum number of cells owned by the processors are 591 and 5085
 
 *****************************************************************
-Transient iteration: 7000     Time: 0.07     Time step: 1e-05
+Transient iteration: 7000     Time: 0.07     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 1.8000e+01 | 1.0000e+01 | 7.0000e+01 |
-| Velocity magnitude           | 4.2783e-02 | 6.8660e-01 | 5.7525e-01 | 5.7525e+02 |
-| Angular velocity magnitude   | 0.0000e+00 | 2.7223e+02 | 3.3011e+01 | 3.3011e+04 |
-| Translational kinetic energy | 2.5877e-08 | 6.6646e-06 | 4.9657e-06 | 4.9657e-03 |
-| Rotational kinetic energy    | 0.0000e+00 | 1.8859e-06 | 7.9981e-08 | 7.9981e-05 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 1.8000e+01 | 1.0000e+01 | 7.0000e+01 | 
+| Velocity magnitude           | 4.2783e-02 | 6.8660e-01 | 5.7525e-01 | 5.7525e+02 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.7223e+02 | 3.3011e+01 | 3.3011e+04 | 
+| Translational kinetic energy | 2.5877e-08 | 6.6646e-06 | 4.9657e-06 | 4.9657e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 1.8859e-06 | 7.9981e-08 | 7.9981e-05 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 298 and 702
 Minimum and maximum number of cells owned by the processors are 535 and 5099
 
 *****************************************************************
-Transient iteration: 8000     Time: 0.08     Time step: 1e-05
+Transient iteration: 8000     Time: 0.08     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 2.1000e+01 | 1.1375e+01 | 9.1000e+01 |
-| Velocity magnitude           | 1.9119e-02 | 7.8470e-01 | 6.3353e-01 | 6.3353e+02 |
-| Angular velocity magnitude   | 0.0000e+00 | 2.7223e+02 | 4.0867e+01 | 4.0867e+04 |
-| Translational kinetic energy | 5.1676e-09 | 8.7051e-06 | 6.1991e-06 | 6.1991e-03 |
-| Rotational kinetic energy    | 0.0000e+00 | 1.8859e-06 | 1.1965e-07 | 1.1965e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 2.1000e+01 | 1.1375e+01 | 9.1000e+01 | 
+| Velocity magnitude           | 1.9119e-02 | 7.8470e-01 | 6.3353e-01 | 6.3353e+02 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.7223e+02 | 4.0867e+01 | 4.0867e+04 | 
+| Translational kinetic energy | 5.1676e-09 | 8.7051e-06 | 6.1991e-06 | 6.1991e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 1.8859e-06 | 1.1965e-07 | 1.1965e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 270 and 730
 Minimum and maximum number of cells owned by the processors are 507 and 5099
 
 *****************************************************************
-Transient iteration: 9000     Time: 0.09     Time step: 1e-05
+Transient iteration: 9000     Time: 0.09     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 2.3000e+01 | 1.2667e+01 | 1.1400e+02 |
-| Velocity magnitude           | 4.1727e-02 | 8.8280e-01 | 6.7562e-01 | 6.7562e+02 |
-| Angular velocity magnitude   | 0.0000e+00 | 2.9468e+02 | 5.1122e+01 | 5.1122e+04 |
-| Translational kinetic energy | 2.4615e-08 | 1.1018e-05 | 7.3169e-06 | 7.3169e-03 |
-| Rotational kinetic energy    | 0.0000e+00 | 2.2098e-06 | 1.7036e-07 | 1.7036e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 2.3000e+01 | 1.2667e+01 | 1.1400e+02 | 
+| Velocity magnitude           | 4.1727e-02 | 8.8280e-01 | 6.7562e-01 | 6.7562e+02 | 
+| Angular velocity magnitude   | 0.0000e+00 | 2.9468e+02 | 5.1122e+01 | 5.1122e+04 | 
+| Translational kinetic energy | 2.4615e-08 | 1.1018e-05 | 7.3169e-06 | 7.3169e-03 | 
+| Rotational kinetic energy    | 0.0000e+00 | 2.2098e-06 | 1.7036e-07 | 1.7036e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 277 and 723
 Minimum and maximum number of cells owned by the processors are 486 and 5099
 
 *****************************************************************
-Transient iteration: 10000    Time: 0.1      Time step: 1e-05
+Transient iteration: 10000    Time: 0.1      Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 2.6000e+01 | 1.4000e+01 | 1.4000e+02 |
-| Velocity magnitude           | 3.3657e-02 | 9.7578e-01 | 7.0286e-01 | 7.0286e+02 |
-| Angular velocity magnitude   | 1.7390e-05 | 3.4218e+02 | 6.1273e+01 | 6.1273e+04 |
-| Translational kinetic energy | 1.6015e-08 | 1.3461e-05 | 8.2574e-06 | 8.2574e-03 |
-| Rotational kinetic energy    | 7.6955e-21 | 2.9796e-06 | 2.1907e-07 | 2.1907e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 2.6000e+01 | 1.4000e+01 | 1.4000e+02 | 
+| Velocity magnitude           | 3.3657e-02 | 9.7578e-01 | 7.0286e-01 | 7.0286e+02 | 
+| Angular velocity magnitude   | 1.7390e-05 | 3.4218e+02 | 6.1273e+01 | 6.1273e+04 | 
+| Translational kinetic energy | 1.6015e-08 | 1.3461e-05 | 8.2574e-06 | 8.2574e-03 | 
+| Rotational kinetic energy    | 7.6955e-21 | 2.9796e-06 | 2.1907e-07 | 2.1907e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 293 and 707
 Minimum and maximum number of cells owned by the processors are 381 and 5113
 
 *****************************************************************
-Transient iteration: 11000    Time: 0.11     Time step: 1e-05
+Transient iteration: 11000    Time: 0.11     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.0000e+01 | 1.5455e+01 | 1.7000e+02 |
-| Velocity magnitude           | 1.9382e-02 | 1.0919e+00 | 7.0678e-01 | 7.0678e+02 |
-| Angular velocity magnitude   | 1.3217e-03 | 3.2689e+02 | 7.2128e+01 | 7.2128e+04 |
-| Translational kinetic energy | 5.3108e-09 | 1.6855e-05 | 8.7839e-06 | 8.7839e-03 |
-| Rotational kinetic energy    | 4.4451e-17 | 2.7192e-06 | 2.7012e-07 | 2.7012e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.0000e+01 | 1.5455e+01 | 1.7000e+02 | 
+| Velocity magnitude           | 1.9382e-02 | 1.0919e+00 | 7.0678e-01 | 7.0678e+02 | 
+| Angular velocity magnitude   | 1.3217e-03 | 3.2689e+02 | 7.2128e+01 | 7.2128e+04 | 
+| Translational kinetic energy | 5.3108e-09 | 1.6855e-05 | 8.7839e-06 | 8.7839e-03 | 
+| Rotational kinetic energy    | 4.4451e-17 | 2.7192e-06 | 2.7012e-07 | 2.7012e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 273 and 727
 Minimum and maximum number of cells owned by the processors are 367 and 5113
 
 *****************************************************************
-Transient iteration: 12000    Time: 0.12     Time step: 1e-05
+Transient iteration: 12000    Time: 0.12     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.1000e+01 | 1.6750e+01 | 2.0100e+02 |
-| Velocity magnitude           | 3.5774e-02 | 1.1693e+00 | 6.9455e-01 | 6.9455e+02 |
-| Angular velocity magnitude   | 2.9633e-03 | 3.8397e+02 | 8.5874e+01 | 8.5874e+04 |
-| Translational kinetic energy | 1.8092e-08 | 1.9329e-05 | 8.8796e-06 | 8.8796e-03 |
-| Rotational kinetic energy    | 2.2346e-16 | 3.7518e-06 | 3.4893e-07 | 3.4893e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.1000e+01 | 1.6750e+01 | 2.0100e+02 | 
+| Velocity magnitude           | 3.5774e-02 | 1.1693e+00 | 6.9455e-01 | 6.9455e+02 | 
+| Angular velocity magnitude   | 2.9633e-03 | 3.8397e+02 | 8.5874e+01 | 8.5874e+04 | 
+| Translational kinetic energy | 1.8092e-08 | 1.9329e-05 | 8.8796e-06 | 8.8796e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 3.7518e-06 | 3.4893e-07 | 3.4893e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 336 and 664
 Minimum and maximum number of cells owned by the processors are 332 and 5113
 
 *****************************************************************
-Transient iteration: 13000    Time: 0.13     Time step: 1e-05
+Transient iteration: 13000    Time: 0.13     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.4000e+01 | 1.8077e+01 | 2.3500e+02 |
-| Velocity magnitude           | 2.0291e-02 | 1.2692e+00 | 6.5781e-01 | 6.5781e+02 |
-| Angular velocity magnitude   | 2.9633e-03 | 3.9057e+02 | 1.0574e+02 | 1.0574e+05 |
-| Translational kinetic energy | 5.8204e-09 | 2.2771e-05 | 8.2684e-06 | 8.2684e-03 |
-| Rotational kinetic energy    | 2.2346e-16 | 3.8818e-06 | 4.5243e-07 | 4.5243e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.4000e+01 | 1.8077e+01 | 2.3500e+02 | 
+| Velocity magnitude           | 2.0256e-02 | 1.2692e+00 | 6.5781e-01 | 6.5781e+02 | 
+| Angular velocity magnitude   | 2.9633e-03 | 3.9056e+02 | 1.0574e+02 | 1.0574e+05 | 
+| Translational kinetic energy | 5.8006e-09 | 2.2771e-05 | 8.2684e-06 | 8.2684e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 3.8816e-06 | 4.5243e-07 | 4.5243e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 295 and 705
 Minimum and maximum number of cells owned by the processors are 332 and 5113
 
 *****************************************************************
-Transient iteration: 14000    Time: 0.14     Time step: 1e-05
+Transient iteration: 14000    Time: 0.14     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.6000e+01 | 1.9357e+01 | 2.7100e+02 |
-| Velocity magnitude           | 3.9952e-02 | 1.3637e+00 | 5.9706e-01 | 5.9706e+02 |
-| Angular velocity magnitude   | 2.9633e-03 | 4.5603e+02 | 1.2138e+02 | 1.2138e+05 |
-| Translational kinetic energy | 2.2566e-08 | 2.6291e-05 | 6.8546e-06 | 6.8546e-03 |
-| Rotational kinetic energy    | 2.2346e-16 | 5.2921e-06 | 5.3017e-07 | 5.3017e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.6000e+01 | 1.9357e+01 | 2.7100e+02 | 
+| Velocity magnitude           | 4.0611e-02 | 1.3637e+00 | 5.9704e-01 | 5.9704e+02 | 
+| Angular velocity magnitude   | 2.9633e-03 | 4.5644e+02 | 1.2139e+02 | 1.2139e+05 | 
+| Translational kinetic energy | 2.3315e-08 | 2.6291e-05 | 6.8549e-06 | 6.8549e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 5.3015e-06 | 5.3030e-07 | 5.3030e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 282 and 718
 Minimum and maximum number of cells owned by the processors are 332 and 5113
 
 *****************************************************************
-Transient iteration: 15000    Time: 0.15     Time step: 1e-05
+Transient iteration: 15000    Time: 0.15     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.0667e+01 | 3.1000e+02 |
-| Velocity magnitude           | 1.9100e-02 | 1.3989e+00 | 5.1929e-01 | 5.1929e+02 |
-| Angular velocity magnitude   | 2.9633e-03 | 3.9272e+02 | 1.3020e+02 | 1.3020e+05 |
-| Translational kinetic energy | 5.1574e-09 | 2.7665e-05 | 4.9291e-06 | 4.9291e-03 |
-| Rotational kinetic energy    | 2.2346e-16 | 3.9246e-06 | 5.7271e-07 | 5.7271e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.0667e+01 | 3.1000e+02 | 
+| Velocity magnitude           | 3.1038e-02 | 1.3989e+00 | 5.2027e-01 | 5.2027e+02 | 
+| Angular velocity magnitude   | 2.9633e-03 | 3.7945e+02 | 1.3044e+02 | 1.3044e+05 | 
+| Translational kinetic energy | 1.3619e-08 | 2.7665e-05 | 4.9361e-06 | 4.9361e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 3.6640e-06 | 5.7209e-07 | 5.7209e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 297 and 703
 Minimum and maximum number of cells owned by the processors are 332 and 5113
 
 *****************************************************************
-Transient iteration: 16000    Time: 0.16     Time step: 1e-05
+Transient iteration: 16000    Time: 0.16     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.1750e+01 | 3.4800e+02 |
-| Velocity magnitude           | 1.0939e-02 | 1.0136e+00 | 4.4673e-01 | 4.4673e+02 |
-| Angular velocity magnitude   | 1.0343e+01 | 4.3322e+02 | 1.3557e+02 | 1.3557e+05 |
-| Translational kinetic energy | 1.6916e-09 | 1.4523e-05 | 3.2743e-06 | 3.2743e-03 |
-| Rotational kinetic energy    | 2.7221e-09 | 4.7760e-06 | 5.8667e-07 | 5.8667e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.1750e+01 | 3.4800e+02 | 
+| Velocity magnitude           | 1.7954e-02 | 1.1621e+00 | 4.4845e-01 | 4.4845e+02 | 
+| Angular velocity magnitude   | 1.0122e+01 | 4.4229e+02 | 1.3339e+02 | 1.3339e+05 | 
+| Translational kinetic energy | 4.5568e-09 | 1.9093e-05 | 3.2906e-06 | 3.2906e-03 | 
+| Rotational kinetic energy    | 2.6071e-09 | 4.9780e-06 | 5.6835e-07 | 5.6835e-04 | 
 -->Repartitionning triangulation
-Load balance finished
-Average, minimum and maximum number of particles on the processors are 500 , 337 and 663
+Load balance finished 
+Average, minimum and maximum number of particles on the processors are 500 , 329 and 671
 Minimum and maximum number of cells owned by the processors are 332 and 5113
 
 *****************************************************************
-Transient iteration: 17000    Time: 0.17     Time step: 1e-05
+Transient iteration: 17000    Time: 0.17     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2059e+01 | 3.7500e+02 |
-| Velocity magnitude           | 1.2833e-02 | 8.6044e-01 | 4.0217e-01 | 4.0217e+02 |
-| Angular velocity magnitude   | 1.1021e+01 | 3.6917e+02 | 1.2024e+02 | 1.2024e+05 |
-| Translational kinetic energy | 2.3283e-09 | 1.0467e-05 | 2.7173e-06 | 2.7173e-03 |
-| Rotational kinetic energy    | 3.0908e-09 | 3.4681e-06 | 4.7636e-07 | 4.7636e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2294e+01 | 3.7900e+02 | 
+| Velocity magnitude           | 1.6657e-02 | 1.1060e+00 | 4.0177e-01 | 4.0177e+02 | 
+| Angular velocity magnitude   | 1.1165e+01 | 3.7824e+02 | 1.1892e+02 | 1.1892e+05 | 
+| Translational kinetic energy | 3.9225e-09 | 1.7294e-05 | 2.7195e-06 | 2.7195e-03 | 
+| Rotational kinetic energy    | 3.1722e-09 | 3.6407e-06 | 4.5363e-07 | 4.5363e-04 | 
 -->Repartitionning triangulation
-Load balance finished
-Average, minimum and maximum number of particles on the processors are 500 , 254 and 746
+Load balance finished 
+Average, minimum and maximum number of particles on the processors are 500 , 251 and 749
+Minimum and maximum number of cells owned by the processors are 367 and 5113
+
+*****************************************************************
+Transient iteration: 18000    Time: 0.18     Time step: 1e-05   
+*****************************************************************
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2444e+01 | 4.0400e+02 | 
+| Velocity magnitude           | 6.9506e-03 | 7.8865e-01 | 3.8125e-01 | 3.8125e+02 | 
+| Angular velocity magnitude   | 7.7018e+00 | 3.3281e+02 | 1.1296e+02 | 1.1296e+05 | 
+| Translational kinetic energy | 6.8297e-10 | 8.7928e-06 | 2.4807e-06 | 2.4807e-03 | 
+| Rotational kinetic energy    | 1.5095e-09 | 2.8186e-06 | 4.1972e-07 | 4.1972e-04 | 
+-->Repartitionning triangulation
+Load balance finished 
+Average, minimum and maximum number of particles on the processors are 500 , 315 and 685
 Minimum and maximum number of cells owned by the processors are 395 and 5113
 
 *****************************************************************
-Transient iteration: 18000    Time: 0.18     Time step: 1e-05
+Transient iteration: 19000    Time: 0.19     Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2111e+01 | 3.9800e+02 |
-| Velocity magnitude           | 3.5999e-03 | 7.4939e-01 | 3.8229e-01 | 3.8229e+02 |
-| Angular velocity magnitude   | 8.0931e+00 | 3.3021e+02 | 1.1292e+02 | 1.1292e+05 |
-| Translational kinetic energy | 1.8321e-10 | 7.9392e-06 | 2.4939e-06 | 2.4939e-03 |
-| Rotational kinetic energy    | 1.6667e-09 | 2.7747e-06 | 4.2226e-07 | 4.2226e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2368e+01 | 4.2500e+02 | 
+| Velocity magnitude           | 1.8061e-02 | 7.3648e-01 | 3.6844e-01 | 3.6844e+02 | 
+| Angular velocity magnitude   | 8.6029e+00 | 3.2619e+02 | 1.1123e+02 | 1.1123e+05 | 
+| Translational kinetic energy | 4.6115e-09 | 7.6681e-06 | 2.3184e-06 | 2.3184e-03 | 
+| Rotational kinetic energy    | 1.8833e-09 | 2.7075e-06 | 4.1322e-07 | 4.1322e-04 | 
 -->Repartitionning triangulation
-Load balance finished
-Average, minimum and maximum number of particles on the processors are 500 , 311 and 689
-Minimum and maximum number of cells owned by the processors are 395 and 5113
-
-*****************************************************************
-Transient iteration: 19000    Time: 0.19     Time step: 1e-05
-*****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2105e+01 | 4.2000e+02 |
-| Velocity magnitude           | 1.2124e-02 | 7.9426e-01 | 3.6899e-01 | 3.6899e+02 |
-| Angular velocity magnitude   | 6.3534e+00 | 3.3021e+02 | 1.1031e+02 | 1.1031e+05 |
-| Translational kinetic energy | 2.0779e-09 | 8.9185e-06 | 2.3210e-06 | 2.3210e-03 |
-| Rotational kinetic energy    | 1.0272e-09 | 2.7747e-06 | 4.1082e-07 | 4.1082e-04 |
--->Repartitionning triangulation
-Load balance finished
-Average, minimum and maximum number of particles on the processors are 500 , 263 and 737
+Load balance finished 
+Average, minimum and maximum number of particles on the processors are 500 , 267 and 733
 Minimum and maximum number of cells owned by the processors are 409 and 5113
 
 *****************************************************************
-Transient iteration: 20000    Time: 0.2      Time step: 1e-05
+Transient iteration: 20000    Time: 0.2      Time step: 1e-05   
 *****************************************************************
-| Variable                     | Min        | Max        | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2150e+01 | 4.4300e+02 |
-| Velocity magnitude           | 7.9530e-03 | 8.1774e-01 | 3.5889e-01 | 3.5889e+02 |
-| Angular velocity magnitude   | 9.7780e+00 | 3.3601e+02 | 1.1100e+02 | 1.1100e+05 |
-| Translational kinetic energy | 8.9418e-10 | 9.4535e-06 | 2.1908e-06 | 2.1908e-03 |
-| Rotational kinetic energy    | 2.4330e-09 | 2.8731e-06 | 4.1748e-07 | 4.1748e-04 |
+| Variable                     | Min        | Max        | Average    | Total      | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2300e+01 | 4.4600e+02 | 
+| Velocity magnitude           | 1.3487e-02 | 7.5409e-01 | 3.5907e-01 | 3.5907e+02 | 
+| Angular velocity magnitude   | 7.3022e+00 | 3.3601e+02 | 1.1152e+02 | 1.1152e+05 | 
+| Translational kinetic energy | 2.5714e-09 | 8.0392e-06 | 2.1910e-06 | 2.1910e-03 | 
+| Rotational kinetic energy    | 1.3569e-09 | 2.8731e-06 | 4.1334e-07 | 4.1334e-04 | 
 -->Repartitionning triangulation
-Load balance finished
+Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 250 and 750
 Minimum and maximum number of cells owned by the processors are 423 and 5113

--- a/applications_tests/dem_3d/load_balancing_solid_object.mpirun=2.output
+++ b/applications_tests/dem_3d/load_balancing_solid_object.mpirun=2.output
@@ -189,10 +189,10 @@ Transient iteration: 13000    Time: 0.13     Time step: 1e-05
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
 | Contact list generation      | 0.0000e+00 | 3.4000e+01 | 1.8077e+01 | 2.3500e+02 | 
-| Velocity magnitude           | 2.0256e-02 | 1.2692e+00 | 6.5781e-01 | 6.5781e+02 | 
+| Velocity magnitude           | 2.0131e-02 | 1.2692e+00 | 6.5781e-01 | 6.5781e+02 | 
 | Angular velocity magnitude   | 2.9633e-03 | 3.9056e+02 | 1.0574e+02 | 1.0574e+05 | 
-| Translational kinetic energy | 5.8006e-09 | 2.2771e-05 | 8.2684e-06 | 8.2684e-03 | 
-| Rotational kinetic energy    | 2.2346e-16 | 3.8816e-06 | 4.5243e-07 | 4.5243e-04 | 
+| Translational kinetic energy | 5.7293e-09 | 2.2771e-05 | 8.2684e-06 | 8.2684e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 3.8815e-06 | 4.5244e-07 | 4.5244e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 295 and 705
@@ -203,10 +203,10 @@ Transient iteration: 14000    Time: 0.14     Time step: 1e-05
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
 | Contact list generation      | 0.0000e+00 | 3.6000e+01 | 1.9357e+01 | 2.7100e+02 | 
-| Velocity magnitude           | 4.0611e-02 | 1.3637e+00 | 5.9704e-01 | 5.9704e+02 | 
-| Angular velocity magnitude   | 2.9633e-03 | 4.5644e+02 | 1.2139e+02 | 1.2139e+05 | 
-| Translational kinetic energy | 2.3315e-08 | 2.6291e-05 | 6.8549e-06 | 6.8549e-03 | 
-| Rotational kinetic energy    | 2.2346e-16 | 5.3015e-06 | 5.3030e-07 | 5.3030e-04 | 
+| Velocity magnitude           | 4.1395e-02 | 1.3637e+00 | 5.9708e-01 | 5.9708e+02 | 
+| Angular velocity magnitude   | 2.9633e-03 | 4.5705e+02 | 1.2138e+02 | 1.2138e+05 | 
+| Translational kinetic energy | 2.4225e-08 | 2.6291e-05 | 6.8546e-06 | 6.8546e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 5.3157e-06 | 5.3013e-07 | 5.3013e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 282 and 718
@@ -217,10 +217,10 @@ Transient iteration: 15000    Time: 0.15     Time step: 1e-05
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
 | Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.0667e+01 | 3.1000e+02 | 
-| Velocity magnitude           | 3.1038e-02 | 1.3989e+00 | 5.2027e-01 | 5.2027e+02 | 
-| Angular velocity magnitude   | 2.9633e-03 | 3.7945e+02 | 1.3044e+02 | 1.3044e+05 | 
-| Translational kinetic energy | 1.3619e-08 | 2.7665e-05 | 4.9361e-06 | 4.9361e-03 | 
-| Rotational kinetic energy    | 2.2346e-16 | 3.6640e-06 | 5.7209e-07 | 5.7209e-04 | 
+| Velocity magnitude           | 4.6113e-02 | 1.3989e+00 | 5.2024e-01 | 5.2024e+02 | 
+| Angular velocity magnitude   | 2.9633e-03 | 3.7955e+02 | 1.3092e+02 | 1.3092e+05 | 
+| Translational kinetic energy | 3.0062e-08 | 2.7665e-05 | 4.9300e-06 | 4.9300e-03 | 
+| Rotational kinetic energy    | 2.2346e-16 | 3.6658e-06 | 5.7749e-07 | 5.7749e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 297 and 703
@@ -231,67 +231,67 @@ Transient iteration: 16000    Time: 0.16     Time step: 1e-05
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
 | Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.1750e+01 | 3.4800e+02 | 
-| Velocity magnitude           | 1.7954e-02 | 1.1621e+00 | 4.4845e-01 | 4.4845e+02 | 
-| Angular velocity magnitude   | 1.0122e+01 | 4.4229e+02 | 1.3339e+02 | 1.3339e+05 | 
-| Translational kinetic energy | 4.5568e-09 | 1.9093e-05 | 3.2906e-06 | 3.2906e-03 | 
-| Rotational kinetic energy    | 2.6071e-09 | 4.9780e-06 | 5.6835e-07 | 5.6835e-04 | 
+| Velocity magnitude           | 3.1814e-02 | 1.1543e+00 | 4.5116e-01 | 4.5116e+02 | 
+| Angular velocity magnitude   | 1.1593e+01 | 4.3876e+02 | 1.3175e+02 | 1.3175e+05 | 
+| Translational kinetic energy | 1.4309e-08 | 1.8835e-05 | 3.3173e-06 | 3.3173e-03 | 
+| Rotational kinetic energy    | 3.4199e-09 | 4.8988e-06 | 5.5512e-07 | 5.5512e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
-Average, minimum and maximum number of particles on the processors are 500 , 329 and 671
+Average, minimum and maximum number of particles on the processors are 500 , 333 and 667
 Minimum and maximum number of cells owned by the processors are 332 and 5113
 
 *****************************************************************
 Transient iteration: 17000    Time: 0.17     Time step: 1e-05   
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2294e+01 | 3.7900e+02 | 
-| Velocity magnitude           | 1.6657e-02 | 1.1060e+00 | 4.0177e-01 | 4.0177e+02 | 
-| Angular velocity magnitude   | 1.1165e+01 | 3.7824e+02 | 1.1892e+02 | 1.1892e+05 | 
-| Translational kinetic energy | 3.9225e-09 | 1.7294e-05 | 2.7195e-06 | 2.7195e-03 | 
-| Rotational kinetic energy    | 3.1722e-09 | 3.6407e-06 | 4.5363e-07 | 4.5363e-04 | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2000e+01 | 3.7400e+02 | 
+| Velocity magnitude           | 2.8328e-02 | 8.4628e-01 | 4.0136e-01 | 4.0136e+02 | 
+| Angular velocity magnitude   | 7.2565e+00 | 3.3235e+02 | 1.1637e+02 | 1.1637e+05 | 
+| Translational kinetic energy | 1.1344e-08 | 1.0125e-05 | 2.7043e-06 | 2.7043e-03 | 
+| Rotational kinetic energy    | 1.3399e-09 | 2.8108e-06 | 4.4560e-07 | 4.4560e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
-Average, minimum and maximum number of particles on the processors are 500 , 251 and 749
+Average, minimum and maximum number of particles on the processors are 500 , 249 and 751
 Minimum and maximum number of cells owned by the processors are 367 and 5113
 
 *****************************************************************
 Transient iteration: 18000    Time: 0.18     Time step: 1e-05   
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2444e+01 | 4.0400e+02 | 
-| Velocity magnitude           | 6.9506e-03 | 7.8865e-01 | 3.8125e-01 | 3.8125e+02 | 
-| Angular velocity magnitude   | 7.7018e+00 | 3.3281e+02 | 1.1296e+02 | 1.1296e+05 | 
-| Translational kinetic energy | 6.8297e-10 | 8.7928e-06 | 2.4807e-06 | 2.4807e-03 | 
-| Rotational kinetic energy    | 1.5095e-09 | 2.8186e-06 | 4.1972e-07 | 4.1972e-04 | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2056e+01 | 3.9700e+02 | 
+| Velocity magnitude           | 5.8498e-03 | 7.9700e-01 | 3.8150e-01 | 3.8150e+02 | 
+| Angular velocity magnitude   | 4.1848e+00 | 3.7667e+02 | 1.1152e+02 | 1.1152e+05 | 
+| Translational kinetic energy | 4.8378e-10 | 8.9802e-06 | 2.4847e-06 | 2.4847e-03 | 
+| Rotational kinetic energy    | 4.4563e-10 | 3.6105e-06 | 4.1190e-07 | 4.1190e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
-Average, minimum and maximum number of particles on the processors are 500 , 315 and 685
+Average, minimum and maximum number of particles on the processors are 500 , 312 and 688
 Minimum and maximum number of cells owned by the processors are 395 and 5113
 
 *****************************************************************
 Transient iteration: 19000    Time: 0.19     Time step: 1e-05   
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2368e+01 | 4.2500e+02 | 
-| Velocity magnitude           | 1.8061e-02 | 7.3648e-01 | 3.6844e-01 | 3.6844e+02 | 
-| Angular velocity magnitude   | 8.6029e+00 | 3.2619e+02 | 1.1123e+02 | 1.1123e+05 | 
-| Translational kinetic energy | 4.6115e-09 | 7.6681e-06 | 2.3184e-06 | 2.3184e-03 | 
-| Rotational kinetic energy    | 1.8833e-09 | 2.7075e-06 | 4.1322e-07 | 4.1322e-04 | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2158e+01 | 4.2100e+02 | 
+| Velocity magnitude           | 1.2311e-02 | 8.5747e-01 | 3.6820e-01 | 3.6820e+02 | 
+| Angular velocity magnitude   | 4.5369e+00 | 3.2619e+02 | 1.0974e+02 | 1.0974e+05 | 
+| Translational kinetic energy | 2.1426e-09 | 1.0394e-05 | 2.3167e-06 | 2.3167e-03 | 
+| Rotational kinetic energy    | 5.2378e-10 | 2.7075e-06 | 4.0241e-07 | 4.0241e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
-Average, minimum and maximum number of particles on the processors are 500 , 267 and 733
+Average, minimum and maximum number of particles on the processors are 500 , 271 and 729
 Minimum and maximum number of cells owned by the processors are 409 and 5113
 
 *****************************************************************
 Transient iteration: 20000    Time: 0.2      Time step: 1e-05   
 *****************************************************************
 | Variable                     | Min        | Max        | Average    | Total      | 
-| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2300e+01 | 4.4600e+02 | 
-| Velocity magnitude           | 1.3487e-02 | 7.5409e-01 | 3.5907e-01 | 3.5907e+02 | 
-| Angular velocity magnitude   | 7.3022e+00 | 3.3601e+02 | 1.1152e+02 | 1.1152e+05 | 
-| Translational kinetic energy | 2.5714e-09 | 8.0392e-06 | 2.1910e-06 | 2.1910e-03 | 
-| Rotational kinetic energy    | 1.3569e-09 | 2.8731e-06 | 4.1334e-07 | 4.1334e-04 | 
+| Contact list generation      | 0.0000e+00 | 3.9000e+01 | 2.2250e+01 | 4.4500e+02 | 
+| Velocity magnitude           | 1.2341e-02 | 8.6657e-01 | 3.5770e-01 | 3.5770e+02 | 
+| Angular velocity magnitude   | 4.1349e+00 | 3.3601e+02 | 1.0973e+02 | 1.0973e+05 | 
+| Translational kinetic energy | 2.1531e-09 | 1.0616e-05 | 2.1728e-06 | 2.1728e-03 | 
+| Rotational kinetic energy    | 4.3508e-10 | 2.8731e-06 | 4.0635e-07 | 4.0635e-04 | 
 -->Repartitionning triangulation
 Load balance finished 
-Average, minimum and maximum number of particles on the processors are 500 , 250 and 750
+Average, minimum and maximum number of particles on the processors are 500 , 244 and 756
 Minimum and maximum number of cells owned by the processors are 423 and 5113

--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -192,8 +192,8 @@ namespace DEM
       particle_floating_mesh_in_contact;
 
     // <particle id, [particle id]>
-    typedef std::unordered_map<types::particle_index,
-                               std::vector<types::particle_index>>
+    typedef ankerl::unordered_dense::map<types::particle_index,
+                                         std::vector<types::particle_index>>
       particle_particle_candidates;
 
     // [[cell iterator]]

--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -165,8 +165,8 @@ namespace DEM
     // <particle id, <particle id, particle-particle info>>
     typedef ankerl::unordered_dense::map<
       types::particle_index,
-      std::unordered_map<types::particle_index,
-                         particle_particle_contact_info<dim>>>
+      ankerl::unordered_dense::map<types::particle_index,
+                                   particle_particle_contact_info<dim>>>
       adjacent_particle_pairs;
 
     // <cell iterator, <particle id, particle iterator>>

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -62,7 +62,7 @@ ParticleParticleFineSearch<dim>::particle_particle_fine_search(
   // Now iterating over contact_pair_candidates (maps of pairs), which
   // is the output of broad search. If a pair is in vicinity (distance <
   // threshold), it is added to the adjacent_particles
-  for (auto const &[particle_one_id, second_particle_container] :
+  for (auto &[particle_one_id, second_particle_container] :
        contact_pair_candidates)
     {
       if (second_particle_container.empty())

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -50,7 +50,8 @@ ParticleParticleFineSearch<dim>::particle_particle_fine_search(
             particle_one_location.distance_square(particle_two_location);
           if (square_distance > neighborhood_threshold)
             {
-              adjacent_particles_list.erase(adjacent_particles_list_iterator++);
+              adjacent_particles_list_iterator =
+                adjacent_particles_list.erase(adjacent_particles_list_iterator);
             }
           else
             {

--- a/source/dem/update_fine_search_candidates.cc
+++ b/source/dem/update_fine_search_candidates.cc
@@ -20,7 +20,7 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
 
       // Get the reference to all the object (particle/wall/face) contact
       // candidates of the current particle from the new broad search
-      auto contact_candidate_element = &contact_candidates[particle_id];
+      auto &contact_candidate_element = contact_candidates[particle_id];
 
       // Get adjacent object (particle/wall/face) content of the current
       // particle (from the fine search history)
@@ -45,39 +45,50 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
                         contact_type ==
                           ContactType::ghost_local_periodic_particle_particle)
             {
-              // Get the reference to all the 2nd particle contact
-              // candidates of the current particle from the new broad search
-              auto object_contact_candidates = &contact_candidates[object_id];
-
               // Check if the adjacent particle from history is a particle
               // candidate of the current particle and get the iterator to that
               // object if so
               auto search_iterator =
-                std::find(contact_candidate_element->begin(),
-                          contact_candidate_element->end(),
+                std::find(contact_candidate_element.begin(),
+                          contact_candidate_element.end(),
                           object_id);
 
-              // Check if the current particle is a particle candidate
-              // of the adjacent particle in history
-              auto search_object_to_particle_iterator =
-                std::find(object_contact_candidates->begin(),
-                          object_contact_candidates->end(),
-                          particle_id);
+
 
               // Particle-particle pairs are removed from the list of the new
               // broad search candidates or from the list of the history of the
               // fine search candidate list depending on the last checks
-              if (search_iterator != contact_candidate_element->end())
+              if (search_iterator != contact_candidate_element.end())
                 {
                   // The current 2nd is a candidate to the current particle.
                   // The 2nd particle is then removed from the new broad search
                   // particle-particle contact candidates list but kept as
                   // history in the fine search list
-                  contact_candidate_element->erase(search_iterator);
+                  search_iterator =
+                    contact_candidate_element.erase(search_iterator);
+
                   ++adjacent_map_iterator;
+
+                  // To prevent searching through the contact_candidates a
+                  // second time if there is a deletion in the first search, we
+                  // continue here instead of use an if / else if / else
+                  // statement
+                  continue;
                 }
-              else if (search_object_to_particle_iterator !=
-                       object_contact_candidates->end())
+
+              // Get the reference to all the 2nd particle contact
+              // candidates of the current particle from the new broad search
+              auto &object_contact_candidates = contact_candidates[object_id];
+
+              // Check if the current particle is a particle candidate
+              // of the adjacent particle in history
+              auto search_object_to_particle_iterator =
+                std::find(object_contact_candidates.begin(),
+                          object_contact_candidates.end(),
+                          particle_id);
+
+              if (search_object_to_particle_iterator !=
+                  object_contact_candidates.end())
                 {
                   if constexpr (contact_type ==
                                   ContactType::local_particle_particle ||
@@ -89,8 +100,9 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
                       // The 2nd particle is then removed from the new broad
                       // search particle-particle contact candidates list but
                       // kept as history in the fine search list
-                      object_contact_candidates->erase(
-                        search_object_to_particle_iterator);
+                      search_object_to_particle_iterator =
+                        object_contact_candidates.erase(
+                          search_object_to_particle_iterator);
                       ++adjacent_map_iterator;
                     }
 
@@ -106,7 +118,8 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
                       // local The 2nd particle is then removed from the history
                       // in the fine search list particle-particle contact
                       // candidates list but kept in new broad search list
-                      adjacent_pairs_content->erase(adjacent_map_iterator++);
+                      adjacent_map_iterator =
+                        adjacent_pairs_content->erase(adjacent_map_iterator);
                     }
                 }
               else
@@ -114,7 +127,8 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
                   // Current particles are no longer contact candidates.
                   // The particle is then removed as a candidate for fine search
                   // contact candidates list
-                  adjacent_pairs_content->erase(adjacent_map_iterator++);
+                  adjacent_map_iterator =
+                    adjacent_pairs_content->erase(adjacent_map_iterator);
                 }
             }
 
@@ -124,18 +138,19 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
             {
               // Check if the wall/face is a candidate of the current particle
               // and get the iterator to that object if so
-              auto search_iterator = contact_candidate_element->find(object_id);
+              auto search_iterator = contact_candidate_element.find(object_id);
 
               // Particle-wall/face pair is removed from the list of the new
               // broad search candidates or from the list of the history of the
               // fine search candidate list depending on the last check
-              if (search_iterator != contact_candidate_element->end())
+              if (search_iterator != contact_candidate_element.end())
                 {
                   // Current wall/face (from new broad search) is a candidate to
                   // the current particle. The wall/face is then removed from
                   // the new broad search particle-wall/face contact candidates
                   // list but kept as history in the fine search list
-                  contact_candidate_element->erase(search_iterator);
+                  search_iterator =
+                    contact_candidate_element.erase(search_iterator);
                   ++adjacent_map_iterator;
                 }
               else
@@ -144,7 +159,8 @@ update_fine_search_candidates(pairs_structure &     pairs_in_contact,
                   // candidate to the current particle. The wall/face is then
                   // removed as a candidate for fine search contact candidates
                   // list
-                  adjacent_pairs_content->erase(adjacent_map_iterator++);
+                  adjacent_map_iterator =
+                    adjacent_pairs_content->erase(adjacent_map_iterator);
                 }
             }
         }


### PR DESCRIPTION
# Description of the problem

- There was an issue with how the DEM maps were being manipulated and that prevented ankerl maps from being usable everywhere

# Description of the solution

- Fix these, now they are everywhere useable. The results are dramatic (30% increase in speed)


# Comments

- Some optimizations can still be done with the particle-wall, but I will take care of this when I get back from vacations
- 
