### PR TITLE
Parameter to disable extrapolation in sharp IB solver

### DIFF
--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -111,7 +111,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
     * The ``enable extrapolation`` parameter controls if extrapolation is used to impose the immersed boundary condition. For debugging purposes, this parameter can be set to ``false``; the particle velocity will then be imposed on velocity degrees of freedom of cells cut by the particle directly, which effectively amplifies the volume occupied by the solid.
 
     .. warning::
-    	Disabling the extrapolation is not recommended since it makes the Sharp-IB solver lose its high-order capabilities, akin to more basic IB methods.
+    	Disabling the extrapolation is not recommended since it makes the Sharp-IB solver first-order accurate in space.
 
 * The ``output`` subsection contains the parameters controlling the information printed in the terminal and output files.
     * The ``calculate force`` parameter controls if the force is evaluated on each particle.

--- a/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
+++ b/doc/source/parameters/sharp-immersed-boundary-solver/sharp-immersed-boundary-solver.rst
@@ -12,8 +12,9 @@ This subsection contains the parameters related to the sharp immersed boundary s
       set number of particles                     = 1
       
       subsection extrapolation function
-        set length ratio  = 4
-        set stencil order = 2
+        set length ratio         = 4
+        set stencil order        = 2
+        set enable extrapolation = true
       end
       
       subsection output
@@ -106,6 +107,11 @@ This subsection contains the parameters related to the sharp immersed boundary s
 
     .. tip::
 	    A good starting value is twice the average aspect ratio of the elements in the mesh multiplied by the order of the underlying FEM scheme.
+
+    * The ``enable extrapolation`` parameter controls if extrapolation is used to impose the immersed boundary condition. For debugging purposes, this parameter can be set to ``false``; the particle velocity will then be imposed on velocity degrees of freedom of cells cut by the particle directly, which effectively amplifies the volume occupied by the solid.
+
+    .. warning::
+    	Disabling the extrapolation is not recommended since it makes the Sharp-IB solver lose its high-order capabilities, akin to more basic IB methods.
 
 * The ``output`` subsection contains the parameters controlling the information printed in the terminal and output files.
     * The ``calculate force`` parameter controls if the force is evaluated on each particle.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1209,6 +1209,7 @@ namespace Parameters
 
     double      particle_nonlinear_tolerance;
     double      length_ratio;
+    bool        enable_extrapolation;
     double      alpha;
     bool        print_dem;
     std::string ib_particles_pvd_file;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2570,6 +2570,14 @@ namespace Parameters
           "4",
           Patterns::Double(),
           "The length ratio used to define the points for the IB stencil. See definition of epsilon_n in the paper on sharp IB.");
+        prm.declare_entry(
+          "enable extrapolation",
+          "true",
+          Patterns::Bool(),
+          "Bool to define if extrapolation should be enabled (default). If disabled, all velocity degrees of freedom "
+          "in a cell will be set to the particle velocity if that cell is cut. Setting to false is intended for "
+          "debugging purposes.");
+
         prm.leave_subsection();
       }
 
@@ -2752,8 +2760,9 @@ namespace Parameters
     {
       prm.enter_subsection("extrapolation function");
       {
-        order        = prm.get_integer("stencil order");
-        length_ratio = prm.get_double("length ratio");
+        order                = prm.get_integer("stencil order");
+        length_ratio         = prm.get_double("length ratio");
+        enable_extrapolation = prm.get_bool("enable extrapolation");
         prm.leave_subsection();
       }
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -3281,11 +3281,20 @@ GLSSharpNavierStokesSolver<dim>::sharp_edge()
                           // used for the definition of the stencil
                           // ("stencil_cell") is on a face between the cell_cut
                           // that is cut ("cell_cut") and the "stencil_cell".
-                          bool point_in_cell = cell_cut->point_inside(
-                            interpolation_points
-                              [stencil.number_of_interpolation_support_points(
-                                 order) -
-                               1]);
+                          bool point_in_cell;
+                          // The extrapolation can be disabled for debugging
+                          // purposes, although in most cases it shouldn't since
+                          // it is a core part of this solver
+                          if (this->simulation_parameters.particlesParameters
+                                ->enable_extrapolation)
+                            point_in_cell = cell_cut->point_inside(
+                              interpolation_points
+                                [stencil.number_of_interpolation_support_points(
+                                   order) -
+                                 1]);
+                          else
+                            point_in_cell = cell_cut->point_inside(
+                              support_points[local_dof_indices[i]]);
 
                           bool         dof_is_dummy = false;
                           bool         cell2_is_cut;
@@ -3338,9 +3347,19 @@ GLSSharpNavierStokesSolver<dim>::sharp_edge()
                               stencil_cell, point);
                           for (unsigned int j = 1; j < ib_coef.size(); ++j)
                             {
-                              unite_cell_interpolation_points[j] =
-                                this->mapping->transform_real_to_unit_cell(
-                                  stencil_cell, interpolation_points[j - 1]);
+                              // The extrapolation can be disabled for debugging
+                              // purposes, although in most cases it shouldn't
+                              // since it is a core part of this solver
+                              if (this->simulation_parameters
+                                    .particlesParameters->enable_extrapolation)
+                                unite_cell_interpolation_points[j] =
+                                  this->mapping->transform_real_to_unit_cell(
+                                    stencil_cell, interpolation_points[j - 1]);
+                              else
+                                unite_cell_interpolation_points[j] =
+                                  this->mapping->transform_real_to_unit_cell(
+                                    stencil_cell,
+                                    support_points[local_dof_indices[i]]);
                             }
 
                           std::vector<double> local_interp_sol(ib_coef.size());


### PR DESCRIPTION
# Description of the problem

- It was found that deactivating extrapolation and imposing particle velocity directly of the velocity DOFs of cut cells can still lead to acceptable results in some cases
- An advantage of doing this is better mass preservation

# Description of the solution

- A parameter is added to deactivate extrapolation for debugging purposes and to identify the importance of mass preservation

# How Has This Been Tested?

- It was tested manually and results were adequate.
- [image 1]: velocity with extrapolation
- [image 2]: velocity without extrapolation
![Screenshot from 2023-08-08 16-12-02](https://github.com/lethe-cfd/lethe/assets/14217956/033715e9-f671-4304-a1b2-596110358b71)
![Screenshot from 2023-08-08 16-10-12](https://github.com/lethe-cfd/lethe/assets/14217956/657fe686-8af3-493d-8f51-6c226961fbbf)

# Documentation

- The new parameter is added to the Sharp IB documentation