### PR TITLE
Physic based linear solvers

### DIFF
--- a/applications_tests/cfd_dem_coupling/dynamic_contact_search.prm
+++ b/applications_tests/cfd_dem_coupling/dynamic_contact_search.prm
@@ -217,12 +217,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/cfd_dem_coupling/liquid_fluidized_bed.prm
+++ b/applications_tests/cfd_dem_coupling/liquid_fluidized_bed.prm
@@ -275,12 +275,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/cfd_dem_coupling/particle_sedimentation.prm
+++ b/applications_tests/cfd_dem_coupling/particle_sedimentation.prm
@@ -217,12 +217,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/cfd_dem_coupling/periodic_particles_qcm.prm
+++ b/applications_tests/cfd_dem_coupling/periodic_particles_qcm.prm
@@ -193,15 +193,17 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 200
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 200
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+    set max krylov vectors                    = 200
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/cfd_dem_coupling/restart_particle_sedimentation.prm
+++ b/applications_tests/cfd_dem_coupling/restart_particle_sedimentation.prm
@@ -217,12 +217,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes/apparent_viscosity_carreau_gd.prm
@@ -139,12 +139,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/cylinder_carreau_gd.prm
+++ b/applications_tests/gd_navier_stokes/cylinder_carreau_gd.prm
@@ -143,12 +143,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/mms-conduction_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms-conduction_gd.prm
@@ -149,12 +149,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/mms-conduction_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms-conduction_gd.prm
@@ -159,4 +159,14 @@ subsection linear solver
     set ilu preconditioner absolute tolerance = 1e-14
     set ilu preconditioner relative tolerance = 1.00
   end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/mms2d-unstructured_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms2d-unstructured_gd.prm
@@ -112,12 +112,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-8
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 4
-  set ilu preconditioner absolute tolerance = 1e-3
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-8
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 4
+    set ilu preconditioner absolute tolerance = 1e-3
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/mms2d_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms2d_gd.prm
@@ -105,12 +105,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-3
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-3
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/mms2d_powerlaw_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms2d_powerlaw_gd.prm
@@ -121,12 +121,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-3
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-3
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/mms3d_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms3d_gd.prm
@@ -118,17 +118,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 5000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-9
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-16
-  set amg n cycles                              = 1
-  set amg w cycles                              = false
-  set amg smoother sweeps                       = 2
-  set amg smoother overlap                      = 1
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 5000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-9
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-16
+    set amg n cycles                              = 1
+    set amg w cycles                              = false
+    set amg smoother sweeps                       = 2
+    set amg smoother overlap                      = 1
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/poiseuille3d_gd.prm
+++ b/applications_tests/gd_navier_stokes/poiseuille3d_gd.prm
@@ -123,17 +123,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 5000
-  set relative residual                         = 1e-8
-  set minimum residual                          = 1e-9
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-12
-  set amg n cycles                              = 1
-  set amg w cycles                              = false
-  set amg smoother sweeps                       = 2
-  set amg smoother overlap                      = 1
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 5000
+    set relative residual                         = 1e-8
+    set minimum residual                          = 1e-9
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-12
+    set amg n cycles                              = 1
+    set amg w cycles                              = false
+    set amg smoother sweeps                       = 2
+    set amg smoother overlap                      = 1
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/poiseuille_gd.prm
+++ b/applications_tests/gd_navier_stokes/poiseuille_gd.prm
@@ -125,12 +125,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-8
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-5
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-8
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-5
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/taylor-green-vortex_gd_bdf1.prm
+++ b/applications_tests/gd_navier_stokes/taylor-green-vortex_gd_bdf1.prm
@@ -134,12 +134,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-8
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-5
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-8
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-5
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/taylor-green-vortex_gd_bdf2.prm
+++ b/applications_tests/gd_navier_stokes/taylor-green-vortex_gd_bdf2.prm
@@ -135,12 +135,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-8
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-5
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-8
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-5
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gd_navier_stokes/taylorcouette_gd.prm
+++ b/applications_tests/gd_navier_stokes/taylorcouette_gd.prm
@@ -125,17 +125,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-8
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = true  # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-8
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gd_navier_stokes/taylorcouette_gd_dimensions.prm
+++ b/applications_tests/gd_navier_stokes/taylorcouette_gd_dimensions.prm
@@ -133,17 +133,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-8
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = true  # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-8
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/buoyant_flow_between_parallel_plates.prm
+++ b/applications_tests/gls_navier_stokes/buoyant_flow_between_parallel_plates.prm
@@ -166,11 +166,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/cahn_hilliard_navier_stokes_coupling.prm
+++ b/applications_tests/gls_navier_stokes/cahn_hilliard_navier_stokes_coupling.prm
@@ -151,13 +151,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 2000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 3
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 2000
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 2000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 3
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 2000
+  end
+  subsection cahn hilliard
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 2000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 3
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 2000
+  end
 end

--- a/applications_tests/gls_navier_stokes/cavity_adjoint_gls.prm
+++ b/applications_tests/gls_navier_stokes/cavity_adjoint_gls.prm
@@ -112,11 +112,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/cavity_ht_average_velocity_restart.prm
+++ b/applications_tests/gls_navier_stokes/cavity_ht_average_velocity_restart.prm
@@ -122,5 +122,13 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
+  subsection VOF
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/conjuguated_heat_transfer_two_boxes.prm
+++ b/applications_tests/gls_navier_stokes/conjuguated_heat_transfer_two_boxes.prm
@@ -116,11 +116,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
+  subsection heat transfer
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/cylinder-rigid-body_gls.prm
+++ b/applications_tests/gls_navier_stokes/cylinder-rigid-body_gls.prm
@@ -140,11 +140,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-11
-  set verbosity                             = quiet
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-11
+    set verbosity                             = quiet
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+  end
 end

--- a/applications_tests/gls_navier_stokes/cylinder_gls.prm
+++ b/applications_tests/gls_navier_stokes/cylinder_gls.prm
@@ -144,12 +144,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-5
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-5
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/ggls-stab_gls.prm
+++ b/applications_tests/gls_navier_stokes/ggls-stab_gls.prm
@@ -132,11 +132,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
+++ b/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
@@ -191,13 +191,37 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_ht_heated-walls_heat-flux_steady.prm
+++ b/applications_tests/gls_navier_stokes/gls_ht_heated-walls_heat-flux_steady.prm
@@ -105,5 +105,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_static_droplet_surface_tension_force.prm
+++ b/applications_tests/gls_navier_stokes/gls_static_droplet_surface_tension_force.prm
@@ -162,13 +162,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_tracer_advection_tanh.prm
+++ b/applications_tests/gls_navier_stokes/gls_tracer_advection_tanh.prm
@@ -154,12 +154,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 100
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 100
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection tracer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 100
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/gls_navier_stokes/gls_tracer_diffusion_mms_2d.prm
@@ -69,7 +69,6 @@ end
 #---------------------------------------------------
 
 subsection multiphysics
-  set tracer = false
   set tracer = true
 end
 
@@ -149,11 +148,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection tracer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_tracer_high_pe_stab.prm
+++ b/applications_tests/gls_navier_stokes/gls_tracer_high_pe_stab.prm
@@ -167,11 +167,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection tracer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_tracer_simplex_diffusion_mms_2d.prm
+++ b/applications_tests/gls_navier_stokes/gls_tracer_simplex_diffusion_mms_2d.prm
@@ -70,7 +70,6 @@ end
 #---------------------------------------------------
 
 subsection multiphysics
-  set tracer = false
   set tracer = true
 end
 
@@ -150,11 +149,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection tracer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_1_isothermal_compressible_fluid.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_1_isothermal_compressible_fluid.prm
@@ -134,13 +134,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_2_isothermal_compressible_fluids.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_2_isothermal_compressible_fluids.prm
@@ -137,13 +137,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_dirichlet_boundary_condition.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_dirichlet_boundary_condition.prm
@@ -158,13 +158,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max krylov vectors                    = 500
-  set max iters                             = 1000
-  set relative residual                     = 1e-5
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_heat-transfer_hydrostat.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_heat-transfer_hydrostat.prm
@@ -176,12 +176,34 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-10
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_ht_adapt-dissipation.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_ht_adapt-dissipation.prm
@@ -177,13 +177,37 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-10
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_ht_heated-walls.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_ht_heated-walls.prm
@@ -127,5 +127,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection VOF
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_ht_heated-walls_heat-flux.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_ht_heated-walls_heat-flux.prm
@@ -140,5 +140,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection VOF
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_ht_heated-walls_multivar_adapt.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_ht_heated-walls_multivar_adapt.prm
@@ -162,5 +162,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection VOF
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_hydrostat.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_hydrostat.prm
@@ -156,12 +156,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-10
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_hydrostat_initial_refine.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_hydrostat_initial_refine.prm
@@ -165,12 +165,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-10
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_hydrostat_mesh-adapt.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_hydrostat_mesh-adapt.prm
@@ -161,12 +161,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-10
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-10
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_peeling.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_peeling.prm
@@ -171,12 +171,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_periodic_boundary_condition.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_periodic_boundary_condition.prm
@@ -144,13 +144,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max krylov vectors                    = 500
-  set max iters                             = 1000
-  set relative residual                     = 1e-5
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_static_droplet_surface_tension_force_with_tanh_filter.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_static_droplet_surface_tension_force_with_tanh_filter.prm
@@ -167,13 +167,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_tanh_filter.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_tanh_filter.prm
@@ -150,13 +150,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_wetting-inverted.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_wetting-inverted.prm
@@ -173,11 +173,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/gls_vof_wetting_mesh-adapt.prm
+++ b/applications_tests/gls_navier_stokes/gls_vof_wetting_mesh-adapt.prm
@@ -172,13 +172,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 500
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 500
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 500
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_conduction_in_solid.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_conduction_in_solid.prm
@@ -133,12 +133,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_laser.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_laser.prm
@@ -158,12 +158,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_linear_thermal_conductivity.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_linear_thermal_conductivity.prm
@@ -151,11 +151,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_radiation.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_radiation.prm
@@ -159,12 +159,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_stefan.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_stefan.prm
@@ -152,11 +152,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_transient_conduction.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_transient_conduction.prm
@@ -133,12 +133,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_transient_conduction_bdf3.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_transient_conduction_bdf3.prm
@@ -133,12 +133,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/applications_tests/gls_navier_stokes/heat_transfer_vof_radiation.prm
+++ b/applications_tests/gls_navier_stokes/heat_transfer_vof_radiation.prm
@@ -147,11 +147,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/high_pe_stab_gls.prm
+++ b/applications_tests/gls_navier_stokes/high_pe_stab_gls.prm
@@ -165,11 +165,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/interface_sharpening_blurred_circle.prm
+++ b/applications_tests/gls_navier_stokes/interface_sharpening_blurred_circle.prm
@@ -148,15 +148,28 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
+++ b/applications_tests/gls_navier_stokes/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
@@ -159,15 +159,28 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end
 
 # --------------------------------------------------

--- a/applications_tests/gls_navier_stokes/mms-conduction_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms-conduction_gls.prm
@@ -146,11 +146,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms-conv-bc_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms-conv-bc_gls.prm
@@ -145,12 +145,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms-transient-conduction-restart_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms-transient-conduction-restart_gls.prm
@@ -167,12 +167,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms-transient-conduction_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms-transient-conduction_gls.prm
@@ -149,11 +149,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d-unstructured_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d-unstructured_gls.prm
@@ -98,11 +98,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_cahn_hilliard.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_cahn_hilliard.prm
@@ -172,13 +172,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 2000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 2000
+  subsection cahn hilliard
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 2000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 2000
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_carreau_1st-order_gls.prm
@@ -114,12 +114,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_carreau_2nd-order_gls.prm
@@ -114,12 +114,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-9
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-9
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_full_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_full_gls.prm
@@ -107,12 +107,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_gls.prm
@@ -93,12 +93,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-3
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-3
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_gls_simplex_refine3.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_gls_simplex_refine3.prm
@@ -93,11 +93,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_gls_simplex_refine4.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_gls_simplex_refine4.prm
@@ -93,12 +93,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_isothermal_compressible_ns_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_isothermal_compressible_ns_gls.prm
@@ -92,12 +92,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-3
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-3
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms2d_weak_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms2d_weak_gls.prm
@@ -100,11 +100,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-7
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-13
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-7
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-13
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms3d_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms3d_gls.prm
@@ -105,17 +105,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 5000
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-9
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-12
-  set amg n cycles                              = 1
-  set amg w cycles                              = false
-  set amg smoother sweeps                       = 2
-  set amg smoother overlap                      = 1
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 5000
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-9
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-12
+    set amg n cycles                              = 1
+    set amg w cycles                              = false
+    set amg smoother sweeps                       = 2
+    set amg smoother overlap                      = 1
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms3d_gls_simplex_refine2.prm
+++ b/applications_tests/gls_navier_stokes/mms3d_gls_simplex_refine2.prm
@@ -100,17 +100,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 5000
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-9
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-12
-  set amg n cycles                              = 1
-  set amg w cycles                              = false
-  set amg smoother sweeps                       = 2
-  set amg smoother overlap                      = 1
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 5000
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-9
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-12
+    set amg n cycles                              = 1
+    set amg w cycles                              = false
+    set amg smoother sweeps                       = 2
+    set amg smoother overlap                      = 1
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms3d_isothermal_compressible_ns_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms3d_isothermal_compressible_ns_gls.prm
@@ -92,17 +92,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 5000
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-9
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-12
-  set amg n cycles                              = 1
-  set amg w cycles                              = false
-  set amg smoother sweeps                       = 2
-  set amg smoother overlap                      = 1
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 5000
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-9
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-12
+    set amg n cycles                              = 1
+    set amg w cycles                              = false
+    set amg smoother sweeps                       = 2
+    set amg smoother overlap                      = 1
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/mms_adv_diff_diss_gls.prm
+++ b/applications_tests/gls_navier_stokes/mms_adv_diff_diss_gls.prm
@@ -198,12 +198,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/partial_slip.prm
+++ b/applications_tests/gls_navier_stokes/partial_slip.prm
@@ -112,12 +112,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/phase_change_viscosity.prm
+++ b/applications_tests/gls_navier_stokes/phase_change_viscosity.prm
@@ -193,12 +193,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-6
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/poiseuille3d-flow-control_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes/poiseuille3d-flow-control_gls_bdf1.prm
@@ -106,11 +106,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-6
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-6
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/poiseuille3d_balanced_grid.prm
+++ b/applications_tests/gls_navier_stokes/poiseuille3d_balanced_grid.prm
@@ -124,11 +124,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/poiseuille3d_gls.prm
+++ b/applications_tests/gls_navier_stokes/poiseuille3d_gls.prm
@@ -124,11 +124,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/poiseuille_gls.prm
+++ b/applications_tests/gls_navier_stokes/poiseuille_gls.prm
@@ -125,12 +125,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-5
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-5
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/poiseuille_restart.prm
+++ b/applications_tests/gls_navier_stokes/poiseuille_restart.prm
@@ -116,13 +116,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set max krylov vectors                    = 200
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set max krylov vectors                    = 200
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/rigid-body-rotation_gls.prm
+++ b/applications_tests/gls_navier_stokes/rigid-body-rotation_gls.prm
@@ -141,17 +141,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = true  # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/taylor-green-vortex-restart_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes/taylor-green-vortex-restart_gls_bdf1.prm
@@ -146,12 +146,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/taylor-green-vortex_gls_bdf1.prm
+++ b/applications_tests/gls_navier_stokes/taylor-green-vortex_gls_bdf1.prm
@@ -132,12 +132,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_navier_stokes/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/gls_navier_stokes/taylorcouette-unstructured_gls.prm
@@ -128,17 +128,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = true  # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_navier_stokes/taylorcouette_gls.prm
+++ b/applications_tests/gls_navier_stokes/taylorcouette_gls.prm
@@ -123,17 +123,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = true  # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/almost_blocked_channels.prm
+++ b/applications_tests/gls_sharp_navier_stokes/almost_blocked_channels.prm
@@ -110,5 +110,7 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/cavatappi_composite_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/cavatappi_composite_test.prm
@@ -108,5 +108,7 @@ subsection timer
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/check_point.prm
+++ b/applications_tests/gls_sharp_navier_stokes/check_point.prm
@@ -230,13 +230,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-20
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
-  set max krylov vectors                    = 1000
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-20
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+    set max krylov vectors                    = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/couette2d_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes/couette2d_gls.prm
@@ -186,12 +186,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/couette2d_gls_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes/couette2d_gls_poisson.prm
@@ -186,12 +186,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/coupled_moving_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes/coupled_moving_stokes.prm
@@ -322,22 +322,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 1000
-  set relative residual                         = 1e-5
-  set minimum residual                          = 1e-12
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-20
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
-  set force linear solver continuation          = true
-  set max krylov vectors                        = 1000
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-5
+    set minimum residual                          = 1e-12
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-20
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+    set force linear solver continuation          = true
+    set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_cone_deathstar.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_cone_deathstar.prm
@@ -135,5 +135,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_cuthollowsphere.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_cuthollowsphere.prm
@@ -154,13 +154,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_ellipsoid_rectangle.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_ellipsoid_rectangle.prm
@@ -163,13 +163,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_multiple_objects.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_multiple_objects.prm
@@ -172,13 +172,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_rbf.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_rbf.prm
@@ -97,13 +97,15 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/flow_around_torus.prm
+++ b/applications_tests/gls_sharp_navier_stokes/flow_around_torus.prm
@@ -154,13 +154,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/load_particles_from_file_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/load_particles_from_file_test.prm
@@ -230,13 +230,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-20
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
-  set max krylov vectors                    = 1000
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-20
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+    set max krylov vectors                    = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/minimal_crown_refinement.prm
+++ b/applications_tests/gls_sharp_navier_stokes/minimal_crown_refinement.prm
@@ -104,6 +104,8 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set method    = gmres
-  set verbosity = quiet
+  subsection fluid dynamics
+    set method    = gmres
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/moving_ib_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_ib_gls.prm
@@ -219,13 +219,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max krylov vectors                    = 250
-  set max iters                             = 1000
-  set relative residual                     = 1e-6
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max krylov vectors                    = 250
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/moving_ib_gls_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_ib_gls_poisson.prm
@@ -220,13 +220,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max krylov vectors                    = 250
-  set max iters                             = 1000
-  set relative residual                     = 1e-6
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max krylov vectors                    = 250
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/moving_rectangle.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_rectangle.prm
@@ -139,13 +139,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/moving_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_stokes.prm
@@ -308,21 +308,23 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 1000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-12
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-20
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
-  set max krylov vectors                        = 1000
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-12
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-20
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+    set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/moving_stokes_2d.prm
+++ b/applications_tests/gls_sharp_navier_stokes/moving_stokes_2d.prm
@@ -237,20 +237,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 1000
-  set relative residual                         = 1e-6
-  set minimum residual                          = 1e-9
-  set ilu preconditioner fill                   = 2
-  set ilu preconditioner absolute tolerance     = 1e-11
-  set ilu preconditioner relative tolerance     = 1
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 1000
+    set relative residual                         = 1e-6
+    set minimum residual                          = 1e-9
+    set ilu preconditioner fill                   = 2
+    set ilu preconditioner absolute tolerance     = 1e-11
+    set ilu preconditioner relative tolerance     = 1
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/opencascade/static_stokes_step.prm
+++ b/applications_tests/gls_sharp_navier_stokes/opencascade/static_stokes_step.prm
@@ -310,6 +310,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+subsection fluid dynamics
   set method                                    = gmres
   set max iters                                 = 1000
   set relative residual                         = 1e-3
@@ -327,4 +328,5 @@ subsection linear solver
   set amg w cycles                              = false
   set verbosity                                 = quiet
   set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/pp_contact_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/pp_contact_test.prm
@@ -255,21 +255,23 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 1000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-11
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-20
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
-  set max krylov vectors                        = 1000
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-11
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-20
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+    set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/pp_lubrication_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/pp_lubrication_test.prm
@@ -178,5 +178,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/pw_contact_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/pw_contact_test.prm
@@ -231,21 +231,23 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 1000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-11
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-20
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
-  set max krylov vectors                        = 1000
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-11
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-20
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+    set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/pw_lubrication_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/pw_lubrication_test.prm
@@ -231,21 +231,23 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 1000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-11
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-20
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
-  set max krylov vectors                        = 1000
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-11
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-20
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+    set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms.prm
+++ b/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms.prm
@@ -151,5 +151,7 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/gls_sharp_navier_stokes/rbf_sphere_mms_adaptive.prm
@@ -166,5 +166,7 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/sphere_mms_pressure_scaling.prm
+++ b/applications_tests/gls_sharp_navier_stokes/sphere_mms_pressure_scaling.prm
@@ -155,5 +155,7 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/sphere_power_law_ramp.prm
+++ b/applications_tests/gls_sharp_navier_stokes/sphere_power_law_ramp.prm
@@ -172,13 +172,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 100
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-6
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 100
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 100
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-6
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 100
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/spinning_cone.prm
+++ b/applications_tests/gls_sharp_navier_stokes/spinning_cone.prm
@@ -134,5 +134,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/spooky_composite_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/spooky_composite_test.prm
@@ -105,5 +105,7 @@ subsection timer
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/static_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes/static_stokes.prm
@@ -307,21 +307,23 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 1000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-12
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-20
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
-  set max krylov vectors                        = 1000
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-12
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-20
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+    set max krylov vectors                        = 1000
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/steady_couette_sphere.prm
+++ b/applications_tests/gls_sharp_navier_stokes/steady_couette_sphere.prm
@@ -196,20 +196,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 500
-  set relative residual                         = 1e-6
-  set minimum residual                          = 1e-9
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-10
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg aggregation threshold                 = 1e-20
-  set amg n cycles                              = 1
-  set amg preconditioner ilu absolute tolerance = 1e-20
-  set amg preconditioner ilu fill               = 2
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg smoother overlap                      = 1
-  set amg smoother sweeps                       = 2
-  set amg w cycles                              = false
-  set verbosity                                 = quiet
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 500
+    set relative residual                         = 1e-6
+    set minimum residual                          = 1e-9
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-10
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 2
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/steady_couette_sphere_poisson.prm
+++ b/applications_tests/gls_sharp_navier_stokes/steady_couette_sphere_poisson.prm
@@ -196,12 +196,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 500
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 500
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/gls_sharp_navier_stokes/taylorcouette2d_carreau_gls.prm
@@ -181,12 +181,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_sharp_navier_stokes/tube_shape_test.prm
+++ b/applications_tests/gls_sharp_navier_stokes/tube_shape_test.prm
@@ -106,5 +106,7 @@ subsection timer
 end
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/gls_vans/beetstra_packed_bed.prm
+++ b/applications_tests/gls_vans/beetstra_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/case0_vans.prm
+++ b/applications_tests/gls_vans/case0_vans.prm
@@ -113,12 +113,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_vans/case1_vans.prm
+++ b/applications_tests/gls_vans/case1_vans.prm
@@ -119,12 +119,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_vans/case1_vans_weak.prm
+++ b/applications_tests/gls_vans/case1_vans_weak.prm
@@ -127,12 +127,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_vans/case2_vans.prm
+++ b/applications_tests/gls_vans/case2_vans.prm
@@ -153,12 +153,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_vans/case3_vans.prm
+++ b/applications_tests/gls_vans/case3_vans.prm
@@ -134,12 +134,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = quiet
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = quiet
+  end
 end

--- a/applications_tests/gls_vans/dallavalle_packed_bed.prm
+++ b/applications_tests/gls_vans/dallavalle_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/difelice_packed_bed.prm
+++ b/applications_tests/gls_vans/difelice_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/gidaspow_packed_bed.prm
+++ b/applications_tests/gls_vans/gidaspow_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/kochhill_packed_bed.prm
+++ b/applications_tests/gls_vans/kochhill_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/pcm_packed_bed.prm
+++ b/applications_tests/gls_vans/pcm_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/qcm_packed_bed.prm
+++ b/applications_tests/gls_vans/qcm_packed_bed.prm
@@ -169,13 +169,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-2
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-11
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-2
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/rong_packed_bed.prm
+++ b/applications_tests/gls_vans/rong_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/gls_vans/spm_packed_bed.prm
+++ b/applications_tests/gls_vans/spm_packed_bed.prm
@@ -168,13 +168,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-12
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = quiet
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-12
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
+    set max krylov vectors                    = 500
+  end
 end

--- a/applications_tests/initial_conditions/initial_conditions.prm
+++ b/applications_tests/initial_conditions/initial_conditions.prm
@@ -32,7 +32,9 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
 end
 
 #---------------------------------------------------

--- a/applications_tests/mf_navier_stokes/mms2d_fe1.prm
+++ b/applications_tests/mf_navier_stokes/mms2d_fe1.prm
@@ -111,9 +111,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method            = gmres
-  set max iters         = 5000
-  set relative residual = 1e-4
-  set minimum residual  = 1e-9
-  set verbosity         = quiet
+  subsection fluid dynamics
+    set method            = gmres
+    set max iters         = 5000
+    set relative residual = 1e-4
+    set minimum residual  = 1e-9
+    set verbosity         = quiet
+  end
 end

--- a/applications_tests/mf_navier_stokes/mms2d_fe2.prm
+++ b/applications_tests/mf_navier_stokes/mms2d_fe2.prm
@@ -111,9 +111,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method            = gmres
-  set max iters         = 5000
-  set relative residual = 1e-4
-  set minimum residual  = 1e-9
-  set verbosity         = quiet
+  subsection fluid dynamics
+    set method            = gmres
+    set max iters         = 5000
+    set relative residual = 1e-4
+    set minimum residual  = 1e-9
+    set verbosity         = quiet
+  end
 end

--- a/applications_tests/mf_navier_stokes/mms3d_fe1.prm
+++ b/applications_tests/mf_navier_stokes/mms3d_fe1.prm
@@ -105,9 +105,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method            = gmres
-  set max iters         = 5000
-  set relative residual = 1e-4
-  set minimum residual  = 1e-9
-  set verbosity         = quiet
+  subsection fluid dynamics
+    set method            = gmres
+    set max iters         = 5000
+    set relative residual = 1e-4
+    set minimum residual  = 1e-9
+    set verbosity         = quiet
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/impeller.prm
+++ b/applications_tests/nitsche_navier_stokes/impeller.prm
@@ -110,12 +110,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/mixer_back_and_forth.prm
+++ b/applications_tests/nitsche_navier_stokes/mixer_back_and_forth.prm
@@ -146,12 +146,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/nitsche_heating_couette.prm
+++ b/applications_tests/nitsche_navier_stokes/nitsche_heating_couette.prm
@@ -156,5 +156,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/nitsche_heating_moving.prm
+++ b/applications_tests/nitsche_navier_stokes/nitsche_heating_moving.prm
@@ -139,5 +139,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/nitsche_heating_static.prm
+++ b/applications_tests/nitsche_navier_stokes/nitsche_heating_static.prm
@@ -138,5 +138,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = quiet
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection heat transfer
+    set verbosity = quiet
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/noslip33_simplex.prm
+++ b/applications_tests/nitsche_navier_stokes/noslip33_simplex.prm
@@ -143,20 +143,22 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                                 = quiet
-  set method                                    = gmres
-  set max iters                                 = 500
-  set max krylov vectors                        = 30
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-10
-  set ilu preconditioner fill                   = 3
-  set ilu preconditioner absolute tolerance     = 1e-12
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg preconditioner ilu fill               = 5
-  set amg preconditioner ilu absolute tolerance = 1e-6
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg n cycles                              = 1
-  set amg w cycles                              = false
-  set amg smoother sweeps                       = 2
-  set amg smoother overlap                      = 1
+  subsection fluid dynamics
+    set verbosity                                 = quiet
+    set method                                    = gmres
+    set max iters                                 = 500
+    set max krylov vectors                        = 30
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-10
+    set ilu preconditioner fill                   = 3
+    set ilu preconditioner absolute tolerance     = 1e-12
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg preconditioner ilu fill               = 5
+    set amg preconditioner ilu absolute tolerance = 1e-6
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg n cycles                              = 1
+    set amg w cycles                              = false
+    set amg smoother sweeps                       = 2
+    set amg smoother overlap                      = 1
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/noslip_22.prm
+++ b/applications_tests/nitsche_navier_stokes/noslip_22.prm
@@ -156,12 +156,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/noslip_33.prm
+++ b/applications_tests/nitsche_navier_stokes/noslip_33.prm
@@ -152,12 +152,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/poiseuille_22.prm
+++ b/applications_tests/nitsche_navier_stokes/poiseuille_22.prm
@@ -166,12 +166,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/poiseuille_two_solids_22.prm
+++ b/applications_tests/nitsche_navier_stokes/poiseuille_two_solids_22.prm
@@ -162,12 +162,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/taylor_couette_nitsche_22.prm
+++ b/applications_tests/nitsche_navier_stokes/taylor_couette_nitsche_22.prm
@@ -138,12 +138,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/two-bar-mixer-restart.prm
+++ b/applications_tests/nitsche_navier_stokes/two-bar-mixer-restart.prm
@@ -146,12 +146,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/applications_tests/nitsche_navier_stokes/two-bar-mixer-start.prm
+++ b/applications_tests/nitsche_navier_stokes/two-bar-mixer-start.prm
@@ -146,12 +146,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
+++ b/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
@@ -207,14 +207,16 @@ For :math:`Re < 700`, standard parameters are suitable to achieve convergence.
 .. code-block:: text
 
     subsection linear solver
-      set verbosity                             = verbose
-      set method                                = gmres
-      set max iters                             = 10000
-      set relative residual                     = 1e-4
-      set minimum residual                      = 1e-9
-      set ilu preconditioner fill               = 2
-      set ilu preconditioner absolute tolerance = 1e-12
-      set ilu preconditioner relative tolerance = 1.00
+      subsection fluid dynamics
+        set verbosity                             = verbose
+        set method                                = gmres
+        set max iters                             = 10000
+        set relative residual                     = 1e-4
+        set minimum residual                      = 1e-9
+        set ilu preconditioner fill               = 2
+        set ilu preconditioner absolute tolerance = 1e-12
+        set ilu preconditioner relative tolerance = 1.00
+      end
     end         
 	
 For :math:`Re \geq 700`, however, it is often necessary to set ``ilu precondtionner fill = 2`` in order to save calculation time. Also, adjusting ``max krylov vectors = 200`` can help to reach convergence.
@@ -222,15 +224,17 @@ For :math:`Re \geq 700`, however, it is often necessary to set ``ilu precondtion
 .. code-block:: text
 
     subsection linear solver
-      set verbosity                             = verbose
-      set method                                = gmres
-      set max iters                             = 10000
-      set relative residual                     = 1e-4
-      set minimum residual                      = 1e-9
-      set ilu preconditioner fill               = 2
-      set ilu preconditioner absolute tolerance = 1e-12
-      set ilu preconditioner relative tolerance = 1.00
-      set max krylov vectors                    = 200
+      subsection fluid dynamics
+        set verbosity                             = verbose
+        set method                                = gmres
+        set max iters                             = 10000
+        set relative residual                     = 1e-4
+        set minimum residual                      = 1e-9
+        set ilu preconditioner fill               = 2
+        set ilu preconditioner absolute tolerance = 1e-12
+        set ilu preconditioner relative tolerance = 1.00
+        set max krylov vectors                    = 200
+      end
     end
 	
 .. tip::

--- a/doc/source/examples/incompressible-flow/2d-lid‐driven-cavity-flow/lid‐driven-cavity-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-lid‐driven-cavity-flow/lid‐driven-cavity-flow.rst
@@ -175,8 +175,10 @@ Each non-linear solver step requires the solution of a linear system of equation
 .. code-block:: text
 
   subsection linear solver
-    set method    = amg
-    set verbosity = verbose
+    subsection fluid dynamics
+      set method    = amg
+      set verbosity = verbose
+    end
   end
 
 Simulation Control

--- a/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
+++ b/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
@@ -185,15 +185,17 @@ Again, in order to reduce the computational time, the ``minimum residual`` for t
 .. code-block:: text
 
     subsection linear solver
-      set verbosity                             = verbose
-      set method                                = gmres
-      set max iters                             = 5000
-      set relative residual                     = 1e-3
-      set minimum residual                      = 1e-8
-      set ilu preconditioner fill               = 1
-      set ilu preconditioner absolute tolerance = 1e-10
-      set ilu preconditioner relative tolerance = 1.00
-      set max krylov vectors                    = 1000
+      subsection fluid dynamics
+        set verbosity                             = verbose
+        set method                                = gmres
+        set max iters                             = 5000
+        set relative residual                     = 1e-3
+        set minimum residual                      = 1e-8
+        set ilu preconditioner fill               = 1
+        set ilu preconditioner absolute tolerance = 1e-10
+        set ilu preconditioner relative tolerance = 1.00
+        set max krylov vectors                    = 1000
+      end
     end      
 	
 	

--- a/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
@@ -163,13 +163,15 @@ For 2D problems, the AMG preconditioner is an adequate preconditioner. It is esp
 .. code-block:: text
 
   subsection linear solver
-    set verbosity                                 = verbose
-    set method                                    = amg
-    set relative residual                         = 1e-4
-    set minimum residual                          = 1e-8
-    set amg preconditioner ilu fill               = 0
-    set amg preconditioner ilu absolute tolerance = 1e-12
-    set amg preconditioner ilu relative tolerance = 1.00
+    subsection fluid dynamics
+      set verbosity                                 = verbose
+      set method                                    = amg
+      set relative residual                         = 1e-4
+      set minimum residual                          = 1e-8
+      set amg preconditioner ilu fill               = 0
+      set amg preconditioner ilu absolute tolerance = 1e-12
+      set amg preconditioner ilu relative tolerance = 1.00
+    end
   end
 
 

--- a/doc/source/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.rst
+++ b/doc/source/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.rst
@@ -228,20 +228,22 @@ Relatively standard parameters are used for the linear solver. From our experien
 .. code-block:: text
 
     subsection linear solver
-      set method                                    = amg
-      set max iters                                 = 100
-      set relative residual                         = 1e-4
-      set minimum residual                          = 1e-10
-      set amg preconditioner ilu fill               = 0
-      set amg preconditioner ilu absolute tolerance = 1e-11
-      set amg preconditioner ilu relative tolerance = 1.00
-      set amg aggregation threshold                 = 1e-14  # Aggregation
-      set amg n cycles                              = 2      # Number of AMG cycles
-      set amg w cycles                              = false  # W cycles, otherwise V cycles
-      set amg smoother sweeps                       = 2      # Sweeps
-      set amg smoother overlap                      = 1      # Overlap
-      set verbosity                                 = verbose
-      set max krylov vectors                        = 500
+      subsection fluid dynamics
+        set method                                    = amg
+        set max iters                                 = 100
+        set relative residual                         = 1e-4
+        set minimum residual                          = 1e-10
+        set amg preconditioner ilu fill               = 0
+        set amg preconditioner ilu absolute tolerance = 1e-11
+        set amg preconditioner ilu relative tolerance = 1.00
+        set amg aggregation threshold                 = 1e-14  # Aggregation
+        set amg n cycles                              = 2      # Number of AMG cycles
+        set amg w cycles                              = false  # W cycles, otherwise V cycles
+        set amg smoother sweeps                       = 2      # Sweeps
+        set amg smoother overlap                      = 1      # Overlap
+        set verbosity                                 = verbose
+        set max krylov vectors                        = 500
+      end
     end
 
 

--- a/doc/source/examples/incompressible-flow/3d-nitsche-mixer-with-pbt-impeller/nitsche-mixer-with-pbt-impeller.rst
+++ b/doc/source/examples/incompressible-flow/3d-nitsche-mixer-with-pbt-impeller/nitsche-mixer-with-pbt-impeller.rst
@@ -297,13 +297,15 @@ Relatively standard parameters are used for the :doc:`../../../parameters/cfd/li
 .. code-block:: text
 
     subsection linear solver
-      set method                                    = amg
-      set max iters                                 = 200
-      set minimum residual                          = 1e-7
-      set amg preconditioner ilu absolute tolerance = 1e-8
-      set amg preconditioner ilu relative tolerance = 2.00
-      set amg aggregation threshold                 = 1e-10  
-      set max krylov vectors                        = 200
+      subsection fluid dynamics
+        set method                                    = amg
+        set max iters                                 = 200
+        set minimum residual                          = 1e-7
+        set amg preconditioner ilu absolute tolerance = 1e-8
+        set amg preconditioner ilu relative tolerance = 2.00
+        set amg aggregation threshold                 = 1e-10  
+        set max krylov vectors                        = 200
+      end
     end
 
 

--- a/doc/source/examples/sharp-immersed-boundary-solver/sedimentation-1-particle/sedimentation-1-particle.rst
+++ b/doc/source/examples/sharp-immersed-boundary-solver/sedimentation-1-particle/sedimentation-1-particle.rst
@@ -236,15 +236,17 @@ Linear Solver
 .. code-block:: text
 
     subsection linear solver
-      set method                                = gmres
-      set max iters                             = 1000
-      set relative residual                     = 1e-4
-      set minimum residual                      = 1e-11
-      set ilu preconditioner fill               = 0
-      set ilu preconditioner absolute tolerance = 1e-20
-      set ilu preconditioner relative tolerance = 1.00
-      set verbosity                             = verbose
-      set max krylov vectors                    = 1000
+      subsection fluid dynamics
+        set method                                = gmres
+        set max iters                             = 1000
+        set relative residual                     = 1e-4
+        set minimum residual                      = 1e-11
+        set ilu preconditioner fill               = 0
+        set ilu preconditioner absolute tolerance = 1e-20
+        set ilu preconditioner relative tolerance = 1.00
+        set verbosity                             = verbose
+        set max krylov vectors                    = 1000
+      end
     end
 
 * The ``method`` is set to ``gmres``. This solver is less computationally expensive than the other option, and this case does not require any special preconditioner. This makes the ``gmres`` solver the best option available.

--- a/doc/source/examples/sharp-immersed-boundary-solver/sedimentation-64-particles/sedimentation-64-particles.rst
+++ b/doc/source/examples/sharp-immersed-boundary-solver/sedimentation-64-particles/sedimentation-64-particles.rst
@@ -207,14 +207,16 @@ Linear Solver
 .. code-block:: text
 
     subsection linear solver
-      set method                                = gmres
-      set max iters                             = 1000
-      set relative residual                     = 1e-4
-      set minimum residual                      = 1e-11
-      set ilu preconditioner fill               = 0
-      set ilu preconditioner absolute tolerance = 1e-6
-      set verbosity                             = verbose
-      set max krylov vectors                    = 1000
+      subsection fluid dynamics
+        set method                                = gmres
+        set max iters                             = 1000
+        set relative residual                     = 1e-4
+        set minimum residual                      = 1e-11
+        set ilu preconditioner fill               = 0
+        set ilu preconditioner absolute tolerance = 1e-6
+        set verbosity                             = verbose
+        set max krylov vectors                    = 1000
+      end
     end
 
 

--- a/doc/source/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.rst
+++ b/doc/source/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.rst
@@ -333,15 +333,17 @@ Linear Solver
 .. code-block:: text
 
     subsection linear solver
-      set method                                = gmres
-      set max iters                             = 5000
-      set relative residual                     = 1e-3
-      set minimum residual                      = 1e-10
-      set ilu preconditioner fill               = 0
-      set ilu preconditioner absolute tolerance = 1e-12
-      set ilu preconditioner relative tolerance = 1
-      set verbosity                             = verbose
-      set max krylov vectors                    = 200
+      subsection fluid dynamics
+        set method                                = gmres
+        set max iters                             = 5000
+        set relative residual                     = 1e-3
+        set minimum residual                      = 1e-10
+        set ilu preconditioner fill               = 0
+        set ilu preconditioner absolute tolerance = 1e-12
+        set ilu preconditioner relative tolerance = 1
+        set verbosity                             = verbose
+        set max krylov vectors                    = 200
+      end
     end
 
 For more information about the non-linear solver, please refer to the `Linear Solver Section <../../../parameters/cfd/linear_solver_control.html>`_

--- a/doc/source/examples/unresolved-cfd-dem/cylindrical-packed-bed/cylindrical-packed-bed.rst
+++ b/doc/source/examples/unresolved-cfd-dem/cylindrical-packed-bed/cylindrical-packed-bed.rst
@@ -345,14 +345,16 @@ Linear Solver
 .. code-block:: text
 
   subsection linear solver
-    set method                                = gmres
-    set max iters                             = 5000
-    set relative residual                     = 1e-3
-    set minimum residual                      = 1e-11
-    set ilu preconditioner fill               = 1
-    set ilu preconditioner absolute tolerance = 1e-14
-    set ilu preconditioner relative tolerance = 1.00
-    set verbosity                             = verbose
+    subsection fluid dynamics
+      set method                                = gmres
+      set max iters                             = 5000
+      set relative residual                     = 1e-3
+      set minimum residual                      = 1e-11
+      set ilu preconditioner fill               = 1
+      set ilu preconditioner absolute tolerance = 1e-14
+      set ilu preconditioner relative tolerance = 1.00
+      set verbosity                             = verbose
+    end
   end
 
 

--- a/doc/source/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.rst
+++ b/doc/source/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.rst
@@ -365,15 +365,17 @@ Linear Solver
 .. code-block:: text
 
     subsection linear solver
-      set method                                = gmres
-      set max iters                             = 5000
-      set relative residual                     = 1e-3
-      set minimum residual                      = 1e-11
-      set ilu preconditioner fill               = 1
-      set ilu preconditioner absolute tolerance = 1e-14
-      set ilu preconditioner relative tolerance = 1.00
-      set verbosity                             = verbose
-      set max krylov vectors                    = 200
+      subsection fluid dynamics
+        set method                                = gmres
+        set max iters                             = 5000
+        set relative residual                     = 1e-3
+        set minimum residual                      = 1e-11
+        set ilu preconditioner fill               = 1
+        set ilu preconditioner absolute tolerance = 1e-14
+        set ilu preconditioner relative tolerance = 1.00
+        set verbosity                             = verbose
+        set max krylov vectors                    = 200
+      end
     end
 
 

--- a/doc/source/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.rst
+++ b/doc/source/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.rst
@@ -378,14 +378,16 @@ Linear Solver
 .. code-block:: text
 
     subsection linear solver
-      set method                                = gmres
-      set max iters                             = 1000
-      set relative residual                     = 1e-3
-      set minimum residual                      = 1e-10
-      set ilu preconditioner fill               = 1
-      set ilu preconditioner absolute tolerance = 1e-12
-      set ilu preconditioner relative tolerance = 1
-      set verbosity                             = verbose
+      subsection fluid dynamics
+        set method                                = gmres
+        set max iters                             = 1000
+        set relative residual                     = 1e-3
+        set minimum residual                      = 1e-10
+        set ilu preconditioner fill               = 1
+        set ilu preconditioner absolute tolerance = 1e-12
+        set ilu preconditioner relative tolerance = 1
+        set verbosity                             = verbose
+      end
     end
 
 For more information about the non-linear solver, please refer to the `Linear Solver Section <../../../parameters/cfd/linear_solver_control.html>`_

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -1,77 +1,79 @@
-=====================
-Linear Solver Control
-=====================
+=============
+Linear Solver
+=============
 
-In this subsection, the control options of linear solvers are specified. These control options may include solution method, maximum number of iterations, tolerance, residual precision and preconditioner information. The default values for these parameters are given in the text box below.
+In this subsection, the control options of the linear solvers are specified. The default values for the linear solver parameters are given in the text box below. Lethe supports different physics (``fluid dynamics``, ``VOF``, ``heat transfer``, ``cahn hilliard`` and ``tracer``) and it is possible to specify linear solver parameters for each of them. In the example below, only ``fluid dynamics`` is used but the same block can be used for other physics.
 
 .. seealso::
-	For further understanding about the numerical method used and advanced parameters, the interested reader is referred to the Theory Documentation.
+	For further understanding about the linear solvers used, the preconditioners supported and all parameters, see the :doc:`../../theory/fluid_dynamics/linear_solvers` theory section.
 
 .. code-block:: text
 
   subsection linear solver
-    # Iterative solver for the linear system of equations
-    set method                                    = gmres
+    subsection fluid dynamics
+      # Iterative solver for the linear system of equations
+      set method                                    = gmres
 
-    # State whether information from the linear solver should be printed
-    set verbosity                                 = verbose
+      # State whether information from the linear solver should be printed
+      set verbosity                                 = verbose
 
-    # Linear solver minimum residual
-    set minimum residual                          = 1e-12
+      # Linear solver minimum residual
+      set minimum residual                          = 1e-12
 
-    # Linear solver residual
-    set relative residual                         = 1e-3
+      # Linear solver residual
+      set relative residual                         = 1e-3
 
-    # Maximum solver iterations
-    set max iters                                 = 1000
+      # Maximum solver iterations
+      set max iters                                 = 1000
 
-    # Force the linear solver to continue even if it fails
-    set force linear solver continuation          = false
+      # Force the linear solver to continue even if it fails
+      set force linear solver continuation          = false
 
-    # Maximum number of krylov vectors for GMRES and AMG solvers
-    set max krylov vectors                        = 100
+      # Maximum number of krylov vectors for GMRES and AMG solvers
+      set max krylov vectors                        = 100
 
-    #-------------------------------------------------------------
-    # ILU preconditioner parameters for GMRES and BICGSTAB solvers
-    #-------------------------------------------------------------
-    # ILU preconditioner fill
-    set ilu preconditioner fill                   = 0
+      #-------------------------------------------------------------
+      # ILU preconditioner parameters for GMRES and BICGSTAB solvers
+      #-------------------------------------------------------------
+      # ILU preconditioner fill
+      set ilu preconditioner fill                   = 0
 
-    # ILU preconditioner tolerance
-    set ilu preconditioner absolute tolerance     = 1e-12
+      # ILU preconditioner tolerance
+      set ilu preconditioner absolute tolerance     = 1e-12
 
-    # ILU relative tolerance
-    set ilu preconditioner relative tolerance     = 1.00
+      # ILU relative tolerance
+      set ilu preconditioner relative tolerance     = 1.00
 
-    #---------------------------------------------------------
-    # ILU smoother/coarsener parameters for AMG preconditioner
-    #---------------------------------------------------------
-    # AMG preconditioner ILU smoother/coarsener fill
-    set amg preconditioner ilu fill               = 0
+      #---------------------------------------------------------
+      # ILU smoother/coarsener parameters for AMG preconditioner
+      #---------------------------------------------------------
+      # AMG preconditioner ILU smoother/coarsener fill
+      set amg preconditioner ilu fill               = 0
 
-    # AMG preconditioner ILU smoother/coarsener absolute tolerance
-    set amg preconditioner ilu absolute tolerance = 1e-12
+      # AMG preconditioner ILU smoother/coarsener absolute tolerance
+      set amg preconditioner ilu absolute tolerance = 1e-12
 
-    # AMG preconditioner ILU smoother/coarsener relative tolerance
-    set amg preconditioner ilu relative tolerance = 1.00
+      # AMG preconditioner ILU smoother/coarsener relative tolerance
+      set amg preconditioner ilu relative tolerance = 1.00
 
-    #---------------------------------------------------
-    # other AMG solver parameters
-    #---------------------------------------------------
-    # AMG aggregation threshold
-    set amg aggregation threshold                 = 1e-14
+      #---------------------------------------------------
+      # other AMG solver parameters
+      #---------------------------------------------------
+      # AMG aggregation threshold
+      set amg aggregation threshold                 = 1e-14
 
-    # AMG number of cycles
-    set amg n cycles                              = 1
+      # AMG number of cycles
+      set amg n cycles                              = 1
 
-    # AMG w cycling. If this is set to true, W cycling is used. Otherwise, V cycling is used.
-    set amg w cycles                              = false
+      # AMG w cycling. If this is set to true, W cycling is used. Otherwise, V cycling is used.
+      set amg w cycles                              = false
 
-    # AMG smoother sweeps
-    set amg smoother sweeps                       = 2
+      # AMG smoother sweeps
+      set amg smoother sweeps                       = 2
 
-    # amg smoother overlap
-    set amg smoother overlap                      = 1
+      # amg smoother overlap
+      set amg smoother overlap                      = 1
+    end
   end
 
 

--- a/examples/incompressible-flow/2d-ahmed-body-simplex/ahmed.prm
+++ b/examples/incompressible-flow/2d-ahmed-body-simplex/ahmed.prm
@@ -113,13 +113,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/incompressible-flow/2d-ahmed-body/ahmed.prm
+++ b/examples/incompressible-flow/2d-ahmed-body/ahmed.prm
@@ -120,13 +120,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/incompressible-flow/2d-backward-facing-step/Reynolds100-600/2D-backward-facing-step-steady.prm
+++ b/examples/incompressible-flow/2d-backward-facing-step/Reynolds100-600/2D-backward-facing-step-steady.prm
@@ -6,7 +6,6 @@
 #---------------------------------------------------
 
 
-
 subsection simulation control
   set method            = steady
   set number mesh adapt = 10
@@ -94,12 +93,14 @@ subsection simulation control
                           #---------------------------------------------------
                           
                           subsection linear solver
-                            set verbosity                             = verbose
-                            set method                                = gmres
-                            set max iters                             = 10000
-                            set relative residual                     = 1e-4
-                            set minimum residual                      = 1e-9
-                            set ilu preconditioner fill               = 2
-                            set ilu preconditioner absolute tolerance = 1e-12
-                            set ilu preconditioner relative tolerance = 1.00
-                          end 
+                            subsection fluid dynamics
+                              set verbosity                             = verbose
+                              set method                                = gmres
+                              set max iters                             = 10000
+                              set relative residual                     = 1e-4
+                              set minimum residual                      = 1e-9
+                              set ilu preconditioner fill               = 2
+                              set ilu preconditioner absolute tolerance = 1e-12
+                              set ilu preconditioner relative tolerance = 1.00
+                              end
+                            end 

--- a/examples/incompressible-flow/2d-backward-facing-step/Reynolds700-1000/2D-backward-facing-step-steadybdf.prm
+++ b/examples/incompressible-flow/2d-backward-facing-step/Reynolds700-1000/2D-backward-facing-step-steadybdf.prm
@@ -6,6 +6,7 @@
 #---------------------------------------------------
 
 
+
 subsection simulation control
   set method                       = steady_bdf
   set stop tolerance               = 1e-6
@@ -111,13 +112,15 @@ subsection simulation control
                             #---------------------------------------------------
                             
                             subsection linear solver
-                              set verbosity                             = verbose
-                              set method                                = gmres
-                              set max iters                             = 10000
-                              set relative residual                     = 1e-4
-                              set minimum residual                      = 1e-9
-                              set ilu preconditioner fill               = 2
-                              set ilu preconditioner absolute tolerance = 1e-12
-                              set ilu preconditioner relative tolerance = 1.00
-                              set max krylov vectors                    = 200
-                              end
+                              subsection fluid dynamics
+                                set verbosity                             = verbose
+                                set method                                = gmres
+                                set max iters                             = 10000
+                                set relative residual                     = 1e-4
+                                set minimum residual                      = 1e-9
+                                set ilu preconditioner fill               = 2
+                                set ilu preconditioner absolute tolerance = 1e-12
+                                set ilu preconditioner relative tolerance = 1.00
+                                set max krylov vectors                    = 200
+                                end
+                                end

--- a/examples/incompressible-flow/2d-flow-around-cylinder/cylinder.prm
+++ b/examples/incompressible-flow/2d-flow-around-cylinder/cylinder.prm
@@ -147,12 +147,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/2d-lid-driven-cavity/Reynolds_7500/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/Reynolds_7500/cavity.prm
@@ -98,6 +98,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+subsection fluid dynamics
   set method                  = gmres
   set ilu preconditioner fill = 2
   set verbosity               = verbose

--- a/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
@@ -93,5 +93,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity = verbose
+  subsection fluid dynamics
+    set verbosity = verbose
+  end
 end

--- a/examples/incompressible-flow/2d-naca0012-low-reynolds/naca.prm
+++ b/examples/incompressible-flow/2d-naca0012-low-reynolds/naca.prm
@@ -174,13 +174,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 1000
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 1000
+  end
 end

--- a/examples/incompressible-flow/2d-nitsche-taylor-couette/adaptative-nitsche-taylor-couette.prm
+++ b/examples/incompressible-flow/2d-nitsche-taylor-couette/adaptative-nitsche-taylor-couette.prm
@@ -148,15 +148,17 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                                 = verbose
-  set method                                    = amg
-  set max iters                                 = 500
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-10
-  set ilu preconditioner fill                   = 3
-  set ilu preconditioner absolute tolerance     = 1e-12
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-12
-  set amg preconditioner ilu relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                                 = verbose
+    set method                                    = amg
+    set max iters                                 = 500
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-10
+    set ilu preconditioner fill                   = 3
+    set ilu preconditioner absolute tolerance     = 1e-12
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-12
+    set amg preconditioner ilu relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/2d-nitsche-taylor-couette/uniform-nitsche-taylor-couette.prm
+++ b/examples/incompressible-flow/2d-nitsche-taylor-couette/uniform-nitsche-taylor-couette.prm
@@ -139,15 +139,17 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                                 = verbose
-  set method                                    = amg
-  set max iters                                 = 500
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-10
-  set ilu preconditioner fill                   = 3
-  set ilu preconditioner absolute tolerance     = 1e-12
-  set ilu preconditioner relative tolerance     = 1.00
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-12
-  set amg preconditioner ilu relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                                 = verbose
+    set method                                    = amg
+    set max iters                                 = 500
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-10
+    set ilu preconditioner fill                   = 3
+    set ilu preconditioner absolute tolerance     = 1e-12
+    set ilu preconditioner relative tolerance     = 1.00
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-12
+    set amg preconditioner ilu relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
+++ b/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
@@ -115,17 +115,19 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 1
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = true  # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = verbose
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = verbose
+  end
 end

--- a/examples/incompressible-flow/2d-transient-flow-around-cylinder/cylinder.prm
+++ b/examples/incompressible-flow/2d-transient-flow-around-cylinder/cylinder.prm
@@ -159,11 +159,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                                 = verbose
-  set method                                    = amg
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-8
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-12
-  set amg preconditioner ilu relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                                 = verbose
+    set method                                    = amg
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-8
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-12
+    set amg preconditioner ilu relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-0.1.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-0.1.prm
@@ -129,12 +129,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
@@ -143,12 +143,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
@@ -150,12 +150,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/incompressible-flow/3d-nitsche-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/incompressible-flow/3d-nitsche-mixer-with-pbt-impeller/mixer.prm
@@ -141,11 +141,13 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 200
-  set minimum residual                          = 1e-7
-  set amg preconditioner ilu absolute tolerance = 1e-8
-  set amg preconditioner ilu relative tolerance = 2.00
-  set amg aggregation threshold                 = 1e-10
-  set max krylov vectors                        = 200
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 200
+    set minimum residual                          = 1e-7
+    set amg preconditioner ilu absolute tolerance = 1e-8
+    set amg preconditioner ilu relative tolerance = 2.00
+    set amg aggregation threshold                 = 1e-10
+    set max krylov vectors                        = 200
+  end
 end

--- a/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
+++ b/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
@@ -138,13 +138,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-9
-  set max krylov vectors                    = 200
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = verbose
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-9
+    set max krylov vectors                    = 200
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = verbose
+  end
 end

--- a/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
@@ -172,19 +172,21 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 5000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = false # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = verbose
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-10
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 5000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = false # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = verbose
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-10
+  end
 end

--- a/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/ribbon-gls.prm
@@ -105,18 +105,20 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-10
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-11
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 2     # Number of AMG cycles
-  set amg w cycles                              = false # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = verbose
-  set max krylov vectors                        = 500
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-10
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-11
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 2     # Number of AMG cycles
+    set amg w cycles                              = false # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = verbose
+    set max krylov vectors                        = 500
+  end
 end

--- a/examples/incompressible-flow/3d-ribbon-mixer-srf/Re1/ribbon-gls-Re1.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-srf/Re1/ribbon-gls-Re1.prm
@@ -105,18 +105,20 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = amg
-  set max iters                                 = 100
-  set relative residual                         = 1e-4
-  set minimum residual                          = 1e-10
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-11
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 2     # Number of AMG cycles
-  set amg w cycles                              = false # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = verbose
-  set max krylov vectors                        = 500
+  subsection fluid dynamics
+    set method                                    = amg
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-10
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-11
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 2     # Number of AMG cycles
+    set amg w cycles                              = false # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = verbose
+    set max krylov vectors                        = 500
+  end
 end

--- a/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
@@ -146,19 +146,21 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                    = gmres
-  set max iters                                 = 5000
-  set relative residual                         = 1e-3
-  set minimum residual                          = 1e-11
-  set amg preconditioner ilu fill               = 0
-  set amg preconditioner ilu absolute tolerance = 1e-10
-  set amg preconditioner ilu relative tolerance = 1.00
-  set amg aggregation threshold                 = 1e-14 # Aggregation
-  set amg n cycles                              = 1     # Number of AMG cycles
-  set amg w cycles                              = false # W cycles, otherwise V cycles
-  set amg smoother sweeps                       = 2     # Sweeps
-  set amg smoother overlap                      = 1     # Overlap
-  set verbosity                                 = verbose
-  set ilu preconditioner fill                   = 0
-  set ilu preconditioner absolute tolerance     = 1e-10
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 5000
+    set relative residual                         = 1e-3
+    set minimum residual                          = 1e-11
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = false # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = verbose
+    set ilu preconditioner fill                   = 0
+    set ilu preconditioner absolute tolerance     = 1e-10
+  end
 end

--- a/examples/multiphysics/3d-dam-break/3d-dam-break.prm
+++ b/examples/multiphysics/3d-dam-break/3d-dam-break.prm
@@ -168,13 +168,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set max krylov vectors                    = 750
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set max krylov vectors                    = 750
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set max krylov vectors                    = 750
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/air-bubble-compression/air-bubble-compression.prm
+++ b/examples/multiphysics/air-bubble-compression/air-bubble-compression.prm
@@ -202,13 +202,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 2
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 500
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 500
+  end
 end

--- a/examples/multiphysics/cahn_hilliard/chns.prm
+++ b/examples/multiphysics/cahn_hilliard/chns.prm
@@ -175,13 +175,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 20000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 2000
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 20000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 2000
+  end
+  subsection cahn hilliard
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 20000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 2000
+  end
 end

--- a/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.prm
+++ b/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.prm
@@ -173,13 +173,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-7
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = verbose
-  set max krylov vectors                    = 1000
-  set max iters                             = 2000
+  subsection fluid dynamics
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-7
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = verbose
+    set max krylov vectors                    = 1000
+    set max iters                             = 2000
+  end
+  subsection heat transfer
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-7
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = verbose
+    set max krylov vectors                    = 1000
+    set max iters                             = 2000
+  end
 end

--- a/examples/multiphysics/dam-break/dam-break-Martin-and-Moyce.prm
+++ b/examples/multiphysics/dam-break/dam-break-Martin-and-Moyce.prm
@@ -169,13 +169,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-5
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/multiphysics/laser-heating/laser-heating.prm
+++ b/examples/multiphysics/laser-heating/laser-heating.prm
@@ -140,13 +140,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/multiphysics/laser-meltpool/laser-meltpool.prm
+++ b/examples/multiphysics/laser-meltpool/laser-meltpool.prm
@@ -207,13 +207,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 10000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 10000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection heat transfer
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 10000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/multiphysics/melting-cavity/melting-cavity.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity.prm
@@ -171,12 +171,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 10000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-10
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 10000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 10000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
@@ -165,12 +165,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-6
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra25k.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra25k.prm
@@ -165,12 +165,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-6
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
@@ -192,13 +192,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max krylov vectors                    = 500
-  set max iters                             = 1000
-  set relative residual                     = 1e-5
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-constant-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-constant-sharpening.prm
@@ -173,13 +173,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max krylov vectors                    = 500
-  set max iters                             = 1000
-  set relative residual                     = 1e-5
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max krylov vectors                    = 500
+    set max iters                             = 1000
+    set relative residual                     = 1e-5
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/rising-bubble/rising-bubble.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble.prm
@@ -200,13 +200,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 8000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-7
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 8000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-7
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
@@ -162,10 +162,20 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity          = verbose
-  set method             = amg
-  set max krylov vectors = 200
-  set max iters          = 200
-  set relative residual  = 1e-5
-  set minimum residual   = 1e-9
+  subsection fluid dynamics
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
+  subsection VOF
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
 end

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
@@ -162,10 +162,20 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity          = verbose
-  set method             = amg
-  set max krylov vectors = 200
-  set max iters          = 200
-  set relative residual  = 1e-5
-  set minimum residual   = 1e-9
+  subsection fluid dynamics
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
+  subsection VOF
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
 end

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
@@ -162,10 +162,20 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity          = verbose
-  set method             = amg
-  set max krylov vectors = 200
-  set max iters          = 200
-  set relative residual  = 1e-5
-  set minimum residual   = 1e-9
+  subsection fluid dynamics
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
+  subsection VOF
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
 end

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
@@ -163,10 +163,20 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity          = verbose
-  set method             = amg
-  set max krylov vectors = 200
-  set max iters          = 200
-  set relative residual  = 1e-5
-  set minimum residual   = 1e-9
+  subsection fluid dynamics
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
+  subsection VOF
+    set verbosity          = verbose
+    set method             = amg
+    set max krylov vectors = 200
+    set max iters          = 200
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+  end
 end

--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -155,8 +155,16 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity         = verbose
-  set method            = gmres
-  set relative residual = 1e-3
-  set minimum residual  = 1e-10
+  subsection fluid dynamics
+    set verbosity         = verbose
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+  end
+  subsection fVOF
+    set verbosity         = verbose
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+  end
 end

--- a/examples/multiphysics/stefan-problem/stefan.prm
+++ b/examples/multiphysics/stefan-problem/stefan.prm
@@ -122,12 +122,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-13
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection heat transfer
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-13
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/tracer-through-cad-junction/tracer-through-cad-junction.prm
+++ b/examples/multiphysics/tracer-through-cad-junction/tracer-through-cad-junction.prm
@@ -129,9 +129,18 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method            = gmres
-  set max iters         = 5000
-  set relative residual = 1e-3
-  set minimum residual  = 1e-8
-  set verbosity         = verbose
+  subsection fluid dynamics
+    set method            = gmres
+    set max iters         = 5000
+    set relative residual = 1e-3
+    set minimum residual  = 1e-8
+    set verbosity         = verbose
+  end
+  subsection tracer
+    set method            = gmres
+    set max iters         = 5000
+    set relative residual = 1e-3
+    set minimum residual  = 1e-8
+    set verbosity         = verbose
+  end
 end

--- a/examples/multiphysics/warming-up-viscous-fluid/warming-up-viscous-fluid.prm
+++ b/examples/multiphysics/warming-up-viscous-fluid/warming-up-viscous-fluid.prm
@@ -154,12 +154,24 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = quiet
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-13
-  set minimum residual                      = 1e-14
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.prm
+++ b/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.prm
@@ -173,13 +173,26 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-6
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
-  set max krylov vectors                    = 500
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-6
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 500
+  end
+  subsection VOF
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-6
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 500
+  end
 end

--- a/examples/sharp-immersed-boundary-solver/3d-composite-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary-solver/3d-composite-mixer-with-pbt-impeller/mixer.prm
@@ -122,10 +122,12 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set method             = gmres
-  set max iters          = 1000
-  set verbosity          = verbose
-  set relative residual  = 1e-3
-  set minimum residual   = 1e-8
-  set max krylov vectors = 500
+  subsection fluid dynamics
+    set method             = gmres
+    set max iters          = 1000
+    set verbosity          = verbose
+    set relative residual  = 1e-3
+    set minimum residual   = 1e-8
+    set max krylov vectors = 500
+  end
 end

--- a/examples/sharp-immersed-boundary-solver/3d-opencascade-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary-solver/3d-opencascade-mixer-with-pbt-impeller/mixer.prm
@@ -121,10 +121,12 @@ subsection non-linear solver
 end
 
 subsection linear solver
-  set method             = gmres
-  set max iters          = 1000
-  set verbosity          = verbose
-  set relative residual  = 1e-3
-  set minimum residual   = 1e-8
-  set max krylov vectors = 500
+  subsection fluid dynamics
+    set method             = gmres
+    set max iters          = 1000
+    set verbosity          = verbose
+    set relative residual  = 1e-3
+    set minimum residual   = 1e-8
+    set max krylov vectors = 500
+  end
 end

--- a/examples/sharp-immersed-boundary-solver/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary-solver/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
@@ -160,13 +160,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 5000
-  set max krylov vectors                    = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-9
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 5000
+    set max krylov vectors                    = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/sharp-immersed-boundary-solver/sedimentation-1-particle/sedimentation-1-particle.prm
+++ b/examples/sharp-immersed-boundary-solver/sedimentation-1-particle/sedimentation-1-particle.prm
@@ -205,13 +205,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-20
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = verbose
-  set max krylov vectors                    = 100
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-20
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = verbose
+    set max krylov vectors                    = 100
+  end
 end

--- a/examples/sharp-immersed-boundary-solver/sedimentation-64-particles/sedimentation-64-particles.prm
+++ b/examples/sharp-immersed-boundary-solver/sedimentation-64-particles/sedimentation-64-particles.prm
@@ -201,12 +201,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-4
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-6
-  set verbosity                             = verbose
-  set max krylov vectors                    = 1000
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-6
+    set verbosity                             = verbose
+    set max krylov vectors                    = 1000
+  end
 end

--- a/examples/sharp-immersed-boundary-solver/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary-solver/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
@@ -213,12 +213,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set verbosity                             = verbose
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-8
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1.00
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
 end

--- a/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.prm
+++ b/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.prm
@@ -248,13 +248,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 0
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = verbose
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = verbose
+    set max krylov vectors                    = 200
+  end
 end

--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
@@ -147,12 +147,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = verbose
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = verbose
+  end
 end

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
@@ -229,12 +229,14 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 5000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-11
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-14
-  set ilu preconditioner relative tolerance = 1.00
-  set verbosity                             = verbose
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-11
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+    set verbosity                             = verbose
+  end
 end

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.prm
@@ -282,13 +282,15 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  set method                                = gmres
-  set max iters                             = 1000
-  set relative residual                     = 1e-3
-  set minimum residual                      = 1e-10
-  set ilu preconditioner fill               = 1
-  set ilu preconditioner absolute tolerance = 1e-12
-  set ilu preconditioner relative tolerance = 1
-  set verbosity                             = verbose
-  set max krylov vectors                    = 200
+  subsection fluid dynamics
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = verbose
+    set max krylov vectors                    = 200
+  end
 end

--- a/include/core/multiphysics.h
+++ b/include/core/multiphysics.h
@@ -35,4 +35,24 @@ enum PhysicsID : unsigned int
   cahn_hilliard  = 4
 };
 
+/**
+ * @brief Utility function used for parsing physics-based
+ * parameters
+ *
+ */
+inline PhysicsID
+get_physics_id(std::string physics_name)
+{
+  if (physics_name == "fluid dynamics")
+    return PhysicsID::fluid_dynamics;
+  else if (physics_name == "heat transfer")
+    return PhysicsID::heat_transfer;
+  else if (physics_name == "tracer")
+    return PhysicsID::tracer;
+  else if (physics_name == "VOF")
+    return PhysicsID::VOF;
+  else
+    return PhysicsID::cahn_hilliard;
+}
+
 #endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -879,8 +879,8 @@ namespace Parameters
   };
 
   /**
-   * @brief LinearSolver - Parameters that controls the solution of the
-   * linear system of equations that arise from the finite element problem.
+   * @brief LinearSolver - Parameters that control the solution of the
+   * linear system of equations that arise from the finite element problem for each of the physics available in Lethe
    */
   struct LinearSolver
   {
@@ -892,113 +892,61 @@ namespace Parameters
       amg,
       direct
     };
-    SolverType solver;
 
-    Verbosity verbosity;
-
-    // Relative residual of the iterative solver
-    double relative_residual;
-
-    // Minimum residual of the iterative solver
-    double minimum_residual;
-
-    // Maximum number of iterations
-    int max_iterations;
-
-    // Maximum number of krylov vectors
-    int max_krylov_vectors;
-
-    // ILU or ILUT fill
-    double ilu_precond_fill;
-
-    // ILU or ILUT absolute tolerance
-    double ilu_precond_atol;
-
-    // ILU or ILUT relative tolerance
-    double ilu_precond_rtol;
-
-    // ILU or ILUT fill
-    double amg_precond_ilu_fill;
-
-    // ILU or ILUT absolute tolerance
-    double amg_precond_ilu_atol;
-
-    // ILU or ILUT relative tolerance
-    double amg_precond_ilu_rtol;
-
-    // AMG aggregation threshold
-    double amg_aggregation_threshold;
-
-    // AMG number of cycles
-    unsigned int amg_n_cycles;
-
-    // AMG W_cycle
-    bool amg_w_cycles;
-
-    // AMG Smoother sweeps
-    unsigned int amg_smoother_sweeps;
-
-    // AMG Smoother overalp
-    unsigned int amg_smoother_overlap;
-
-    // Block linear solver to throw error.
-    bool force_linear_solver_continuation;
-
-    // Maps of parameters to account for the different physics
-
+    // Create maps for the parameters of different physics
     // Type of linear solver
-    std::map<PhysicsID, SolverType> _solver;
+    std::map<PhysicsID, SolverType> solver;
 
     // Verbosity
-    std::map<PhysicsID, Verbosity> _verbosity;
+    std::map<PhysicsID, Verbosity> verbosity;
 
     // Relative residuals of the iterative solver
-    std::map<PhysicsID, double> _relative_residual;
+    std::map<PhysicsID, double> relative_residual;
 
     // Minimum residual of the iterative solver
-    std::map<PhysicsID, double> _minimum_residual;
+    std::map<PhysicsID, double> minimum_residual;
 
     // Maximum number of iterations
-    std::map<PhysicsID, int> _max_iterations;
+    std::map<PhysicsID, int> max_iterations;
 
     // Maximum number of krylov vectors
-    std::map<PhysicsID, int> _max_krylov_vectors;
+    std::map<PhysicsID, int> max_krylov_vectors;
 
     // ILU or ILUT fill
-    std::map<PhysicsID, double> _ilu_precond_fill;
+    std::map<PhysicsID, double> ilu_precond_fill;
 
     // ILU or ILUT absolute tolerance
-    std::map<PhysicsID, double> _ilu_precond_atol;
+    std::map<PhysicsID, double> ilu_precond_atol;
 
     // ILU or ILUT relative tolerance
-    std::map<PhysicsID, double> _ilu_precond_rtol;
+    std::map<PhysicsID, double> ilu_precond_rtol;
 
     // ILU or ILUT fill
-    std::map<PhysicsID, double> _amg_precond_ilu_fill;
+    std::map<PhysicsID, double> amg_precond_ilu_fill;
 
     // ILU or ILUT absolute tolerance
-    std::map<PhysicsID, double> _amg_precond_ilu_atol;
+    std::map<PhysicsID, double> amg_precond_ilu_atol;
 
     // ILU or ILUT relative tolerance
-    std::map<PhysicsID, double> _amg_precond_ilu_rtol;
+    std::map<PhysicsID, double> amg_precond_ilu_rtol;
 
     // AMG aggregation threshold
-    std::map<PhysicsID, double> _amg_aggregation_threshold;
+    std::map<PhysicsID, double> amg_aggregation_threshold;
 
     // AMG number of cycles
-    std::map<PhysicsID, int> _amg_n_cycles;
+    std::map<PhysicsID, int> amg_n_cycles;
 
     // AMG W_cycle
-    std::map<PhysicsID, bool> _amg_w_cycles;
+    std::map<PhysicsID, bool> amg_w_cycles;
 
     // AMG Smoother sweeps
-    std::map<PhysicsID, int> _amg_smoother_sweeps;
+    std::map<PhysicsID, int> amg_smoother_sweeps;
 
     // AMG Smoother overalp
-    std::map<PhysicsID, int> _amg_smoother_overlap;
+    std::map<PhysicsID, int> amg_smoother_overlap;
 
     // Block linear solver to throw error.
-    std::map<PhysicsID, bool> _force_linear_solver_continuation;
+    std::map<PhysicsID, bool> force_linear_solver_continuation;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -880,7 +880,8 @@ namespace Parameters
 
   /**
    * @brief LinearSolver - Parameters that control the solution of the
-   * linear system of equations that arise from the finite element problem for each of the physics available in Lethe
+   * linear system of equations that arise from the finite element problem for
+   * each of the physics available in Lethe
    */
   struct LinearSolver
   {
@@ -893,65 +894,63 @@ namespace Parameters
       direct
     };
 
-    // Create maps for the parameters of different physics
-    // Type of linear solver
-    std::map<PhysicsID, SolverType> solver;
+    SolverType solver;
 
-    // Verbosity
-    std::map<PhysicsID, Verbosity> verbosity;
+    // Verbosity of linear solver
+    Verbosity verbosity;
 
     // Relative residuals of the iterative solver
-    std::map<PhysicsID, double> relative_residual;
+    double relative_residual;
 
     // Minimum residual of the iterative solver
-    std::map<PhysicsID, double> minimum_residual;
+    double minimum_residual;
 
     // Maximum number of iterations
-    std::map<PhysicsID, int> max_iterations;
+    int max_iterations;
 
     // Maximum number of krylov vectors
-    std::map<PhysicsID, int> max_krylov_vectors;
+    int max_krylov_vectors;
 
     // ILU or ILUT fill
-    std::map<PhysicsID, double> ilu_precond_fill;
+    double ilu_precond_fill;
 
     // ILU or ILUT absolute tolerance
-    std::map<PhysicsID, double> ilu_precond_atol;
+    double ilu_precond_atol;
 
     // ILU or ILUT relative tolerance
-    std::map<PhysicsID, double> ilu_precond_rtol;
+    double ilu_precond_rtol;
 
     // ILU or ILUT fill
-    std::map<PhysicsID, double> amg_precond_ilu_fill;
+    double amg_precond_ilu_fill;
 
     // ILU or ILUT absolute tolerance
-    std::map<PhysicsID, double> amg_precond_ilu_atol;
+    double amg_precond_ilu_atol;
 
     // ILU or ILUT relative tolerance
-    std::map<PhysicsID, double> amg_precond_ilu_rtol;
+    double amg_precond_ilu_rtol;
 
     // AMG aggregation threshold
-    std::map<PhysicsID, double> amg_aggregation_threshold;
+    double amg_aggregation_threshold;
 
     // AMG number of cycles
-    std::map<PhysicsID, int> amg_n_cycles;
+    int amg_n_cycles;
 
     // AMG W_cycle
-    std::map<PhysicsID, bool> amg_w_cycles;
+    bool amg_w_cycles;
 
     // AMG Smoother sweeps
-    std::map<PhysicsID, int> amg_smoother_sweeps;
+    int amg_smoother_sweeps;
 
     // AMG Smoother overalp
-    std::map<PhysicsID, int> amg_smoother_overlap;
+    int amg_smoother_overlap;
 
     // Block linear solver to throw error.
-    std::map<PhysicsID, bool> force_linear_solver_continuation;
+    bool force_linear_solver_continuation;
 
     static void
-    declare_parameters(ParameterHandler &prm);
+    declare_parameters(ParameterHandler &prm, const std::string &physics_name);
     void
-    parse_parameters(ParameterHandler &prm);
+    parse_parameters(ParameterHandler &prm, const std::string &physics_name);
   };
 
   /**

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -944,6 +944,62 @@ namespace Parameters
     // Block linear solver to throw error.
     bool force_linear_solver_continuation;
 
+    // Maps of parameters to account for the different physics
+
+    // Type of linear solver
+    std::map<PhysicsID, SolverType> _solver;
+
+    // Verbosity
+    std::map<PhysicsID, Verbosity> _verbosity;
+
+    // Relative residuals of the iterative solver
+    std::map<PhysicsID, double> _relative_residual;
+
+    // Minimum residual of the iterative solver
+    std::map<PhysicsID, double> _minimum_residual;
+
+    // Maximum number of iterations
+    std::map<PhysicsID, int> _max_iterations;
+
+    // Maximum number of krylov vectors
+    std::map<PhysicsID, int> _max_krylov_vectors;
+
+    // ILU or ILUT fill
+    std::map<PhysicsID, double> _ilu_precond_fill;
+
+    // ILU or ILUT absolute tolerance
+    std::map<PhysicsID, double> _ilu_precond_atol;
+
+    // ILU or ILUT relative tolerance
+    std::map<PhysicsID, double> _ilu_precond_rtol;
+
+    // ILU or ILUT fill
+    std::map<PhysicsID, double> _amg_precond_ilu_fill;
+
+    // ILU or ILUT absolute tolerance
+    std::map<PhysicsID, double> _amg_precond_ilu_atol;
+
+    // ILU or ILUT relative tolerance
+    std::map<PhysicsID, double> _amg_precond_ilu_rtol;
+
+    // AMG aggregation threshold
+    std::map<PhysicsID, double> _amg_aggregation_threshold;
+
+    // AMG number of cycles
+    std::map<PhysicsID, int> _amg_n_cycles;
+
+    // AMG W_cycle
+    std::map<PhysicsID, bool> _amg_w_cycles;
+
+    // AMG Smoother sweeps
+    std::map<PhysicsID, int> _amg_smoother_sweeps;
+
+    // AMG Smoother overalp
+    std::map<PhysicsID, int> _amg_smoother_overlap;
+
+    // Block linear solver to throw error.
+    std::map<PhysicsID, bool> _force_linear_solver_continuation;
+
     static void
     declare_parameters(ParameterHandler &prm);
     void

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -933,16 +933,16 @@ namespace Parameters
     double amg_aggregation_threshold;
 
     // AMG number of cycles
-    int amg_n_cycles;
+    unsigned int amg_n_cycles;
 
     // AMG W_cycle
     bool amg_w_cycles;
 
     // AMG Smoother sweeps
-    int amg_smoother_sweeps;
+    unsigned int amg_smoother_sweeps;
 
     // AMG Smoother overalp
-    int amg_smoother_overlap;
+    unsigned int amg_smoother_overlap;
 
     // Block linear solver to throw error.
     bool force_linear_solver_continuation;

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -394,7 +394,7 @@ private:
 
   TimerOutput computing_timer;
 
-  const SimulationParameters<dim> &simulation_parameters;
+  SimulationParameters<dim> simulation_parameters;
 
 
   // Core elements for the Cahn-Hilliard equations variables (Phi and eta)

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -394,7 +394,7 @@ private:
 
   TimerOutput computing_timer;
 
-  SimulationParameters<dim> simulation_parameters;
+  const SimulationParameters<dim> &simulation_parameters;
 
 
   // Core elements for the Cahn-Hilliard equations variables (Phi and eta)

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -21,8 +21,6 @@
 #define lethe_gd_navier_stokes_h
 
 #include <core/exceptions.h>
-#include <core/multiphysics.h>
-#include <core/parameters.h>
 
 #include <solvers/navier_stokes_base.h>
 
@@ -58,7 +56,7 @@ public:
 private:
   const double                               gamma;
   const double                               viscosity;
-  const Parameters::LinearSolver             &linear_solver_parameters;
+  const Parameters::LinearSolver             linear_solver_parameters;
   const TrilinosWrappers::BlockSparseMatrix &stokes_matrix;
   const TrilinosWrappers::SparseMatrix &     pressure_mass_matrix;
   const BSPreconditioner *                   amat_preconditioner;
@@ -305,12 +303,11 @@ BlockSchurPreconditioner<BSPreconditioner>::vmult(
   {
     //        computing_timer.enter_section("Pressure");
     SolverControl solver_control(
-      linear_solver_parameters.max_iterations.at(PhysicsID::fluid_dynamics),
+      linear_solver_parameters.max_iterations,
       std::max(
         1e-3 * src.block(1).l2_norm(),
         // linear_solver_parameters.relative_residual*src.block(0).l2_norm(),
-        linear_solver_parameters.minimum_residual.at(
-          PhysicsID::fluid_dynamics)));
+        linear_solver_parameters.minimum_residual));
     TrilinosWrappers::SolverCG cg(solver_control);
 
     dst.block(1) = 0.0;
@@ -332,10 +329,9 @@ BlockSchurPreconditioner<BSPreconditioner>::vmult(
   {
     //        computing_timer.enter_section("A Matrix");
     SolverControl solver_control(
-      linear_solver_parameters.max_iterations.at(PhysicsID::fluid_dynamics),
+      linear_solver_parameters.max_iterations,
       std::max(1e-1 * src.block(0).l2_norm(),
-               linear_solver_parameters.minimum_residual.at(
-                 PhysicsID::fluid_dynamics)));
+               linear_solver_parameters.minimum_residual));
 
 
 

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -21,6 +21,8 @@
 #define lethe_gd_navier_stokes_h
 
 #include <core/exceptions.h>
+#include <core/multiphysics.h>
+#include <core/parameters.h>
 
 #include <solvers/navier_stokes_base.h>
 
@@ -56,7 +58,7 @@ public:
 private:
   const double                               gamma;
   const double                               viscosity;
-  const Parameters::LinearSolver             linear_solver_parameters;
+  const Parameters::LinearSolver             &linear_solver_parameters;
   const TrilinosWrappers::BlockSparseMatrix &stokes_matrix;
   const TrilinosWrappers::SparseMatrix &     pressure_mass_matrix;
   const BSPreconditioner *                   amat_preconditioner;
@@ -279,8 +281,7 @@ BlockSchurPreconditioner<BSPreconditioner>::BlockSchurPreconditioner(
   const TrilinosWrappers::SparseMatrix &     P,
   const BSPreconditioner *                   p_amat_preconditioner,
   const BSPreconditioner *                   p_pmass_preconditioner,
-
-  Parameters::LinearSolver p_solver_parameters)
+  Parameters::LinearSolver                   p_solver_parameters)
   : gamma(gamma)
   , viscosity(viscosity)
   , linear_solver_parameters(p_solver_parameters)
@@ -304,11 +305,12 @@ BlockSchurPreconditioner<BSPreconditioner>::vmult(
   {
     //        computing_timer.enter_section("Pressure");
     SolverControl solver_control(
-      linear_solver_parameters.max_iterations,
+      linear_solver_parameters.max_iterations.at(PhysicsID::fluid_dynamics),
       std::max(
         1e-3 * src.block(1).l2_norm(),
         // linear_solver_parameters.relative_residual*src.block(0).l2_norm(),
-        linear_solver_parameters.minimum_residual));
+        linear_solver_parameters.minimum_residual.at(
+          PhysicsID::fluid_dynamics)));
     TrilinosWrappers::SolverCG cg(solver_control);
 
     dst.block(1) = 0.0;
@@ -330,9 +332,10 @@ BlockSchurPreconditioner<BSPreconditioner>::vmult(
   {
     //        computing_timer.enter_section("A Matrix");
     SolverControl solver_control(
-      linear_solver_parameters.max_iterations,
+      linear_solver_parameters.max_iterations.at(PhysicsID::fluid_dynamics),
       std::max(1e-1 * src.block(0).l2_norm(),
-               linear_solver_parameters.minimum_residual));
+               linear_solver_parameters.minimum_residual.at(
+                 PhysicsID::fluid_dynamics)));
 
 
 

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -481,7 +481,7 @@ private:
 
   TimerOutput computing_timer;
 
-  const SimulationParameters<dim> &simulation_parameters;
+  SimulationParameters<dim> simulation_parameters;
 
 
   // Core elements for the heat transfer simulation

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -481,7 +481,7 @@ private:
 
   TimerOutput computing_timer;
 
-  SimulationParameters<dim> simulation_parameters;
+  const SimulationParameters<dim> &simulation_parameters;
 
 
   // Core elements for the heat transfer simulation

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -37,7 +37,7 @@ class SimulationParameters
 {
 public:
   Parameters::Testing                               test;
-  Parameters::LinearSolver                          linear_solver;
+  std::map<PhysicsID, Parameters::LinearSolver>     linear_solver;
   Parameters::NonLinearSolver                       non_linear_solver;
   Parameters::MeshAdaptation                        mesh_adaptation;
   Parameters::Mesh                                  mesh;
@@ -101,9 +101,13 @@ public:
     Parameters::MeshAdaptation::declare_parameters(prm);
     mesh_box_refinement = std::make_shared<Parameters::MeshBoxRefinement>();
     mesh_box_refinement->declare_parameters(prm);
-
     Parameters::NonLinearSolver::declare_parameters(prm);
-    Parameters::LinearSolver::declare_parameters(prm);
+
+    std::vector<std::string> physics_names = {
+      "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
+    for (auto physics_name : physics_names)
+      Parameters::LinearSolver::declare_parameters(prm, physics_name);
+
     Parameters::PostProcessing::declare_parameters(prm);
     Parameters::DynamicFlowControl ::declare_parameters(prm);
     particlesParameters = std::make_shared<Parameters::IBParticles<dim>>();
@@ -128,7 +132,25 @@ public:
   {
     dimensionality.parse_parameters(prm);
     test.parse_parameters(prm);
-    linear_solver.parse_parameters(prm);
+
+    std::vector<std::string> physics_names = {
+      "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
+    for (auto physics_name : physics_names)
+      {
+        PhysicsID physics_id;
+        if (physics_name == "fluid dynamics")
+          physics_id = PhysicsID::fluid_dynamics;
+        else if (physics_name == "heat transfer")
+          physics_id = PhysicsID::heat_transfer;
+        else if (physics_name == "tracer")
+          physics_id = PhysicsID::tracer;
+        else if (physics_name == "VOF")
+          physics_id = PhysicsID::VOF;
+        else if (physics_name == "cahn hilliard")
+          physics_id = PhysicsID::cahn_hilliard;
+        linear_solver[physics_id].parse_parameters(prm, physics_name);
+      }
+
     non_linear_solver.parse_parameters(prm);
     mesh_adaptation.parse_parameters(prm);
     mesh.parse_parameters(prm);

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -103,8 +103,6 @@ public:
     mesh_box_refinement->declare_parameters(prm);
     Parameters::NonLinearSolver::declare_parameters(prm);
 
-    std::vector<std::string> physics_names = {
-      "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
     for (auto physics_name : physics_names)
       Parameters::LinearSolver::declare_parameters(prm, physics_name);
 
@@ -133,21 +131,9 @@ public:
     dimensionality.parse_parameters(prm);
     test.parse_parameters(prm);
 
-    std::vector<std::string> physics_names = {
-      "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
     for (auto physics_name : physics_names)
       {
-        PhysicsID physics_id;
-        if (physics_name == "fluid dynamics")
-          physics_id = PhysicsID::fluid_dynamics;
-        else if (physics_name == "heat transfer")
-          physics_id = PhysicsID::heat_transfer;
-        else if (physics_name == "tracer")
-          physics_id = PhysicsID::tracer;
-        else if (physics_name == "VOF")
-          physics_id = PhysicsID::VOF;
-        else if (physics_name == "cahn hilliard")
-          physics_id = PhysicsID::cahn_hilliard;
+        PhysicsID physics_id = get_physics_id(physics_name);
         linear_solver[physics_id].parse_parameters(prm, physics_name);
       }
 
@@ -280,6 +266,12 @@ public:
 
 private:
   Parameters::PhysicalProperties physical_properties;
+  // names for the physics supported by Lethe
+  std::vector<std::string> physics_names = {"fluid dynamics",
+                                            "heat transfer",
+                                            "tracer",
+                                            "VOF",
+                                            "cahn hilliard"};
 };
 
 #endif

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -360,7 +360,7 @@ private:
 
   TimerOutput computing_timer;
 
-  SimulationParameters<dim> simulation_parameters;
+  const SimulationParameters<dim> &simulation_parameters;
 
 
   // Core elements for the tracer

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -360,7 +360,7 @@ private:
 
   TimerOutput computing_timer;
 
-  const SimulationParameters<dim> &simulation_parameters;
+  SimulationParameters<dim> simulation_parameters;
 
 
   // Core elements for the tracer

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -719,7 +719,7 @@ private:
 
   TimerOutput computing_timer;
 
-  SimulationParameters<dim> simulation_parameters;
+  const SimulationParameters<dim> &simulation_parameters;
 
   // Core elements for the VOF simulation
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> triangulation;

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -719,7 +719,7 @@ private:
 
   TimerOutput computing_timer;
 
-  const SimulationParameters<dim> &simulation_parameters;
+  SimulationParameters<dim> simulation_parameters;
 
   // Core elements for the VOF simulation
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> triangulation;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1951,104 +1951,6 @@ namespace Parameters
   {
     prm.enter_subsection("linear solver");
     {
-      prm.declare_entry(
-        "verbosity",
-        "verbose",
-        Patterns::Selection("quiet|verbose|extra verbose"),
-        "State whether output from solver runs should be printed. "
-        "Choices are <quiet|verbose|extra verbose>.");
-      prm.declare_entry(
-        "method",
-        "gmres",
-        Patterns::Selection("gmres|bicgstab|amg|direct"),
-        "The iterative solver for the linear system of equations. "
-        "Choices are <gmres|bicgstab|amg|tfqmr|direct>. gmres is a GMRES iterative "
-        "solver "
-        "with ILU preconditioning. bicgstab is a BICGSTAB iterative solver "
-        "with ILU preconditioning. "
-        "amg is GMRES + AMG preconditioning with an ILU coarsener and "
-        "smoother. On coarse meshes, the gmres/bicgstab solver with ILU "
-        "preconditioning is more efficient. "
-        "As the number of mesh elements increase, the amg solver is the most "
-        "efficient. Generally, at 1M elements, the amg solver always "
-        "outperforms the gmres or bicgstab");
-      prm.declare_entry("relative residual",
-                        "1e-3",
-                        Patterns::Double(),
-                        "Linear solver residual");
-      prm.declare_entry("minimum residual",
-                        "1e-12",
-                        Patterns::Double(),
-                        "Linear solver minimum residual");
-      prm.declare_entry("max iters",
-                        "1000",
-                        Patterns::Integer(),
-                        "Maximum solver iterations");
-
-      prm.declare_entry("max krylov vectors",
-                        "100",
-                        Patterns::Integer(),
-                        "Maximum number of krylov vectors for GMRES");
-
-      prm.declare_entry("ilu preconditioner fill",
-                        "0",
-                        Patterns::Double(),
-                        "Ilu preconditioner fill");
-
-      prm.declare_entry("ilu preconditioner absolute tolerance",
-                        "1e-12",
-                        Patterns::Double(),
-                        "Ilu preconditioner tolerance");
-
-      prm.declare_entry("ilu preconditioner relative tolerance",
-                        "1.00",
-                        Patterns::Double(),
-                        "Ilu relative tolerance");
-
-      prm.declare_entry("amg preconditioner ilu fill",
-                        "0",
-                        Patterns::Double(),
-                        "amg preconditioner ilu smoother/coarsener fill");
-
-      prm.declare_entry(
-        "amg preconditioner ilu absolute tolerance",
-        "1e-12",
-        Patterns::Double(),
-        "amg preconditioner ilu smoother/coarsener absolute tolerance");
-
-      prm.declare_entry(
-        "amg preconditioner ilu relative tolerance",
-        "1.00",
-        Patterns::Double(),
-        "amg preconditioner ilu smoother/coarsener relative tolerance");
-
-      prm.declare_entry("amg aggregation threshold",
-                        "1e-14",
-                        Patterns::Double(),
-                        "amg aggregation threshold");
-      prm.declare_entry("amg n cycles",
-                        "1",
-                        Patterns::Integer(),
-                        "amg number of cycles");
-      prm.declare_entry("amg w cycles",
-                        "false",
-                        Patterns::Bool(),
-                        "amg w cycling. If this is set to true, W cycling is "
-                        "used. Otherwise, V cycling is used.");
-      prm.declare_entry("amg smoother sweeps",
-                        "2",
-                        Patterns::Integer(),
-                        "amg smoother sweeps");
-      prm.declare_entry("amg smoother overlap",
-                        "1",
-                        Patterns::Integer(),
-                        "amg smoother overlap");
-      prm.declare_entry(
-        "force linear solver continuation",
-        "false",
-        Patterns::Bool(),
-        "A boolean that will force the linear solver to continue even if it fails");
-
       std::vector<std::string> physics_names = {
         "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
 
@@ -2166,54 +2068,6 @@ namespace Parameters
   {
     prm.enter_subsection("linear solver");
     {
-      const std::string op = prm.get("verbosity");
-      if (op == "verbose")
-        verbosity = Parameters::Verbosity::verbose;
-      else if (op == "quiet")
-        verbosity = Parameters::Verbosity::quiet;
-      else if (op == "extra verbose")
-        verbosity = Parameters::Verbosity::extra_verbose;
-      else
-        throw(
-          std::runtime_error("Unknown verbosity mode for the linear solver"));
-
-      const std::string sv = prm.get("method");
-      if (sv == "amg")
-        solver = SolverType::amg;
-      else if (sv == "gmres")
-        solver = SolverType::gmres;
-      else if (sv == "bicgstab")
-        solver = SolverType::bicgstab;
-      else if (sv == "direct")
-        solver = SolverType::direct;
-      else
-        throw std::logic_error(
-          "Error, invalid iterative solver type. Choices are amg, gmres, bicgstab or direct");
-
-      relative_residual  = prm.get_double("relative residual");
-      minimum_residual   = prm.get_double("minimum residual");
-      max_iterations     = prm.get_integer("max iters");
-      max_krylov_vectors = prm.get_integer("max krylov vectors");
-
-      ilu_precond_fill = prm.get_double("ilu preconditioner fill");
-      ilu_precond_atol =
-        prm.get_double("ilu preconditioner absolute tolerance");
-      ilu_precond_rtol =
-        prm.get_double("ilu preconditioner relative tolerance");
-      amg_precond_ilu_fill = prm.get_double("amg preconditioner ilu fill");
-      amg_precond_ilu_atol =
-        prm.get_double("amg preconditioner ilu absolute tolerance");
-      amg_precond_ilu_rtol =
-        prm.get_double("amg preconditioner ilu relative tolerance");
-      amg_aggregation_threshold = prm.get_double("amg aggregation threshold");
-      amg_n_cycles              = prm.get_integer("amg n cycles");
-      amg_w_cycles              = prm.get_bool("amg w cycles");
-      amg_smoother_sweeps       = prm.get_integer("amg smoother sweeps");
-      amg_smoother_overlap      = prm.get_integer("amg smoother overlap");
-      force_linear_solver_continuation =
-        prm.get_bool("force linear solver continuation");
-
-
       std::vector<std::string> physics_names = {
         "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
 
@@ -2235,56 +2089,55 @@ namespace Parameters
           {
             const std::string sv = prm.get("method");
             if (sv == "amg")
-              _solver[physics_id] = SolverType::amg;
+              solver[physics_id] = SolverType::amg;
             else if (sv == "gmres")
-              _solver[physics_id] = SolverType::gmres;
+              solver[physics_id] = SolverType::gmres;
             else if (sv == "bicgstab")
-              _solver[physics_id] = SolverType::bicgstab;
+              solver[physics_id] = SolverType::bicgstab;
             else if (sv == "direct")
-              _solver[physics_id] = SolverType::direct;
+              solver[physics_id] = SolverType::direct;
             else
               throw std::logic_error(
                 "Error, invalid iterative solver type. Choices are amg, gmres, bicgstab or direct");
 
             const std::string op = prm.get("verbosity");
             if (op == "verbose")
-              _verbosity[physics_id] = Parameters::Verbosity::verbose;
+              verbosity[physics_id] = Parameters::Verbosity::verbose;
             else if (op == "quiet")
-              _verbosity[physics_id] = Parameters::Verbosity::quiet;
+              verbosity[physics_id] = Parameters::Verbosity::quiet;
             else if (op == "extra verbose")
-              _verbosity[physics_id] = Parameters::Verbosity::extra_verbose;
+              verbosity[physics_id] = Parameters::Verbosity::extra_verbose;
             else
               throw(std::runtime_error(
                 "Unknown verbosity mode for the linear solver"));
 
-            _relative_residual[physics_id] =
-              prm.get_double("relative residual");
-            _minimum_residual[physics_id] = prm.get_double("minimum residual");
-            _max_iterations[physics_id]   = prm.get_integer("max iters");
-            _max_krylov_vectors[physics_id] =
+            relative_residual[physics_id] = prm.get_double("relative residual");
+            minimum_residual[physics_id]  = prm.get_double("minimum residual");
+            max_iterations[physics_id]    = prm.get_integer("max iters");
+            max_krylov_vectors[physics_id] =
               prm.get_integer("max krylov vectors");
 
-            _ilu_precond_fill[physics_id] =
+            ilu_precond_fill[physics_id] =
               prm.get_double("ilu preconditioner fill");
-            _ilu_precond_atol[physics_id] =
+            ilu_precond_atol[physics_id] =
               prm.get_double("ilu preconditioner absolute tolerance");
-            _ilu_precond_rtol[physics_id] =
+            ilu_precond_rtol[physics_id] =
               prm.get_double("ilu preconditioner relative tolerance");
-            _amg_precond_ilu_fill[physics_id] =
+            amg_precond_ilu_fill[physics_id] =
               prm.get_double("amg preconditioner ilu fill");
-            _amg_precond_ilu_atol[physics_id] =
+            amg_precond_ilu_atol[physics_id] =
               prm.get_double("amg preconditioner ilu absolute tolerance");
-            _amg_precond_ilu_rtol[physics_id] =
+            amg_precond_ilu_rtol[physics_id] =
               prm.get_double("amg preconditioner ilu relative tolerance");
-            _amg_aggregation_threshold[physics_id] =
+            amg_aggregation_threshold[physics_id] =
               prm.get_double("amg aggregation threshold");
-            _amg_n_cycles[physics_id] = prm.get_integer("amg n cycles");
-            _amg_w_cycles[physics_id] = prm.get_bool("amg w cycles");
-            _amg_smoother_sweeps[physics_id] =
+            amg_n_cycles[physics_id] = prm.get_integer("amg n cycles");
+            amg_w_cycles[physics_id] = prm.get_bool("amg w cycles");
+            amg_smoother_sweeps[physics_id] =
               prm.get_integer("amg smoother sweeps");
-            _amg_smoother_overlap[physics_id] =
+            amg_smoother_overlap[physics_id] =
               prm.get_integer("amg smoother overlap");
-            _force_linear_solver_continuation[physics_id] =
+            force_linear_solver_continuation[physics_id] =
               prm.get_bool("force linear solver continuation");
           }
           prm.leave_subsection();

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1947,201 +1947,171 @@ namespace Parameters
   }
 
   void
-  LinearSolver::declare_parameters(ParameterHandler &prm)
+  LinearSolver::declare_parameters(ParameterHandler & prm,
+                                   const std::string &physics_name)
   {
     prm.enter_subsection("linear solver");
     {
-      std::vector<std::string> physics_names = {
-        "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
+      prm.enter_subsection(physics_name);
+      {
+        prm.declare_entry(
+          "verbosity",
+          "verbose",
+          Patterns::Selection("quiet|verbose|extra verbose"),
+          "State whether output from solver runs should be printed. "
+          "Choices are <quiet|verbose|extra verbose>.");
+        prm.declare_entry(
+          "method",
+          "gmres",
+          Patterns::Selection("gmres|bicgstab|amg|direct"),
+          "The iterative solver for the linear system of equations. "
+          "Choices are <gmres|bicgstab|amg|tfqmr|direct>. gmres is a GMRES iterative "
+          "solver "
+          "with ILU preconditioning. bicgstab is a BICGSTAB iterative solver "
+          "with ILU preconditioning. "
+          "amg is GMRES + AMG preconditioning with an ILU coarsener and "
+          "smoother. On coarse meshes, the gmres/bicgstab solver with ILU "
+          "preconditioning is more efficient. "
+          "As the number of mesh elements increase, the amg solver is the most "
+          "efficient. Generally, at 1M elements, the amg solver always "
+          "outperforms the gmres or bicgstab");
+        prm.declare_entry("relative residual",
+                          "1e-3",
+                          Patterns::Double(),
+                          "Linear solver residual");
+        prm.declare_entry("minimum residual",
+                          "1e-12",
+                          Patterns::Double(),
+                          "Linear solver minimum residual");
+        prm.declare_entry("max iters",
+                          "1000",
+                          Patterns::Integer(),
+                          "Maximum solver iterations");
 
-      for (auto physics_name : physics_names)
-        {
-          prm.enter_subsection(physics_name);
-          {
-            prm.declare_entry(
-              "verbosity",
-              "verbose",
-              Patterns::Selection("quiet|verbose|extra verbose"),
-              "State whether output from solver runs should be printed. "
-              "Choices are <quiet|verbose|extra verbose>.");
-            prm.declare_entry(
-              "method",
-              "gmres",
-              Patterns::Selection("gmres|bicgstab|amg|direct"),
-              "The iterative solver for the linear system of equations. "
-              "Choices are <gmres|bicgstab|amg|tfqmr|direct>. gmres is a GMRES iterative "
-              "solver "
-              "with ILU preconditioning. bicgstab is a BICGSTAB iterative solver "
-              "with ILU preconditioning. "
-              "amg is GMRES + AMG preconditioning with an ILU coarsener and "
-              "smoother. On coarse meshes, the gmres/bicgstab solver with ILU "
-              "preconditioning is more efficient. "
-              "As the number of mesh elements increase, the amg solver is the most "
-              "efficient. Generally, at 1M elements, the amg solver always "
-              "outperforms the gmres or bicgstab");
-            prm.declare_entry("relative residual",
-                              "1e-3",
-                              Patterns::Double(),
-                              "Linear solver residual");
-            prm.declare_entry("minimum residual",
-                              "1e-12",
-                              Patterns::Double(),
-                              "Linear solver minimum residual");
-            prm.declare_entry("max iters",
-                              "1000",
-                              Patterns::Integer(),
-                              "Maximum solver iterations");
+        prm.declare_entry("max krylov vectors",
+                          "100",
+                          Patterns::Integer(),
+                          "Maximum number of krylov vectors for GMRES");
 
-            prm.declare_entry("max krylov vectors",
-                              "100",
-                              Patterns::Integer(),
-                              "Maximum number of krylov vectors for GMRES");
+        prm.declare_entry("ilu preconditioner fill",
+                          "0",
+                          Patterns::Double(),
+                          "Ilu preconditioner fill");
 
-            prm.declare_entry("ilu preconditioner fill",
-                              "0",
-                              Patterns::Double(),
-                              "Ilu preconditioner fill");
+        prm.declare_entry("ilu preconditioner absolute tolerance",
+                          "1e-12",
+                          Patterns::Double(),
+                          "Ilu preconditioner tolerance");
 
-            prm.declare_entry("ilu preconditioner absolute tolerance",
-                              "1e-12",
-                              Patterns::Double(),
-                              "Ilu preconditioner tolerance");
+        prm.declare_entry("ilu preconditioner relative tolerance",
+                          "1.00",
+                          Patterns::Double(),
+                          "Ilu relative tolerance");
 
-            prm.declare_entry("ilu preconditioner relative tolerance",
-                              "1.00",
-                              Patterns::Double(),
-                              "Ilu relative tolerance");
+        prm.declare_entry("amg preconditioner ilu fill",
+                          "0",
+                          Patterns::Double(),
+                          "amg preconditioner ilu smoother/coarsener fill");
 
-            prm.declare_entry("amg preconditioner ilu fill",
-                              "0",
-                              Patterns::Double(),
-                              "amg preconditioner ilu smoother/coarsener fill");
+        prm.declare_entry(
+          "amg preconditioner ilu absolute tolerance",
+          "1e-12",
+          Patterns::Double(),
+          "amg preconditioner ilu smoother/coarsener absolute tolerance");
 
-            prm.declare_entry(
-              "amg preconditioner ilu absolute tolerance",
-              "1e-12",
-              Patterns::Double(),
-              "amg preconditioner ilu smoother/coarsener absolute tolerance");
+        prm.declare_entry(
+          "amg preconditioner ilu relative tolerance",
+          "1.00",
+          Patterns::Double(),
+          "amg preconditioner ilu smoother/coarsener relative tolerance");
 
-            prm.declare_entry(
-              "amg preconditioner ilu relative tolerance",
-              "1.00",
-              Patterns::Double(),
-              "amg preconditioner ilu smoother/coarsener relative tolerance");
-
-            prm.declare_entry("amg aggregation threshold",
-                              "1e-14",
-                              Patterns::Double(),
-                              "amg aggregation threshold");
-            prm.declare_entry("amg n cycles",
-                              "1",
-                              Patterns::Integer(),
-                              "amg number of cycles");
-            prm.declare_entry(
-              "amg w cycles",
-              "false",
-              Patterns::Bool(),
-              "amg w cycling. If this is set to true, W cycling is "
-              "used. Otherwise, V cycling is used.");
-            prm.declare_entry("amg smoother sweeps",
-                              "2",
-                              Patterns::Integer(),
-                              "amg smoother sweeps");
-            prm.declare_entry("amg smoother overlap",
-                              "1",
-                              Patterns::Integer(),
-                              "amg smoother overlap");
-            prm.declare_entry(
-              "force linear solver continuation",
-              "false",
-              Patterns::Bool(),
-              "A boolean that will force the linear solver to continue even if it fails");
-          }
-          prm.leave_subsection();
-        }
+        prm.declare_entry("amg aggregation threshold",
+                          "1e-14",
+                          Patterns::Double(),
+                          "amg aggregation threshold");
+        prm.declare_entry("amg n cycles",
+                          "1",
+                          Patterns::Integer(),
+                          "amg number of cycles");
+        prm.declare_entry("amg w cycles",
+                          "false",
+                          Patterns::Bool(),
+                          "amg w cycling. If this is set to true, W cycling is "
+                          "used. Otherwise, V cycling is used.");
+        prm.declare_entry("amg smoother sweeps",
+                          "2",
+                          Patterns::Integer(),
+                          "amg smoother sweeps");
+        prm.declare_entry("amg smoother overlap",
+                          "1",
+                          Patterns::Integer(),
+                          "amg smoother overlap");
+        prm.declare_entry(
+          "force linear solver continuation",
+          "false",
+          Patterns::Bool(),
+          "A boolean that will force the linear solver to continue even if it fails");
+      }
+      prm.leave_subsection();
     }
-
     prm.leave_subsection();
   }
   void
-  LinearSolver::parse_parameters(ParameterHandler &prm)
+  LinearSolver::parse_parameters(ParameterHandler & prm,
+                                 const std::string &physics_name)
   {
     prm.enter_subsection("linear solver");
     {
-      std::vector<std::string> physics_names = {
-        "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
+      prm.enter_subsection(physics_name);
+      {
+        const std::string sv = prm.get("method");
+        if (sv == "amg")
+          solver = SolverType::amg;
+        else if (sv == "gmres")
+          solver = SolverType::gmres;
+        else if (sv == "bicgstab")
+          solver = SolverType::bicgstab;
+        else if (sv == "direct")
+          solver = SolverType::direct;
+        else
+          throw std::logic_error(
+            "Error, invalid iterative solver type. Choices are amg, gmres, bicgstab or direct");
 
-      for (auto physics_name : physics_names)
-        {
-          PhysicsID physics_id;
-          if (physics_name == "fluid dynamics")
-            physics_id = PhysicsID::fluid_dynamics;
-          else if (physics_name == "heat transfer")
-            physics_id = PhysicsID::heat_transfer;
-          else if (physics_name == "tracer")
-            physics_id = PhysicsID::tracer;
-          else if (physics_name == "VOF")
-            physics_id = PhysicsID::VOF;
-          else if (physics_name == "cahn hilliard")
-            physics_id = PhysicsID::cahn_hilliard;
+        const std::string op = prm.get("verbosity");
+        if (op == "verbose")
+          verbosity = Parameters::Verbosity::verbose;
+        else if (op == "quiet")
+          verbosity = Parameters::Verbosity::quiet;
+        else if (op == "extra verbose")
+          verbosity = Parameters::Verbosity::extra_verbose;
+        else
+          throw(
+            std::runtime_error("Unknown verbosity mode for the linear solver"));
 
-          prm.enter_subsection(physics_name);
-          {
-            const std::string sv = prm.get("method");
-            if (sv == "amg")
-              solver[physics_id] = SolverType::amg;
-            else if (sv == "gmres")
-              solver[physics_id] = SolverType::gmres;
-            else if (sv == "bicgstab")
-              solver[physics_id] = SolverType::bicgstab;
-            else if (sv == "direct")
-              solver[physics_id] = SolverType::direct;
-            else
-              throw std::logic_error(
-                "Error, invalid iterative solver type. Choices are amg, gmres, bicgstab or direct");
+        relative_residual  = prm.get_double("relative residual");
+        minimum_residual   = prm.get_double("minimum residual");
+        max_iterations     = prm.get_integer("max iters");
+        max_krylov_vectors = prm.get_integer("max krylov vectors");
 
-            const std::string op = prm.get("verbosity");
-            if (op == "verbose")
-              verbosity[physics_id] = Parameters::Verbosity::verbose;
-            else if (op == "quiet")
-              verbosity[physics_id] = Parameters::Verbosity::quiet;
-            else if (op == "extra verbose")
-              verbosity[physics_id] = Parameters::Verbosity::extra_verbose;
-            else
-              throw(std::runtime_error(
-                "Unknown verbosity mode for the linear solver"));
-
-            relative_residual[physics_id] = prm.get_double("relative residual");
-            minimum_residual[physics_id]  = prm.get_double("minimum residual");
-            max_iterations[physics_id]    = prm.get_integer("max iters");
-            max_krylov_vectors[physics_id] =
-              prm.get_integer("max krylov vectors");
-
-            ilu_precond_fill[physics_id] =
-              prm.get_double("ilu preconditioner fill");
-            ilu_precond_atol[physics_id] =
-              prm.get_double("ilu preconditioner absolute tolerance");
-            ilu_precond_rtol[physics_id] =
-              prm.get_double("ilu preconditioner relative tolerance");
-            amg_precond_ilu_fill[physics_id] =
-              prm.get_double("amg preconditioner ilu fill");
-            amg_precond_ilu_atol[physics_id] =
-              prm.get_double("amg preconditioner ilu absolute tolerance");
-            amg_precond_ilu_rtol[physics_id] =
-              prm.get_double("amg preconditioner ilu relative tolerance");
-            amg_aggregation_threshold[physics_id] =
-              prm.get_double("amg aggregation threshold");
-            amg_n_cycles[physics_id] = prm.get_integer("amg n cycles");
-            amg_w_cycles[physics_id] = prm.get_bool("amg w cycles");
-            amg_smoother_sweeps[physics_id] =
-              prm.get_integer("amg smoother sweeps");
-            amg_smoother_overlap[physics_id] =
-              prm.get_integer("amg smoother overlap");
-            force_linear_solver_continuation[physics_id] =
-              prm.get_bool("force linear solver continuation");
-          }
-          prm.leave_subsection();
-        }
+        ilu_precond_fill = prm.get_double("ilu preconditioner fill");
+        ilu_precond_atol =
+          prm.get_double("ilu preconditioner absolute tolerance");
+        ilu_precond_rtol =
+          prm.get_double("ilu preconditioner relative tolerance");
+        amg_precond_ilu_fill = prm.get_double("amg preconditioner ilu fill");
+        amg_precond_ilu_atol =
+          prm.get_double("amg preconditioner ilu absolute tolerance");
+        amg_precond_ilu_rtol =
+          prm.get_double("amg preconditioner ilu relative tolerance");
+        amg_aggregation_threshold = prm.get_double("amg aggregation threshold");
+        amg_n_cycles              = prm.get_integer("amg n cycles");
+        amg_w_cycles              = prm.get_bool("amg w cycles");
+        amg_smoother_sweeps       = prm.get_integer("amg smoother sweeps");
+        amg_smoother_overlap      = prm.get_integer("amg smoother overlap");
+        force_linear_solver_continuation =
+          prm.get_bool("force linear solver continuation");
+      }
+      prm.leave_subsection();
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2048,7 +2048,117 @@ namespace Parameters
         "false",
         Patterns::Bool(),
         "A boolean that will force the linear solver to continue even if it fails");
+
+      std::vector<std::string> physics_names = {
+        "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
+
+      for (auto physics_name : physics_names)
+        {
+          prm.enter_subsection(physics_name);
+          {
+            prm.declare_entry(
+              "verbosity",
+              "verbose",
+              Patterns::Selection("quiet|verbose|extra verbose"),
+              "State whether output from solver runs should be printed. "
+              "Choices are <quiet|verbose|extra verbose>.");
+            prm.declare_entry(
+              "method",
+              "gmres",
+              Patterns::Selection("gmres|bicgstab|amg|direct"),
+              "The iterative solver for the linear system of equations. "
+              "Choices are <gmres|bicgstab|amg|tfqmr|direct>. gmres is a GMRES iterative "
+              "solver "
+              "with ILU preconditioning. bicgstab is a BICGSTAB iterative solver "
+              "with ILU preconditioning. "
+              "amg is GMRES + AMG preconditioning with an ILU coarsener and "
+              "smoother. On coarse meshes, the gmres/bicgstab solver with ILU "
+              "preconditioning is more efficient. "
+              "As the number of mesh elements increase, the amg solver is the most "
+              "efficient. Generally, at 1M elements, the amg solver always "
+              "outperforms the gmres or bicgstab");
+            prm.declare_entry("relative residual",
+                              "1e-3",
+                              Patterns::Double(),
+                              "Linear solver residual");
+            prm.declare_entry("minimum residual",
+                              "1e-12",
+                              Patterns::Double(),
+                              "Linear solver minimum residual");
+            prm.declare_entry("max iters",
+                              "1000",
+                              Patterns::Integer(),
+                              "Maximum solver iterations");
+
+            prm.declare_entry("max krylov vectors",
+                              "100",
+                              Patterns::Integer(),
+                              "Maximum number of krylov vectors for GMRES");
+
+            prm.declare_entry("ilu preconditioner fill",
+                              "0",
+                              Patterns::Double(),
+                              "Ilu preconditioner fill");
+
+            prm.declare_entry("ilu preconditioner absolute tolerance",
+                              "1e-12",
+                              Patterns::Double(),
+                              "Ilu preconditioner tolerance");
+
+            prm.declare_entry("ilu preconditioner relative tolerance",
+                              "1.00",
+                              Patterns::Double(),
+                              "Ilu relative tolerance");
+
+            prm.declare_entry("amg preconditioner ilu fill",
+                              "0",
+                              Patterns::Double(),
+                              "amg preconditioner ilu smoother/coarsener fill");
+
+            prm.declare_entry(
+              "amg preconditioner ilu absolute tolerance",
+              "1e-12",
+              Patterns::Double(),
+              "amg preconditioner ilu smoother/coarsener absolute tolerance");
+
+            prm.declare_entry(
+              "amg preconditioner ilu relative tolerance",
+              "1.00",
+              Patterns::Double(),
+              "amg preconditioner ilu smoother/coarsener relative tolerance");
+
+            prm.declare_entry("amg aggregation threshold",
+                              "1e-14",
+                              Patterns::Double(),
+                              "amg aggregation threshold");
+            prm.declare_entry("amg n cycles",
+                              "1",
+                              Patterns::Integer(),
+                              "amg number of cycles");
+            prm.declare_entry(
+              "amg w cycles",
+              "false",
+              Patterns::Bool(),
+              "amg w cycling. If this is set to true, W cycling is "
+              "used. Otherwise, V cycling is used.");
+            prm.declare_entry("amg smoother sweeps",
+                              "2",
+                              Patterns::Integer(),
+                              "amg smoother sweeps");
+            prm.declare_entry("amg smoother overlap",
+                              "1",
+                              Patterns::Integer(),
+                              "amg smoother overlap");
+            prm.declare_entry(
+              "force linear solver continuation",
+              "false",
+              Patterns::Bool(),
+              "A boolean that will force the linear solver to continue even if it fails");
+          }
+          prm.leave_subsection();
+        }
     }
+
     prm.leave_subsection();
   }
   void
@@ -2102,6 +2212,83 @@ namespace Parameters
       amg_smoother_overlap      = prm.get_integer("amg smoother overlap");
       force_linear_solver_continuation =
         prm.get_bool("force linear solver continuation");
+
+
+      std::vector<std::string> physics_names = {
+        "fluid dynamics", "heat transfer", "tracer", "VOF", "cahn hilliard"};
+
+      for (auto physics_name : physics_names)
+        {
+          PhysicsID physics_id;
+          if (physics_name == "fluid dynamics")
+            physics_id = PhysicsID::fluid_dynamics;
+          else if (physics_name == "heat transfer")
+            physics_id = PhysicsID::heat_transfer;
+          else if (physics_name == "tracer")
+            physics_id = PhysicsID::tracer;
+          else if (physics_name == "VOF")
+            physics_id = PhysicsID::VOF;
+          else if (physics_name == "cahn hilliard")
+            physics_id = PhysicsID::cahn_hilliard;
+
+          prm.enter_subsection(physics_name);
+          {
+            const std::string sv = prm.get("method");
+            if (sv == "amg")
+              _solver[physics_id] = SolverType::amg;
+            else if (sv == "gmres")
+              _solver[physics_id] = SolverType::gmres;
+            else if (sv == "bicgstab")
+              _solver[physics_id] = SolverType::bicgstab;
+            else if (sv == "direct")
+              _solver[physics_id] = SolverType::direct;
+            else
+              throw std::logic_error(
+                "Error, invalid iterative solver type. Choices are amg, gmres, bicgstab or direct");
+
+            const std::string op = prm.get("verbosity");
+            if (op == "verbose")
+              _verbosity[physics_id] = Parameters::Verbosity::verbose;
+            else if (op == "quiet")
+              _verbosity[physics_id] = Parameters::Verbosity::quiet;
+            else if (op == "extra verbose")
+              _verbosity[physics_id] = Parameters::Verbosity::extra_verbose;
+            else
+              throw(std::runtime_error(
+                "Unknown verbosity mode for the linear solver"));
+
+            _relative_residual[physics_id] =
+              prm.get_double("relative residual");
+            _minimum_residual[physics_id] = prm.get_double("minimum residual");
+            _max_iterations[physics_id]   = prm.get_integer("max iters");
+            _max_krylov_vectors[physics_id] =
+              prm.get_integer("max krylov vectors");
+
+            _ilu_precond_fill[physics_id] =
+              prm.get_double("ilu preconditioner fill");
+            _ilu_precond_atol[physics_id] =
+              prm.get_double("ilu preconditioner absolute tolerance");
+            _ilu_precond_rtol[physics_id] =
+              prm.get_double("ilu preconditioner relative tolerance");
+            _amg_precond_ilu_fill[physics_id] =
+              prm.get_double("amg preconditioner ilu fill");
+            _amg_precond_ilu_atol[physics_id] =
+              prm.get_double("amg preconditioner ilu absolute tolerance");
+            _amg_precond_ilu_rtol[physics_id] =
+              prm.get_double("amg preconditioner ilu relative tolerance");
+            _amg_aggregation_threshold[physics_id] =
+              prm.get_double("amg aggregation threshold");
+            _amg_n_cycles[physics_id] = prm.get_integer("amg n cycles");
+            _amg_w_cycles[physics_id] = prm.get_bool("amg w cycles");
+            _amg_smoother_sweeps[physics_id] =
+              prm.get_integer("amg smoother sweeps");
+            _amg_smoother_overlap[physics_id] =
+              prm.get_integer("amg smoother overlap");
+            _force_linear_solver_continuation[physics_id] =
+              prm.get_bool("force linear solver continuation");
+          }
+          prm.leave_subsection();
+        }
     }
     prm.leave_subsection();
   }

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1285,7 +1285,7 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
   const double linear_solver_tolerance = 1e-15;
 
   if (this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-        .verbosity != Parameters::Verbosity::quiet)
+        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
@@ -1297,23 +1297,27 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
   TrilinosWrappers::MPI::Vector completely_distributed_solution(
     locally_owned_dofs_voidfraction, this->mpi_communicator);
 
-  SolverControl solver_control(this->cfd_dem_simulation_parameters
-                                 .cfd_parameters.linear_solver.max_iterations,
-                               linear_solver_tolerance,
-                               true,
-                               true);
+  SolverControl solver_control(
+    this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
+      .max_iterations[PhysicsID::fluid_dynamics],
+    linear_solver_tolerance,
+    true,
+    true);
 
   TrilinosWrappers::SolverCG solver(solver_control);
 
   //**********************************************
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
-  const double ilu_fill = this->cfd_dem_simulation_parameters.cfd_parameters
-                            .linear_solver.ilu_precond_fill;
-  const double ilu_atol = this->cfd_dem_simulation_parameters.cfd_parameters
-                            .linear_solver.ilu_precond_atol;
-  const double ilu_rtol = this->cfd_dem_simulation_parameters.cfd_parameters
-                            .linear_solver.ilu_precond_rtol;
+  const double ilu_fill =
+    this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
+      .ilu_precond_fill[PhysicsID::fluid_dynamics];
+  const double ilu_atol =
+    this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
+      .ilu_precond_atol[PhysicsID::fluid_dynamics];
+  const double ilu_rtol =
+    this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
+      .ilu_precond_rtol[PhysicsID::fluid_dynamics];
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -1329,7 +1333,7 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
                *ilu_preconditioner);
 
   if (this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-        .verbosity != Parameters::Verbosity::quiet)
+        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
                   << " steps " << std::endl;

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1285,7 +1285,8 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
   const double linear_solver_tolerance = 1e-15;
 
   if (this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+        .at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
@@ -1299,7 +1300,8 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
 
   SolverControl solver_control(
     this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-      .max_iterations[PhysicsID::fluid_dynamics],
+      .at(PhysicsID::fluid_dynamics)
+      .max_iterations,
     linear_solver_tolerance,
     true,
     true);
@@ -1311,13 +1313,16 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
   //*********************************************
   const double ilu_fill =
     this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-      .ilu_precond_fill[PhysicsID::fluid_dynamics];
+      .at(PhysicsID::fluid_dynamics)
+      .ilu_precond_fill;
   const double ilu_atol =
     this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-      .ilu_precond_atol[PhysicsID::fluid_dynamics];
+      .at(PhysicsID::fluid_dynamics)
+      .ilu_precond_atol;
   const double ilu_rtol =
     this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-      .ilu_precond_rtol[PhysicsID::fluid_dynamics];
+      .at(PhysicsID::fluid_dynamics)
+      .ilu_precond_rtol;
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -1333,7 +1338,8 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
                *ilu_preconditioner);
 
   if (this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+        .at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
                   << " steps " << std::endl;

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -819,28 +819,31 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
     initial_step ? nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver
-      .minimum_residual[PhysicsID::cahn_hilliard];
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+      .minimum_residual;
   const double relative_residual =
-    simulation_parameters.linear_solver
-      .relative_residual[PhysicsID::cahn_hilliard];
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+      .relative_residual;
 
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::cahn_hilliard] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill = simulation_parameters.linear_solver
-                            .ilu_precond_fill[PhysicsID::cahn_hilliard];
-  const double ilu_atol = simulation_parameters.linear_solver
-                            .ilu_precond_atol[PhysicsID::cahn_hilliard];
-  const double ilu_rtol = simulation_parameters.linear_solver
-                            .ilu_precond_rtol[PhysicsID::cahn_hilliard];
+  const double ilu_fill =
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+      .ilu_precond_fill;
+  const double ilu_atol =
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+      .ilu_precond_atol;
+  const double ilu_rtol =
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+      .ilu_precond_rtol;
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -852,15 +855,16 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
     locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::cahn_hilliard],
+                                 .at(PhysicsID::cahn_hilliard)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
     false,
-    simulation_parameters.linear_solver
-      .max_krylov_vectors[PhysicsID::cahn_hilliard]);
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+      .max_krylov_vectors);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -871,8 +875,8 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
                system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity[PhysicsID::cahn_hilliard] !=
-      Parameters::Verbosity::quiet)
+  if (simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
                   << " steps " << std::endl;

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -819,23 +819,28 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
     initial_step ? nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver.minimum_residual;
+    simulation_parameters.linear_solver
+      .minimum_residual[PhysicsID::cahn_hilliard];
   const double relative_residual =
-    simulation_parameters.linear_solver.relative_residual;
+    simulation_parameters.linear_solver
+      .relative_residual[PhysicsID::cahn_hilliard];
 
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity !=
-      Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver
+        .verbosity[PhysicsID::cahn_hilliard] != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill = simulation_parameters.linear_solver.ilu_precond_fill;
-  const double ilu_atol = simulation_parameters.linear_solver.ilu_precond_atol;
-  const double ilu_rtol = simulation_parameters.linear_solver.ilu_precond_rtol;
+  const double ilu_fill = simulation_parameters.linear_solver
+                            .ilu_precond_fill[PhysicsID::cahn_hilliard];
+  const double ilu_atol = simulation_parameters.linear_solver
+                            .ilu_precond_atol[PhysicsID::cahn_hilliard];
+  const double ilu_rtol = simulation_parameters.linear_solver
+                            .ilu_precond_rtol[PhysicsID::cahn_hilliard];
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -846,14 +851,16 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
   TrilinosWrappers::MPI::Vector completely_distributed_solution(
     locally_owned_dofs, mpi_communicator);
 
-  SolverControl solver_control(
-    simulation_parameters.linear_solver.max_iterations,
-    linear_solver_tolerance,
-    true,
-    true);
+  SolverControl solver_control(simulation_parameters.linear_solver
+                                 .max_iterations[PhysicsID::cahn_hilliard],
+                               linear_solver_tolerance,
+                               true,
+                               true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
-    false, simulation_parameters.linear_solver.max_krylov_vectors);
+    false,
+    simulation_parameters.linear_solver
+      .max_krylov_vectors[PhysicsID::cahn_hilliard]);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -864,7 +871,7 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
                system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity !=
+  if (simulation_parameters.linear_solver.verbosity[PhysicsID::cahn_hilliard] !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -838,22 +838,21 @@ GDNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
                                                const bool renewed_matrix)
 {
   const double absolute_residual =
-    this->simulation_parameters.linear_solver
-      .minimum_residual[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .minimum_residual;
   const double relative_residual =
-    this->simulation_parameters.linear_solver
-      .relative_residual[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .relative_residual;
 
-  if (this->simulation_parameters.linear_solver
-        .solver[PhysicsID::fluid_dynamics] ==
-      Parameters::LinearSolver::SolverType::gmres)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .solver == Parameters::LinearSolver::SolverType::gmres)
     solve_system_GMRES(initial_step,
                        absolute_residual,
                        relative_residual,
                        renewed_matrix);
   else if (this->simulation_parameters.linear_solver
-             .solver[PhysicsID::fluid_dynamics] ==
-           Parameters::LinearSolver::SolverType::amg)
+             .at(PhysicsID::fluid_dynamics)
+             .solver == Parameters::LinearSolver::SolverType::amg)
     solve_system_AMG(initial_step,
                      absolute_residual,
                      relative_residual,
@@ -872,12 +871,15 @@ GDNavierStokesSolver<dim>::setup_ILU()
   //**********************************************
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
-  const double ilu_fill = this->simulation_parameters.linear_solver
-                            .ilu_precond_fill[PhysicsID::fluid_dynamics];
-  const double ilu_atol = this->simulation_parameters.linear_solver
-                            .ilu_precond_atol[PhysicsID::fluid_dynamics];
-  const double ilu_rtol = this->simulation_parameters.linear_solver
-                            .ilu_precond_rtol[PhysicsID::fluid_dynamics];
+  const double ilu_fill =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .ilu_precond_fill;
+  const double ilu_atol =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .ilu_precond_atol;
+  const double ilu_rtol =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .ilu_precond_rtol;
 
   velocity_ilu_preconditioner =
     std::make_shared<TrilinosWrappers::PreconditionILU>();
@@ -900,7 +902,7 @@ GDNavierStokesSolver<dim>::setup_ILU()
     pressure_mass_matrix,
     &(*velocity_ilu_preconditioner),
     &(*pressure_ilu_preconditioner),
-    this->simulation_parameters.linear_solver);
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics));
 }
 
 template <int dim>
@@ -939,19 +941,21 @@ GDNavierStokesSolver<dim>::setup_AMG()
   bool       higher_order_elements = false;
   if (this->fe->degree > 1)
     higher_order_elements = true;
-  const unsigned int n_cycles = this->simulation_parameters.linear_solver
-                                  .amg_n_cycles[PhysicsID::fluid_dynamics];
-  const bool w_cycle = this->simulation_parameters.linear_solver
-                         .amg_w_cycles[PhysicsID::fluid_dynamics];
+  const unsigned int n_cycles =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .amg_n_cycles;
+  const bool w_cycle =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .amg_w_cycles;
   const double aggregation_threshold =
-    this->simulation_parameters.linear_solver
-      .amg_aggregation_threshold[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .amg_aggregation_threshold;
   const unsigned int smoother_sweeps =
-    this->simulation_parameters.linear_solver
-      .amg_smoother_sweeps[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .amg_smoother_sweeps;
   const unsigned int smoother_overlap =
-    this->simulation_parameters.linear_solver
-      .amg_smoother_overlap[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .amg_smoother_overlap;
   const bool  output_details = false;
   const char *smoother_type  = "Chebyshev";  //"ILU";
   const char *coarse_type    = "Amesos-KLU"; //"ILU";
@@ -1025,7 +1029,7 @@ GDNavierStokesSolver<dim>::setup_AMG()
     pressure_mass_matrix,
     &(*velocity_amg_preconditioner),
     &(*pressure_amg_preconditioner),
-    this->simulation_parameters.linear_solver);
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics));
 }
 
 
@@ -1042,8 +1046,8 @@ GDNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
   const double linear_solver_tolerance =
     std::max(relative_residual * this->system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
@@ -1054,7 +1058,8 @@ GDNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
     this->locally_owned_dofs, this->mpi_communicator);
 
   SolverControl solver_control(this->simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::fluid_dynamics],
+                                 .at(PhysicsID::fluid_dynamics)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);
@@ -1071,8 +1076,8 @@ GDNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
                  this->newton_update,
                  this->system_rhs,
                  *system_ilu_preconditioner);
-    if (this->simulation_parameters.linear_solver
-          .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+    if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .verbosity != Parameters::Verbosity::quiet)
       {
         this->pcout << "  -Iterative solver took : "
                     << solver_control.last_step() << " steps " << std::endl;
@@ -1099,8 +1104,8 @@ GDNavierStokesSolver<dim>::solve_system_AMG(const bool   initial_step,
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
@@ -1112,7 +1117,8 @@ GDNavierStokesSolver<dim>::solve_system_AMG(const bool   initial_step,
 
 
   SolverControl solver_control(this->simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::fluid_dynamics],
+                                 .at(PhysicsID::fluid_dynamics)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);
@@ -1126,8 +1132,8 @@ GDNavierStokesSolver<dim>::solve_system_AMG(const bool   initial_step,
                  this->newton_update,
                  this->system_rhs,
                  *system_amg_preconditioner);
-    if (this->simulation_parameters.linear_solver
-          .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+    if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .verbosity != Parameters::Verbosity::quiet)
       {
         this->pcout << "  -Iterative solver took : "
                     << solver_control.last_step() << " steps " << std::endl;
@@ -1153,8 +1159,8 @@ GDNavierStokesSolver<dim>::solve_L2_system(const bool initial_step,
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
@@ -1163,7 +1169,8 @@ GDNavierStokesSolver<dim>::solve_L2_system(const bool initial_step,
     this->locally_owned_dofs, this->mpi_communicator);
 
   SolverControl solver_control(this->simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::fluid_dynamics],
+                                 .at(PhysicsID::fluid_dynamics)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);
@@ -1173,12 +1180,15 @@ GDNavierStokesSolver<dim>::solve_L2_system(const bool initial_step,
   //**********************************************
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
-  const double ilu_fill = this->simulation_parameters.linear_solver
-                            .ilu_precond_fill[PhysicsID::fluid_dynamics];
-  const double ilu_atol = this->simulation_parameters.linear_solver
-                            .ilu_precond_atol[PhysicsID::fluid_dynamics];
-  const double ilu_rtol = this->simulation_parameters.linear_solver
-                            .ilu_precond_rtol[PhysicsID::fluid_dynamics];
+  const double ilu_fill =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .ilu_precond_fill;
+  const double ilu_atol =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .ilu_precond_atol;
+  const double ilu_rtol =
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .ilu_precond_rtol;
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
   pmass_preconditioner.initialize(pressure_mass_matrix, preconditionerOptions);
@@ -1194,8 +1204,8 @@ GDNavierStokesSolver<dim>::solve_L2_system(const bool initial_step,
                system_rhs,
                preconditioner);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
                   << " steps " << std::endl;

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1113,28 +1113,31 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
     initial_step ? nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver
-      .minimum_residual[PhysicsID::heat_transfer];
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .minimum_residual;
   const double relative_residual =
-    simulation_parameters.linear_solver
-      .relative_residual[PhysicsID::heat_transfer];
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .relative_residual;
 
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::heat_transfer] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill = simulation_parameters.linear_solver
-                            .ilu_precond_fill[PhysicsID::heat_transfer];
-  const double ilu_atol = simulation_parameters.linear_solver
-                            .ilu_precond_atol[PhysicsID::heat_transfer];
-  const double ilu_rtol = simulation_parameters.linear_solver
-                            .ilu_precond_rtol[PhysicsID::heat_transfer];
+  const double ilu_fill =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .ilu_precond_fill;
+  const double ilu_atol =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .ilu_precond_atol;
+  const double ilu_rtol =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .ilu_precond_rtol;
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -1146,15 +1149,16 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
     locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::heat_transfer],
+                                 .at(PhysicsID::heat_transfer)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
     false,
-    simulation_parameters.linear_solver
-      .max_krylov_vectors[PhysicsID::heat_transfer]);
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .max_krylov_vectors);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -1165,8 +1169,8 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
                system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity[PhysicsID::heat_transfer] !=
-      Parameters::Verbosity::quiet)
+  if (simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
                   << " steps " << std::endl;

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1113,23 +1113,28 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
     initial_step ? nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver.minimum_residual;
+    simulation_parameters.linear_solver
+      .minimum_residual[PhysicsID::heat_transfer];
   const double relative_residual =
-    simulation_parameters.linear_solver.relative_residual;
+    simulation_parameters.linear_solver
+      .relative_residual[PhysicsID::heat_transfer];
 
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity !=
-      Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver
+        .verbosity[PhysicsID::heat_transfer] != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill = simulation_parameters.linear_solver.ilu_precond_fill;
-  const double ilu_atol = simulation_parameters.linear_solver.ilu_precond_atol;
-  const double ilu_rtol = simulation_parameters.linear_solver.ilu_precond_rtol;
+  const double ilu_fill = simulation_parameters.linear_solver
+                            .ilu_precond_fill[PhysicsID::heat_transfer];
+  const double ilu_atol = simulation_parameters.linear_solver
+                            .ilu_precond_atol[PhysicsID::heat_transfer];
+  const double ilu_rtol = simulation_parameters.linear_solver
+                            .ilu_precond_rtol[PhysicsID::heat_transfer];
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -1140,14 +1145,16 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
   TrilinosWrappers::MPI::Vector completely_distributed_solution(
     locally_owned_dofs, mpi_communicator);
 
-  SolverControl solver_control(
-    simulation_parameters.linear_solver.max_iterations,
-    linear_solver_tolerance,
-    true,
-    true);
+  SolverControl solver_control(simulation_parameters.linear_solver
+                                 .max_iterations[PhysicsID::heat_transfer],
+                               linear_solver_tolerance,
+                               true,
+                               true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
-    false, simulation_parameters.linear_solver.max_krylov_vectors);
+    false,
+    simulation_parameters.linear_solver
+      .max_krylov_vectors[PhysicsID::heat_transfer]);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -1158,7 +1165,7 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
                system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity !=
+  if (simulation_parameters.linear_solver.verbosity[PhysicsID::heat_transfer] !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -451,11 +451,14 @@ MFNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
                                                const bool /* renewed_matrix */)
 {
   const double absolute_residual =
-    this->simulation_parameters.linear_solver.minimum_residual;
+    this->simulation_parameters.linear_solver
+      .minimum_residual[PhysicsID::fluid_dynamics];
   const double relative_residual =
-    this->simulation_parameters.linear_solver.relative_residual;
+    this->simulation_parameters.linear_solver
+      .relative_residual[PhysicsID::fluid_dynamics];
 
-  if (this->simulation_parameters.linear_solver.solver ==
+  if (this->simulation_parameters.linear_solver
+        .solver[PhysicsID::fluid_dynamics] ==
       Parameters::LinearSolver::SolverType::gmres)
     solve_system_GMRES(initial_step, absolute_residual, relative_residual);
   else
@@ -489,23 +492,24 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity !=
-      Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver
+        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations,
-    linear_solver_tolerance,
-    true,
-    true);
+  SolverControl solver_control(this->simulation_parameters.linear_solver
+                                 .max_iterations[PhysicsID::fluid_dynamics],
+                               linear_solver_tolerance,
+                               true,
+                               true);
 
   SolverGMRES<VectorType>::AdditionalData solver_parameters;
 
   solver_parameters.max_n_tmp_vectors =
-    this->simulation_parameters.linear_solver.max_krylov_vectors;
+    this->simulation_parameters.linear_solver
+      .max_krylov_vectors[PhysicsID::fluid_dynamics];
 
   while (success == false and iter < max_iter)
     {
@@ -529,7 +533,8 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
                          system_rhs,
                          preconditioner);
 
-            if (this->simulation_parameters.linear_solver.verbosity !=
+            if (this->simulation_parameters.linear_solver
+                  .verbosity[PhysicsID::fluid_dynamics] !=
                 Parameters::Verbosity::quiet)
               {
                 this->pcout
@@ -545,8 +550,9 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
         {
           this->pcout << " GMRES solver failed!" << std::endl;
 
-          if (iter == max_iter - 1 && !this->simulation_parameters.linear_solver
-                                         .force_linear_solver_continuation)
+          if (iter == max_iter - 1 &&
+              !this->simulation_parameters.linear_solver
+                 .force_linear_solver_continuation[PhysicsID::fluid_dynamics])
             throw e;
         }
       iter += 1;

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -451,15 +451,14 @@ MFNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
                                                const bool /* renewed_matrix */)
 {
   const double absolute_residual =
-    this->simulation_parameters.linear_solver
-      .minimum_residual[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .minimum_residual;
   const double relative_residual =
-    this->simulation_parameters.linear_solver
-      .relative_residual[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .relative_residual;
 
-  if (this->simulation_parameters.linear_solver
-        .solver[PhysicsID::fluid_dynamics] ==
-      Parameters::LinearSolver::SolverType::gmres)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .solver == Parameters::LinearSolver::SolverType::gmres)
     solve_system_GMRES(initial_step, absolute_residual, relative_residual);
   else
     AssertThrow(false, ExcMessage("This solver is not allowed"));
@@ -492,15 +491,16 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver
-        .verbosity[PhysicsID::fluid_dynamics] != Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
   SolverControl solver_control(this->simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::fluid_dynamics],
+                                 .at(PhysicsID::fluid_dynamics)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);
@@ -508,8 +508,8 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
   SolverGMRES<VectorType>::AdditionalData solver_parameters;
 
   solver_parameters.max_n_tmp_vectors =
-    this->simulation_parameters.linear_solver
-      .max_krylov_vectors[PhysicsID::fluid_dynamics];
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .max_krylov_vectors;
 
   while (success == false and iter < max_iter)
     {
@@ -534,8 +534,8 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
                          preconditioner);
 
             if (this->simulation_parameters.linear_solver
-                  .verbosity[PhysicsID::fluid_dynamics] !=
-                Parameters::Verbosity::quiet)
+                  .at(PhysicsID::fluid_dynamics)
+                  .verbosity != Parameters::Verbosity::quiet)
               {
                 this->pcout
                   << "  -Iterative solver took : " << solver_control.last_step()
@@ -550,9 +550,9 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
         {
           this->pcout << " GMRES solver failed!" << std::endl;
 
-          if (iter == max_iter - 1 &&
-              !this->simulation_parameters.linear_solver
-                 .force_linear_solver_continuation[PhysicsID::fluid_dynamics])
+          if (iter == max_iter - 1 && !this->simulation_parameters.linear_solver
+                                         .at(PhysicsID::fluid_dynamics)
+                                         .force_linear_solver_continuation)
             throw e;
         }
       iter += 1;

--- a/source/solvers/postprocessors_smoothing.cc
+++ b/source/solvers/postprocessors_smoothing.cc
@@ -111,11 +111,11 @@ PostProcessorSmoothing<dim, VectorType>::solve_L2_projection()
     TrilinosWrappers::MPI::Vector(this->locally_owned_dofs,
                                   this->mpi_communicator);
 
-  SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations,
-    linear_solver_tolerance,
-    true,
-    true);
+  SolverControl solver_control(this->simulation_parameters.linear_solver
+                                 .max_iterations[PhysicsID::fluid_dynamics],
+                               linear_solver_tolerance,
+                               true,
+                               true);
 
   TrilinosWrappers::SolverCG solver(solver_control);
 

--- a/source/solvers/postprocessors_smoothing.cc
+++ b/source/solvers/postprocessors_smoothing.cc
@@ -112,7 +112,8 @@ PostProcessorSmoothing<dim, VectorType>::solve_L2_projection()
                                   this->mpi_communicator);
 
   SolverControl solver_control(this->simulation_parameters.linear_solver
-                                 .max_iterations[PhysicsID::fluid_dynamics],
+                                 .at(PhysicsID::fluid_dynamics)
+                                 .max_iterations,
                                linear_solver_tolerance,
                                true,
                                true);

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -730,23 +730,26 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
     initial_step ? nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver.minimum_residual;
+    simulation_parameters.linear_solver.minimum_residual[PhysicsID::tracer];
   const double relative_residual =
-    simulation_parameters.linear_solver.relative_residual;
+    simulation_parameters.linear_solver.relative_residual[PhysicsID::tracer];
 
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity !=
+  if (this->simulation_parameters.linear_solver.verbosity[PhysicsID::tracer] !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill = simulation_parameters.linear_solver.ilu_precond_fill;
-  const double ilu_atol = simulation_parameters.linear_solver.ilu_precond_atol;
-  const double ilu_rtol = simulation_parameters.linear_solver.ilu_precond_rtol;
+  const double ilu_fill =
+    simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::tracer];
+  const double ilu_atol =
+    simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::tracer];
+  const double ilu_rtol =
+    simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::tracer];
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -758,13 +761,14 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
     locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(
-    simulation_parameters.linear_solver.max_iterations,
+    simulation_parameters.linear_solver.max_iterations[PhysicsID::tracer],
     linear_solver_tolerance,
     true,
     true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
-    false, simulation_parameters.linear_solver.max_krylov_vectors);
+    false,
+    simulation_parameters.linear_solver.max_krylov_vectors[PhysicsID::tracer]);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -775,7 +779,7 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
                system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity !=
+  if (simulation_parameters.linear_solver.verbosity[PhysicsID::tracer] !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -730,26 +730,26 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
     initial_step ? nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver.minimum_residual[PhysicsID::tracer];
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).minimum_residual;
   const double relative_residual =
-    simulation_parameters.linear_solver.relative_residual[PhysicsID::tracer];
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).relative_residual;
 
   const double linear_solver_tolerance =
     std::max(relative_residual * system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity[PhysicsID::tracer] !=
-      Parameters::Verbosity::quiet)
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::tracer)
+        .verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
   const double ilu_fill =
-    simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::tracer];
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).ilu_precond_fill;
   const double ilu_atol =
-    simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::tracer];
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).ilu_precond_atol;
   const double ilu_rtol =
-    simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::tracer];
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).ilu_precond_rtol;
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -761,14 +761,15 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
     locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(
-    simulation_parameters.linear_solver.max_iterations[PhysicsID::tracer],
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).max_iterations,
     linear_solver_tolerance,
     true,
     true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
     false,
-    simulation_parameters.linear_solver.max_krylov_vectors[PhysicsID::tracer]);
+    simulation_parameters.linear_solver.at(PhysicsID::tracer)
+      .max_krylov_vectors);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -779,7 +780,7 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
                system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity[PhysicsID::tracer] !=
+  if (simulation_parameters.linear_solver.at(PhysicsID::tracer).verbosity !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1405,7 +1405,7 @@ VolumeOfFluid<dim>::solve_projection_phase_fraction(
     this->locally_owned_dofs, triangulation->get_communicator());
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF).max_iterations,
     linear_solver_tolerance,
     true,
     true);
@@ -1413,11 +1413,14 @@ VolumeOfFluid<dim>::solve_projection_phase_fraction(
   TrilinosWrappers::SolverCG solver(solver_control);
 
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_fill;
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_atol;
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_rtol;
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -1611,7 +1614,7 @@ VolumeOfFluid<dim>::solve_projected_phase_fraction_gradient()
     present_projected_phase_fraction_gradient_solution;
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF).max_iterations,
     linear_solver_tolerance,
     true,
     true);
@@ -1619,11 +1622,14 @@ VolumeOfFluid<dim>::solve_projected_phase_fraction_gradient()
   TrilinosWrappers::SolverCG solver(solver_control);
 
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_fill;
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_atol;
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_rtol;
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -1798,7 +1804,7 @@ VolumeOfFluid<dim>::solve_curvature()
   completely_distributed_curvature_solution = present_curvature_solution;
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF).max_iterations,
     linear_solver_tolerance,
     true,
     true);
@@ -1806,11 +1812,14 @@ VolumeOfFluid<dim>::solve_curvature()
   TrilinosWrappers::SolverCG solver(solver_control);
 
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_fill;
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_atol;
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_rtol;
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -2310,14 +2319,14 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
     initial_step ? this->nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver.minimum_residual[PhysicsID::VOF];
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).minimum_residual;
   const double relative_residual =
-    simulation_parameters.linear_solver.relative_residual[PhysicsID::VOF];
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).relative_residual;
 
   const double linear_solver_tolerance =
     std::max(relative_residual * this->system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity[PhysicsID::VOF] !=
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::VOF).verbosity !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
@@ -2325,11 +2334,11 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
     }
 
   const double ilu_fill =
-    simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).ilu_precond_fill;
   const double ilu_atol =
-    simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).ilu_precond_atol;
   const double ilu_rtol =
-    simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).ilu_precond_rtol;
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -2341,14 +2350,14 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
     this->locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(
-    simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).max_iterations,
     linear_solver_tolerance,
     true,
     true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
     false,
-    simulation_parameters.linear_solver.max_krylov_vectors[PhysicsID::VOF]);
+    simulation_parameters.linear_solver.at(PhysicsID::VOF).max_krylov_vectors);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -2359,7 +2368,7 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
                this->system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity[PhysicsID::VOF] !=
+  if (simulation_parameters.linear_solver.at(PhysicsID::VOF).verbosity !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
@@ -2558,7 +2567,7 @@ VolumeOfFluid<dim>::solve_interface_sharpening(
 
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF).max_iterations,
     linear_solver_tolerance,
     true,
     true);
@@ -2569,11 +2578,14 @@ VolumeOfFluid<dim>::solve_interface_sharpening(
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_fill;
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_atol;
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
+    this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
+      .ilu_precond_rtol;
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1405,7 +1405,7 @@ VolumeOfFluid<dim>::solve_projection_phase_fraction(
     this->locally_owned_dofs, triangulation->get_communicator());
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations,
+    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
     linear_solver_tolerance,
     true,
     true);
@@ -1413,11 +1413,11 @@ VolumeOfFluid<dim>::solve_projection_phase_fraction(
   TrilinosWrappers::SolverCG solver(solver_control);
 
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill;
+    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol;
+    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol;
+    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -1611,7 +1611,7 @@ VolumeOfFluid<dim>::solve_projected_phase_fraction_gradient()
     present_projected_phase_fraction_gradient_solution;
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations,
+    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
     linear_solver_tolerance,
     true,
     true);
@@ -1619,11 +1619,11 @@ VolumeOfFluid<dim>::solve_projected_phase_fraction_gradient()
   TrilinosWrappers::SolverCG solver(solver_control);
 
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill;
+    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol;
+    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol;
+    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -1798,7 +1798,7 @@ VolumeOfFluid<dim>::solve_curvature()
   completely_distributed_curvature_solution = present_curvature_solution;
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations,
+    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
     linear_solver_tolerance,
     true,
     true);
@@ -1806,11 +1806,11 @@ VolumeOfFluid<dim>::solve_curvature()
   TrilinosWrappers::SolverCG solver(solver_control);
 
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill;
+    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol;
+    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol;
+    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
@@ -2310,23 +2310,26 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
     initial_step ? this->nonzero_constraints : this->zero_constraints;
 
   const double absolute_residual =
-    simulation_parameters.linear_solver.minimum_residual;
+    simulation_parameters.linear_solver.minimum_residual[PhysicsID::VOF];
   const double relative_residual =
-    simulation_parameters.linear_solver.relative_residual;
+    simulation_parameters.linear_solver.relative_residual[PhysicsID::VOF];
 
   const double linear_solver_tolerance =
     std::max(relative_residual * this->system_rhs.l2_norm(), absolute_residual);
 
-  if (this->simulation_parameters.linear_solver.verbosity !=
+  if (this->simulation_parameters.linear_solver.verbosity[PhysicsID::VOF] !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Tolerance of iterative solver is : "
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill = simulation_parameters.linear_solver.ilu_precond_fill;
-  const double ilu_atol = simulation_parameters.linear_solver.ilu_precond_atol;
-  const double ilu_rtol = simulation_parameters.linear_solver.ilu_precond_rtol;
+  const double ilu_fill =
+    simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
+  const double ilu_atol =
+    simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
+  const double ilu_rtol =
+    simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);
 
@@ -2338,13 +2341,14 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
     this->locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(
-    simulation_parameters.linear_solver.max_iterations,
+    simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
     linear_solver_tolerance,
     true,
     true);
 
   TrilinosWrappers::SolverGMRES::AdditionalData solver_parameters(
-    false, simulation_parameters.linear_solver.max_krylov_vectors);
+    false,
+    simulation_parameters.linear_solver.max_krylov_vectors[PhysicsID::VOF]);
 
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
@@ -2355,7 +2359,7 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
                this->system_rhs,
                ilu_preconditioner);
 
-  if (simulation_parameters.linear_solver.verbosity !=
+  if (simulation_parameters.linear_solver.verbosity[PhysicsID::VOF] !=
       Parameters::Verbosity::quiet)
     {
       this->pcout << "  -Iterative solver took : " << solver_control.last_step()
@@ -2554,7 +2558,7 @@ VolumeOfFluid<dim>::solve_interface_sharpening(
 
 
   SolverControl solver_control(
-    this->simulation_parameters.linear_solver.max_iterations,
+    this->simulation_parameters.linear_solver.max_iterations[PhysicsID::VOF],
     linear_solver_tolerance,
     true,
     true);
@@ -2565,11 +2569,11 @@ VolumeOfFluid<dim>::solve_interface_sharpening(
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
   const double ilu_fill =
-    this->simulation_parameters.linear_solver.ilu_precond_fill;
+    this->simulation_parameters.linear_solver.ilu_precond_fill[PhysicsID::VOF];
   const double ilu_atol =
-    this->simulation_parameters.linear_solver.ilu_precond_atol;
+    this->simulation_parameters.linear_solver.ilu_precond_atol[PhysicsID::VOF];
   const double ilu_rtol =
-    this->simulation_parameters.linear_solver.ilu_precond_rtol;
+    this->simulation_parameters.linear_solver.ilu_precond_rtol[PhysicsID::VOF];
 
   TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
     ilu_fill, ilu_atol, ilu_rtol, 0);

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -169,7 +169,8 @@ test()
   NSparam.restart_parameters.checkpoint = true;
   NSparam.restart_parameters.frequency  = 1;
   NSparam.non_linear_solver.verbosity   = Parameters::Verbosity::quiet;
-  NSparam.linear_solver.verbosity       = Parameters::Verbosity::quiet;
+  NSparam.linear_solver.at(PhysicsID::fluid_dynamics).verbosity =
+    Parameters::Verbosity::quiet;
   NSparam.boundary_conditions.createNoSlip();
 
   RestartNavierStokes<2> problem_2d(NSparam);


### PR DESCRIPTION
# Description of the problem
Until now, it was not possible in Lethe to specify different parameters for the linear solver for each of the physics involved in a simulation (e.g., fluid dynamics + VOF, fluid_dynamics + heat transfer). 

# Description of the solution
Instead of having one struct for the linear solver parameters, a map of structs was created in order to have a different subsection for all of the physics. Therefore, all of the linear solver parameters can be now specified for each physic and they all have the same default values. 

# How Has This Been Tested?

- All the parameter files in the application tests were updated in order to have a subsection in the linear solver parameters subsection that accounted for each of the physics involved. None of the outputs needed to be updated.
- The `tests/solvers/restart_01.cc` test was also updated as it uses the verbosity parameter of the linear solver parameters. 

# Documentation
- The main page describing the linear solver parameters was updated to mention the possibility of specifying parameters for each physic. 
- The parameter files of the examples were also updated accordingly. Therefore, the examples that explicitly mentioned the linear solver section in the documentation had to be updated as well. 

# Future changes
A following PR will refactor the linear solver across all applications, which will lead to the addition of a  "preconditioner" parameter to the linear solver parameters for each physic.