### PR TITLE
Refactor surface tension gradient parameter

### DIFF
--- a/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
+++ b/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
@@ -3,6 +3,7 @@
 
 set dimension = 2
 
+#---------------------------------------------------
 # Simulation and IO Control
 #---------------------------------------------------
 
@@ -28,17 +29,17 @@ subsection multiphysics
   set fluid dynamics = true
 end
 
+#---------------------------------------------------
+# VOF
+#---------------------------------------------------
+
 subsection VOF
   subsection surface tension force
     set enable                                   = true
     set phase fraction gradient diffusion factor = 4
     set curvature diffusion factor               = 1
     set output auxiliary fields                  = true
-
-    subsection marangoni effect
-      set enable                   = true
-      set surface tension gradient = 0.1
-    end
+    set enable marangoni effect                  = true
   end
 end
 
@@ -102,8 +103,9 @@ subsection physical properties
     subsection fluid-fluid interaction
       set first fluid id              = 0
       set second fluid id             = 1
-      set surface tension model       = constant
+      set surface tension model       = linear
       set surface tension coefficient = 0.023
+      set surface tension gradient    = 0.1
     end
   end
 end

--- a/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
+++ b/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
@@ -101,11 +101,11 @@ subsection physical properties
   subsection material interaction 0
     set type = fluid-fluid
     subsection fluid-fluid interaction
-      set first fluid id              = 0
-      set second fluid id             = 1
-      set surface tension model       = linear
-      set surface tension coefficient = 0.023
-      set surface tension gradient    = 0.1
+      set first fluid id                              = 0
+      set second fluid id                             = 1
+      set surface tension model                       = linear
+      set surface tension coefficient                 = 0.023
+      set temperature-driven surface tension gradient = 0.1
     end
   end
 end

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -59,9 +59,9 @@ Physical Properties
         set solid id                    = 0
 
         # Surface tension
-        set surface tension model       = constant
-        set surface tension coefficient = 0.0
-        set surface tension gradient    = 0.0
+        set surface tension model                       = constant
+        set surface tension coefficient                 = 0
+        set temperature-driven surface tension gradient = 0
       end
     end
   end
@@ -115,14 +115,14 @@ Physical Properties
 
     * The ``surface tension model`` specifies the model used to calculate the surface tension coefficient of the fluid-fluid pair. At the moment, a ``constant`` and a ``linear`` model are supported. For more detail on the surface tension models, see `Surface Tension Models`_.
 
-    * The ``surface tension coefficient`` parameter is the constant surface tension coefficient of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1}`. The surface tension coefficient is used as defined in the Weber number (:math:`We`):
+    * The ``surface tension coefficient`` parameter is a constant surface tension coefficient of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1}`. The surface tension coefficient is used as defined in the Weber number (:math:`We`):
 
       .. math::
           We = Re \cdot \frac{\mu_\text{ref} \; u_\text{ref}}{\sigma}
 
       where :math:`Re` is the Reynolds number, :math:`\mu_\text{ref}` and :math:`u_\text{ref}` are some reference viscosity and velocity characterizing the flow problem, and :math:`\sigma` is the surface tension coefficient.
 
-    * The ``surface tension gradient`` parameter is the surface tension gradient with respect to the temperature of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2} \cdot \text{Temperature}^{-1}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1} \cdot \text{K}^{-1}`. This parameter is used in the calculation of the surface tension using the ``linear`` surface tension model (see `Surface Tension Models`_).
+    * The ``temperature-driven surface tension gradient`` parameter is the surface tension gradient with respect to the temperature of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2} \cdot \text{Temperature}^{-1}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1} \cdot \text{K}^{-1}`. This parameter is used in the calculation of the surface tension using the ``linear`` surface tension model (see `Surface Tension Models`_).
       
     * The ``cahn hilliard mobility model`` specifies the model used to calculate the mobility used in the Cahn-Hilliard equations for the fluid-fluid pair. Two models are available: a ``constant`` mobility and a ``quartic`` mobility. The reader is refered to :doc:`cahn_hilliard` for more details.
       
@@ -502,7 +502,7 @@ Lethe supports two types of surface tension models: ``constant`` and ``linear``.
 .. math::
   \sigma(T) = \sigma_0 + \frac{d\sigma}{dT} \cdot T
 
-where :math:`\sigma_0` is the ``surface tension coefficient`` and :math:`\frac{d\sigma}{dT}` is the ``surface tension gradient`` with respect to the temperature :math:`T`.
+where :math:`\sigma_0` is the ``surface tension coefficient`` evaluated at :math:`T = 0 \: \text{K}` and :math:`\frac{d\sigma}{dT}` is the ``surface tension gradient`` with respect to the temperature :math:`T`.
 
 .. Warning::
     In Lethe, the ``linear`` surface tension model is only used to account for the thermocapillary effect known as the Marangoni effect. Therefore, to enable the Marangoni effect, the surface tension model must be set to ``linear`` and a ``surface tension gradient`` different from zero :math:`(\frac{d\sigma}{dT} \neq 0)` must be specified.

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -497,7 +497,7 @@ Interface Physical Property Models
 Surface Tension Models
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Lethe supports two types of surface tension models: ``constant`` and ``linear``. A ``constant`` surface tension model assumes a constant value of surface tension. While a ``linear`` surface tension assumes that the surface tension evolves linearly with the temperature:
+Lethe supports two types of surface tension models: ``constant`` and ``linear``. A ``constant`` surface tension model assumes a constant value of surface tension, while a ``linear`` surface tension assumes that the surface tension evolves linearly with the temperature:
 
 .. math::
   \sigma(T) = \sigma_0 + \frac{d\sigma}{dT} \cdot T

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -140,13 +140,13 @@ Physical Properties
   The default values for all physical properties models in Lethe is ``constant``. Consequently, it is not necessary (and not recommended) to specify the physical property model unless this model is not constant. This generates parameter files that are easier to read.
 
 
-Material Physical Properties
-****************************
+Material Physical Property Models
+**********************************
 
 .. _two phase simulations:
 
 Two Phase Simulations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 .. note:: 
   Two phase simulations require that either ``set VOF = true`` or ``set cahn hilliard = true`` in the :doc:`multiphysics` subsection. By convention, air is usually the ``fluid 0`` and the other fluid of interest is the ``fluid 1``.
 
@@ -182,7 +182,7 @@ For two phases, the properties are defined for each fluid. Default values are:
 .. _conjugate heat transfer:
 
 Conjugate Heat Transfer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Conjugate heat transfer enables the addition of solid regions in which the fluid dynamics is not solved for. To enable the presence of a solid region, ``number of solids`` must be set to 1. By default, the region with the ``material_id=0`` will be the fluid region whereas the region with ``material_id=1`` will be the solid region. The physical properties of the solid region are set in an identical fashion as those of the fluid.
 
@@ -215,7 +215,7 @@ Conjugate heat transfer enables the addition of solid regions in which the fluid
 .. _rheological_models:
 
 Rheological Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 Two families of rheological models are supported in Lethe. The first one are generalized non Newtonian rheologies (for shear thinning and shear thickening flows). In these models, the viscosity depends on the shear rate. The second family of rheological models possess a viscosity that is independent of the shear rate, but that may depend on other fields such as the temperature.
 
@@ -372,7 +372,7 @@ This model is parameterized using the ``phase change`` subsection
 .. _density_models:
 
 Density Models
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Lethe supports both ``constant`` and ``isothermal_ideal_gas`` density models. Constant density assumes a constant density value. Isothermal ideal gas density assumes that the fluid's density varies according the following state equation:
 
@@ -432,7 +432,7 @@ In the ``phase_change`` thermal conductivity model, two different values (``ther
 where :math:`k_l`, :math:`k_s` and  :math:`\alpha_l` denote thermal conductivities of the liquid and solid phases and the liquid fraction.
 
 Specific Heat Models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 Lethe supports two types of specific heat models. Setting ``specific heat=constant`` sets a constant specific heat. Lethe also supports a ``phase_change`` specific heat model. This model can simulate the melting and solidification of a material. The model follows the work of Blais & Ilinca `[1] <https://doi.org/10.1016/j.compfluid.2018.03.037>`_. This approach defines the specific heat :math:`C_p` as:
 
@@ -489,15 +489,15 @@ This model is parameterized using the following section:
 * The ``specific heat solid`` is :math:`C_{p,s}`
 
 
-Interface Physical Properties
-*****************************
+Interface Physical Property Models
+***********************************
 
 .. _surface_tension_models:
 
 Surface Tension Models
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Lethe supports two types of surface tension models: ``constant`` and ``linear``. A ``constant`` surface tension model assumes a constant value of surface tension. While, a ``linear`` surface tension assumes that the surface tension evolves linearly with the temperature:
+Lethe supports two types of surface tension models: ``constant`` and ``linear``. A ``constant`` surface tension model assumes a constant value of surface tension. While a ``linear`` surface tension assumes that the surface tension evolves linearly with the temperature:
 
 .. math::
   \sigma(T) = \sigma_0 + \frac{d\sigma}{dT} \cdot T
@@ -518,7 +518,7 @@ Lethe supports two types of mobility models for the Cahn-Hilliard equations. Set
 with :math:`D` the value set for ``cahn hilliard mobility constant``. A quartic mobility is required to recover a correct velocity according to Bretin *et al.* `[2] <https://doi.org/10.48550/arXiv.2105.09627>`_ Therefore, it is preferable to use it when solving the coupled Cahn-Hilliard and Navier-Stokes equations.
 
 References
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+***********
 
 `[1] <https://doi.org/10.1016/j.compfluid.2018.03.037>`_ B. Blais and F. Ilinca, “Development and validation of a stabilized immersed boundary CFD model for freezing and melting with natural convection,” *Comput. Fluids*, vol. 172, pp. 564–581, Aug. 2018, doi: 10.1016/j.compfluid.2018.03.037.
 

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -60,7 +60,8 @@ Physical Properties
 
         # Surface tension
         set surface tension model       = constant
-        set surface tension coefficient = 0
+        set surface tension coefficient = 0.0
+        set surface tension gradient    = 0.0
       end
     end
   end
@@ -112,14 +113,16 @@ Physical Properties
       .. attention::
           The ``second fluid id`` should be greater than the ``first fluid id``.
 
-    * The ``surface tension model`` specifies the model used to calculate the surface tension coefficient of the fluid-fluid pair. At the moment, only the ``constant`` model is supported.
+    * The ``surface tension model`` specifies the model used to calculate the surface tension coefficient of the fluid-fluid pair. At the moment, a ``constant`` and a ``linear`` model are supported. For more detail on the surface tension models, see `Surface Tension Models`_.
 
-    * The ``surface tension coefficient`` parameter is the constant surface tension coefficient of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1}`. The surface tension coefficient is used to define the Weber number (:math:`We`):
+    * The ``surface tension coefficient`` parameter is the constant surface tension coefficient of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1}`. The surface tension coefficient is used as defined in the Weber number (:math:`We`):
 
       .. math::
           We = Re \cdot \frac{\mu_\text{ref} \; u_\text{ref}}{\sigma}
 
       where :math:`Re` is the Reynolds number, :math:`\mu_\text{ref}` and :math:`u_\text{ref}` are some reference viscosity and velocity characterizing the flow problem, and :math:`\sigma` is the surface tension coefficient.
+
+    * The ``surface tension gradient`` parameter is the surface tension gradient with respect to the temperature of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2} \cdot \text{Temperature}^{-1}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1} \cdot \text{K}^{-1}`. This parameter is used in the calculation of the surface tension using the ``linear`` surface tension model (see `Surface Tension Models`_).
       
     * The ``cahn hilliard mobility model`` specifies the model used to calculate the mobility used in the Cahn-Hilliard equations for the fluid-fluid pair. Two models are available: a ``constant`` mobility and a ``quartic`` mobility. The reader is refered to :doc:`cahn_hilliard` for more details.
       
@@ -135,6 +138,10 @@ Physical Properties
 
 .. note:: 
   The default values for all physical properties models in Lethe is ``constant``. Consequently, it is not necessary (and not recommended) to specify the physical property model unless this model is not constant. This generates parameter files that are easier to read.
+
+
+Material Physical Properties
+****************************
 
 .. _two phase simulations:
 
@@ -481,8 +488,27 @@ This model is parameterized using the following section:
 
 * The ``specific heat solid`` is :math:`C_{p,s}`
 
-Cahn-Hilliard Mobility Model
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Interface Physical Properties
+*****************************
+
+.. _surface_tension_models:
+
+Surface Tension Models
+~~~~~~~~~~~~~~~~~~~~~~
+
+Lethe supports two types of surface tension models: ``constant`` and ``linear``. A ``constant`` surface tension model assumes a constant value of surface tension. While, a ``linear`` surface tension assumes that the surface tension evolves linearly with the temperature:
+
+.. math::
+  \sigma(T) = \sigma_0 + \frac{d\sigma}{dT} \cdot T
+
+where :math:`\sigma_0` is the ``surface tension coefficient`` and :math:`\frac{d\sigma}{dT}` is the ``surface tension gradient`` with respect to the temperature :math:`T`.
+
+.. Warning::
+    In Lethe, the ``linear`` surface tension model is only used to account for the thermocapillary effect known as the Marangoni effect. Therefore, to enable the Marangoni effect, the surface tension model must be set to ``linear`` and a ``surface tension gradient`` different from zero :math:`(\frac{d\sigma}{dT} \neq 0)` must be specified.
+
+Cahn-Hilliard Mobility Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Lethe supports two types of mobility models for the Cahn-Hilliard equations. Setting ``cahn hilliard mobility model = constant`` sets a constant mobility. Setting a ``cahn hilliard mobility model = quartic`` sets a quartic model for mobility:
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -16,6 +16,10 @@ The default values of the VOF parameters are given in the text box below.
 .. code-block:: text
 
   subsection VOF
+
+    set viscous dissipative fluid = fluid 1
+    set diffusivity               = 0
+
     subsection interface sharpening
       set enable                  = false
       set frequency               = 10
@@ -46,15 +50,8 @@ The default values of the VOF parameters are given in the text box below.
       set output auxiliary fields               = false
       set phase fraction gradient filter factor = 4
       set curvature filter factor               = 1
-
-      subsection marangoni effect
-        set enable                   = false
-        set surface tension gradient = 0.0
-      end
+      set enable marangoni effect               = false
     end
-
-    set viscous dissipative fluid = fluid 1
-    set diffusivity               = 0
 
     subsection peeling wetting
       set enable peeling = false
@@ -73,13 +70,25 @@ The default values of the VOF parameters are given in the text box below.
     end
   end
 
+* ``viscous dissipative fluid``: defines fluid(s) to which viscous dissipation is applied.
+
+  Choices are: ``fluid 0``, ``fluid 1`` (default) or ``both``, with the fluid IDs defined in Physical properties - :ref:`two phase simulations`.
+
+  .. tip::
+    Applying viscous dissipation in one of the fluids instead of both is particularly useful when one of the fluids is air. For numerical stability, the ``kinematic viscosity`` of the air is usually increased. However, we do not want to have viscous dissipation in the air, because it would result in an unrealistic increase in its temperature. This parameter is used only if ``set heat transfer = true`` and ``set viscous dissipation = true`` in :doc:`./multiphysics`.
+
+* ``diffusivity``: value of the diffusivity (diffusion coefficient) in the transport equation of the phase fraction. Default value is ``0`` to have pure advection. Increase ``diffusivity`` to :ref:`improve wetting`.
+
+
+Interface Sharpening
+~~~~~~~~~~~~~~~~~~~~~
 
 * ``subsection interface sharpening``: defines parameters to counter numerical diffusion of the VOF method and to avoid the interface between the two fluids becoming more and more blurry after each time step. The reader is refered to the Interface sharpening section of :doc:`../../../theory/multiphysics/vof` theory guide for additional details on this sharpening method.
 
   * ``enable``: controls if interface sharpening is enabled.
   * ``frequency``: sets the frequency (in number of iterations) for the interface sharpening computation.
   * ``interface sharpness``: sharpness of the moving interface (parameter :math:`a` in the `interface sharpening model <https://www.researchgate.net/publication/287118331_Development_of_efficient_interface_sharpening_procedure_for_viscous_incompressible_flows>`_). This parameter must be larger than 1 for interface sharpening. Choosing values less than 1 leads to interface smoothing instead of sharpening. A good value would be around 1.5.
-  
+
   * ``type``: defines the interface sharpening type, either ``constant`` or ``adaptative``
 
     * ``set type = constant``: the sharpening ``threshold`` is the same throughout the simulation. This ``threshold``, between ``0`` and ``1`` (``0.5`` by default), corresponds to the phase fraction at which the interface is located.
@@ -90,18 +99,18 @@ The default values of the VOF parameters are given in the text box below.
       In case of adaptative interface sharpening (``set type = adaptative``), mass conservation must be monitored (``set monitoring = true`` in ``mass conservation`` subsection).
 
     .. admonition:: Example of a warning message if sharpening is adaptative but the mass conservation tolerance is not reached:
-  
+
       .. code-block:: text
 
-        WARNING: Maximum number of iterations (5) reached in the 
+        WARNING: Maximum number of iterations (5) reached in the
         adaptative sharpening threshold algorithm, remaining error
         on mass conservation is: 0.02
-        Consider increasing the sharpening threshold range or the 
+        Consider increasing the sharpening threshold range or the
         number of iterations to reach the mass conservation tolerance.
 
     .. tip::
 
-      Usually the first iterations with sharpening are the most at risk to reach the ``max iterations`` without the ``tolerance`` being met, particularly if the mesh is quite coarse. 
+      Usually the first iterations with sharpening are the most at risk to reach the ``max iterations`` without the ``tolerance`` being met, particularly if the mesh is quite coarse.
 
       As most of the other iterations converge in only one step (corresponding to a final threshold of :math:`0.5`), increasing the sharpening search range through a higher ``threshold max deviation`` will relax the condition on the first iterations with a limited impact on the computational cost.
 
@@ -110,15 +119,23 @@ The default values of the VOF parameters are given in the text box below.
   .. seealso::
 
     The :doc:`../../examples/multiphysics/dam-break/dam-break` example discussed the interface sharperning mechanism.
-    
+
+
+Phase Filtration
+~~~~~~~~~~~~~~~~~~
+
 * ``subsection phase filtration``: This subsection defines the filter applied to the phase fraction. This affects the definition of the interface.
 
-  * ``type``: defines the filter type, either ``none`` or ``tanh``
+* ``type``: defines the filter type, either ``none`` or ``tanh``
 
-    * ``set type = none``: the phase fraction is not filtered
-    * ``set type = tanh``: the filter function described in the Interface filtration section of :doc:`../../../theory/multiphysics/vof` theory guide is applied.
-  * ``beta``: value of the :math:`\beta` parameter of the ``tanh`` filter
-  * ``verbosity``: enables the display of filtered phase fraction values. Choices are ``quiet`` (no output) and ``verbose`` (displays values)
+  * ``set type = none``: the phase fraction is not filtered
+  * ``set type = tanh``: the filter function described in the Interface filtration section of :doc:`../../../theory/multiphysics/vof` theory guide is applied.
+* ``beta``: value of the :math:`\beta` parameter of the ``tanh`` filter
+* ``verbosity``: enables the display of filtered phase fraction values. Choices are ``quiet`` (no output) and ``verbose`` (displays values)
+
+
+Surface Tension Force
+~~~~~~~~~~~~~~~~~~~~~~
 
 * ``subsection surface tension force``: Surface tension is the tendency of a liquid to maintain the minimum possible surface area. This subsection defines parameters to ensure an accurate interface between the two phases, used when at least one phase is liquid. 
 
@@ -150,22 +167,26 @@ The default values of the VOF parameters are given in the text box below.
 
     Use the procedure suggested in: :ref:`choosing values for the surface tension force filters`.
 
-  * ``subsection marangoni effect``: Marangoni effect is a thermocapillary effect, considered in simulations if ``set enable = true`` and if the ``surface tension gradient`` is not zero :math:`\left(\frac{\partial \sigma}{\partial T} \neq 0\right)`.
+  * ``enable marangoni effect``: Marangoni effect is a thermocapillary effect. It is considered in simulations if this parameter is set to ``true``. Additionally, the ``heat transfer`` auxiliary physics must be enabled (see: :doc:`./multiphysics`) and a non constant ``surface tension model`` with its parameters must be specified in the ``physical properties`` subsection (see: :doc:`./physical_properties`).
 
 .. seealso::
 
   The surface tension force is used in the :doc:`../../examples/multiphysics/rising-bubble/rising-bubble` example.
 
+.. _choosing values for the surface tension force filters:
 
-* ``viscous dissipative fluid``: defines fluid(s) to which viscous dissipation is applied. 
+Choosing Values for the Surface Tension Force Filters
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  Choices are: ``fluid 0``, ``fluid 1`` (default) or ``both``, with the fluid IDs defined in Physical properties - :ref:`two phase simulations`.
+The following procedure is recommended to choose proper values for the ``phase fraction gradient filter factor`` and ``curvature filter factor``:
 
-  .. tip::
-    Applying viscous dissipation in one of the fluids instead of both is particularly useful when one of the fluids is air. For numerical stability, the ``kinematic viscosity`` of the air is usually increased. However, we do not want to have viscous dissipation in the air, because it would result in an unrealistic increase in its temperature. This parameter is used only if ``set heat transfer = true`` and ``set viscous dissipation = true`` in :doc:`./multiphysics`. 
+1. Use ``set output auxiliary fields = true`` to write filtered phase fraction gradient and filtered curvature fields.
+2. Choose a value close to 1, for example, :math:`\alpha = 4` and :math:`\beta = 1`.
+3. Run the simulation and check whether the filtered phase fraction gradient field is smooth and without oscillation.
+4.  If the filtered phase fraction gradient and filtered curvature fields show oscillations, increase the value :math:`\alpha` and :math:`\beta` to larger values, and repeat this process until reaching smooth filtered phase fraction gradient and filtered curvature fields without oscillations.
 
-
-* ``diffusivity``: value of the diffusivity (diffusion coefficient) in the transport equation of the phase fraction. Default value is ``0`` to have pure advection. Increase ``diffusivity`` to :ref:`improve wetting`.
+Peeling and Wetting
+~~~~~~~~~~~~~~~~~~~~~~
 
 * ``subsection peeling wetting``: Peeling and wetting mechanisms are very important to consider when there are solid boundaries in the domain, like a wall. If the fluid is already on the wall and its velocity drives it away from it, the fluid should be able to detach from the wall, meaning to `peel` from it. If the fluid is not already on the wall and its velocity drives it toward it, the fluid should be able to attach to the wall, meaning to `wet` it. This subsection defines the parameters for peeling and wetting mechanisms at the VOF boundaries, as defined in :doc:`boundary_conditions_multiphysics`. 
 
@@ -196,7 +217,8 @@ The default values of the VOF parameters are given in the text box below.
     The cell is then filled with the higher density fluid by changing its phase value progressively.
 
     .. tip ::
-      Using ``set enable wetting = false`` and relying on the ``diffusivity`` to wet the boundaries (see :ref:`improve wetting`) can give better results when the densities of the two fluids are of a very different order of magnitude. 
+
+      Using ``set enable wetting = false`` and relying on the ``diffusivity`` to wet the boundaries (see :ref:`improve wetting`) can give better results when the densities of the two fluids are of a very different order of magnitude.
 
       Typically, when one fluid is more than a hundred times denser than the other, the wetting mechanism can result in the denser fluid crawling on the wall in a non-physical way. Again, this is still a heuristic, so do not hesitate to write to the team through the `Lethe GitHub page <https://github.com/lethe-cfd/lethe>`_ would you need assistance.
 
@@ -209,6 +231,28 @@ The default values of the VOF parameters are given in the text box below.
         Peeling/wetting correction at step 2
           -number of wet cells: 24
           -number of peeled cells: 1
+
+.. _improve wetting:
+
+Improving the Wetting Mechanism
++++++++++++++++++++++++++++++++++++
+
+In the framework of incompressible fluids, a layer of the lowest density fluid (e.g. air) can form between the highest density fluid (e.g. water) and the boundary, preventing its wetting. Two strategies can be used to improve the wetting mechanism:
+
+1. Increase the ``diffusivity`` to the transport equation (e.g. ``set diffusivity = 1e-2``), so that the higher density fluid spreads even more to the boundary location.
+
+.. tip::
+  It is strongly advised to sharpen the interface more often (e.g. ``set frequency = 2`` or even ``1``) to limit interface blurriness due the added diffusivity. As peeling-wetting is handled after the transport equation is solved, but before interface sharpening, sharpening will not prevent the wetting from occurring.
+
+2. Remove the conservation condition on the lowest density fluid (e.g. ``set conservative fluid = fluid 1``). The mass conservation equation in the cells of interest is replaced by a zero-pressure condition, to allow the fluid to get out of the domain.
+
+.. tip::
+  This can give more precise results as the interface remains sharp, but the time step (in :doc:`simulation_control`) must be low enough to prevent numerical instabilities.
+
+.. _mass conservation:
+
+Mass Conservation
+~~~~~~~~~~~~~~~~~~~~~
 
 * ``subsection mass conservation``: By default, mass conservation (continuity) equations are solved on the whole domain, i.e. on both fluids (``set conservative fluid = both``). However, replacing the mass conservation by a zero-pressure condition on one of the fluid (typically, the air), so that it can get in and out of the domain, can be useful to :ref:`improve wetting`. This subsection defines parameters that can be used to solve mass conservation in one fluid instead of both, and to monitor the surface/volume (2D/3D) occupied by the other fluid of interest.
 
@@ -245,38 +289,3 @@ The default values of the VOF parameters are given in the text box below.
     For instance, with ``set tolerance = 0.02`` the sharpening threshold will be adapted so that the mass of the ``monitored fluid`` varies less than :math:`\pm 2\%` from the initial mass (at :math:`t = 0.0` sec).
 
   * ``verbosity``: states whether from the mass conservation data should be printed. Choices are quiet (no output), verbose (output information from the ``adaptive`` sharpening threshold) and extra verbose (output of the monitoring table in the terminal at the end of the simulation).
-
-
-
-
-
-
-.. _improve wetting:
-
-Improving the Wetting Mechanism
-+++++++++++++++++++++++++++++++++++
-
-In the framework of incompressible fluids, a layer of the lowest density fluid (e.g. air) can form between the highest density fluid (e.g. water) and the boundary, preventing its wetting. Two strategies can be used to improve the wetting mechanism:
-
-1. Increase the ``diffusivity`` to the transport equation (e.g. ``set diffusivity = 1e-2``), so that the higher density fluid spreads even more to the boundary location. 
-
-.. tip::
-  It is strongly advised to sharpen the interface more often (e.g. ``set frequency = 2`` or even ``1``) to limit interface blurriness due the added diffusivity. As peeling-wetting is handled after the transport equation is solved, but before interface sharpening, sharpening will not prevent the wetting from occurring.
-
-2. Remove the conservation condition on the lowest density fluid (e.g. ``set conservative fluid = fluid 1``). The mass conservation equation in the cells of interest is replaced by a zero-pressure condition, to allow the fluid to get out of the domain. 
-
-.. tip::
-  This can give more precise results as the interface remains sharp, but the time step (in :doc:`simulation_control`) must be low enough to prevent numerical instabilities.
-
-
-.. _choosing values for the surface tension force filters:
-
-Choosing Values for the Surface Tension Force Filters
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-The following procedure is recommended to choose proper values for the ``phase fraction gradient filter factor`` and ``curvature filter factor``:
-
-1. Use ``set output auxiliary fields = true`` to write filtered phase fraction gradient and filtered curvature fields.
-2. Choose a value close to 1, for example, :math:`\alpha = 4` and :math:`\beta = 1`.
-3. Run the simulation and check whether the filtered phase fraction gradient field is smooth and without oscillation.
-4.  If the filtered phase fraction gradient and filtered curvature fields show oscillations, increase the value :math:`\alpha` and :math:`\beta` to larger values, and repeat this process until reaching smooth filtered phase fraction gradient and filtered curvature fields without oscillations.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -297,7 +297,8 @@ namespace Parameters
   {
     // Surface tension coefficient (sigma) in N/m
     double surface_tension_coefficient;
-    // Surface tension gradient (dsigma/dT) in N/(m*K)
+    // Surface tension gradient with respect to the temperature (dsigma/dT) in
+    // N/(m*K)
     double surface_tension_gradient;
 
     void

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -297,6 +297,8 @@ namespace Parameters
   {
     // Surface tension coefficient (sigma) in N/m
     double surface_tension_coefficient;
+    // Surface tension gradient (dsigma/dT) in N/(m*K)
+    double surface_tension_gradient;
 
     void
     declare_parameters(ParameterHandler &prm);
@@ -416,7 +418,8 @@ namespace Parameters
     // Surface tension models
     enum class SurfaceTensionModel
     {
-      constant
+      constant,
+      linear
     } surface_tension_model;
     SurfaceTensionParameters surface_tension_parameters;
 

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -172,10 +172,6 @@ namespace Parameters
     // Enable marangoni effect
     bool enable_marangoni_effect;
 
-    // Surface tension gradient with respect to temperature
-    // This will be moved to the property manager in another PR.
-    double surface_tension_gradient;
-
     void
     declare_parameters(ParameterHandler &prm);
     void

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -158,7 +158,7 @@ public:
 
   /**
    * @brief value Calculates the surface tension coefficient
-   * @param fields_value Value of the various field on which the property 
+* @param field_vectors Vectors of the fields on which the surface tension
    * depends. In this case, it depends on the temperature.
    * @return value of the physical property calculated with the fields_value
    */

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -27,14 +27,15 @@ class SurfaceTensionModel : public InterfacePropertyModel
 {
 public:
   /**
-   * @brief Instantiates and returns a pointer to a SurfaceTensionModel object by casting it to
-   * the proper child class
+   * @brief Instantiates and returns a pointer to a SurfaceTensionModel object
+   * by casting it to the proper child class
    *
-   * @param surface_tension_parameters Parameters for the surface tension coefficient calculation
+   * @param material_interaction_parameters Parameters for the surface tension
+   * coefficient calculation
    */
   static std::shared_ptr<SurfaceTensionModel>
   model_cast(
-    const Parameters::SurfaceTensionParameters &surface_tension_parameters);
+    const Parameters::MaterialInteractions &material_interaction_parameters);
 };
 
 
@@ -53,7 +54,8 @@ public:
 
   /**
    * @brief value Calculates the surface tension coefficient
-   * @param fields_value Value of the various field on which the property may depend.
+   * @param fields_value Value of the various field on which the property may
+   * depend.
    * @return value of the physical property calculated with the fields_value
    */
   double
@@ -64,7 +66,8 @@ public:
 
   /**
    * @brief vector_value Calculates the vector of surface tension coefficient.
-   * @param field_vectors Vectors of the fields on which the surface tension coefficient may depend.
+   * @param field_vectors Vectors of the fields on which the surface tension
+   * coefficient may depend.
    * @param property_vector Vectors of the surface tension coefficient values
    */
   void
@@ -77,11 +80,14 @@ public:
   }
 
   /**
-   * @brief jacobian Calculates the jacobian (the partial derivative) of the surface tension coefficient with respect to a field
-   * @param field_values Value of the various fields on which the property may depend.
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the
+   * surface tension coefficient with respect to a field
+   * @param field_values Value of the various fields on which the property may
+   * depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated.
-   * @return value of the partial derivative of the surface tension coefficient with respect to the field.
+   * @return value of the partial derivative of the surface tension coefficient
+   * with respect to the field.
    */
   double
   jacobian(const std::map<field, double> & /*field_values*/,
@@ -91,10 +97,14 @@ public:
   }
 
   /**
-   * @brief vector_jacobian Calculates the derivative of the surface tension coefficient with respect to a field.
-   * @param field_vectors Vector for the values of the fields used to evaluate the property.
-   * @param id Identifier of the field with respect to which a derivative should be calculated.
-   * @param jacobian vector of the value of the derivative of the surface tension coefficient with respect to the field id.
+   * @brief vector_jacobian Calculates the derivative of the surface tension
+   * coefficient with respect to a field.
+   * @param field_vectors Vector for the values of the fields used to evaluate
+   * the property.
+   * @param id Identifier of the field with respect to which a derivative should
+   * be calculated.
+   * @param jacobian vector of the value of the derivative of the surface
+   * tension coefficient with respect to the field id.
    */
   void
   vector_jacobian(
@@ -107,6 +117,104 @@ public:
 
 private:
   const double surface_tension_coefficient;
+};
+
+/**
+ * @brief Linear surface tension. The surface tension is given by:
+ * sigma_0 + dsimga/dT * T.
+ */
+class SurfaceTensionLinear : public SurfaceTensionModel
+{
+public:
+  /**
+   * @brief Default constructor
+   */
+  SurfaceTensionLinear(
+    const Parameters::SurfaceTensionParameters &p_surface_tension_parameters)
+    : surface_tension_coefficient(
+        p_surface_tension_parameters.surface_tension_coefficient)
+    , surface_tension_gradient(
+        p_surface_tension_parameters.surface_tension_gradient)
+  {
+    this->model_depends_on[field::temperature] = true;
+  }
+
+  /**
+   * @brief value Calculates the surface tension coefficient
+   * @param fields_value Value of the various field on which the property may
+   * depend. In this case, it depends on the temperature.
+   * @return value of the physical property calculated with the fields_value
+   */
+  double
+  value(const std::map<field, double> &fields_value) override
+  {
+    const double temperature = fields_value.at(field::temperature);
+    return surface_tension_coefficient + surface_tension_gradient * temperature;
+  }
+
+  /**
+   * @brief vector_value Calculates the vector of surface tension coefficient.
+   * @param field_vectors Vectors of the fields on which the surface tension
+   * may depend. In this case, it depends on the temperature.
+   * @param property_vector Vectors of the surface tension coefficient values
+   */
+  void
+  vector_value(const std::map<field, std::vector<double>> &field_vectors,
+               std::vector<double> &property_vector) override
+  {
+    const std::vector<double> &temperature =
+      field_vectors.at(field::temperature);
+    for (unsigned int i = 0; i < property_vector.size(); ++i)
+      property_vector[i] =
+        surface_tension_coefficient + surface_tension_gradient * temperature[i];
+  }
+
+  /**
+   * @brief jacobian Calculates the jacobian (the partial derivative) of the
+   * surface tension coefficient with respect to a field
+   * @param field_values Value of the various fields on which the property may
+   * depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated.
+   * @return value of the partial derivative of the surface tension coefficient
+   * with respect to the field.
+   */
+  double
+  jacobian(const std::map<field, double> & /*field_values*/, field id) override
+  {
+    if (id == field::temperature)
+      return surface_tension_gradient;
+    else
+      return 0;
+  }
+
+  /**
+   * @brief vector_jacobian Calculates the derivative of the surface tension
+   * coefficient with respect to a field.
+   * @param field_vectors Vector for the values of the fields used to evaluate
+   * the property.
+   * @param id Identifier of the field with respect to which a derivative should
+   * be calculated.
+   * @param jacobian vector of the value of the derivative of the surface
+   * tension coefficient with respect to the field id.
+   */
+  void
+  vector_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field          id,
+    std::vector<double> &jacobian_vector) override
+  {
+    if (id == field::temperature)
+      std::fill(jacobian_vector.begin(),
+                jacobian_vector.end(),
+                surface_tension_gradient);
+    else
+      std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+  }
+
+private:
+  const double surface_tension_coefficient;
+  const double surface_tension_gradient;
 };
 
 #endif

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -158,8 +158,8 @@ public:
 
   /**
    * @brief value Calculates the surface tension coefficient
-   * @param fields_value Value of the various field on which the property may
-   * depend. In this case, it depends on the temperature.
+   * @param fields_value Value of the various field on which the property 
+   * depends. In this case, it depends on the temperature.
    * @return value of the physical property calculated with the fields_value
    */
   double
@@ -172,7 +172,7 @@ public:
   /**
    * @brief vector_value Calculates the vector of surface tension coefficient.
    * @param field_vectors Vectors of the fields on which the surface tension
-   * may depend. In this case, it depends on the temperature.
+   * depends. In this case, it depends on the temperature.
    * @param property_vector Vectors of the surface tension coefficient values
    */
   void

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -36,6 +36,21 @@ public:
   static std::shared_ptr<SurfaceTensionModel>
   model_cast(
     const Parameters::MaterialInteractions &material_interaction_parameters);
+
+  /**
+   * @brief is_constant_surface_tension_model Returns a boolean indicating if
+   * the model is a constant surface tension model.
+   * @return Boolean value of if the model corresponds to a constant surface
+   * tension model.
+   */
+  bool
+  is_constant_surface_tension_model()
+  {
+    return surface_tension_is_constant;
+  }
+
+protected:
+  bool surface_tension_is_constant = false;
 };
 
 
@@ -50,7 +65,9 @@ public:
    */
   SurfaceTensionConstant(const double p_surface_tension_coefficient)
     : surface_tension_coefficient(p_surface_tension_coefficient)
-  {}
+  {
+    this->surface_tension_is_constant = true;
+  }
 
   /**
    * @brief value Calculates the surface tension coefficient

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -158,7 +158,7 @@ public:
 
   /**
    * @brief value Calculates the surface tension coefficient
-* @param field_vectors Vectors of the fields on which the surface tension
+   * @param field_vectors Vectors of the fields on which the surface tension
    * depends. In this case, it depends on the temperature.
    * @return value of the physical property calculated with the fields_value
    */

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -1006,6 +1006,7 @@ public:
   std::vector<double> thermal_expansion_0;
   std::vector<double> thermal_expansion_1;
   std::vector<double> surface_tension;
+  std::vector<double> surface_tension_gradient;
   std::vector<double> mobility_cahn_hilliard;
 
   // FEValues for the Navier-Stokes problem

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -255,6 +255,12 @@ public:
     return constant_density;
   }
 
+  bool
+  surface_tension_is_constant() const
+  {
+    return constant_surface_tension;
+  }
+
   unsigned int
   get_material_interaction_id(
     const material_interactions_type material_interaction_type,
@@ -327,6 +333,7 @@ private:
 
   bool non_newtonian_flow;
   bool constant_density;
+  bool constant_surface_tension;
 
   // Temporary scaling variable are overly used right now. They will eventually
   // be deprecated for the majority of places they are used.

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -190,7 +190,7 @@ public:
         not(multiphysics.vof_parameters.conservation.monitoring))
       {
         throw std::logic_error(
-          "Inconsistency in .prm!\n in subsection vof, with sharpening type = adaptative\n "
+          "Inconsistency in .prm!\n in subsection VOF, with sharpening type = adaptative\n "
           "use: monitoring = true");
       }
     if (multiphysics.vof_parameters.surface_tension_force.enable &&
@@ -199,7 +199,7 @@ public:
       {
         throw std::logic_error(
           "Inconsistency in .prm!\n "
-          "In subsection vof, with surface tension force enabled,\n "
+          "In subsection VOF, with surface tension force enabled,\n "
           "but no material interactions specified in\n subsection physical properties.\n "
           "Use:\n\n"
           "  set number of material interactions = 1\n"
@@ -231,7 +231,7 @@ public:
         if (no_fluid_fluid_interaction_error)
           {
             throw std::logic_error(
-              "Inconsistency in .prm!\n in subsection vof, with surface tension force enabled,\n "
+              "Inconsistency in .prm!\n in subsection VOF, with surface tension force enabled,\n "
               "but no fluid-fluid material interactions specified in\n subsection physical properties\n "
               "Use:\n\n"
               "  subsection material interaction $material_interaction_id\n"
@@ -281,8 +281,8 @@ public:
           {
             throw std::logic_error(
               "Inconsistency in .prm!\n "
-              "In subsection multiphysics, with VOF and heat transfer enabled,\n "
-              "and in subsection vof, with marangoni effect enabled,\n "
+              "In subsection multiphysics, VOF and heat transfer enabled,\n "
+              "and in subsection vof, marangoni effect enabled,\n "
               "but no material interactions specified in subsection physical\n "
               "properties. This is necessary to account for Marangoni \n "
               "effect. In subsection physical properties, use:\n\n"

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -193,56 +193,124 @@ public:
           "Inconsistency in .prm!\n in subsection VOF, with sharpening type = adaptative\n "
           "use: monitoring = true");
       }
-    if (multiphysics.vof_parameters.surface_tension_force.enable &&
-        !multiphysics.heat_transfer &&
-        physical_properties.number_of_material_interactions == 0)
+
+    // Interface physical property models consistency check
+    if (multiphysics.vof_parameters.surface_tension_force.enable)
       {
-        throw std::logic_error(
-          "Inconsistency in .prm!\n "
-          "In subsection VOF, with surface tension force enabled,\n "
-          "but no material interactions specified in\n subsection physical properties.\n "
-          "Use:\n\n"
-          "  set number of material interactions = 1\n"
-          "  subsection material interaction 0\n"
-          "    set type = fluid-fluid\n"
+        std::string constant_surface_tension_model(
           "    subsection fluid-fluid interaction\n"
           "      set first fluid id              = 0\n"
           "      set second fluid id             = 1\n"
           "      set surface tension model       = constant\n"
           "      set surface tension coefficient = $value_of_coefficient\n"
-          "    end\n"
-          "  end\n");
-      }
-    if (multiphysics.vof_parameters.surface_tension_force.enable &&
-        !multiphysics.vof_parameters.surface_tension_force
-           .enable_marangoni_effect)
-      {
-        bool no_fluid_fluid_interaction_error = true;
-        for (unsigned int i = 0;
-             i < physical_properties.number_of_material_interactions;
-             ++i)
+          "    end\n");
+
+        std::string linear_surface_tension_model(
+          "    subsection fluid-fluid interaction\n"
+          "      set first fluid id                              = 0\n"
+          "      set second fluid id                             = 1\n"
+          "      set surface tension model                       = linear\n"
+          "      set surface tension coefficient                 = $value_of_coefficient\n"
+          "      set temperature-driven surface tension gradient = $value_of_gradient\n"
+          "    end\n");
+
+        if (!multiphysics.vof_parameters.surface_tension_force
+               .enable_marangoni_effect) // constant surface tension model
           {
-            if (physical_properties.material_interactions[i]
-                  .material_interaction_type ==
-                Parameters::MaterialInteractions::MaterialInteractionsType::
-                  fluid_fluid)
-              no_fluid_fluid_interaction_error = false;
+            if (physical_properties.number_of_material_interactions == 0)
+              {
+                throw std::logic_error(
+                  "Inconsistency in .prm!\n "
+                  "In subsection VOF, with surface tension force enabled,\n "
+                  "but no material interactions specified in\n "
+                  "subsection physical properties.\n "
+                  "Use:\n\n"
+                  "  set number of material interactions = 1\n"
+                  "  subsection material interaction 0\n"
+                  "    set type = fluid-fluid\n" +
+                  constant_surface_tension_model + "  end\n");
+              }
+            else if (multiphysics.VOF &&
+                     multiphysics
+                       .heat_transfer) // disabled Marangoni effect error
+              {
+                if (!is_constant_surface_tension_model(
+                      physical_properties.material_interactions))
+                  {
+                    throw std::logic_error(
+                      "Inconsistency in .prm!\n "
+                      "In subsection multiphysics, VOF and heat transfer enabled,\n "
+                      "and in subsection physical properties, a non-constant surface\n "
+                      "tension model, but Marangoni effect disabled in subsection\n "
+                      "surface tension force of subsection VOF. This is necessary to account\n "
+                      "for Marangoni effect. In subsection VOF, use:\n\n "
+                      "  subsection surface tension force\n"
+                      "    set enable                  = true\n"
+                      "    set enable marangoni effect = true\n"
+                      "  end\n");
+                  }
+              }
+            else
+              {
+                if (no_fluid_fluid_interaction_error(
+                      physical_properties.material_interactions))
+                  {
+                    throw std::logic_error(
+                      "Inconsistency in .prm!\n "
+                      "in subsection VOF, surface tension force enabled,\n "
+                      "but no fluid-fluid material interactions specified in \n "
+                      "subsection physical properties\n "
+                      "Use:\n\n"
+                      "  subsection material interaction $material_interaction_id\n"
+                      "    set type = fluid-fluid\n" +
+                      constant_surface_tension_model + "  end\n");
+                  }
+              }
           }
-        if (no_fluid_fluid_interaction_error)
+        else // non-constant surface tension model
           {
-            throw std::logic_error(
-              "Inconsistency in .prm!\n in subsection VOF, with surface tension force enabled,\n "
-              "but no fluid-fluid material interactions specified in\n subsection physical properties\n "
-              "Use:\n\n"
-              "  subsection material interaction $material_interaction_id\n"
-              "    set type = fluid-fluid\n"
-              "    subsection fluid-fluid interaction\n"
-              "      set first fluid id              = 0\n"
-              "      set second fluid id             = 1\n"
-              "      set surface tension model       = constant\n"
-              "      set surface tension coefficient = $value_of_coefficient\n"
-              "    end\n"
-              "  end\n");
+            if (physical_properties.number_of_material_interactions == 0)
+              {
+                throw std::logic_error(
+                  "Inconsistency in .prm!\n "
+                  "In subsection VOF, marangoni effect enabled,\n "
+                  "but no material interactions specified in subsection physical\n "
+                  "properties. This is necessary to account for Marangoni \n "
+                  "effect. In subsection physical properties, use:\n\n"
+                  "  set number of material interactions = 1\n"
+                  "  subsection material interaction 0\n"
+                  "    set type = fluid-fluid\n" +
+                  linear_surface_tension_model + "  end\n");
+              }
+            else
+              {
+                if (no_fluid_fluid_interaction_error(
+                      physical_properties.material_interactions))
+                  {
+                    throw std::logic_error(
+                      "Inconsistency in .prm!\n "
+                      "In subsection VOF, Marangoni effect enabled,\n "
+                      "but no fluid-fluid material interactions specified in subsection\n "
+                      "physical properties. This is necessary to account for Marangoni\n "
+                      "effect. In subsection physical properties, use:\n\n"
+                      "  subsection material interaction $material_interaction_id\n"
+                      "    set type = fluid-fluid\n" +
+                      linear_surface_tension_model + "  end\n");
+                  }
+                if (is_constant_surface_tension_model(
+                      physical_properties.material_interactions))
+                  {
+                    throw std::logic_error(
+                      "Inconsistency in .prm!\n "
+                      "In subsection VOF, Marangoni effect enabled,\n "
+                      "but a constant surface tension model is specified in subsection\n "
+                      "physical properties. This is necessary to account for Marangoni \n "
+                      "effect. In subsection physical properties, use:\n\n"
+                      "  subsection material interaction $material_interaction_id\n"
+                      "    set type = fluid-fluid\n" +
+                      linear_surface_tension_model + "  end\n");
+                  }
+              }
           }
       }
 
@@ -271,125 +339,39 @@ public:
           "    end\n"
           "  end\n");
       }
+  }
 
-    if (multiphysics.VOF && multiphysics.heat_transfer &&
-        multiphysics.vof_parameters.surface_tension_force
-          .enable_marangoni_effect &&
-        multiphysics.vof_parameters.surface_tension_force.enable)
+  inline bool
+  no_fluid_fluid_interaction_error(
+    std::vector<Parameters::MaterialInteractions> &material_interactions)
+  {
+    for (const Parameters::MaterialInteractions &material_interaction :
+         material_interactions)
       {
-        if (physical_properties.number_of_material_interactions == 0)
+        if (material_interaction.material_interaction_type ==
+            Parameters::MaterialInteractions::MaterialInteractionsType::
+              fluid_fluid)
           {
-            throw std::logic_error(
-              "Inconsistency in .prm!\n "
-              "In subsection multiphysics, VOF and heat transfer enabled,\n "
-              "and in subsection vof, marangoni effect enabled,\n "
-              "but no material interactions specified in subsection physical\n "
-              "properties. This is necessary to account for Marangoni \n "
-              "effect. In subsection physical properties, use:\n\n"
-              "  set number of material interactions = 1\n"
-              "  subsection material interaction 0\n"
-              "    set type = fluid-fluid\n"
-              "    subsection fluid-fluid interaction\n"
-              "      set first fluid id              = 0\n"
-              "      set second fluid id             = 1\n"
-              "      set surface tension model       = linear\n"
-              "      set surface tension coefficient = $value_of_coefficient\n"
-              "      set surface tension gradient    = $value_of_gradient\n"
-              "    end\n"
-              "  end\n");
-          }
-        else
-          {
-            bool no_fluid_fluid_interaction_error = true;
-            bool constant_surface_tension_error   = true;
-            for (unsigned int i = 0;
-                 i < physical_properties.number_of_material_interactions;
-                 ++i)
-              {
-                if (physical_properties.material_interactions[i]
-                      .material_interaction_type ==
-                    Parameters::MaterialInteractions::MaterialInteractionsType::
-                      fluid_fluid)
-                  no_fluid_fluid_interaction_error = false;
-
-                if (physical_properties.material_interactions[i]
-                      .surface_tension_model !=
-                    Parameters::MaterialInteractions::SurfaceTensionModel::
-                      constant)
-                  constant_surface_tension_error = false;
-              }
-            if (no_fluid_fluid_interaction_error)
-              {
-                throw std::logic_error(
-                  "Inconsistency in .prm!\n "
-                  "In subsection multiphysics, with VOF and heat transfer enabled,\n "
-                  "and in subsection vof, with marangoni effect enabled,\n "
-                  "but no fluid-fluid material interactions specified in subsection\n "
-                  "physical properties. This is necessary to account for Marangoni\n "
-                  "effect. In subsection physical properties, use:\n\n"
-                  "  subsection material interaction $material_interaction_id\n"
-                  "    set type = fluid-fluid\n"
-                  "    subsection fluid-fluid interaction\n"
-                  "      set first fluid id              = 0\n"
-                  "      set second fluid id             = 1\n"
-                  "      set surface tension model       = linear\n"
-                  "      set surface tension coefficient = $value_of_coefficient\n"
-                  "      set surface tension gradient    = $value_of_gradient\n"
-                  "    end\n"
-                  "  end\n");
-              }
-            if (constant_surface_tension_error)
-              {
-                throw std::logic_error(
-                  "Inconsistency in .prm!\n "
-                  "In subsection multiphysics, with VOF and heat transfer enabled,\n "
-                  "and in subsection vof, with marangoni effect enabled,\n "
-                  "but a constant surface tension model is specified in subsection\n "
-                  "physical properties. This is necessary to account for Marangoni \n "
-                  "effect. In subsection physical properties, use:\n\n"
-                  "  subsection material interaction $material_interaction_id\n"
-                  "    set type = fluid-fluid\n"
-                  "    subsection fluid-fluid interaction\n"
-                  "      set first fluid id              = 0\n"
-                  "      set second fluid id             = 1\n"
-                  "      set surface tension model       = linear\n"
-                  "      set surface tension coefficient = $value_of_coefficient\n"
-                  "      set surface tension gradient    = $value_of_gradient\n"
-                  "    end\n"
-                  "  end\n");
-              }
+            return false;
           }
       }
+    return true;
+  }
 
-    if (multiphysics.VOF && multiphysics.heat_transfer &&
-        !multiphysics.vof_parameters.surface_tension_force
-           .enable_marangoni_effect)
+  inline bool
+  is_constant_surface_tension_model(
+    std::vector<Parameters::MaterialInteractions> &material_interactions)
+  {
+    for (const Parameters::MaterialInteractions &material_interaction :
+         material_interactions)
       {
-        bool disabled_marangoni_effect_error = false;
-        for (unsigned int i = 0;
-             i < physical_properties.number_of_material_interactions;
-             ++i)
+        if (material_interaction.surface_tension_model !=
+            Parameters::MaterialInteractions::SurfaceTensionModel::constant)
           {
-            if (physical_properties.material_interactions[i]
-                  .surface_tension_model !=
-                Parameters::MaterialInteractions::SurfaceTensionModel::constant)
-              disabled_marangoni_effect_error = true;
-          }
-        if (disabled_marangoni_effect_error)
-          {
-            throw std::logic_error(
-              "Inconsistency in .prm!\n "
-              "In subsection multiphysics, with VOF and heat transfer enabled,\n "
-              "and in subsection physical properties, with a non-constant surface\n "
-              "tension model, but Marangoni effect disabled in subsection\n "
-              "surface tension force of subsection vof. This is necessary to account\n "
-              "for Marangoni effect. In subsection vof, use:\n\n "
-              "  subsection surface tension force\n"
-              "    set enable                  = true\n"
-              "    set enable marangoni effect = true\n"
-              "  end\n");
+            return false;
           }
       }
+    return true;
   }
 
 private:

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -214,7 +214,8 @@ public:
           "  end\n");
       }
     if (multiphysics.vof_parameters.surface_tension_force.enable &&
-        !multiphysics.heat_transfer)
+        !multiphysics.vof_parameters.surface_tension_force
+           .enable_marangoni_effect)
       {
         bool no_fluid_fluid_interaction_error = true;
         for (unsigned int i = 0;
@@ -271,35 +272,11 @@ public:
           "  end\n");
       }
 
-    if (multiphysics.heat_transfer &&
-        multiphysics.vof_parameters.surface_tension_force
-          .enable_marangoni_effect &&
-        !multiphysics.VOF)
-      {
-        throw std::logic_error(
-          "Inconsistency in .prm!\n "
-          "In subsection multiphysics, with heat transfer enabled, and in \n "
-          "subsection vof with marangoni effect enabled, but VOF not enabled in \n "
-          "subsection multiphysics. This is necessary to account for Marangoni \n "
-          "effect. In subsection multiphysics, use:\n\n"
-          "  set VOF  = true\n");
-      }
-
-    if (multiphysics.VOF &&
+    if (multiphysics.VOF && multiphysics.heat_transfer &&
         multiphysics.vof_parameters.surface_tension_force
           .enable_marangoni_effect &&
         multiphysics.vof_parameters.surface_tension_force.enable)
       {
-        if (!multiphysics.heat_transfer)
-          {
-            throw std::logic_error(
-              "Inconsistency in .prm!\n "
-              "In subsection multiphysics, with VOF enabled, and in subsection vof\n "
-              "with marangoni effect enabled, but heat transfer not enabled in \n "
-              "subsection multiphysics. This is necessary to account for Marangoni \n "
-              "effect. In subsection multiphysics, use:\n\n"
-              "  set heat transfer  = true\n");
-          }
         if (physical_properties.number_of_material_interactions == 0)
           {
             throw std::logic_error(
@@ -412,23 +389,6 @@ public:
               "    set enable marangoni effect = true\n"
               "  end\n");
           }
-      }
-
-    if (multiphysics.VOF && multiphysics.heat_transfer &&
-        multiphysics.vof_parameters.surface_tension_force
-          .enable_marangoni_effect &&
-        !multiphysics.vof_parameters.surface_tension_force.enable)
-      {
-        throw std::logic_error(
-          "Inconsistency in .prm!\n "
-          "In subsection multiphysics, with VOF and heat transfer enabled,\n "
-          "and in subsection vof, with marangoni effect enabled, but surface\n "
-          "tension force disabled in subsection surface tension force of \n "
-          "subsection vof. In subsection vof, use:\n\n"
-          "  subsection surface tension force\n"
-          "    set enable                  = true\n"
-          "    set enable marangoni effect = true\n"
-          "  end\n");
       }
   }
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -418,15 +418,21 @@ namespace Parameters
   {
     prm.declare_entry(
       "surface tension coefficient",
-      "0",
+      "0.0",
       Patterns::Double(),
       "Surface tension coefficient for the corresponding pair of fluids or fluid-solid pair");
+    prm.declare_entry(
+      "surface tension gradient",
+      "0.0",
+      Patterns::Double(),
+      "Surface tension gradient with respect to the temperature for the corresponding pair of fluids or fluid-solid pair");
   }
 
   void
   SurfaceTensionParameters::parse_parameters(ParameterHandler &prm)
   {
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
+    surface_tension_gradient    = prm.get_double("surface tension gradient");
   }
 
   void
@@ -951,7 +957,7 @@ namespace Parameters
         "type",
         "fluid-fluid",
         Patterns::Selection("fluid-fluid|fluid-solid"),
-        "Type of materials interacting. Choices are <fluid-fluid|fluid-solid>");
+        "Type of materials interacting. The choices are <fluid-fluid|fluid-solid>");
 
       // Fluid-fluid interactions
       prm.enter_subsection("fluid-fluid interaction");
@@ -971,9 +977,9 @@ namespace Parameters
         prm.declare_entry(
           "surface tension model",
           "constant",
-          Patterns::Selection("constant"),
-          "Model used for the calculation of the surface tension coefficient"
-          "At the moment, the only choice is <constant>");
+          Patterns::Selection("constant|linear"),
+          "Model used for the calculation of the surface tension coefficient\n"
+          "The choices are <constant|linear>.");
         surface_tension_parameters.declare_parameters(prm);
 
         // Cahn-Hilliard mobility
@@ -981,8 +987,8 @@ namespace Parameters
           "cahn hilliard mobility model",
           "constant",
           Patterns::Selection("constant|quartic"),
-          "Model used for the calculation of the mobility in the Cahn-Hilliard equations"
-          "Choices are <constant|quartic>");
+          "Model used for the calculation of the mobility in the Cahn-Hilliard equations\n"
+          "The choices are <constant|quartic>.");
         mobility_cahn_hilliard_parameters.declare_parameters(prm);
       }
       prm.leave_subsection();
@@ -1003,9 +1009,9 @@ namespace Parameters
         prm.declare_entry(
           "surface tension model",
           "constant",
-          Patterns::Selection("constant"),
-          "Model used for the calculation of the surface tension coefficient"
-          "At the moment, the only choice is <constant>");
+          Patterns::Selection("constant|linear"),
+          "Model used for the calculation of the surface tension coefficient\n"
+          "The choices are <constant|linear>.");
         surface_tension_parameters.declare_parameters(prm);
       }
       prm.leave_subsection();
@@ -1027,7 +1033,7 @@ namespace Parameters
         material_interaction_type = MaterialInteractionsType::fluid_solid;
       else
         throw(std::runtime_error(
-          "Invalid material interaction type. Choices are <fluid-fluid|fluid-solid>"));
+          "Invalid material interaction type. The choices are <fluid-fluid|fluid-solid>."));
 
       if (material_interaction_type == MaterialInteractionsType::fluid_fluid)
         {
@@ -1050,9 +1056,14 @@ namespace Parameters
               surface_tension_model = SurfaceTensionModel::constant;
               surface_tension_parameters.parse_parameters(prm);
             }
+          else if (op == "linear")
+            {
+              surface_tension_model = SurfaceTensionModel::linear;
+              surface_tension_parameters.parse_parameters(prm);
+            }
           else
             throw(std::runtime_error(
-              "Invalid surface tension model. At the moment, the only choice is <constant>"));
+              "Invalid surface tension model. The choices are <constant|linear>."));
 
           // Cahn-Hilliard mobility
           op = prm.get("cahn hilliard mobility model");
@@ -1069,7 +1080,7 @@ namespace Parameters
             }
           else
             throw(std::runtime_error(
-              "Invalid mobility model. The choices are <constant|quartic>"));
+              "Invalid mobility model. The choices are <constant|quartic>."));
 
           prm.leave_subsection();
         }
@@ -1090,9 +1101,14 @@ namespace Parameters
               surface_tension_model = SurfaceTensionModel::constant;
               surface_tension_parameters.parse_parameters(prm);
             }
+          else if (op == "linear")
+            {
+              surface_tension_model = SurfaceTensionModel::linear;
+              surface_tension_parameters.parse_parameters(prm);
+            }
           else
             throw(std::runtime_error(
-              "Invalid surface tension model. At the moment, the only choice is <constant>"));
+              "Invalid surface tension model. The choices are <constant|linear>."));
           std::pair<std::pair<unsigned int, unsigned int>, SurfaceTensionModel>
             fluid_solid_surface_tension_interaction(fluid_solid_interaction,
                                                     surface_tension_model);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -422,7 +422,7 @@ namespace Parameters
       Patterns::Double(),
       "Surface tension coefficient for the corresponding pair of fluids or fluid-solid pair");
     prm.declare_entry(
-      "surface tension gradient",
+      "temperature-driven surface tension gradient",
       "0.0",
       Patterns::Double(),
       "Surface tension gradient with respect to the temperature for the corresponding pair of fluids or fluid-solid pair");
@@ -432,7 +432,7 @@ namespace Parameters
   SurfaceTensionParameters::parse_parameters(ParameterHandler &prm)
   {
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
-    surface_tension_gradient    = prm.get_double("surface tension gradient");
+    surface_tension_gradient    = prm.get_double("temperature-driven surface tension gradient");
   }
 
   void
@@ -700,6 +700,7 @@ namespace Parameters
       AssertThrow(number_of_material_interactions <= max_material_interactions,
                   NumberOfMaterialInteractionsError(
                     number_of_material_interactions));
+      material_interactions.resize(number_of_material_interactions);
       for (unsigned int i_material_interaction = 0;
            i_material_interaction < number_of_material_interactions;
            ++i_material_interaction)

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -432,7 +432,8 @@ namespace Parameters
   SurfaceTensionParameters::parse_parameters(ParameterHandler &prm)
   {
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
-    surface_tension_gradient    = prm.get_double("temperature-driven surface tension gradient");
+    surface_tension_gradient =
+      prm.get_double("temperature-driven surface tension gradient");
   }
 
   void

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -462,19 +462,11 @@ Parameters::VOF_SurfaceTensionForce::declare_parameters(ParameterHandler &prm)
       "State whether the output from the surface tension force calculations should be printed "
       "Choices are <quiet|verbose>.");
 
-    prm.enter_subsection("marangoni effect");
-    {
-      prm.declare_entry("enable",
-                        "false",
-                        Patterns::Bool(),
-                        "Enable marangoni effect calculation <true|false>");
 
-      prm.declare_entry("surface tension gradient",
-                        "0.0",
-                        Patterns::Double(),
-                        "Surface tension gradient with respect to temperature");
-    }
-    prm.leave_subsection();
+    prm.declare_entry("enable marangoni effect",
+                      "false",
+                      Patterns::Bool(),
+                      "Enable marangoni effect calculation <true|false>");
   }
   prm.leave_subsection();
 }
@@ -499,14 +491,7 @@ Parameters::VOF_SurfaceTensionForce::parse_parameters(ParameterHandler &prm)
     else
       throw(std::runtime_error("Invalid verbosity level"));
 
-    prm.enter_subsection("marangoni effect");
-    {
-      enable_marangoni_effect = prm.get_bool("enable");
-
-      // Surface tension gradient
-      surface_tension_gradient = prm.get_double("surface tension gradient");
-    }
-    prm.leave_subsection();
+    enable_marangoni_effect = prm.get_bool("enable marangoni effect");
   }
   prm.leave_subsection();
 }

--- a/source/core/surface_tension_model.cc
+++ b/source/core/surface_tension_model.cc
@@ -18,8 +18,14 @@
 
 std::shared_ptr<SurfaceTensionModel>
 SurfaceTensionModel::model_cast(
-  const Parameters::SurfaceTensionParameters &surface_tension_parameters)
+  const Parameters::MaterialInteractions &material_interaction_parameter)
 {
-  return std::make_shared<SurfaceTensionConstant>(
-    surface_tension_parameters.surface_tension_coefficient);
+  if (material_interaction_parameter.surface_tension_model ==
+      Parameters::MaterialInteractions::SurfaceTensionModel::linear)
+    return std::make_shared<SurfaceTensionLinear>(
+      material_interaction_parameter.surface_tension_parameters);
+  else
+    return std::make_shared<SurfaceTensionConstant>(
+      material_interaction_parameter.surface_tension_parameters
+        .surface_tension_coefficient);
 }

--- a/source/core/surface_tension_model.cc
+++ b/source/core/surface_tension_model.cc
@@ -18,14 +18,14 @@
 
 std::shared_ptr<SurfaceTensionModel>
 SurfaceTensionModel::model_cast(
-  const Parameters::MaterialInteractions &material_interaction_parameter)
+  const Parameters::MaterialInteractions &material_interaction_parameters)
 {
-  if (material_interaction_parameter.surface_tension_model ==
+  if (material_interaction_parameters.surface_tension_model ==
       Parameters::MaterialInteractions::SurfaceTensionModel::linear)
     return std::make_shared<SurfaceTensionLinear>(
-      material_interaction_parameter.surface_tension_parameters);
+      material_interaction_parameters.surface_tension_parameters);
   else
     return std::make_shared<SurfaceTensionConstant>(
-      material_interaction_parameter.surface_tension_parameters
+      material_interaction_parameters.surface_tension_parameters
         .surface_tension_coefficient);
 }

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -10,56 +10,56 @@
 DeclException1(
   BuoyancyWithoutFluidDynamicsError,
   bool,
-  << "Buoyancy force is activated (" << arg1
+  << std::boolalpha << "Buoyancy force is activated (" << arg1
   << "), while fluid dynamics is not activated (false)." << std::endl
   << "Buoyancy force cannot be activated without activating fluid dynamics.");
 
 DeclException1(
   BuoyancyWithoutHeatTransferError,
   bool,
-  << "Buoyancy force is activated (" << arg1
+  << std::boolalpha << "Buoyancy force is activated (" << arg1
   << "), while heat transfer is not activated (false)." << std::endl
   << "Buoyancy force cannot be activated without activating heat transfer.");
 
 DeclException1(
   MarangoniWithoutFluidDynamicsError,
   bool,
-  << "Marangoni effect is activated (" << arg1
+  << std::boolalpha << "Marangoni effect is activated (" << arg1
   << "), while fluid dynamics is not activated (false)." << std::endl
   << "Marangoni effect cannot be activated without activating fluid dynamics.");
 
 DeclException1(
   MarangoniWithoutHeatTransferError,
   bool,
-  << "Marangoni effect is activated (" << arg1
+  << std::boolalpha << "Marangoni effect is activated (" << arg1
   << "), while heat transfer is not activated (false)." << std::endl
   << "Marangoni effect cannot be activated without activating heat transfer.");
 
 DeclException1(
   MarangoniWithoutSurfaceTensionForceError,
   bool,
-  << "Marangoni effect is activated (" << arg1
+  << std::boolalpha << "Marangoni effect is activated (" << arg1
   << "), while surface tension force is not activated (false)." << std::endl
   << "Marangoni effect cannot be activated without activating surface tension force.");
 
 DeclException1(
   SurfaceTensionForceWithoutVOFError,
   bool,
-  << "Surface tension force is activated (" << arg1
+  << std::boolalpha << "Surface tension force is activated (" << arg1
   << "), while VOF is not activated (false)." << std::endl
   << "Surface tension force cannot be activated without activating VOF.");
 
 DeclException1(
   MarangoniWithoutVOFError,
   bool,
-  << "Marangoni effect is activated (" << arg1
+  << std::boolalpha << "Marangoni effect is activated (" << arg1
   << "), while VOF is not activated (false)." << std::endl
   << "Marangoni effect cannot be activated without activating VOF.");
 
 DeclException1(
   InterfaceSharpeningWithoutVOFError,
   bool,
-  << "Interface sharpening is activated (" << arg1
+  << std::boolalpha << "Interface sharpening is activated (" << arg1
   << "), while VOF is not activated (false)." << std::endl
   << "Interface sharpening cannot be activated without activating VOF.");
 
@@ -205,37 +205,43 @@ MultiphysicsInterface<dim>::inspect_multiphysics_models_dependencies(
           VOF_enabled);
 
   // Dependence of buoyant force on fluid dynamics
-  Assert(!(buoyancy_force_enabled == true && fluid_dynamics_enabled == false),
-         BuoyancyWithoutFluidDynamicsError(buoyancy_force_enabled));
+  AssertThrow(!(buoyancy_force_enabled == true &&
+                fluid_dynamics_enabled == false),
+              BuoyancyWithoutFluidDynamicsError(buoyancy_force_enabled));
 
   // Dependence of buoyant force on heat transfer
-  Assert(!(buoyancy_force_enabled == true && heat_transfer_enabled == false),
-         BuoyancyWithoutHeatTransferError(buoyancy_force_enabled));
+  AssertThrow(!(buoyancy_force_enabled == true &&
+                heat_transfer_enabled == false),
+              BuoyancyWithoutHeatTransferError(buoyancy_force_enabled));
 
   // Dependence of Marangoni effect on fluid dynamics
-  Assert(!(marangoni_effect_enabled == true && fluid_dynamics_enabled == false),
-         MarangoniWithoutFluidDynamicsError(marangoni_effect_enabled));
+  AssertThrow(!(marangoni_effect_enabled == true &&
+                fluid_dynamics_enabled == false),
+              MarangoniWithoutFluidDynamicsError(marangoni_effect_enabled));
 
   // Dependence of Marangoni effect on heat transfer
-  Assert(!(marangoni_effect_enabled == true && heat_transfer_enabled == false),
-         MarangoniWithoutHeatTransferError(marangoni_effect_enabled));
+  AssertThrow(!(marangoni_effect_enabled == true &&
+                heat_transfer_enabled == false),
+              MarangoniWithoutHeatTransferError(marangoni_effect_enabled));
 
   // Dependence of Marangoni effect on surface tension force
-  Assert(!(marangoni_effect_enabled == true &&
-           surface_tension_force_enabled == false),
-         MarangoniWithoutSurfaceTensionForceError(marangoni_effect_enabled));
+  AssertThrow(!(marangoni_effect_enabled == true &&
+                surface_tension_force_enabled == false),
+              MarangoniWithoutSurfaceTensionForceError(
+                marangoni_effect_enabled));
 
   // Dependence of surface tension force on VOF
-  Assert(!(surface_tension_force_enabled == true && VOF_enabled == false),
-         SurfaceTensionForceWithoutVOFError(surface_tension_force_enabled));
+  AssertThrow(!(surface_tension_force_enabled == true && VOF_enabled == false),
+              SurfaceTensionForceWithoutVOFError(
+                surface_tension_force_enabled));
 
   // Dependence of Marangoni effect on VOF
-  Assert(!(marangoni_effect_enabled == true && VOF_enabled == false),
-         MarangoniWithoutVOFError(marangoni_effect_enabled));
+  AssertThrow(!(marangoni_effect_enabled == true && VOF_enabled == false),
+              MarangoniWithoutVOFError(marangoni_effect_enabled));
 
   // Dependence of interface sharpening on VOF
-  Assert(!(interface_sharpening_enabled == true && VOF_enabled == false),
-         InterfaceSharpeningWithoutVOFError(interface_sharpening_enabled));
+  AssertThrow(!(interface_sharpening_enabled == true && VOF_enabled == false),
+              InterfaceSharpeningWithoutVOFError(interface_sharpening_enabled));
 }
 
 template class MultiphysicsInterface<2>;

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -117,6 +117,7 @@ NavierStokesScratchData<dim>::enable_vof(
   thermal_expansion_0        = std::vector<double>(n_q_points);
   thermal_expansion_1        = std::vector<double>(n_q_points);
   surface_tension            = std::vector<double>(n_q_points);
+  surface_tension_gradient   = std::vector<double>(n_q_points);
   compressibility_multiplier = std::vector<double>(n_q_points);
 
   // Create filter
@@ -154,6 +155,7 @@ NavierStokesScratchData<dim>::enable_vof(
   thermal_expansion_0        = std::vector<double>(n_q_points);
   thermal_expansion_1        = std::vector<double>(n_q_points);
   surface_tension            = std::vector<double>(n_q_points);
+  surface_tension_gradient   = std::vector<double>(n_q_points);
   compressibility_multiplier = std::vector<double>(n_q_points);
 
   // Create filter
@@ -188,14 +190,15 @@ NavierStokesScratchData<dim>::enable_cahn_hilliard(
                                           n_q_points));
 
   // Allocate physical properties
-  density_0              = std::vector<double>(n_q_points);
-  density_1              = std::vector<double>(n_q_points);
-  dynamic_viscosity_0    = std::vector<double>(n_q_points);
-  dynamic_viscosity_1    = std::vector<double>(n_q_points);
-  thermal_expansion_0    = std::vector<double>(n_q_points);
-  thermal_expansion_1    = std::vector<double>(n_q_points);
-  surface_tension        = std::vector<double>(n_q_points);
-  mobility_cahn_hilliard = std::vector<double>(n_q_points);
+  density_0                = std::vector<double>(n_q_points);
+  density_1                = std::vector<double>(n_q_points);
+  dynamic_viscosity_0      = std::vector<double>(n_q_points);
+  dynamic_viscosity_1      = std::vector<double>(n_q_points);
+  thermal_expansion_0      = std::vector<double>(n_q_points);
+  thermal_expansion_1      = std::vector<double>(n_q_points);
+  surface_tension          = std::vector<double>(n_q_points);
+  surface_tension_gradient = std::vector<double>(n_q_points);
+  mobility_cahn_hilliard   = std::vector<double>(n_q_points);
 }
 
 
@@ -386,6 +389,10 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
               const auto surface_tension_model =
                 properties_manager.get_surface_tension(material_interaction_id);
               surface_tension_model->vector_value(fields, surface_tension);
+              // Gather surface tension gradient only if necessary
+              if (!properties_manager.surface_tension_is_constant())
+                surface_tension_model->vector_jacobian(
+                  fields, field::temperature, surface_tension_gradient);
             }
 
           density_model_0->vector_value(fields, density_0);

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -145,8 +145,7 @@ PhysicalPropertiesManager::initialize(
   for (unsigned int i = 0; i < number_of_material_interactions; ++i)
     {
       surface_tension.push_back(SurfaceTensionModel::model_cast(
-        physical_properties.material_interactions[i]
-          .surface_tension_parameters));
+        physical_properties.material_interactions[i]));
       establish_fields_required_by_model(*surface_tension[i]);
       mobility_ch.push_back(MobilityCahnHilliardModel::model_cast(
         physical_properties.material_interactions[i]));

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -58,8 +58,9 @@ PhysicalPropertiesManager::initialize(
   kinematic_viscosity_scale = physical_properties.fluids[0].kinematic_viscosity;
   density_scale             = physical_properties.fluids[0].density;
 
-  non_newtonian_flow = false;
-  constant_density   = true;
+  non_newtonian_flow       = false;
+  constant_density         = true;
+  constant_surface_tension = true;
 
   required_fields[field::temperature]               = false;
   required_fields[field::previous_temperature]      = false;
@@ -147,6 +148,8 @@ PhysicalPropertiesManager::initialize(
       surface_tension.push_back(SurfaceTensionModel::model_cast(
         physical_properties.material_interactions[i]));
       establish_fields_required_by_model(*surface_tension[i]);
+      if (!surface_tension.back()->is_constant_surface_tension_model())
+        constant_surface_tension = false;
       mobility_ch.push_back(MobilityCahnHilliardModel::model_cast(
         physical_properties.material_interactions[i]));
       establish_fields_required_by_model(*mobility_ch[i]);

--- a/tests/core/surface_tension_linear.cc
+++ b/tests/core/surface_tension_linear.cc
@@ -1,5 +1,5 @@
 /**
- * @brief Tests the constant surface tension model. This model should always
+ * @brief Tests the linear surface tension model. This model should always
  * return sigma_0 + dsigma/dT * T.
  */
 

--- a/tests/core/surface_tension_linear.cc
+++ b/tests/core/surface_tension_linear.cc
@@ -1,0 +1,114 @@
+/**
+ * @brief Tests the constant surface tension model. This model should always
+ * return sigma_0 + dsigma/dT * T.
+ */
+
+// Lethe
+#include <core/surface_tension_model.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beginning" << std::endl;
+
+  Parameters::SurfaceTensionParameters surface_tension_parameters;
+  surface_tension_parameters.surface_tension_coefficient = 72.86;
+  surface_tension_parameters.surface_tension_gradient    = 0.5;
+
+  SurfaceTensionLinear surface_tension_model(surface_tension_parameters);
+
+  deallog
+    << "Testing linear surface tension - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)"
+    << std::endl;
+
+  // Field values must contain temperature
+  std::map<field, double> field_values;
+
+  field_values[field::temperature] = 0;
+  deallog << " T = 0, surface tension = "
+          << surface_tension_model.value(field_values)
+          << ", dsigma/dT analytical = "
+          << surface_tension_model.jacobian(field_values, field::temperature)
+          << ", dsigma/dT numerical = "
+          << surface_tension_model.numerical_jacobian(field_values,
+                                                      field::temperature)
+          << std::endl;
+
+  field_values[field::temperature] = 300;
+  deallog << " T = 300, surface tension = "
+          << surface_tension_model.value(field_values)
+          << ", dsigma/dT analytical = "
+          << surface_tension_model.jacobian(field_values, field::temperature)
+          << ", dsigma/dT numerical = "
+          << surface_tension_model.numerical_jacobian(field_values,
+                                                      field::temperature)
+          << std::endl;
+
+  deallog
+    << "Surface tension vector values - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)"
+    << std::endl;
+  std::vector<double>                  temperature_vector({300, 400, 500, 600});
+  std::map<field, std::vector<double>> field_vectors;
+  field_vectors[field::temperature] = temperature_vector;
+  unsigned int        n_values      = temperature_vector.size();
+  std::vector<double> surface_tension_values(n_values);
+  std::vector<double> surface_tension_gradient_values(n_values);
+
+  surface_tension_model.vector_value(field_vectors, surface_tension_values);
+  surface_tension_model.vector_jacobian(field_vectors,
+                                        field::temperature,
+                                        surface_tension_gradient_values);
+
+  deallog << " T = {" << Utilities::to_string(temperature_vector[0]);
+  for (unsigned int i = 1; i < n_values; ++i)
+    deallog << ", " << Utilities::to_string(temperature_vector[i]);
+  deallog << "}" << std::endl;
+  deallog << " sigma = {" << surface_tension_values[0];
+  for (unsigned int i = 1; i < n_values; ++i)
+    deallog << ", " << surface_tension_values[i];
+  deallog << "}" << std::endl;
+  deallog << " dsigma/dT = {" << surface_tension_gradient_values[0];
+  for (unsigned int i = 1; i < n_values; ++i)
+    deallog << ", " << surface_tension_gradient_values[i];
+  deallog << "}" << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/surface_tension_linear.output
+++ b/tests/core/surface_tension_linear.output
@@ -1,0 +1,10 @@
+
+DEAL::Beginning
+DEAL::Testing linear surface tension - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)
+DEAL:: T = 0, surface tension = 72.86, dsigma/dT analytical = 0.500000, dsigma/dT numerical = 0.500000
+DEAL:: T = 300, surface tension = 222.860, dsigma/dT analytical = 0.500000, dsigma/dT numerical = 0.500000
+DEAL::Surface tension vector values - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)
+DEAL:: T = {300, 400, 500, 600}
+DEAL:: sigma = {222.860, 272.860, 322.860, 372.860}
+DEAL:: dsigma/dT = {0.500000, 0.500000, 0.500000, 0.500000}
+DEAL::OK


### PR DESCRIPTION
# Description of the problem
- After creating a new material interaction class to set interface physical properties, a ``constant`` surface tension model was added (#818). However, to consider Marangoni effet, a linear surface tension model is needed. This model was implicitly implemented in the assemblers.
# Description of the solution
- With this PR, a temperature-dependent linear surface tension model is added to the surface tension models.
# How Has This Been Tested?
- The ``.prm`` file of the gls_droplet_marangoni_effect application test was updated and a new unit test for the linear surface tension model was added.
- [x] applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
- [x] tests/core/surface_tension_linear.cc (.output)
# Documentation
- Documentation on surface tension was updated:
- [x] doc/source/parameters/cfd/physical_properties.rst
- [x] doc/source/parameters/cfd/volume_of_fluid.rst
# Future changes
- For non-time dependent temperature schemes, it would be useful to implement a position-dependent surface tension model that would avoid the need to solve the heat transfer physics to get the temperature.
- Review the formulation of the linear surface tension model, by adding a reference temperature for ``sigma_0``.
- Deprecate peeling and wetting. 
# Comments
- VOF parameters documentation was restructured with new subtitles to improve the reading experience.