### PR TITLE
Reduce memory rbf

### DIFF
--- a/applications_tests/gls_sharp_navier_stokes/cavatappi_composite_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/cavatappi_composite_test.prm
@@ -65,7 +65,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/check_point.prm
+++ b/applications_tests/gls_sharp_navier_stokes/check_point.prm
@@ -95,7 +95,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 6

--- a/applications_tests/gls_sharp_navier_stokes/coupled_moving_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes/coupled_moving_stokes.prm
@@ -161,7 +161,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_cone_deathstar.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_cone_deathstar.prm
@@ -62,7 +62,6 @@ end
 subsection particles
   set number of particles                     = 2
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_cuthollowsphere.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_cuthollowsphere.prm
@@ -91,7 +91,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_ellipsoid_rectangle.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_ellipsoid_rectangle.prm
@@ -91,7 +91,6 @@ end
 subsection particles
   set number of particles                     = 2
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_rbf.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_rbf.prm
@@ -75,8 +75,9 @@ subsection particles
   end
 
   subsection particle info 0
-    set type            = rbf
-    set shape arguments = rbf_test_shape.input
+    set type                       = rbf
+    set shape arguments            = rbf_test_shape.input
+    set mesh based precalculations = false
     subsection position
       set Function expression = 0.01;0.01;0.01
     end
@@ -112,3 +113,4 @@ subsection linear solver
     set ilu preconditioner relative tolerance = 1.00
   end
 end
+

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_rbf.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_rbf.prm
@@ -77,7 +77,7 @@ subsection particles
   subsection particle info 0
     set type                       = rbf
     set shape arguments            = rbf_test_shape.input
-    set mesh based precalculations = false
+    set mesh-based precalculations = false
     subsection position
       set Function expression = 0.01;0.01;0.01
     end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_torus.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_torus.prm
@@ -91,7 +91,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/load_particles_from_file_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/load_particles_from_file_test.prm
@@ -96,7 +96,6 @@ end
 
 subsection particles
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/moving_ib_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_ib_gls.prm
@@ -90,7 +90,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = true
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 6

--- a/applications_tests/gls_sharp_navier_stokes/moving_ib_gls_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_ib_gls_poisson.prm
@@ -90,7 +90,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 6

--- a/applications_tests/gls_sharp_navier_stokes/moving_rectangle.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_rectangle.prm
@@ -60,7 +60,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = true
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 6

--- a/applications_tests/gls_sharp_navier_stokes/moving_stokes_2d.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_stokes_2d.prm
@@ -147,7 +147,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 6

--- a/applications_tests/gls_sharp_navier_stokes/opencascade/static_stokes_step.prm
+++ b/applications_tests/gls_sharp_navier_stokes/opencascade/static_stokes_step.prm
@@ -160,7 +160,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms.prm
+++ b/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms.prm
@@ -124,8 +124,9 @@ subsection particles
   end
 
   subsection particle info 0
-    set type            = rbf
-    set shape arguments = rbf_sphere.input
+    set type                       = rbf
+    set shape arguments            = rbf_sphere.input
+    set mesh based precalculations = false
   end
 end
 
@@ -157,3 +158,4 @@ subsection linear solver
     set verbosity = quiet
   end
 end
+

--- a/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms.prm
+++ b/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms.prm
@@ -126,7 +126,7 @@ subsection particles
   subsection particle info 0
     set type                       = rbf
     set shape arguments            = rbf_sphere.input
-    set mesh based precalculations = false
+    set mesh-based precalculations = false
   end
 end
 

--- a/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms_adaptive.prm
@@ -139,8 +139,9 @@ subsection particles
   end
 
   subsection particle info 0
-    set type            = rbf
-    set shape arguments = rbf_sphere_adaptive.input
+    set type                       = rbf
+    set shape arguments            = rbf_sphere_adaptive.input
+    set mesh based precalculations = false
   end
 end
 
@@ -172,3 +173,4 @@ subsection linear solver
     set verbosity = quiet
   end
 end
+

--- a/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms_adaptive.prm
@@ -141,7 +141,7 @@ subsection particles
   subsection particle info 0
     set type                       = rbf
     set shape arguments            = rbf_sphere_adaptive.input
-    set mesh based precalculations = false
+    set mesh-based precalculations = false
   end
 end
 

--- a/applications_tests/gls_sharp_navier_stokes/sphere_power_law_ramp.prm
+++ b/applications_tests/gls_sharp_navier_stokes/sphere_power_law_ramp.prm
@@ -118,7 +118,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 6

--- a/applications_tests/gls_sharp_navier_stokes/spinning_cone.prm
+++ b/applications_tests/gls_sharp_navier_stokes/spinning_cone.prm
@@ -62,7 +62,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/spooky_composite_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/spooky_composite_test.prm
@@ -65,7 +65,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/applications_tests/gls_sharp_navier_stokes/static_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes/static_stokes.prm
@@ -160,7 +160,6 @@ end
 subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
-  set levels not precalculated                = 0
 
   subsection extrapolation function
     set stencil order = 2

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -8,6 +8,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
 
     subsection particles
       set assemble Navier-Stokes inside particles = false
+      set levels not precalculated                = 0
       set number of particles                     = 1
       
       subsection extrapolation function
@@ -92,6 +93,8 @@ This subsection contains the parameters related to the sharp immersed boundary s
   end
 
 * The ``number of particles`` is the number of particles simulated by the sharp-edge IB.
+
+* The ``levels not precalculated`` parameter controls the number of layers of the hierarchical grid used by Lethe that are ignored by precalculations. It allows to reduce the memory footprint at the cost of an increased computing time. At the moment, this is used only for RBF shapes. The value should be increased when the RBF contains a lot of nodes and/or the grid is extremely fine.
 
 * The ``assemble Navier-Stokes inside particles`` parameter determines if the Navier-Stokes equations are solved inside the particles or not. If the Navier-Stokes equations are not solved (the parameter is false), the solver will solve a Poisson equation for each variable in the problem. This eliminates the need to define a reference value for the pressure.
 

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -59,10 +59,11 @@ This subsection contains the parameters related to the sharp immersed boundary s
       end
       
       subsection particle info 0
-        set type              = sphere 
-        set shape arguments   = 1
-        set integrate motion  = false
-        set pressure location = 0; 0; 0
+        set type                       = sphere
+        set shape arguments            = 1
+        set integrate motion           = false
+        set pressure location          = 0; 0; 0
+        set mesh based precalculations = true
         
         subsection position
           set Function expression = 0; 0; 0
@@ -251,6 +252,8 @@ The following parameter and subsection are all inside the subsection ``particle 
         As could be expected, using this type of shape requires that ``dealii`` be compiled with OpenCascade. This module can be installed with candi, by uncommenting the appropriate line in ``candi.cfg``.
 
 * The ``integrate motion`` parameter controls if the dynamics equations of the particles are calculated. If this parameter is set to false, the particles position, velocity, and angular velocity are defined directly by the functions. If ``integrate motion=true`` the position and the velocity will be defined by the integration of the particle dynamic.
+
+* The ``mesh based precalculations`` parameter controls if the mesh-based precalculations are applied. These precalculations are critical for good performance in medium to high detailed RBFs (and its composites), but can introduce deformations. These deformations appear when some RBF nodes are located outside of the background mesh.
 
 * The ``pressure location`` parameter is used to define the X, Y, and Z coordinate offsets of the pressure reference point relative to the center of the particle. These parameters are used when the ``assemble Navier-Stokes inside particles`` parameter is set to ``true`` to define the pressure reference point.
 

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -8,7 +8,6 @@ This subsection contains the parameters related to the sharp immersed boundary s
 
     subsection particles
       set assemble Navier-Stokes inside particles = false
-      set levels not precalculated                = 0
       set number of particles                     = 1
       
       subsection extrapolation function
@@ -93,8 +92,6 @@ This subsection contains the parameters related to the sharp immersed boundary s
   end
 
 * The ``number of particles`` is the number of particles simulated by the sharp-edge IB.
-
-* The ``levels not precalculated`` parameter controls the number of layers of the hierarchical grid used by Lethe that are ignored by precalculations. It allows to reduce the memory footprint at the cost of an increased computing time. At the moment, this is used only for RBF shapes. The value should be increased when the RBF contains a lot of nodes and/or the grid is extremely fine.
 
 * The ``assemble Navier-Stokes inside particles`` parameter determines if the Navier-Stokes equations are solved inside the particles or not. If the Navier-Stokes equations are not solved (the parameter is false), the solver will solve a Poisson equation for each variable in the problem. This eliminates the need to define a reference value for the pressure.
 

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -8,7 +8,6 @@ This subsection contains the parameters related to the sharp immersed boundary s
 
     subsection particles
       set assemble Navier-Stokes inside particles = false
-      set levels not precalculated                = 0
       set number of particles                     = 1
       
       subsection extrapolation function
@@ -92,8 +91,6 @@ This subsection contains the parameters related to the sharp immersed boundary s
   end
 
 * The ``number of particles`` is the number of particles simulated by the sharp-edge IB.
-
-* The ``levels not precalculated`` parameter controls the number of layers of the hierarchical grid used by Lethe that are ignored by precalculations. It allows to reduce the memory footprint at the cost of an increased computing time. At the moment, this is used only for RBF shapes. The value should be increased when the RBF contains a lot of nodes and/or the grid is extremely fine.
 
 * The ``assemble Navier-Stokes inside particles`` parameter determines if the Navier-Stokes equations are solved inside the particles or not. If the Navier-Stokes equations are not solved (the parameter is false), the solver will solve a Poisson equation for each variable in the problem. This eliminates the need to define a reference value for the pressure.
 

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -63,7 +63,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
         set shape arguments            = 1
         set integrate motion           = false
         set pressure location          = 0; 0; 0
-        set mesh based precalculations = true
+        set mesh-based precalculations = true
         
         subsection position
           set Function expression = 0; 0; 0
@@ -253,7 +253,7 @@ The following parameter and subsection are all inside the subsection ``particle 
 
 * The ``integrate motion`` parameter controls if the dynamics equations of the particles are calculated. If this parameter is set to false, the particles position, velocity, and angular velocity are defined directly by the functions. If ``integrate motion=true`` the position and the velocity will be defined by the integration of the particle dynamic.
 
-* The ``mesh based precalculations`` parameter controls if the mesh-based precalculations are applied. These precalculations are critical for good performance in medium to high detailed RBFs (and its composites), but can introduce deformations. These deformations appear when some RBF nodes are located outside of the background mesh.
+* The ``mesh-based precalculations`` parameter controls if the mesh-based precalculations are applied. These precalculations are critical for good performance in medium to high detailed RBFs (and its composites), but can introduce deformations. These deformations appear when some RBF nodes are located outside of the background mesh.
 
 * The ``pressure location`` parameter is used to define the X, Y, and Z coordinate offsets of the pressure reference point relative to the center of the particle. These parameters are used when the ``assemble Navier-Stokes inside particles`` parameter is set to ``true`` to define the pressure reference point.
 

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -336,6 +336,11 @@ public:
   // Bool that indicates if the motion of this particle must be integrated. If
   // it is false, the position and velocity are defined by the function.
   bool integrate_motion;
+  // Bool that indicates if mesh based precalculations should be performed.
+  // For RBF shapes with nodes outside the background mesh, slight deformations
+  // can happen near the boundary when mesh based precalculations is used (due
+  // to the RBF nodes partitioning algorithm).
+  bool mesh_based_precalculations;
   // Current residual of the particle velocity.
   double residual_velocity;
   // Current residual of the particle angular velocity.

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -226,10 +226,12 @@ public:
    * @param updated_dof_handler the reference to the new dof_handler
    * @param levels_not_precalculated the number of finer levels that won't be
    * precalculated
+   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   update_precalculations(DoFHandler<dim> &  updated_dof_handler,
-                         const unsigned int levels_not_precalculated);
+                         const unsigned int levels_not_precalculated,
+                         const bool         mesh_based_precalculations);
 
 
   // This class defines values related to a particle used in the sharp interface

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -224,7 +224,7 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   update_precalculations(DoFHandler<dim> &updated_dof_handler,
@@ -233,7 +233,7 @@ public:
   /**
    * @brief Updates precalculations if needed, then computes and removes superfluous data
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,
@@ -350,9 +350,9 @@ public:
   // Bool that indicates if the motion of this particle must be integrated. If
   // it is false, the position and velocity are defined by the function.
   bool integrate_motion;
-  // Bool that indicates if mesh based precalculations should be performed.
+  // Bool that indicates if mesh-based precalculations should be performed.
   // For RBF shapes with nodes outside the background mesh, slight deformations
-  // can happen near the boundary when mesh based precalculations is used (due
+  // can happen near the boundary when mesh-based precalculations is used (due
   // to the RBF nodes partitioning algorithm).
   bool mesh_based_precalculations;
   // Current residual of the particle velocity.

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -240,7 +240,7 @@ public:
                           const bool       mesh_based_precalculations);
 
   /**
-   * Loads data from the files for file-based Shapes (RBF at the moment)
+   * @brief Loads data from the files for file-based Shapes (RBF at the moment)
    */
   void
   load_data_from_file();

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -224,26 +224,20 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param levels_not_precalculated the number of finer levels that won't be
-   * precalculated
    * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
-  update_precalculations(DoFHandler<dim> &  updated_dof_handler,
-                         const unsigned int levels_not_precalculated,
-                         const bool         mesh_based_precalculations);
+  update_precalculations(DoFHandler<dim> &updated_dof_handler,
+                         const bool       mesh_based_precalculations);
 
   /**
    * @brief Updates precalculations if needed, then computes and removes superfluous data
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param levels_not_precalculated the number of finer levels that won't be
-   * precalculated
    * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
-  remove_superfluous_data(DoFHandler<dim> &  updated_dof_handler,
-                          const unsigned int levels_not_precalculated,
-                          const bool         mesh_based_precalculations);
+  remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,
+                          const bool       mesh_based_precalculations);
 
   /**
    * Loads data from the files for file-based Shapes (RBF at the moment)

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -233,7 +233,7 @@ public:
   /**
    * @brief Updates precalculations if needed, then computes and removes superfluous data
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if type=RBF)
    */
   void
   remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -233,6 +233,24 @@ public:
                          const unsigned int levels_not_precalculated,
                          const bool         mesh_based_precalculations);
 
+  /**
+   * @brief Updates precalculations if needed, then computes and removes superfluous data
+   * @param updated_dof_handler the reference to the new dof_handler
+   * @param levels_not_precalculated the number of finer levels that won't be
+   * precalculated
+   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   */
+  void
+  remove_superfluous_data(DoFHandler<dim> &  updated_dof_handler,
+                          const unsigned int levels_not_precalculated,
+                          const bool         mesh_based_precalculations);
+
+  /**
+   * Loads data from the files for file-based Shapes (RBF at the moment)
+   */
+  void
+  load_data_from_file();
+
 
   // This class defines values related to a particle used in the sharp interface
   // IB. Each particle defined will have these value used in the solver.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1200,7 +1200,6 @@ namespace Parameters
     unsigned int                 nb;
     unsigned int                 order;
     unsigned int                 initial_refinement;
-    unsigned int                 levels_not_precalculated;
     double                       inside_radius;
     double                       outside_radius;
     bool                         time_extrapolation_of_refinement_zone;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1794,12 +1794,12 @@ public:
     const typename DoFHandler<dim>::active_cell_iterator cell);
 
 private:
-  size_t                               number_of_nodes;
-  std::shared_ptr<HyperRectangle<dim>> bounding_box;
-  std::vector<size_t>                  iterable_nodes;
+  size_t                                            number_of_nodes;
+  std::shared_ptr<HyperRectangle<dim>>              bounding_box;
+  std::vector<std::shared_ptr<std::vector<size_t>>> iterable_nodes;
 
   std::map<const typename DoFHandler<dim>::cell_iterator,
-           std::shared_ptr<std::vector<size_t>>>
+           std::shared_ptr<std::vector<std::shared_ptr<std::vector<size_t>>>>>
                    likely_nodes_map;
   size_t           max_number_of_nodes;
   DoFHandler<dim> *dof_handler;
@@ -1815,12 +1815,12 @@ private:
   double minimal_support_radius;
 
 public:
-  std::vector<size_t>           nodes_id;
-  std::vector<double>           weights;
-  std::vector<Point<dim>>       nodes_positions;
-  std::vector<Point<dim>>       rotated_nodes_positions;
-  std::vector<double>           support_radii;
-  std::vector<RBFBasisFunction> basis_functions;
+  std::vector<std::shared_ptr<std::vector<size_t>>> nodes_id;
+  std::vector<double>                               weights;
+  std::vector<Point<dim>>                           nodes_positions;
+  std::vector<Point<dim>>                           rotated_nodes_positions;
+  std::vector<double>                               support_radii;
+  std::vector<RBFBasisFunction>                     basis_functions;
 };
 
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1794,9 +1794,10 @@ private:
     const typename DoFHandler<dim>::cell_iterator,
     std::shared_ptr<std::vector<
       std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>>
-                   likely_nodes_map;
-  size_t           max_number_of_inside_nodes;
-  DoFHandler<dim> *dof_handler;
+                                     likely_nodes_map;
+  std::unordered_map<size_t, size_t> useful_rbf_node_map;
+  size_t                             max_number_of_inside_nodes;
+  DoFHandler<dim> *                  dof_handler;
 
   double minimal_support_radius;
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -912,7 +912,7 @@ public:
     , constituents(constituents)
     , operations(operations)
   {
-    // Calculation of the effective radius and setting of status for components
+    // Calculation of the effective radius and setting of constituents' status
     for (auto const &[constituent_id, constituent] : constituents)
       {
         this->effective_radius =
@@ -1016,7 +1016,7 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+  * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   update_precalculations(DoFHandler<dim> &updated_dof_handler,

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1794,12 +1794,16 @@ public:
     const typename DoFHandler<dim>::active_cell_iterator cell);
 
 private:
-  size_t                                            number_of_nodes;
-  std::shared_ptr<HyperRectangle<dim>>              bounding_box;
-  std::vector<std::shared_ptr<std::vector<size_t>>> iterable_nodes;
+  size_t                               number_of_nodes;
+  std::shared_ptr<HyperRectangle<dim>> bounding_box;
+  std::vector<
+    std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
+    iterable_nodes;
 
-  std::map<const typename DoFHandler<dim>::cell_iterator,
-           std::shared_ptr<std::vector<std::shared_ptr<std::vector<size_t>>>>>
+  std::map<
+    const typename DoFHandler<dim>::cell_iterator,
+    std::shared_ptr<std::vector<
+      std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>>
                    likely_nodes_map;
   size_t           max_number_of_nodes;
   DoFHandler<dim> *dof_handler;
@@ -1815,12 +1819,14 @@ private:
   double minimal_support_radius;
 
 public:
-  std::vector<std::shared_ptr<std::vector<size_t>>> nodes_id;
-  std::vector<double>                               weights;
-  std::vector<Point<dim>>                           nodes_positions;
-  std::vector<Point<dim>>                           rotated_nodes_positions;
-  std::vector<double>                               support_radii;
-  std::vector<RBFBasisFunction>                     basis_functions;
+  std::vector<
+    std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
+                                nodes_id;
+  std::vector<double>           weights;
+  std::vector<Point<dim>>       nodes_positions;
+  std::vector<Point<dim>>       rotated_nodes_positions;
+  std::vector<double>           support_radii;
+  std::vector<RBFBasisFunction> basis_functions;
 };
 
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1792,7 +1792,6 @@ public:
 private:
   std::string                          filename;
   size_t                               number_of_nodes;
-  size_t                               total_number_of_nodes;
   std::shared_ptr<HyperRectangle<dim>> bounding_box;
   std::vector<
     std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1013,6 +1013,20 @@ public:
                          const bool         mesh_based_precalculations);
 
   /**
+   * @brief Load data from file
+   */
+  void
+  load_data_from_file();
+
+  /**
+   * @brief Remove data that doesn't affect the cells owned by local process
+   */
+  void
+  remove_superfluous_data(DoFHandler<dim> &  updated_dof_handler,
+                          const unsigned int levels_not_precalculated,
+                          const bool         mesh_based_precalculations);
+
+  /**
    * @brief Computes the assigned boolean operations
    * @param constituent_shapes_values map containing the computed values for the component shapes
    * @param constituent_shapes_gradients map containing the computed gradients for the component shapes
@@ -1305,7 +1319,9 @@ public:
    * @brief Remove data that doesn't affect the cells owned by local process
    */
   void
-  remove_superfluous_data();
+  remove_superfluous_data(DoFHandler<dim> &  dof_handler,
+                          const unsigned int levels_not_precalculated,
+                          const bool         mesh_based_precalculations);
 
   /**
    * @brief Return the evaluation of the signed distance function of this solid
@@ -1766,19 +1782,11 @@ public:
   }
 
   /**
-   * @brief Checks if possible nodes affecting the current cell have been identified, and returns the proper vector to use for iteration
+   * @brief Swap the vector of all nodes with a likely node vector
    * @param cell A likely one where the evaluation point is located
    */
   void
-  prepare_iterable_nodes(
-    const typename DoFHandler<dim>::active_cell_iterator cell);
-
-  /**
-   * @brief Resets the iterable nodes to all nodes
-   * @param cell A likely one where the evaluation point is located
-   */
-  void
-  reset_iterable_nodes(
+  swap_iterable_nodes(
     const typename DoFHandler<dim>::active_cell_iterator cell);
 
 private:
@@ -1802,9 +1810,6 @@ private:
   double minimal_support_radius;
 
 public:
-  std::vector<
-    std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
-                          nodes_id;
   std::vector<double>     weights;
   std::vector<double>     nodes_positions_x;
   std::vector<double>     nodes_positions_y;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1812,7 +1812,7 @@ private:
   // reducing the memory footprint: increasing levels_not_precalculated
   // increases evaluation time.
   int    levels_not_precalculated;
-  double maximal_support_radius;
+  double minimal_support_radius;
 
 public:
   std::vector<size_t>           nodes_id;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -100,6 +100,7 @@ public:
     , effective_radius(radius)
     , position(position)
     , orientation(orientation)
+    , part_of_a_composite(false)
   {}
 
   /**
@@ -280,6 +281,15 @@ public:
   std::string
   point_to_string(const Point<dim> &evaluation_point) const;
 
+  /**
+   * Sets whether the shape is part of a composite
+   */
+  void
+  set_part_of_a_composite(const bool part_of_a_composite)
+  {
+    this->part_of_a_composite = part_of_a_composite;
+  }
+
   // Effective radius used for crown refinement
   double effective_radius;
 
@@ -301,6 +311,7 @@ protected:
   std::unordered_map<std::string, double>         value_cache;
   std::unordered_map<std::string, Tensor<1, dim>> gradient_cache;
   std::unordered_map<std::string, Point<dim>>     closest_point_cache;
+  bool                                            part_of_a_composite;
 };
 
 
@@ -901,11 +912,12 @@ public:
     , constituents(constituents)
     , operations(operations)
   {
-    // Calculation of the effective radius
-    for (auto const &[component_id, component] : constituents)
+    // Calculation of the effective radius and setting of status for components
+    for (auto const &[constituent_id, constituent] : constituents)
       {
         this->effective_radius =
-          std::max(this->effective_radius, component->effective_radius);
+          std::max(this->effective_radius, constituent->effective_radius);
+        constituent->set_part_of_a_composite(true);
       }
   }
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1838,9 +1838,7 @@ private:
 
 public:
   std::vector<double>     weights;
-  std::vector<double>     nodes_positions_x;
-  std::vector<double>     nodes_positions_y;
-  std::vector<double>     nodes_positions_z;
+  std::vector<Point<dim>> nodes_positions;
   std::vector<Point<dim>> rotated_nodes_positions;
   std::vector<double>     support_radii;
   std::vector<double>     basis_functions;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1804,12 +1804,14 @@ private:
 public:
   std::vector<
     std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
-                                nodes_id;
-  std::vector<double>           weights;
-  std::vector<Point<dim>>       nodes_positions;
-  std::vector<Point<dim>>       rotated_nodes_positions;
-  std::vector<double>           support_radii;
-  std::vector<RBFBasisFunction> basis_functions;
+                          nodes_id;
+  std::vector<double>     weights;
+  std::vector<double>     nodes_positions_x;
+  std::vector<double>     nodes_positions_y;
+  std::vector<double>     nodes_positions_z;
+  std::vector<Point<dim>> rotated_nodes_positions;
+  std::vector<double>     support_radii;
+  std::vector<double>     basis_functions;
 };
 
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1827,6 +1827,7 @@ public:
   std::vector<Point<dim>> rotated_nodes_positions;
   std::vector<double>     support_radii;
   std::vector<double>     basis_functions;
+  std::vector<bool>       useful_rbf_nodes;
 };
 
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -282,7 +282,10 @@ public:
   point_to_string(const Point<dim> &evaluation_point) const;
 
   /**
-   * Sets whether the shape is part of a composite
+   * @brief Defines if this shape is part of a composite.
+   * If true, cache management is deactivated and delegated to the upper level
+   * shape, to avoid cache duplication.
+   * @param part_of_a_composite is true if this shape is a constituent of a composite shape
    */
   void
   set_part_of_a_composite(const bool part_of_a_composite)
@@ -1030,7 +1033,8 @@ public:
   load_data_from_file();
 
   /**
-   * @brief Remove data that doesn't affect the cells owned by local process
+   * @brief Remove data that affects only artificial cells (not locally owned and not ghost).
+   * The data is removed if it would never be accessed by the local process.
    * @param dof_handler the reference to the new dof_handler
    * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
@@ -1329,7 +1333,10 @@ public:
   load_data_from_file();
 
   /**
-   * @brief Remove data that doesn't affect the cells owned by local process
+   * @brief Remove data that affects only artificial cells (not locally owned and not ghost).
+   * The data is removed if it would never be accessed by the local process.
+   * @param dof_handler the reference to the new dof_handler
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   remove_superfluous_data(DoFHandler<dim> &dof_handler,

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1016,7 +1016,7 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
-  * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   update_precalculations(DoFHandler<dim> &updated_dof_handler,
@@ -1032,7 +1032,7 @@ public:
   /**
    * @brief Remove data that doesn't affect the cells owned by local process   *
    * @param dof_handler the reference to the new dof_handler
-   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,
@@ -1314,7 +1314,7 @@ public:
    * sum.
    * @param shape_arguments_str the name of the file used to load the data
    * @param position the location of the RBF shape
-   * @param orientation the orientation of the shape in relation to each main
+   * @param orientation the orientation of the shape with respect to each main
    * axis
    */
   RBFShape<dim>(const std::string   shape_arguments_str,
@@ -1449,7 +1449,7 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param dof_handler the reference to the new dof_handler
-   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    * */
   void
   update_precalculations(DoFHandler<dim> &updated_dof_handler,
@@ -1804,9 +1804,8 @@ private:
   size_t                               number_of_nodes;
   std::shared_ptr<HyperRectangle<dim>> bounding_box;
 
-  // Elements of this vector contain the RBF nones located in an active cell of
-  // which the tuple contains: the cell barycenter, the cell diameter, and the
-  // RBF nodes located inside
+  // Elements of this vector are tuples containing: the cell barycenter, the
+  // cell diameter, and the RBF nodes located inside the active cell
   std::vector<
     std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
     iterable_nodes;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1029,7 +1029,9 @@ public:
   load_data_from_file();
 
   /**
-   * @brief Remove data that doesn't affect the cells owned by local process
+   * @brief Remove data that doesn't affect the cells owned by local process   *
+   * @param dof_handler the reference to the new dof_handler
+   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
   remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1002,12 +1002,11 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param levels_not_precalculated the number of finer levels that won't be
-   * precalculated
+   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
-  update_precalculations(DoFHandler<dim> &  updated_dof_handler,
-                         const unsigned int levels_not_precalculated);
+  update_precalculations(DoFHandler<dim> &updated_dof_handler,
+                         const bool       mesh_based_precalculations);
 
   /**
    * @brief Computes the assigned boolean operations
@@ -1428,12 +1427,11 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param dof_handler the reference to the new dof_handler
-   * @param levels_not_precalculated the number of finer levels that won't be
-   * precalculated
-   */
+   * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
+   * */
   void
-  update_precalculations(DoFHandler<dim> &  dof_handler,
-                         const unsigned int levels_not_precalculated);
+  update_precalculations(DoFHandler<dim> &updated_dof_handler,
+                         const bool       mesh_based_precalculations);
 
   /**
    * @brief Rotate RBF nodes in the global reference frame (the reference frame of the triangulation).
@@ -1810,12 +1808,6 @@ private:
   Point<dim>       position_precalculated;
   Tensor<1, 3>     orientation_precalculated;
 
-  // levels_not_precalculated is used in order to not precompute and store the
-  // likely RBF nodes for the finer levels of cells in the grid. Setting this
-  // parameter is a tradeoff between having faster distance evaluations and
-  // reducing the memory footprint: increasing levels_not_precalculated
-  // increases evaluation time.
-  int    levels_not_precalculated;
   double minimal_support_radius;
 
 public:

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1030,7 +1030,7 @@ public:
   load_data_from_file();
 
   /**
-   * @brief Remove data that doesn't affect the cells owned by local process 
+   * @brief Remove data that doesn't affect the cells owned by local process
    * @param dof_handler the reference to the new dof_handler
    * @param mesh_based_precalculations mesh-based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -16,6 +16,8 @@
 #ifndef lethe_shape_h
 #define lethe_shape_h
 
+#include <core/utilities.h>
+
 #include <deal.II/base/auto_derivative_function.h>
 #include <deal.II/base/function.h>
 
@@ -1284,36 +1286,26 @@ public:
    * distance field with a linear combination of radial basis functions. Each
    * radial basis function has a location and properties that are used in the
    * sum.
-   * @param support_radius the scaling of the reach of the nodes
-   * @param basis_function the basis function that is used to parametrize the RBF object
-   * @param weight the weighting associated to each node for the sum operation
-   * @param nodes the center of each basis function
+   * @param shape_arguments_str the name of the file used to load the data
    * @param position the location of the RBF shape
    * @param orientation the orientation of the shape in relation to each main
    * axis
    */
-  RBFShape<dim>(const std::vector<double> &          support_radii,
-                const std::vector<RBFBasisFunction> &basis_functions,
-                const std::vector<double> &          weights,
-                const std::vector<Point<dim>> &      nodes,
-                const Point<dim> &                   position,
-                const Tensor<1, 3> &                 orientation);
+  RBFShape<dim>(const std::string   shape_arguments_str,
+                const Point<dim> &  position,
+                const Tensor<1, 3> &orientation);
 
   /**
-   * @brief An RBFShape represents a physical object by describing its signed
-   * distance field with a linear combination of radial basis functions. Each
-   * radial basis function has a location and properties that are used in the
-   * sum.
-   * @param shape_arguments the concatenated vector of all shape arguments for
-   * an RBF in the order: weights, support_radii, basis_functions, nodes_x,
-   * nodes_y, nodes_z
-   * @param position the location of the RBF shape
-   * @param orientation the orientation of the shape in relation to each main
-   * axis
+   * @brief Load RBF data from file
    */
-  RBFShape<dim>(const std::vector<double> &shape_arguments,
-                const Point<dim> &         position,
-                const Tensor<1, 3> &       orientation);
+  void
+  load_data_from_file();
+
+  /**
+   * @brief Remove data that doesn't affect the cells owned by local process
+   */
+  void
+  remove_superfluous_data();
 
   /**
    * @brief Return the evaluation of the signed distance function of this solid
@@ -1774,12 +1766,6 @@ public:
   }
 
   /**
-   * @brief Checks if the particle moved since the last precalculations
-   */
-  bool
-  has_shape_moved();
-
-  /**
    * @brief Checks if possible nodes affecting the current cell have been identified, and returns the proper vector to use for iteration
    * @param cell A likely one where the evaluation point is located
    */
@@ -1796,7 +1782,9 @@ public:
     const typename DoFHandler<dim>::active_cell_iterator cell);
 
 private:
+  std::string                          filename;
   size_t                               number_of_nodes;
+  size_t                               total_number_of_nodes;
   std::shared_ptr<HyperRectangle<dim>> bounding_box;
   std::vector<
     std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
@@ -1809,8 +1797,6 @@ private:
                    likely_nodes_map;
   size_t           max_number_of_inside_nodes;
   DoFHandler<dim> *dof_handler;
-  Point<dim>       position_precalculated;
-  Tensor<1, 3>     orientation_precalculated;
 
   double minimal_support_radius;
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1023,7 +1023,8 @@ public:
                          const bool       mesh_based_precalculations);
 
   /**
-   * @brief Load data from file
+   * @brief Load data from file. To be called at initialization, after repartitioning or when shape has moved.
+   * This function is used only for RBF shapes and its composites at the moment.
    */
   void
   load_data_from_file();
@@ -1321,7 +1322,8 @@ public:
                 const Tensor<1, 3> &orientation);
 
   /**
-   * @brief Load RBF data from file
+   * @brief Load RBF data from file. To be called at initialization, after repartitioning or when shape has moved.
+   * This function is used only for RBF shapes and its composites at the moment.
    */
   void
   load_data_from_file();

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1016,13 +1016,11 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
-   * @param levels_not_precalculated the number of finer levels that won't be precalculated
    * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
-  update_precalculations(DoFHandler<dim> &  updated_dof_handler,
-                         const unsigned int levels_not_precalculated,
-                         const bool         mesh_based_precalculations);
+  update_precalculations(DoFHandler<dim> &updated_dof_handler,
+                         const bool       mesh_based_precalculations);
 
   /**
    * @brief Load data from file
@@ -1034,9 +1032,8 @@ public:
    * @brief Remove data that doesn't affect the cells owned by local process
    */
   void
-  remove_superfluous_data(DoFHandler<dim> &  updated_dof_handler,
-                          const unsigned int levels_not_precalculated,
-                          const bool         mesh_based_precalculations);
+  remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,
+                          const bool       mesh_based_precalculations);
 
   /**
    * @brief Computes the assigned boolean operations
@@ -1331,9 +1328,8 @@ public:
    * @brief Remove data that doesn't affect the cells owned by local process
    */
   void
-  remove_superfluous_data(DoFHandler<dim> &  dof_handler,
-                          const unsigned int levels_not_precalculated,
-                          const bool         mesh_based_precalculations);
+  remove_superfluous_data(DoFHandler<dim> &dof_handler,
+                          const bool       mesh_based_precalculations);
 
   /**
    * @brief Return the evaluation of the signed distance function of this solid
@@ -1449,13 +1445,11 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param dof_handler the reference to the new dof_handler
-   * @param levels_not_precalculated the number of finer levels that won't be precalculated
    * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    * */
   void
-  update_precalculations(DoFHandler<dim> &  updated_dof_handler,
-                         const unsigned int levels_not_precalculated,
-                         const bool         mesh_based_precalculations);
+  update_precalculations(DoFHandler<dim> &updated_dof_handler,
+                         const bool       mesh_based_precalculations);
 
   /**
    * @brief Rotate RBF nodes in the global reference frame (the reference frame of the triangulation).

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1805,7 +1805,7 @@ private:
     std::shared_ptr<std::vector<
       std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>>
                    likely_nodes_map;
-  size_t           max_number_of_nodes;
+  size_t           max_number_of_inside_nodes;
   DoFHandler<dim> *dof_handler;
   Point<dim>       position_precalculated;
   Tensor<1, 3>     orientation_precalculated;

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1002,11 +1002,13 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler
+   * @param levels_not_precalculated the number of finer levels that won't be precalculated
    * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    */
   void
-  update_precalculations(DoFHandler<dim> &updated_dof_handler,
-                         const bool       mesh_based_precalculations);
+  update_precalculations(DoFHandler<dim> &  updated_dof_handler,
+                         const unsigned int levels_not_precalculated,
+                         const bool         mesh_based_precalculations);
 
   /**
    * @brief Computes the assigned boolean operations
@@ -1427,11 +1429,13 @@ public:
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param dof_handler the reference to the new dof_handler
+   * @param levels_not_precalculated the number of finer levels that won't be precalculated
    * @param mesh_based_precalculations mesh based precalculations that can lead to slight shape misrepresentation (if RBF typed)
    * */
   void
-  update_precalculations(DoFHandler<dim> &updated_dof_handler,
-                         const bool       mesh_based_precalculations);
+  update_precalculations(DoFHandler<dim> &  updated_dof_handler,
+                         const unsigned int levels_not_precalculated,
+                         const bool         mesh_based_precalculations);
 
   /**
    * @brief Rotate RBF nodes in the global reference frame (the reference frame of the triangulation).

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -24,6 +24,8 @@
 #include <deal.II/grid/manifold.h>
 #include <deal.II/grid/manifold_lib.h>
 
+#include <boost/range/adaptor/map.hpp>
+
 #ifdef DEAL_II_WITH_OPENCASCADE
 #  include <deal.II/opencascade/manifold_lib.h>
 #  include <deal.II/opencascade/utilities.h>
@@ -916,7 +918,7 @@ public:
     , operations(operations)
   {
     // Calculation of the effective radius and setting of constituents' status
-    for (auto const &[constituent_id, constituent] : constituents)
+    for (auto const &constituent : constituents | boost::adaptors::map_values)
       {
         this->effective_radius =
           std::max(this->effective_radius, constituent->effective_radius);
@@ -956,7 +958,7 @@ public:
           }
       }
     // Calculation of the effective radius
-    for (auto const &[constituent_id, constituent] : constituents)
+    for (auto const &constituent : constituents | boost::adaptors::map_values)
       {
         this->effective_radius =
           std::max(this->effective_radius, constituent->effective_radius);

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1813,10 +1813,9 @@ private:
     const typename DoFHandler<dim>::cell_iterator,
     std::shared_ptr<std::vector<
       std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>>
-                                     likely_nodes_map;
-  std::unordered_map<size_t, size_t> useful_rbf_node_map;
-  size_t                             max_number_of_inside_nodes;
-  DoFHandler<dim> *                  dof_handler;
+                   likely_nodes_map;
+  size_t           max_number_of_inside_nodes;
+  DoFHandler<dim> *dof_handler;
 
   double minimal_support_radius;
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1805,10 +1805,23 @@ private:
   std::string                          filename;
   size_t                               number_of_nodes;
   std::shared_ptr<HyperRectangle<dim>> bounding_box;
+
+  // Elements of this vector contain the RBF nones located in an active cell of
+  // which the tuple contains: the cell barycenter, the cell diameter, and the
+  // RBF nodes located inside
   std::vector<
     std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
     iterable_nodes;
-
+  // Entries of this map contain vectors of tuples containing the cell
+  // barycenter, diameter and likely nodes that are in that cell. The various
+  // elements of the vector are the tuples which contain information on the RBF
+  // nodes that affect the levelset evaluation in this cell. Note: the division
+  // of RBF nodes is made by separating nodes by which active cells they are in,
+  // and then these RBF nodes groups are referenced by the cells in a subsequent
+  // cell (by using a vector of pointers). This is required to avoid repeating
+  // the nodes IDs multiple times (to keep memory requirements low); they only
+  // appear once in a vector, then this vector is used by passing its shared
+  // pointer.
   std::map<
     const typename DoFHandler<dim>::cell_iterator,
     std::shared_ptr<std::vector<
@@ -1817,7 +1830,7 @@ private:
   size_t           max_number_of_inside_nodes;
   DoFHandler<dim> *dof_handler;
 
-  double minimal_support_radius;
+  double maximal_support_radius;
 
 public:
   std::vector<double>     weights;

--- a/source/core/ib_particle.cc
+++ b/source/core/ib_particle.cc
@@ -260,6 +260,10 @@ IBParticle<dim>::update_precalculations(
   const unsigned int levels_not_precalculated,
   const bool         mesh_based_precalculations)
 {
+  if (integrate_motion || velocity.norm() > 1e-16 || omega.norm() > 1e-16)
+    {
+      this->load_data_from_file();
+    }
   if (typeid(*shape) == typeid(RBFShape<dim>))
     {
       std::static_pointer_cast<RBFShape<dim>>(shape)->update_precalculations(
@@ -274,6 +278,35 @@ IBParticle<dim>::update_precalculations(
                                  levels_not_precalculated,
                                  mesh_based_precalculations);
     }
+}
+
+template <int dim>
+void
+IBParticle<dim>::remove_superfluous_data(
+  DoFHandler<dim> &  updated_dof_handler,
+  const unsigned int levels_not_precalculated,
+  const bool         mesh_based_precalculations)
+{
+  if (typeid(*shape) == typeid(RBFShape<dim>))
+    std::static_pointer_cast<RBFShape<dim>>(shape)->remove_superfluous_data(
+      updated_dof_handler,
+      levels_not_precalculated,
+      mesh_based_precalculations);
+  else if (typeid(*shape) == typeid(CompositeShape<dim>))
+    std::static_pointer_cast<CompositeShape<dim>>(shape)
+      ->remove_superfluous_data(updated_dof_handler,
+                                levels_not_precalculated,
+                                mesh_based_precalculations);
+}
+
+template <int dim>
+void
+IBParticle<dim>::load_data_from_file()
+{
+  if (typeid(*shape) == typeid(RBFShape<dim>))
+    std::static_pointer_cast<RBFShape<dim>>(shape)->load_data_from_file();
+  else if (typeid(*shape) == typeid(CompositeShape<dim>))
+    std::static_pointer_cast<CompositeShape<dim>>(shape)->load_data_from_file();
 }
 
 template class IBParticle<2>;

--- a/source/core/ib_particle.cc
+++ b/source/core/ib_particle.cc
@@ -255,10 +255,8 @@ IBParticle<dim>::set_orientation(const Tensor<1, 3> new_orientation)
 
 template <int dim>
 void
-IBParticle<dim>::update_precalculations(
-  DoFHandler<dim> &  updated_dof_handler,
-  const unsigned int levels_not_precalculated,
-  const bool         mesh_based_precalculations)
+IBParticle<dim>::update_precalculations(DoFHandler<dim> &updated_dof_handler,
+                                        const bool mesh_based_precalculations)
 {
   if (integrate_motion || velocity.norm() > 1e-16 || omega.norm() > 1e-16)
     {
@@ -267,35 +265,27 @@ IBParticle<dim>::update_precalculations(
   if (typeid(*shape) == typeid(RBFShape<dim>))
     {
       std::static_pointer_cast<RBFShape<dim>>(shape)->update_precalculations(
-        updated_dof_handler,
-        levels_not_precalculated,
-        mesh_based_precalculations);
+        updated_dof_handler, mesh_based_precalculations);
     }
   else if (typeid(*shape) == typeid(CompositeShape<dim>))
     {
       std::static_pointer_cast<CompositeShape<dim>>(shape)
         ->update_precalculations(updated_dof_handler,
-                                 levels_not_precalculated,
                                  mesh_based_precalculations);
     }
 }
 
 template <int dim>
 void
-IBParticle<dim>::remove_superfluous_data(
-  DoFHandler<dim> &  updated_dof_handler,
-  const unsigned int levels_not_precalculated,
-  const bool         mesh_based_precalculations)
+IBParticle<dim>::remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,
+                                         const bool mesh_based_precalculations)
 {
   if (typeid(*shape) == typeid(RBFShape<dim>))
     std::static_pointer_cast<RBFShape<dim>>(shape)->remove_superfluous_data(
-      updated_dof_handler,
-      levels_not_precalculated,
-      mesh_based_precalculations);
+      updated_dof_handler, mesh_based_precalculations);
   else if (typeid(*shape) == typeid(CompositeShape<dim>))
     std::static_pointer_cast<CompositeShape<dim>>(shape)
       ->remove_superfluous_data(updated_dof_handler,
-                                levels_not_precalculated,
                                 mesh_based_precalculations);
 }
 

--- a/source/core/ib_particle.cc
+++ b/source/core/ib_particle.cc
@@ -257,17 +257,22 @@ template <int dim>
 void
 IBParticle<dim>::update_precalculations(
   DoFHandler<dim> &  updated_dof_handler,
-  const unsigned int levels_not_precalculated)
+  const unsigned int levels_not_precalculated,
+  const bool         mesh_based_precalculations)
 {
   if (typeid(*shape) == typeid(RBFShape<dim>))
     {
       std::static_pointer_cast<RBFShape<dim>>(shape)->update_precalculations(
-        updated_dof_handler, levels_not_precalculated);
+        updated_dof_handler,
+        levels_not_precalculated,
+        mesh_based_precalculations);
     }
   else if (typeid(*shape) == typeid(CompositeShape<dim>))
     {
       std::static_pointer_cast<CompositeShape<dim>>(shape)
-        ->update_precalculations(updated_dof_handler, levels_not_precalculated);
+        ->update_precalculations(updated_dof_handler,
+                                 levels_not_precalculated,
+                                 mesh_based_precalculations);
     }
 }
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2585,6 +2585,14 @@ namespace Parameters
         "The number of particles represented by IB. The maximal number of particles is equal to 10 when defined individually. If particles are loaded from a file, this parameter is overridden, and there is no limit to the number of particles.");
 
       prm.declare_entry(
+        "levels not precalculated",
+        "0",
+        Patterns::Integer(),
+        "Number of levels that are ignored in precalculations. Setting this "
+        "parameter higher allows for a lower memory footprint at the cost of"
+        " higher computing time.");
+
+      prm.declare_entry(
         "assemble Navier-Stokes inside particles",
         "false",
         Patterns::Bool(),
@@ -2857,6 +2865,7 @@ namespace Parameters
 
       nb = prm.get_integer("number of particles");
 
+      levels_not_precalculated = prm.get_integer("levels not precalculated");
       assemble_navier_stokes_inside =
         prm.get_bool("assemble Navier-Stokes inside particles");
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2460,7 +2460,7 @@ namespace Parameters
       Patterns::Bool(),
       "Bool to define if the particle trajectory is integrated meaning its velocity and position will be updated at each time step according to the hydrodynamic force applied to it");
     prm.declare_entry(
-      "mesh based precalculations",
+      "mesh-based precalculations",
       "true",
       Patterns::Bool(),
       "Bool to define if precalculations should be performed between refinements. Precalculations can introduce shape deformation when the type is RBF and some nodes are located outside the background mesh.");
@@ -2869,7 +2869,7 @@ namespace Parameters
 
           particles[i].integrate_motion = prm.get_bool("integrate motion");
           particles[i].mesh_based_precalculations =
-            prm.get_bool("mesh based precalculations");
+            prm.get_bool("mesh-based precalculations");
 
           prm.enter_subsection("position");
           particles[i].f_position->parse_parameters(prm);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2459,6 +2459,11 @@ namespace Parameters
       "false",
       Patterns::Bool(),
       "Bool to define if the particle trajectory is integrated meaning its velocity and position will be updated at each time step according to the hydrodynamic force applied to it");
+    prm.declare_entry(
+      "mesh based precalculations",
+      "true",
+      Patterns::Bool(),
+      "Bool to define if precalculations should be performed between refinements. Precalculations can introduce shape deformation when the type is RBF and some nodes are located outside the background mesh.");
 
     prm.enter_subsection("position");
     particles[index].f_position =
@@ -2578,14 +2583,6 @@ namespace Parameters
         "1",
         Patterns::Integer(),
         "The number of particles represented by IB. The maximal number of particles is equal to 10 when defined individually. If particles are loaded from a file, this parameter is overridden, and there is no limit to the number of particles.");
-
-      prm.declare_entry(
-        "levels not precalculated",
-        "0",
-        Patterns::Integer(),
-        "Number of levels that are ignored in precalculations. Setting this "
-        "parameter higher allows for a lower memory footprint at the cost of"
-        " higher computing time.");
 
       prm.declare_entry(
         "assemble Navier-Stokes inside particles",
@@ -2860,7 +2857,6 @@ namespace Parameters
 
       nb = prm.get_integer("number of particles");
 
-      levels_not_precalculated = prm.get_integer("levels not precalculated");
       assemble_navier_stokes_inside =
         prm.get_bool("assemble Navier-Stokes inside particles");
 
@@ -2872,6 +2868,8 @@ namespace Parameters
           prm.enter_subsection(section);
 
           particles[i].integrate_motion = prm.get_bool("integrate motion");
+          particles[i].mesh_based_precalculations =
+            prm.get_bool("mesh based precalculations");
 
           prm.enter_subsection("position");
           particles[i].f_position->parse_parameters(prm);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2585,14 +2585,6 @@ namespace Parameters
         "The number of particles represented by IB. The maximal number of particles is equal to 10 when defined individually. If particles are loaded from a file, this parameter is overridden, and there is no limit to the number of particles.");
 
       prm.declare_entry(
-        "levels not precalculated",
-        "0",
-        Patterns::Integer(),
-        "Number of levels that are ignored in precalculations. Setting this "
-        "parameter higher allows for a lower memory footprint at the cost of"
-        " higher computing time.");
-
-      prm.declare_entry(
         "assemble Navier-Stokes inside particles",
         "false",
         Patterns::Bool(),
@@ -2865,7 +2857,6 @@ namespace Parameters
 
       nb = prm.get_integer("number of particles");
 
-      levels_not_precalculated = prm.get_integer("levels not precalculated");
       assemble_navier_stokes_inside =
         prm.get_bool("assemble Navier-Stokes inside particles");
 

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1682,9 +1682,10 @@ RBFShape<dim>::initialize_bounding_box()
       low_bounding_point[d]  = std::numeric_limits<double>::max();
       for (size_t i = 0; i < number_of_nodes; i++)
         {
-          temp_point[0]       = nodes_positions_x[i];
-          temp_point[1]       = nodes_positions_y[i];
-          temp_point[dim - 1] = nodes_positions_z[i];
+          temp_point[0] = nodes_positions_x[i];
+          temp_point[1] = nodes_positions_y[i];
+          if constexpr (dim == 3)
+            temp_point[2] = nodes_positions_z[i];
           low_bounding_point[d] =
             std::min(low_bounding_point[d], temp_point[d]);
           high_bounding_point[d] =
@@ -1972,7 +1973,8 @@ RBFShape<dim>::load_data_from_file()
   basis_functions.swap(rbf_data["basis_function"]);
   nodes_positions_x.swap(rbf_data["node_x"]);
   nodes_positions_y.swap(rbf_data["node_y"]);
-  nodes_positions_z.swap(rbf_data["node_z"]);
+  if constexpr (dim == 3)
+    nodes_positions_z.swap(rbf_data["node_z"]);
 
   std::shared_ptr<std::vector<size_t>> temp_nodes_id =
     std::make_shared<std::vector<size_t>>(number_of_nodes);
@@ -2094,9 +2096,10 @@ RBFShape<dim>::rotate_nodes()
   rotated_nodes_positions.resize(weights.size());
   for (unsigned int i = 0; i < weights.size(); ++i)
     {
-      temp_point[0]              = nodes_positions_x[i];
-      temp_point[1]              = nodes_positions_y[i];
-      temp_point[dim - 1]        = nodes_positions_z[i];
+      temp_point[0] = nodes_positions_x[i];
+      temp_point[1] = nodes_positions_y[i];
+      if constexpr (dim == 3)
+        temp_point[2] = nodes_positions_z[i];
       rotated_nodes_positions[i] = this->reverse_align_and_center(temp_point);
     }
   nodes_positions_x.clear();

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1800,7 +1800,8 @@ RBFShape<dim>::update_precalculations(
   for (unsigned int level = 0; level + levels_not_precalculated < maximal_level;
        level++)
     {
-      const auto &cell_iterator = dof_handler.cell_iterators_on_level(level);
+      max_number_of_inside_nodes = 1;
+      const auto &cell_iterator  = dof_handler.cell_iterators_on_level(level);
       for (const auto &cell : cell_iterator)
         {
           if (cell->is_artificial_on_level())

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1816,13 +1816,10 @@ RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
           temp_cell = it->first;
           if (temp_cell->is_active())
             {
-              if (cell->point_inside(temp_cell->barycenter()))
-                {
-                  temp_cell_tuple = std::make_tuple(temp_cell->barycenter(),
-                                                    temp_cell->diameter(),
-                                                    std::get<2>(it->second));
-                  likely_nodes_map[cell]->push_back(temp_cell_tuple);
-                }
+              temp_cell_tuple = std::make_tuple(temp_cell->barycenter(),
+                                                temp_cell->diameter(),
+                                                std::get<2>(it->second));
+              likely_nodes_map[cell]->push_back(temp_cell_tuple);
             }
         }
     }
@@ -1843,9 +1840,7 @@ RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
           const bool cell_smaller_than_rbf_radius =
             (cell->diameter() < maximal_support_radius);
           if (cell_smaller_than_rbf_radius)
-            {
-              likely_nodes_map[cell] = likely_nodes_map[cell->parent()];
-            }
+            likely_nodes_map[cell] = likely_nodes_map[cell->parent()];
           else
             determine_likely_nodes_for_one_cell(cell, cell->barycenter());
         }

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1556,7 +1556,7 @@ RBFShape<dim>::value(const Point<dim> &evaluation_point,
   double value = std::max(bounding_box_distance, 0.0);
   double normalized_distance, basis;
   // Algorithm inspired by Optimad Bitpit. https://github.com/optimad/bitpit
-  // Here we loop on ever portions (of RBF nodes located in active cells close
+  // Here we loop on every portion (of RBF nodes located in active cells close
   // to the evaluation point) and on every RBF node located in these active
   // cells.
   for (size_t portion_id = 0; portion_id < iterable_nodes.size(); portion_id++)
@@ -1606,14 +1606,14 @@ RBFShape<dim>::gradient(const Point<dim> &evaluation_point,
         "of at least one RBF node. It this isn't the case, an error has been "
         "introduced in the code. ");
     }
-  // Here we loop on ever portions (of RBF nodes located in active cells close
+  // Here we loop on every portion (of RBF nodes located in active cells close
   // to the evaluation point) and on every RBF node located in these active
   // cells.
   for (size_t portion_id = 0; portion_id < iterable_nodes.size(); portion_id++)
     {
       for (const size_t &node_id : *(std::get<2>(iterable_nodes[portion_id])))
         {
-          // Calculation of the dr/dx
+          // Calculation of dr/dx
           relative_position =
             (evaluation_point - rotated_nodes_positions[node_id]);
           distance            = (relative_position).norm();

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1671,25 +1671,29 @@ template <int dim>
 void
 RBFShape<dim>::initialize_bounding_box()
 {
-  Point<dim>     high_bounding_point{};
-  Point<dim>     low_bounding_point{};
-  Point<dim>     bounding_box_center{};
-  Point<dim>     temp_point{};
-  Tensor<1, dim> half_lengths = Tensor<1, dim>();
+  Point<dim>           high_bounding_point{};
+  Point<dim>           low_bounding_point{};
+  Point<dim>           bounding_box_center{};
+  double               temp_coordinate;
+  Tensor<1, dim>       half_lengths = Tensor<1, dim>();
+  std::vector<double> *nodes_positions_d;
   for (int d = 0; d < dim; d++)
     {
       high_bounding_point[d] = std::numeric_limits<double>::lowest();
       low_bounding_point[d]  = std::numeric_limits<double>::max();
+      if (d == 0)
+        nodes_positions_d = &nodes_positions_x;
+      else if (d == 1)
+        nodes_positions_d = &nodes_positions_y;
+      else if constexpr (dim == 3)
+        nodes_positions_d = &nodes_positions_z;
       for (size_t i = 0; i < number_of_nodes; i++)
         {
-          temp_point[0] = nodes_positions_x[i];
-          temp_point[1] = nodes_positions_y[i];
-          if constexpr (dim == 3)
-            temp_point[2] = nodes_positions_z[i];
+          temp_coordinate = (*nodes_positions_d)[i];
           low_bounding_point[d] =
-            std::min(low_bounding_point[d], temp_point[d]);
+            std::min(low_bounding_point[d], temp_coordinate);
           high_bounding_point[d] =
-            std::max(high_bounding_point[d], temp_point[d]);
+            std::max(high_bounding_point[d], temp_coordinate);
         }
       bounding_box_center[d] =
         0.5 * (low_bounding_point[d] + high_bounding_point[d]);

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1958,8 +1958,7 @@ RBFShape<dim>::load_data_from_file()
   // that the usual initialization function can be called.
   std::map<std::string, std::vector<double>> rbf_data;
   fill_vectors_from_file(rbf_data, filename, " ");
-  number_of_nodes       = rbf_data["weight"].size();
-  total_number_of_nodes = number_of_nodes;
+  number_of_nodes = rbf_data["weight"].size();
 
   weights.swap(rbf_data["weight"]);
   support_radii.swap(rbf_data["support_radius"]);

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1333,13 +1333,13 @@ CompositeShape<dim>::update_precalculations(
 {
   if (!mesh_based_precalculations)
     return;
-  for (auto const &[component_id, component] : constituents)
-    if (typeid(*component) == typeid(RBFShape<dim>))
-      std::static_pointer_cast<RBFShape<dim>>(component)
+  for (auto const &constituent : constituents | boost::adaptors::map_values)
+    if (typeid(*constituent) == typeid(RBFShape<dim>))
+      std::static_pointer_cast<RBFShape<dim>>(constituent)
         ->update_precalculations(updated_dof_handler,
                                  mesh_based_precalculations);
-    else if (typeid(*component) == typeid(CompositeShape<dim>))
-      std::static_pointer_cast<CompositeShape<dim>>(component)
+    else if (typeid(*constituent) == typeid(CompositeShape<dim>))
+      std::static_pointer_cast<CompositeShape<dim>>(constituent)
         ->update_precalculations(updated_dof_handler,
                                  mesh_based_precalculations);
 }
@@ -1348,11 +1348,12 @@ template <int dim>
 void
 CompositeShape<dim>::load_data_from_file()
 {
-  for (auto const &[component_id, component] : constituents)
-    if (typeid(*component) == typeid(RBFShape<dim>))
-      std::static_pointer_cast<RBFShape<dim>>(component)->load_data_from_file();
-    else if (typeid(*component) == typeid(CompositeShape<dim>))
-      std::static_pointer_cast<CompositeShape<dim>>(component)
+  for (auto const &constituent : constituents | boost::adaptors::map_values)
+    if (typeid(*constituent) == typeid(RBFShape<dim>))
+      std::static_pointer_cast<RBFShape<dim>>(constituent)
+        ->load_data_from_file();
+    else if (typeid(*constituent) == typeid(CompositeShape<dim>))
+      std::static_pointer_cast<CompositeShape<dim>>(constituent)
         ->load_data_from_file();
 }
 
@@ -1362,13 +1363,13 @@ CompositeShape<dim>::remove_superfluous_data(
   DoFHandler<dim> &updated_dof_handler,
   const bool       mesh_based_precalculations)
 {
-  for (auto const &[component_id, component] : constituents)
-    if (typeid(*component) == typeid(RBFShape<dim>))
-      std::static_pointer_cast<RBFShape<dim>>(component)
+  for (auto const &constituent : constituents | boost::adaptors::map_values)
+    if (typeid(*constituent) == typeid(RBFShape<dim>))
+      std::static_pointer_cast<RBFShape<dim>>(constituent)
         ->remove_superfluous_data(updated_dof_handler,
                                   mesh_based_precalculations);
-    else if (typeid(*component) == typeid(CompositeShape<dim>))
-      std::static_pointer_cast<CompositeShape<dim>>(component)
+    else if (typeid(*constituent) == typeid(CompositeShape<dim>))
+      std::static_pointer_cast<CompositeShape<dim>>(constituent)
         ->remove_superfluous_data(updated_dof_handler,
                                   mesh_based_precalculations);
 }

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1797,7 +1797,8 @@ RBFShape<dim>::update_precalculations(
            std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
     temporary_nodes_portions_map;
   temporary_nodes_portions_map.clear();
-  for (unsigned int level = 0; level < maximal_level; level++)
+  for (unsigned int level = 0; level + levels_not_precalculated < maximal_level;
+       level++)
     {
       const auto &cell_iterator = dof_handler.cell_iterators_on_level(level);
       for (const auto &cell : cell_iterator)
@@ -1885,7 +1886,8 @@ RBFShape<dim>::update_precalculations(
         {
           temp_cell = it->first;
           if (temp_cell->is_active() ||
-              static_cast<unsigned int>(temp_cell->level() + 1) ==
+              static_cast<unsigned int>(temp_cell->level() + 1 +
+                                        levels_not_precalculated) >=
                 maximal_level)
             {
               if (cell->point_inside(temp_cell->barycenter()))

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1803,9 +1803,6 @@ RBFShape<dim>::update_precalculations(
 
   // We give all the subsets to the 0 level, as an initial partitioning
   const auto &cell_iterator = dof_handler.cell_iterators_on_level(0);
-  double      distance;
-  std::shared_ptr<std::vector<size_t>> temp_nodes =
-    std::make_shared<std::vector<size_t>>();
   typename DoFHandler<dim>::cell_iterator temp_cell;
   std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>
        temp_cell_tuple{};
@@ -1836,27 +1833,8 @@ RBFShape<dim>::update_precalculations(
                                                     std::get<2>(it->second));
                   likely_nodes_map[cell]->push_back(temp_cell_tuple);
                 }
-              else
-                for (const size_t &node_id : *temp_nodes)
-                  {
-                    distance =
-                      (cell->barycenter() - rotated_nodes_positions[node_id])
-                        .norm();
-                    if (distance + 0.5 * cell->diameter() <
-                        support_radii[node_id])
-                      {
-                        temp_cell_tuple =
-                          std::make_tuple(temp_cell->barycenter(),
-                                          temp_cell->diameter(),
-                                          std::get<2>(it->second));
-                        likely_nodes_map[cell]->push_back(temp_cell_tuple);
-                        break;
-                      }
-                  }
             }
         }
-      if (likely_nodes_map[cell]->size() < 1)
-        likely_nodes_map.erase(cell);
     }
 
   // We then treat all other levels
@@ -2240,7 +2218,7 @@ RBFShape<dim>::swap_iterable_nodes(
   // Here we check if the likely nodes have been identified
   auto iterator = likely_nodes_map.find(cell);
   if (iterator != likely_nodes_map.end())
-    iterable_nodes.swap(*likely_nodes_map[cell]);
+    iterable_nodes.swap(*(likely_nodes_map[cell]));
 }
 
 template <int dim>

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1288,8 +1288,9 @@ CompositeShape<dim>::static_copy() const
 template <int dim>
 void
 CompositeShape<dim>::update_precalculations(
-  DoFHandler<dim> &updated_dof_handler,
-  const bool       mesh_based_precalculations)
+  DoFHandler<dim> &  updated_dof_handler,
+  const unsigned int levels_not_precalculated,
+  const bool         mesh_based_precalculations)
 {
   if (!mesh_based_precalculations)
     return;
@@ -1297,10 +1298,12 @@ CompositeShape<dim>::update_precalculations(
     if (typeid(*component) == typeid(RBFShape<dim>))
       std::static_pointer_cast<RBFShape<dim>>(component)
         ->update_precalculations(updated_dof_handler,
+                                 levels_not_precalculated,
                                  mesh_based_precalculations);
     else if (typeid(*component) == typeid(CompositeShape<dim>))
       std::static_pointer_cast<CompositeShape<dim>>(component)
         ->update_precalculations(updated_dof_handler,
+                                 levels_not_precalculated,
                                  mesh_based_precalculations);
 }
 
@@ -1767,8 +1770,10 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
 
 template <int dim>
 void
-RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
-                                      const bool mesh_based_precalculations)
+RBFShape<dim>::update_precalculations(
+  DoFHandler<dim> &  dof_handler,
+  const unsigned int levels_not_precalculated,
+  const bool         mesh_based_precalculations)
 {
   if (!mesh_based_precalculations)
     return;

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -804,12 +804,12 @@ OpenCascadeShape<dim>::gradient_with_cell_guess(
         {
           // Rotate the solution found to the global reference frame and cache
           // the solution.
+          auto rotate_in_globalpoint =
+            this->reverse_align_and_center(projected_point);
           if (!this->part_of_a_composite)
             {
               this->value_cache[point_in_string] =
                 -(centered_point - projected_point).norm();
-              auto rotate_in_globalpoint =
-                this->reverse_align_and_center(projected_point);
               this->gradient_cache[point_in_string] =
                 (rotate_in_globalpoint - evaluation_point) /
                 ((rotate_in_globalpoint - evaluation_point).norm() + 1.0e-16);
@@ -822,12 +822,12 @@ OpenCascadeShape<dim>::gradient_with_cell_guess(
         }
       else
         {
+          auto rotate_in_globalpoint =
+            this->reverse_align_and_center(projected_point);
           if (!this->part_of_a_composite)
             {
               this->value_cache[point_in_string] =
                 (centered_point - projected_point).norm();
-              auto rotate_in_globalpoint =
-                this->reverse_align_and_center(projected_point);
               this->gradient_cache[point_in_string] =
                 -(rotate_in_globalpoint - evaluation_point) /
                 ((rotate_in_globalpoint - evaluation_point).norm() + 1.0e-16);

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -2011,9 +2011,10 @@ RBFShape<dim>::remove_superfluous_data(
   if (!mesh_based_precalculations)
     return;
 
-  this->update_precalculations(updated_dof_handler,
-                               levels_not_precalculated,
-                               mesh_based_precalculations);
+  if (likely_nodes_map.empty())
+    this->update_precalculations(updated_dof_handler,
+                                 levels_not_precalculated,
+                                 mesh_based_precalculations);
 
   // We loop over the likely nodes map and take note of the RBF nodes that are
   // required

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1827,7 +1827,7 @@ RBFShape<dim>::update_precalculations(
             static_cast<unsigned int>(temp_cell->level() + 1 +
                                       levels_not_precalculated) >=
             maximal_level;
-          if (temp_cell->is_active() && !level_above_precalculation_limit)
+          if (temp_cell->is_active() || level_above_precalculation_limit)
             {
               if (cell->point_inside(temp_cell->barycenter()))
                 {

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1625,6 +1625,7 @@ RBFShape<dim>::gradient(const Point<dim> &evaluation_point,
               // If the evaluation point overlaps with the node position, we
               // assume that the contribution of this node is 0. This assumption
               // can be made because radial basis functions are symmetrical. If
+              // can be made because radial basis functions are symmetrical. If
               // the basis function is not differentiable at its node (e.g.
               // linear function), this approximation will still hold since the
               // approximated distance field is already imperfect and
@@ -1685,7 +1686,7 @@ RBFShape<dim>::initialize_bounding_box()
         nodes_positions_d = &nodes_positions_x;
       else if (d == 1)
         nodes_positions_d = &nodes_positions_y;
-      else if constexpr (dim == 3)
+      else
         nodes_positions_d = &nodes_positions_z;
       for (size_t i = 0; i < number_of_nodes; i++)
         {

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1766,7 +1766,7 @@ RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
           max_number_of_inside_nodes =
             std::max(max_number_of_inside_nodes, current_cell_nodes->size());
           current_cell_nodes->shrink_to_fit();
-          if (current_cell_nodes->size() > 0)
+          if (!current_cell_nodes->empty())
             temporary_nodes_portions_map[cell] =
               std::make_tuple(cell->barycenter(),
                               cell->diameter(),
@@ -1783,10 +1783,11 @@ RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
           auto               cell       = it->first;
           const unsigned int cell_level = cell->level();
           bool cell_still_needed = cell->is_active() || cell_level == level;
+
+          auto previous_it = it;
+          ++it;
           if (!cell_still_needed)
-            temporary_nodes_portions_map.erase(it++->first);
-          else
-            it++;
+            temporary_nodes_portions_map.erase(previous_it);
         }
     }
 
@@ -1851,10 +1852,11 @@ RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
     {
       auto cell              = it->first;
       bool cell_still_needed = cell->is_active() && !cell->is_artificial();
+
+      auto previous_it = it;
+      ++it;
       if (!cell_still_needed)
-        likely_nodes_map.erase(it++->first);
-      else
-        it++;
+        likely_nodes_map.erase(previous_it);
     }
 
   // Here we loop on all (local or ghost) and active cells to define which RBF

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1633,9 +1633,9 @@ RBFShape<dim>::gradient(const Point<dim> &evaluation_point,
               for (int d = 0; d < dim; d++)
                 dr_dx_derivative[d] = 0;
             }
-          // Calculation of the dr_norm/dr
+          // Calculation of dr_norm/dr
           drnorm_dr_derivative = 1.0 / support_radii[node_id];
-          // Calculation of the d(basis)/dr
+          // Calculation of d(basis)/dr
           // We cast the basis function value to the proper RBFBasisFunction
           dbasis_drnorm_derivative = evaluate_basis_function_derivative(
             static_cast<enum RBFShape<dim>::RBFBasisFunction>(
@@ -1710,7 +1710,7 @@ RBFShape<dim>::update_precalculations(DoFHandler<dim> &dof_handler,
     return;
   // We first reset the mapping, since the grid partitioning may change between
   // calls of this function. The precalculation cost is low enough that this
-  // reset does not have a significant impact of global computational cost.
+  // reset does not have a significant impact on global computational cost.
   likely_nodes_map.clear();
 
   this->dof_handler                = &dof_handler;
@@ -1890,10 +1890,8 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
   bool parent_found = false;
   std::vector<
     std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>
-    temporary_iterable_nodes{1};
-  temporary_iterable_nodes[0] = {Point<dim>{},
-                                 0,
-                                 std::make_shared<std::vector<size_t>>()};
+    temporary_iterable_nodes{
+      {Point<dim>{}, 0, std::make_shared<std::vector<size_t>>()}};
   if (cell->level() > 0)
     try
       {
@@ -1912,7 +1910,7 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
   double     distance, max_distance;
   double     cell_diameter = cell->diameter();
   Point<dim> centered_support_point;
-  Point<dim> temp_cell_barycenter{};
+  Point<dim> temp_cell_barycenter;
   double     temp_cell_diameter;
 
   likely_nodes_map[cell]          = std::make_shared<std::vector<
@@ -1960,7 +1958,7 @@ RBFShape<dim>::load_data_from_file()
 
   // The following lines retrieve information regarding an RBF
   // with a given file name. Then, it converts the information
-  // into one vector which is used to initialize the RBF shape.
+  // into a vector which is used to initialize the RBF shape.
   // All the information is concatenated into only one object so
   // that the usual initialization function can be called.
   std::map<std::string, std::vector<double>> rbf_data;
@@ -2037,7 +2035,7 @@ RBFShape<dim>::remove_superfluous_data(DoFHandler<dim> &updated_dof_handler,
   weights.swap(temp_weights);
   temp_weights.clear();
 
-  // Nodes positions treatment
+  // Nodes' positions treatment
   counter = 0;
   temp_rotated_nodes_positions.resize(current_number_of_kept_rbf_nodes);
   for (size_t i = 0; i < number_of_nodes; i++)

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1509,28 +1509,38 @@ RBFShape<dim>::remove_superfluous_data()
   std::vector<double>           temp_support_radii;
   std::vector<RBFBasisFunction> temp_basis_functions;
 
+  // Here we treat all vectors separately to keep the maximum memory low
+  // Weights treatment
   temp_weights.resize(current_number_of_kept_rbf_nodes);
-  temp_rotated_nodes_positions.resize(current_number_of_kept_rbf_nodes);
-  temp_support_radii.resize(current_number_of_kept_rbf_nodes);
-  temp_basis_functions.resize(current_number_of_kept_rbf_nodes);
-
   for (auto it = useful_rbf_node_map.cbegin(); it != useful_rbf_node_map.cend();
        it++)
-    {
-      temp_weights[it->second] = weights[it->first];
-      temp_rotated_nodes_positions[it->second] =
-        rotated_nodes_positions[it->first];
-      temp_support_radii[it->second]   = support_radii[it->first];
-      temp_basis_functions[it->second] = basis_functions[it->first];
-    }
+    temp_weights[it->second] = weights[it->first];
   weights.swap(temp_weights);
-  rotated_nodes_positions.swap(temp_rotated_nodes_positions);
-  support_radii.swap(temp_support_radii);
-  basis_functions.swap(temp_basis_functions);
-
   temp_weights.clear();
+
+  // Nodes positions treatment
+  temp_rotated_nodes_positions.resize(current_number_of_kept_rbf_nodes);
+  for (auto it = useful_rbf_node_map.cbegin(); it != useful_rbf_node_map.cend();
+       it++)
+    temp_rotated_nodes_positions[it->second] =
+      rotated_nodes_positions[it->first];
+  rotated_nodes_positions.swap(temp_rotated_nodes_positions);
   temp_rotated_nodes_positions.clear();
+
+  // Support radii treatment
+  temp_support_radii.resize(current_number_of_kept_rbf_nodes);
+  for (auto it = useful_rbf_node_map.cbegin(); it != useful_rbf_node_map.cend();
+       it++)
+    temp_support_radii[it->second] = support_radii[it->first];
+  support_radii.swap(temp_support_radii);
   temp_support_radii.clear();
+
+  // Basis functions treatment
+  temp_basis_functions.resize(current_number_of_kept_rbf_nodes);
+  for (auto it = useful_rbf_node_map.cbegin(); it != useful_rbf_node_map.cend();
+       it++)
+    temp_basis_functions[it->second] = basis_functions[it->first];
+  basis_functions.swap(temp_basis_functions);
   temp_basis_functions.clear();
 }
 

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1473,8 +1473,6 @@ RBFShape<dim>::RBFShape(const std::vector<double> &shape_arguments,
   max_number_of_inside_nodes = 1;
   position_precalculated     = Point<dim>(this->position);
   orientation_precalculated  = Tensor<1, 3>(this->orientation);
-  minimal_support_radius =
-    *std::min_element(std::begin(support_radii), std::end(support_radii));
 
   for (size_t n_i = 0; n_i < number_of_nodes; n_i++)
     {
@@ -1486,6 +1484,8 @@ RBFShape<dim>::RBFShape(const std::vector<double> &shape_arguments,
       nodes_positions[n_i][1] = shape_arguments[4 * number_of_nodes + n_i];
       nodes_positions[n_i][2] = shape_arguments[5 * number_of_nodes + n_i];
     }
+  minimal_support_radius =
+    *std::min_element(std::begin(support_radii), std::end(support_radii));
   rotate_nodes();
   initialize_bounding_box();
   this->effective_radius = bounding_box->half_lengths.norm();
@@ -1749,7 +1749,7 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
       // only check the distance with 1 support point, added to the support
       // radius
       max_distance =
-        cell_diameter + 0.5 * temp_cell_diameter + minimal_support_radius;
+        0.5 * cell_diameter + 0.5 * temp_cell_diameter + minimal_support_radius;
       if (distance < max_distance)
         {
           likely_nodes_map[cell]->push_back(iterable_nodes[portion_id]);

--- a/source/core/shape_parsing.cc
+++ b/source/core/shape_parsing.cc
@@ -138,11 +138,6 @@ ShapeGenerator::initialize_shape_from_vector(
                                                  position,
                                                  orientation);
     }
-  else if (type == "rbf")
-    {
-      shape =
-        std::make_shared<RBFShape<dim>>(shape_arguments, position, orientation);
-    }
   else
     StandardExceptions::ExcNotImplemented();
   return shape;
@@ -159,50 +154,7 @@ ShapeGenerator::initialize_shape_from_file(const std::string   type,
   std::vector<double>         shape_arguments;
   if (type == "rbf")
     {
-      bool default_case = (file_name == "1"); // Default case. This is the
-                                              // default argument for
-                                              // shapes defined in the parameter
-                                              // file.
-      if (!default_case)
-        {
-          // The following lines retrieve information regarding an RBF
-          // with a given file name. Then, it converts the information
-          // into one vector which is used to initialize the RBF shape.
-          // All the information is concatenated into only one object so
-          // that the usual initialization function can be called.
-          std::map<std::string, std::vector<double>> rbf_data;
-          fill_vectors_from_file(rbf_data, file_name, " ");
-          size_t number_of_nodes = rbf_data["weight"].size();
-          shape_arguments.reserve((dim + 3) * number_of_nodes);
-          shape_arguments.insert(shape_arguments.end(),
-                                 rbf_data["weight"].begin(),
-                                 rbf_data["weight"].end());
-          shape_arguments.insert(shape_arguments.end(),
-                                 rbf_data["support_radius"].begin(),
-                                 rbf_data["support_radius"].end());
-          shape_arguments.insert(shape_arguments.end(),
-                                 rbf_data["basis_function"].begin(),
-                                 rbf_data["basis_function"].end());
-          shape_arguments.insert(shape_arguments.end(),
-                                 rbf_data["node_x"].begin(),
-                                 rbf_data["node_x"].end());
-          shape_arguments.insert(shape_arguments.end(),
-                                 rbf_data["node_y"].begin(),
-                                 rbf_data["node_y"].end());
-          shape_arguments.insert(shape_arguments.end(),
-                                 rbf_data["node_z"].begin(),
-                                 rbf_data["node_z"].end());
-        }
-      else
-        {
-          // Default weight, support radius, basis function, x, y
-          shape_arguments = {2.0, 1.0, 2.0, 0.0, 0.0};
-          if constexpr (dim == 3)
-            // and z
-            shape_arguments.insert(shape_arguments.end(), 0.0);
-        }
-      shape =
-        std::make_shared<RBFShape<dim>>(shape_arguments, position, orientation);
+      shape = std::make_shared<RBFShape<dim>>(file_name, position, orientation);
     }
   else if (type == "composite")
     {

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -4512,9 +4512,7 @@ GLSSharpNavierStokesSolver<dim>::update_precalculations_for_ib()
   for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
     {
       particles[p_i].update_precalculations(
-        this->dof_handler,
-        this->simulation_parameters.particlesParameters
-          ->levels_not_precalculated);
+        this->dof_handler, particles[p_i].mesh_based_precalculations);
     }
 }
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -4516,7 +4516,10 @@ GLSSharpNavierStokesSolver<dim>::update_precalculations_for_ib()
   for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
     {
       particles[p_i].update_precalculations(
-        this->dof_handler, particles[p_i].mesh_based_precalculations);
+        this->dof_handler,
+        this->simulation_parameters.particlesParameters
+          ->levels_not_precalculated,
+        particles[p_i].mesh_based_precalculations);
     }
 }
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -443,10 +443,7 @@ GLSSharpNavierStokesSolver<dim>::refinement_control(
         {
           TimerOutput::Scope t(this->computing_timer, "removing_rbf_nodes");
           particles[p_i].remove_superfluous_data(
-            this->dof_handler,
-            this->simulation_parameters.particlesParameters
-              ->levels_not_precalculated,
-            particles[p_i].mesh_based_precalculations);
+            this->dof_handler, particles[p_i].mesh_based_precalculations);
         }
     }
 }
@@ -4540,10 +4537,7 @@ GLSSharpNavierStokesSolver<dim>::update_precalculations_for_ib()
   for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
     {
       particles[p_i].update_precalculations(
-        this->dof_handler,
-        this->simulation_parameters.particlesParameters
-          ->levels_not_precalculated,
-        particles[p_i].mesh_based_precalculations);
+        this->dof_handler, particles[p_i].mesh_based_precalculations);
     }
 }
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -1633,8 +1633,13 @@ GLSSharpNavierStokesSolver<dim>::output_field_hook(DataOut<dim> &data_out)
     {
       all_shapes.push_back(particle.shape);
     }
-  std::shared_ptr<Shape<dim>> combined_shapes =
-    std::make_shared<CompositeShape<dim>>(all_shapes, Point<dim>(), Point<3>());
+  std::shared_ptr<Shape<dim>> combined_shapes;
+  if (particles.size() == 1)
+    combined_shapes = particles[0].shape;
+  else
+    combined_shapes = std::make_shared<CompositeShape<dim>>(all_shapes,
+                                                            Point<dim>(),
+                                                            Point<3>());
 
   levelset_postprocessor =
     std::make_shared<LevelsetPostprocessor<dim>>(combined_shapes);

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -180,31 +180,13 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                           // previously evaluated cell. If we didn't find it in
                           // the previous evaluation, we assess whether the DOF
                           // is inside or outside the shape.
-                          auto iterator =
-                            inside_outside_support_point_vector[p].find(
-                              local_dof_indices[j]);
-                          if (iterator ==
-                              inside_outside_support_point_vector[p].end())
+                          if (particles[p].get_levelset(
+                                support_points[local_dof_indices[j]], cell) <=
+                              0)
                             {
-                              if (particles[p].get_levelset(
-                                    support_points[local_dof_indices[j]],
-                                    cell) <= 0)
-                                {
-                                  ++nb_dof_inside;
-                                  inside_outside_support_point_vector
-                                    [p][local_dof_indices[j]] = true;
-                                }
-                              else
-                                inside_outside_support_point_vector
-                                  [p][local_dof_indices[j]] = false;
-                            }
-                          else
-                            {
-                              if (inside_outside_support_point_vector
-                                    [p][local_dof_indices[j]] == true)
-                                {
-                                  ++nb_dof_inside;
-                                }
+                              ++nb_dof_inside;
+                              inside_outside_support_point_vector
+                                [p][local_dof_indices[j]] = true;
                             }
                         }
                     }

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -437,18 +437,18 @@ GLSSharpNavierStokesSolver<dim>::refinement_control(
           update_precalculations_for_ib();
         }
     }
-   if (triangulation_modified_at_least_once || initial_refinement)
-     {
-       for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
-         {
-           TimerOutput::Scope t(this->computing_timer, "removing_rbf_nodes");
-           particles[p_i].remove_superfluous_data(
-             this->dof_handler,
-             this->simulation_parameters.particlesParameters
-               ->levels_not_precalculated,
-             particles[p_i].mesh_based_precalculations);
-         }
-     }
+  if (triangulation_modified_at_least_once || initial_refinement)
+    {
+      for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
+        {
+          TimerOutput::Scope t(this->computing_timer, "removing_rbf_nodes");
+          particles[p_i].remove_superfluous_data(
+            this->dof_handler,
+            this->simulation_parameters.particlesParameters
+              ->levels_not_precalculated,
+            particles[p_i].mesh_based_precalculations);
+        }
+    }
 }
 
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -1678,11 +1678,6 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::postprocess_fd(bool firstIter)
 {
-  if (this->simulation_control->is_output_iteration())
-    {
-      this->write_output_results(this->present_solution);
-    }
-
   bool enable =
     this->simulation_parameters.analytical_solution->calculate_error();
   this->simulation_parameters.analytical_solution->set_enable(false);


### PR DESCRIPTION
# Description of the problem

- Memory requirements was too high for dense RBF shapes (high number of RBF nodes) in very fine grids.

# Description of the solution

- Nodes precalculations was changed: _before_, every cell had a vector with the IDs of the contributing RBF nodes, and _now_ every node is in only one vector, associated to a fine cell. The cells then have a list of shared pointers that reference these vectors of IDs.
-- The performance is barely affected in terms of computing speed, but very much improved for memory requirements even for the densest RBF tested and in fine grids.
-- A side effect of this (for the moment) is that RBF nodes that are in no cell are lost, so their contribution on the shape is as well. This happens only near the domain boundaries. An option to prevent mesh based precalculations was added for cases where accurate surface representation is important near the background grid boundary.

- Another change is that information of RBF nodes that don't affect locally owned cells are removed (a reload function is then used  when the shape moves).
- An additional change is that cache of constituents in CompositeShapes is not used anymore: this prevents duplication of information.

# How Has This Been Tested?

- Tests still pass.

# Documentation

- Changes are reflected in the sharp IB parameters section.

# Future changes

- A modification will be made to the algorithm to keep the effect of RBF nodes located outside the background grid.
