### PR TITLE
Remove redundant set function expression

### DIFF
--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -227,19 +227,19 @@ namespace BoundaryConditions
                       "Direction for periodic boundary condition");
 
     prm.enter_subsection("u");
-    bcFunctions[i_bc].u.declare_parameters(prm, 1);
+    bcFunctions[i_bc].u.declare_parameters(prm);
     prm.leave_subsection();
 
     prm.enter_subsection("v");
-    bcFunctions[i_bc].v.declare_parameters(prm, 1);
+    bcFunctions[i_bc].v.declare_parameters(prm);
     prm.leave_subsection();
 
     prm.enter_subsection("w");
-    bcFunctions[i_bc].w.declare_parameters(prm, 1);
+    bcFunctions[i_bc].w.declare_parameters(prm);
     prm.leave_subsection();
 
     prm.enter_subsection("p");
-    bcPressureFunction[i_bc].p.declare_parameters(prm, 1);
+    bcPressureFunction[i_bc].p.declare_parameters(prm);
     prm.leave_subsection();
 
     // Center of rotation of the boundary condition for torque calculation
@@ -818,7 +818,7 @@ namespace BoundaryConditions
       "Inner angle of contact between the fluid 1 and the boundary (in degrees)");
 
     prm.enter_subsection("phi");
-    bcFunctions[i_bc].phi.declare_parameters(prm, 1);
+    bcFunctions[i_bc].phi.declare_parameters(prm);
     prm.leave_subsection();
 
     return;

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -228,22 +228,18 @@ namespace BoundaryConditions
 
     prm.enter_subsection("u");
     bcFunctions[i_bc].u.declare_parameters(prm, 1);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     prm.enter_subsection("v");
     bcFunctions[i_bc].v.declare_parameters(prm, 1);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     prm.enter_subsection("w");
     bcFunctions[i_bc].w.declare_parameters(prm, 1);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     prm.enter_subsection("p");
     bcPressureFunction[i_bc].p.declare_parameters(prm, 1);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     // Center of rotation of the boundary condition for torque calculation
@@ -672,7 +668,6 @@ namespace BoundaryConditions
     prm.enter_subsection("dirichlet");
     tracer[i_bc] = std::make_shared<Functions::ParsedFunction<dim>>();
     tracer[i_bc]->declare_parameters(prm);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
   }
 
@@ -824,7 +819,6 @@ namespace BoundaryConditions
 
     prm.enter_subsection("phi");
     bcFunctions[i_bc].phi.declare_parameters(prm, 1);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     return;
@@ -992,7 +986,6 @@ namespace BoundaryConditions
     prm.enter_subsection("dirichlet");
     phase_fraction[i_bc] = std::make_shared<Functions::ParsedFunction<dim>>();
     phase_fraction[i_bc]->declare_parameters(prm);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
   }
 

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -83,17 +83,12 @@ namespace Parameters
 
       prm.enter_subsection("solid velocity");
       solid_velocity.declare_parameters(prm, dim);
-      if (dim == 2)
-        prm.set("Function expression", "0; 0");
-      if (dim == 3)
-        prm.set("Function expression", "0; 0; 0");
       prm.leave_subsection();
 
 
 
       prm.enter_subsection("solid temperature");
       solid_temperature.declare_parameters(prm, 1);
-      prm.set("Function expression", "0");
       prm.leave_subsection();
 
       prm.declare_entry("enable particles motion",
@@ -309,15 +304,10 @@ namespace Parameters
 
       prm.enter_subsection("translational velocity");
       translational_velocity.declare_parameters(prm, dim);
-      if (dim == 2)
-        prm.set("Function expression", "0; 0");
-      if (dim == 3)
-        prm.set("Function expression", "0; 0; 0");
       prm.leave_subsection();
 
       prm.enter_subsection("angular velocity");
-      angular_velocity.declare_parameters(prm, dim);
-      prm.set("Function expression", "0; 0; 0");
+      angular_velocity.declare_parameters(prm, 3);
       prm.leave_subsection();
 
 

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -88,7 +88,7 @@ namespace Parameters
 
 
       prm.enter_subsection("solid temperature");
-      solid_temperature.declare_parameters(prm, 1);
+      solid_temperature.declare_parameters(prm);
       prm.leave_subsection();
 
       prm.declare_entry("enable particles motion",

--- a/include/solvers/initial_conditions.h
+++ b/include/solvers/initial_conditions.h
@@ -140,17 +140,14 @@ namespace Parameters
 
       prm.enter_subsection("temperature");
       temperature.declare_parameters(prm);
-      prm.set("Function expression", "0");
       prm.leave_subsection();
 
       prm.enter_subsection("tracer");
       tracer.declare_parameters(prm);
-      prm.set("Function expression", "0");
       prm.leave_subsection();
 
       prm.enter_subsection("VOF");
       VOF.declare_parameters(prm);
-      prm.set("Function expression", "0");
       prm.enter_subsection("projection step");
       prm.declare_entry(
         "enable",
@@ -167,7 +164,6 @@ namespace Parameters
 
       prm.enter_subsection("cahn hilliard");
       cahn_hilliard.declare_parameters(prm, 2);
-      prm.set("Function expression", "0; 0;");
       prm.leave_subsection();
 
       ramp.declare_parameters(prm);

--- a/include/solvers/source_terms.h
+++ b/include/solvers/source_terms.h
@@ -92,27 +92,19 @@ namespace SourceTerms
                       "Enable the calculation of a source term");
 
     prm.enter_subsection("xyz");
-    navier_stokes_source.declare_parameters(prm, dim);
-    if (dim == 2)
-      prm.set("Function expression", "0; 0; 0");
-    if (dim == 3)
-      prm.set("Function expression", "0; 0; 0; 0;");
+    navier_stokes_source.declare_parameters(prm, dim + 1);
     prm.leave_subsection();
-
 
     prm.enter_subsection("heat transfer");
     heat_transfer_source.declare_parameters(prm);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     prm.enter_subsection("tracer");
     tracer_source.declare_parameters(prm);
-    prm.set("Function expression", "0");
     prm.leave_subsection();
 
     prm.enter_subsection("cahn hilliard");
-    cahn_hilliard_source.declare_parameters(prm);
-    prm.set("Function expression", "0; 0;");
+    cahn_hilliard_source.declare_parameters(prm, 2);
     prm.leave_subsection();
 
     prm.leave_subsection();

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1302,10 +1302,6 @@ namespace Parameters
       prm.enter_subsection("path");
       laser_scan_path = std::make_shared<Functions::ParsedFunction<dim>>(dim);
       laser_scan_path->declare_parameters(prm, dim);
-      if (dim == 2)
-        prm.set("Function expression", "0; 0");
-      if (dim == 3)
-        prm.set("Function expression", "0; 0; 0");
       prm.leave_subsection();
 
       prm.declare_entry("start time",
@@ -2419,34 +2415,24 @@ namespace Parameters
     particles[index].f_position =
       std::make_shared<Functions::ParsedFunction<dim>>(dim);
     particles[index].f_position->declare_parameters(prm, dim);
-    if (dim == 2)
-      prm.set("Function expression", "0; 0");
-    if (dim == 3)
-      prm.set("Function expression", "0; 0; 0");
     prm.leave_subsection();
 
     prm.enter_subsection("orientation");
     particles[index].f_orientation =
       std::make_shared<Functions::ParsedFunction<dim>>(3);
-    particles[index].f_orientation->declare_parameters(prm, dim);
-    prm.set("Function expression", "0; 0; 0");
+    particles[index].f_orientation->declare_parameters(prm, 3);
     prm.leave_subsection();
 
     prm.enter_subsection("velocity");
     particles[index].f_velocity =
       std::make_shared<Functions::ParsedFunction<dim>>(dim);
     particles[index].f_velocity->declare_parameters(prm, dim);
-    if (dim == 2)
-      prm.set("Function expression", "0; 0");
-    if (dim == 3)
-      prm.set("Function expression", "0; 0; 0");
     prm.leave_subsection();
 
     prm.enter_subsection("omega");
     particles[index].f_omega =
       std::make_shared<Functions::ParsedFunction<dim>>(3);
-    particles[index].f_omega->declare_parameters(prm, dim);
-    prm.set("Function expression", "0; 0; 0");
+    particles[index].f_omega->declare_parameters(prm, 3);
     prm.leave_subsection();
 
     prm.declare_entry(
@@ -2727,10 +2713,6 @@ namespace Parameters
 
         prm.enter_subsection("gravity");
         f_gravity->declare_parameters(prm, dim);
-        if (dim == 2)
-          prm.set("Function expression", "0; 0");
-        if (dim == 3)
-          prm.set("Function expression", "0; 0; 0");
         prm.leave_subsection();
 
         prm.leave_subsection();

--- a/source/fem-dem/parameters_cfd_dem.cc
+++ b/source/fem-dem/parameters_cfd_dem.cc
@@ -13,7 +13,7 @@ namespace Parameters
       Patterns::Selection("function|pcm|qcm|spm"),
       "Choose the method for the calculation of the void fraction");
     prm.enter_subsection("function");
-    void_fraction.declare_parameters(prm, 1);
+    void_fraction.declare_parameters(prm);
     prm.leave_subsection();
     prm.declare_entry("read dem",
                       "false",

--- a/source/solvers/analytical_solutions.cc
+++ b/source/solvers/analytical_solutions.cc
@@ -47,37 +47,29 @@ namespace AnalyticalSolutions
 
     {
       prm.enter_subsection("uvwp");
-      uvwp.declare_parameters(prm, dim);
-      if (dim == 2)
-        prm.set("Function expression", "0; 0; 0;");
-      if (dim == 3)
-        prm.set("Function expression", "0; 0; 0; 0;");
+      uvwp.declare_parameters(prm, dim + 1);
       prm.leave_subsection();
     }
     {
       prm.enter_subsection("temperature");
       temperature.declare_parameters(prm);
-      prm.set("Function expression", "0");
       prm.leave_subsection();
     }
 
     {
       prm.enter_subsection("tracer");
       tracer.declare_parameters(prm);
-      prm.set("Function expression", "0");
       prm.leave_subsection();
     }
     {
       prm.enter_subsection("VOF");
       phase.declare_parameters(prm);
-      prm.set("Function expression", "0");
       prm.leave_subsection();
     }
 
     {
       prm.enter_subsection("cahn hilliard");
-      cahn_hilliard.declare_parameters(prm);
-      prm.set("Function expression", "0; 0;");
+      cahn_hilliard.declare_parameters(prm, 2);
       prm.leave_subsection();
     }
 


### PR DESCRIPTION
# Description of the problem

- When solving issue #770, it was notice that when declaring parameters of a parsed function (using ``declaring_parameters()``) with the number of components, a "Function expression" with ``n_components`` of value ``0`` is initialized. Therefore, there is no need to reset the "Function expression" if wanted default values are zeros.
Reference: https://www.dealii.org/developer/doxygen/deal.II/parsed__function_8cc_source.html (lines 35 and following)

# Description of the solution

- Unnecessary redundant lines were removed from the code and the ``n_components`` argument of the ``declaring_parameters()`` function was adjusted where needed.

# How Has This Been Tested?

- All tests passed

