### PR TITLE
Fix link of example

### DIFF
--- a/doc/source/examples/rpt/rpt.rst
+++ b/doc/source/examples/rpt/rpt.rst
@@ -26,7 +26,7 @@ Radioactive Particle Tracking (RPT)
 
       rpt_2 [label="Tuning Count Calculation Model \nParameters with NOMAD", href="https://lethe-cfd.github.io/lethe/examples/rpt/tuning-parameters-with-nomad/tuning-parameters-with-nomad.html", tooltip="Tuning count calculation model parameters with NOMAD"];
 
-      rpt_3 [label="Particle FEM reconstruction", href="https://lethe-cfd.github.io/lethe/examples/rpt/particle_fem_reconstruction/particle_fem_reconstruction.html", tooltip="Particle FEM reconstruction"];
+      rpt_3 [label="Particle FEM reconstruction", href="https://lethe-cfd.github.io/lethe/examples/rpt/particle-fem-reconstruction/particle-fem-reconstruction.html", tooltip="Particle FEM reconstruction"];
 
       rpt -> rpt_1:w;
       rpt -> rpt_2:w;  


### PR DESCRIPTION
# Description of the problem

Link to particle FEM reconstruction example in RPT map in the documentation was not working.

# Description of the solution

The link was corrected.
