### PR TITLE
Implemented minimal refinement functionality

### DIFF
--- a/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.output
+++ b/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.output
@@ -1,0 +1,33 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       64
+   Number of degrees of freedom: 243
+   Volume of triangulation:      9
+Initial refinement around IB particles - Step : 1 of 5
+   Number of active cells:       160
+   Number of degrees of freedom: 567
+   Volume of triangulation:      9
+Initial refinement around IB particles - Step : 2 of 5
+   Number of active cells:       328
+   Number of degrees of freedom: 1119
+   Volume of triangulation:      9
+Initial refinement around IB particles - Step : 3 of 5
+   Number of active cells:       328
+   Number of degrees of freedom: 1119
+   Volume of triangulation:      9
+Initial refinement around IB particles - Step : 4 of 5
+   Number of active cells:       328
+   Number of degrees of freedom: 1119
+   Volume of triangulation:      9
+Initial refinement around IB particles - Step : 5 of 5
+   Number of active cells:       328
+   Number of degrees of freedom: 1119
+   Volume of triangulation:      9
+
+*****************************
+Steady iteration:        1/1
+*****************************
++------------------------------------------+
+|  Force  summary particles                |
++------------------------------------------+
+particle_ID  time    T_z     f_x    f_y    f_xv   f_yv   f_xp    f_yp   
+          0 1.0000 -0.0062 22.6933 0.0054 9.4262 0.0054 13.2671 -0.0000

--- a/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.output
+++ b/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.output
@@ -3,24 +3,24 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 243
    Volume of triangulation:      9
 Initial refinement around IB particles - Step : 1 of 5
-   Number of active cells:       160
-   Number of degrees of freedom: 567
+   Number of active cells:       154
+   Number of degrees of freedom: 549
    Volume of triangulation:      9
 Initial refinement around IB particles - Step : 2 of 5
-   Number of active cells:       328
-   Number of degrees of freedom: 1119
+   Number of active cells:       316
+   Number of degrees of freedom: 1095
    Volume of triangulation:      9
 Initial refinement around IB particles - Step : 3 of 5
-   Number of active cells:       328
-   Number of degrees of freedom: 1119
+   Number of active cells:       316
+   Number of degrees of freedom: 1095
    Volume of triangulation:      9
 Initial refinement around IB particles - Step : 4 of 5
-   Number of active cells:       328
-   Number of degrees of freedom: 1119
+   Number of active cells:       316
+   Number of degrees of freedom: 1095
    Volume of triangulation:      9
 Initial refinement around IB particles - Step : 5 of 5
-   Number of active cells:       328
-   Number of degrees of freedom: 1119
+   Number of active cells:       316
+   Number of degrees of freedom: 1095
    Volume of triangulation:      9
 
 *****************************
@@ -30,4 +30,4 @@ Steady iteration:        1/1
 |  Force  summary particles                |
 +------------------------------------------+
 particle_ID  time    T_z     f_x    f_y    f_xv   f_yv   f_xp    f_yp   
-          0 1.0000 -0.0062 22.6933 0.0054 9.4262 0.0054 13.2671 -0.0000
+          0 1.0000 -0.0062 22.6933 0.0054 9.4262 0.0054 13.2671 0.0000 

--- a/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.prm
@@ -1,0 +1,109 @@
+subsection simulation control
+  set method            = steady
+  set number mesh adapt = 0
+  set output frequency  = 0
+  set log precision     = 4
+  set subdivision       = 1
+end
+
+subsection FEM
+  set velocity order = 1
+  set pressure order = 1
+end
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 1,1: -1.5,-1.5 : 1.5,1.5  : true
+  set initial refinement = 3
+end
+
+subsection boundary conditions
+  set number = 6
+  subsection bc 0
+    set id   = 0
+    set type = function
+    subsection u
+      set Function expression = 1
+    end
+    subsection v
+      set Function expression = 0
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+  subsection bc 1
+    set id   = 2
+    set type = slip
+  end
+  subsection bc 2
+    set id   = 3
+    set type = slip
+  end
+  subsection bc 3
+    set id   = 4
+    set type = slip
+  end
+  subsection bc 4
+    set id   = 5
+    set type = slip
+  end
+  subsection bc 5
+    set id   = 1
+    set type = outlet
+  end
+end
+
+subsection particles
+  set number of particles = 1
+
+  subsection extrapolation function
+    set length ratio  = 1
+    set stencil order = 2
+  end
+
+  subsection output
+    set calculate force                               = true
+    set enable extra sharp interface vtu output field = false
+    set print DEM                                     = false
+  end
+
+  subsection local mesh refinement
+    set initial refinement                = 5
+    set refine mesh inside radius factor  = 1
+    set refine mesh outside radius factor = 1
+  end
+
+  subsection particle info 0
+    set type              = sphere
+    set shape arguments   = 0.5
+    set integrate motion  = false
+    set pressure location = 0; 0
+
+    subsection position
+      set Function expression = 0.05; 0
+    end
+  end
+end
+
+subsection forces
+  set verbosity = verbose
+end
+
+subsection mesh adaptation
+  set type                 = kelly
+  set variable             = velocity
+  set max refinement level = 5
+  set min refinement level = 1
+end
+
+subsection non-linear solver
+  set verbosity = quiet
+end
+
+subsection linear solver
+  set method    = gmres
+  set verbosity = quiet
+end
+

--- a/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.prm
+++ b/applications_tests/gls_sharp_navier_stokes_2d/minimal_crown_refinement.prm
@@ -1,9 +1,8 @@
 subsection simulation control
-  set method            = steady
-  set number mesh adapt = 0
-  set output frequency  = 0
-  set log precision     = 4
-  set subdivision       = 1
+  set method           = steady
+  set output frequency = 0
+  set log precision    = 4
+  set subdivision      = 1
 end
 
 subsection FEM
@@ -106,4 +105,3 @@ subsection linear solver
   set method    = gmres
   set verbosity = quiet
 end
-

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -135,7 +135,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
 	    The refined cells are all those for which at least one of the degrees of freedom (dof) location satisfies both the ``refine mesh inside radius factor`` and the ``refine mesh outside radius factor`` thresholds. Each cycle of refinement reduces the length of the elements by a factor two.
 
     .. note::
-        Using values ``refine mesh outside radius factor = 1`` and ``refine mesh inside radius factor = 1`` activates a minimal refinement mode. This enables the solver to select automatically the smallest region near the particle that is permitted by the method.
+        Using values ``refine mesh outside radius factor = 1`` and ``refine mesh inside radius factor = 1`` activates a minimal refinement mode. This enables the solver to select automatically the smallest region near the particle that guarantees stability of the solution.
 
     .. note::
 	    This near-particle zone will be systematically refined at each refinement step until reaching the ``max refinement level`` parameter (:doc:`../cfd/mesh_adaptation_control`).

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -135,6 +135,9 @@ This subsection contains the parameters related to the sharp immersed boundary s
 	    The refined cells are all those for which at least one of the degrees of freedom (dof) location satisfies both the ``refine mesh inside radius factor`` and the ``refine mesh outside radius factor`` thresholds. Each cycle of refinement reduces the length of the elements by a factor two.
 
     .. note::
+        Using values ``refine mesh outside radius factor = 1`` and ``refine mesh inside radius factor = 1`` activates a minimal refinement mode. This enables the solver to select automatically the smallest region near the particle that is permitted by the method.
+
+    .. note::
 	    This near-particle zone will be systematically refined at each refinement step until reaching the ``max refinement level`` parameter (:doc:`../cfd/mesh_adaptation_control`).
 
     * The ``refinement zone extrapolation`` parameter controls how the refinement zone is evaluated. By default, the refinement zone is around the particle's last position (If this parameter is false). If this parameter is set to true, the refinement zone position is extrapolated from the particle's current velocity. It will then apply all the initial refinement steps at the particle's new position. This is used when the particle moves significantly between two time steps.

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -132,6 +132,7 @@ public:
    *  @param evaluation_point The point at which the evaluation is performed
    *  @param outer_radius The factor to be multiplied by the effective radius to check if the evaluation point is inside the outer limits
    *  @param inside_radius The factor to be multiplied by the effective radius to check if the evaluation point is outside the inner limits
+   *  @param absolute_distance Whether the distance is defined as absolute or relative to radius
    *  @param cell_guess A guess of the cell containing the evaluation point, which
    *  is useful to reduce computation time
    */
@@ -140,6 +141,7 @@ public:
     const Point<dim> &                                    evaluation_point,
     const double                                          outer_radius,
     const double                                          inside_radius,
+    const bool                                            absolute_distance,
     const typename DoFHandler<dim>::active_cell_iterator &cell_guess);
 
   /**
@@ -148,7 +150,8 @@ public:
   bool
   is_inside_crown(const Point<dim> &evaluation_point,
                   const double      outer_radius,
-                  const double      inside_radius);
+                  const double      inside_radius,
+                  const bool        absolute_distance);
 
   /**
    * @brief

--- a/include/fem-dem/gls_sharp_navier_stokes.h
+++ b/include/fem-dem/gls_sharp_navier_stokes.h
@@ -587,7 +587,6 @@ private:
            std::tuple<bool, unsigned int, unsigned int>>
     cut_cells_map;
 
-
   /*
    * This map uses the cell as the key, and stores the following information:
    * if the cell is overconstrained (bool), what particle overconstrains this

--- a/source/core/ib_particle.cc
+++ b/source/core/ib_particle.cc
@@ -197,13 +197,24 @@ IBParticle<dim>::is_inside_crown(
   const Point<dim> &                                    evaluation_point,
   const double                                          outer_radius,
   const double                                          inside_radius,
+  const bool                                            absolute_distance,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
   const double radius = shape->effective_radius;
 
   double distance = shape->value_with_cell_guess(evaluation_point, cell_guess);
-  bool   is_inside_outer_ring  = distance <= radius * (outer_radius - 1);
-  bool   is_outside_inner_ring = distance >= radius * (inside_radius - 1);
+  bool   is_inside_outer_ring;
+  bool   is_outside_inner_ring;
+  if (absolute_distance)
+    {
+      is_inside_outer_ring  = distance <= outer_radius;
+      is_outside_inner_ring = distance >= inside_radius;
+    }
+  else
+    {
+      is_inside_outer_ring  = distance <= radius * (outer_radius - 1);
+      is_outside_inner_ring = distance >= radius * (inside_radius - 1);
+    }
 
   return is_inside_outer_ring && is_outside_inner_ring;
 }
@@ -212,13 +223,24 @@ template <int dim>
 bool
 IBParticle<dim>::is_inside_crown(const Point<dim> &evaluation_point,
                                  const double      outer_radius,
-                                 const double      inside_radius)
+                                 const double      inside_radius,
+                                 const bool        absolute_distance)
 {
   const double radius = shape->effective_radius;
 
-  double distance              = shape->value(evaluation_point);
-  bool   is_inside_outer_ring  = distance <= radius * (outer_radius - 1);
-  bool   is_outside_inner_ring = distance >= radius * (inside_radius - 1);
+  double distance = shape->value(evaluation_point);
+  bool   is_inside_outer_ring;
+  bool   is_outside_inner_ring;
+  if (absolute_distance)
+    {
+      is_inside_outer_ring  = distance <= outer_radius;
+      is_outside_inner_ring = distance >= inside_radius;
+    }
+  else
+    {
+      is_inside_outer_ring  = distance <= radius * (outer_radius - 1);
+      is_outside_inner_ring = distance >= radius * (inside_radius - 1);
+    }
 
   return is_inside_outer_ring && is_outside_inner_ring;
 }

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -886,6 +886,10 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                       bool is_inside_crown;
                       if (minimal_crown_refinement_enabled)
                         {
+                          // The factor depends on dim, since cell->diameter()
+                          // returns a higher value in 3D than in 2D. For
+                          // example, for a unit square vs. unit cube we get
+                          // sqrt(2) and sqrt(3).
                           double factor   = (dim == 3 ? 0.5 : 0.75);
                           is_inside_crown = particles[p].is_inside_crown(
                             support_points[local_dof_indices[j]],

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -886,10 +886,11 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                       bool is_inside_crown;
                       if (minimal_crown_refinement_enabled)
                         {
+                          double factor   = (dim == 3 ? 0.5 : 0.75);
                           is_inside_crown = particles[p].is_inside_crown(
                             support_points[local_dof_indices[j]],
-                            0.75 * smallest_cut_cell,
-                            -0.75 * smallest_cut_cell,
+                            factor * smallest_cut_cell,
+                            -factor * smallest_cut_cell,
                             true, // indicates that we use the absolute
                                   // distance definition
                             cell);

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -886,10 +886,11 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                       bool is_inside_crown;
                       if (minimal_crown_refinement_enabled)
                         {
-                          // The factor depends on dim, since cell->diameter()
-                          // returns the longest diagonal. The diagonal is
-                          // higher in 3D than in 2D. The chosen factor is equal
-                          // to the length of the smallest cell.
+                          // The factor should be equal to the length of the
+                          // current smallest cell. Since cell->diameter()
+                          // returns the longest diagonal, we divide the
+                          // diameter by the diagonal of a unit hypercube to
+                          // obtain the correct length.
                           double factor   = 1 / sqrt(dim);
                           is_inside_crown = particles[p].is_inside_crown(
                             support_points[local_dof_indices[j]],

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -887,10 +887,10 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                       if (minimal_crown_refinement_enabled)
                         {
                           // The factor depends on dim, since cell->diameter()
-                          // returns a higher value in 3D than in 2D. For
-                          // example, for a unit square vs. unit cube we get
-                          // sqrt(2) and sqrt(3).
-                          double factor   = (dim == 3 ? 0.5 : 0.75);
+                          // returns the longest diagonal. The diagonal is
+                          // higher in 3D than in 2D. The chosen factor is equal
+                          // to the length of the smallest cell.
+                          double factor   = 1 / sqrt(dim);
                           is_inside_crown = particles[p].is_inside_crown(
                             support_points[local_dof_indices[j]],
                             factor * smallest_cut_cell,

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -888,8 +888,8 @@ GLSSharpNavierStokesSolver<dim>::refine_ib()
                         {
                           is_inside_crown = particles[p].is_inside_crown(
                             support_points[local_dof_indices[j]],
-                            0.5 * smallest_cut_cell,
-                            -0.5 * smallest_cut_cell,
+                            0.75 * smallest_cut_cell,
+                            -0.75 * smallest_cut_cell,
                             true, // indicates that we use the absolute
                                   // distance definition
                             cell);


### PR DESCRIPTION
# Description of the problem

- Until now we had to select a relative distance (relative to the effective radius of the shape) to define the crown refinement region
- When using a finer mesh, this meant having to decrease manually the parameters, or having a layer of refined cells thicker than necessary (we only need a layer of 2 uncut refined cells)

# Description of the solution

- This PR allows Lethe to define the distance automatically, so that the layer of uncut refined cells is always minimal: 2 cells thickness
- I added an option to define absolute distance instead of relative, and we call is_inside_crown with the absolute distance that depends on the smallest cell diameter

# How Has This Been Tested?

- A 2D test was added
- All tests still pass

# Documentation

- New feature was added to sharp parameters documentation

![image](https://github.com/lethe-cfd/lethe/assets/14217956/9075d769-7d0e-4eb9-82ec-8ddcd8b17f05)

