### PR TITLE
Remove vtu output from tests

### DIFF
--- a/applications_tests/dem/ball_with_floating_walls.prm
+++ b/applications_tests/dem/ball_with_floating_walls.prm
@@ -10,7 +10,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.5
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/box_grid_rotation.prm
+++ b/applications_tests/dem/box_grid_rotation.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/box_grid_slide.prm
+++ b/applications_tests/dem/box_grid_slide.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/circle_restart.prm
+++ b/applications_tests/dem/circle_restart.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.9
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/circle_restart_generator.prm
+++ b/applications_tests/dem/circle_restart_generator.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.5
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/circle_with_floating_walls.prm
+++ b/applications_tests/dem/circle_with_floating_walls.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.2
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/force_boundary_box.prm
+++ b/applications_tests/dem/force_boundary_box.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 2e-2
   set log frequency    = 10000
-  set output frequency = 10000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/initial_value_insertion.prm
+++ b/applications_tests/dem/initial_value_insertion.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.0001
   set time end         = 0.001
   set log frequency    = 2
-  set output frequency = 100000
+  set output frequency = 0
   #set output path                                      = ./output_dem/
 end
 

--- a/applications_tests/dem/insert_list_2d.prm
+++ b/applications_tests/dem/insert_list_2d.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.0001
   set log frequency    = 100
-  set output frequency = 10000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/insert_list_3d.prm
+++ b/applications_tests/dem/insert_list_3d.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.11
   set log frequency    = 10000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/insert_periodic_boundary_gmsh.prm
+++ b/applications_tests/dem/insert_periodic_boundary_gmsh.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step         = 1.5e-6
   set time end          = 1.5e-6
   set log frequency     = 1
-  set output frequency  = 1
+  set output frequency  = 0
   set output boundaries = true
 end
 

--- a/applications_tests/dem/insert_plane_3d.prm
+++ b/applications_tests/dem/insert_plane_3d.prm
@@ -14,7 +14,7 @@ subsection simulation control
   set time step        = 0.0001
   set time end         = 0.5
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
   #set output path     = ./output_dem/
 end
 

--- a/applications_tests/dem/insert_z-x-y.prm
+++ b/applications_tests/dem/insert_z-x-y.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.0001
   set time end         = 0.001
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
   #set output path     = ./output_dem/
 end
 

--- a/applications_tests/dem/load_balancing_mobility_status.prm
+++ b/applications_tests/dem/load_balancing_mobility_status.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-3
   set time end         = 1
   set log frequency    = 100
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 # --------------------------------------------------

--- a/applications_tests/dem/outlet_boundary.prm
+++ b/applications_tests/dem/outlet_boundary.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.06
   set log frequency    = 100000
-  set output frequency = 100000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_ball.prm
+++ b/applications_tests/dem/packing_in_ball.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_ball_dynamic_contact.prm
+++ b/applications_tests/dem/packing_in_ball_dynamic_contact.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_ball_dynamic_load_balance.prm
+++ b/applications_tests/dem/packing_in_ball_dynamic_load_balance.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_box.prm
+++ b/applications_tests/dem/packing_in_box.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_circle.prm
+++ b/applications_tests/dem/packing_in_circle.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_cylinder.prm
+++ b/applications_tests/dem/packing_in_cylinder.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.2
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/packing_in_square.prm
+++ b/applications_tests/dem/packing_in_square.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.5
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/parallel_contacts_in_circle.prm
+++ b/applications_tests/dem/parallel_contacts_in_circle.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.5
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/periodic_boundary_box.prm
+++ b/applications_tests/dem/periodic_boundary_box.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1.5e-5
   set time end         = 0.25
   set log frequency    = 10000
-  set output frequency = 10000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/periodic_boundary_collisions.prm
+++ b/applications_tests/dem/periodic_boundary_collisions.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 10000
-  set output frequency = 10000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/periodic_boundary_load_balancing.prm
+++ b/applications_tests/dem/periodic_boundary_load_balancing.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1.5e-5
   set time end         = 0.25
   set log frequency    = 10000
-  set output frequency = 10000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/rotating_in_ball.prm
+++ b/applications_tests/dem/rotating_in_ball.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.1
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/rotating_in_circle.prm
+++ b/applications_tests/dem/rotating_in_circle.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.4
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/sliding_in_box.prm
+++ b/applications_tests/dem/sliding_in_box.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.15
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/sliding_restart.prm
+++ b/applications_tests/dem/sliding_restart.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 0.4
   set log frequency    = 1000000
-  set output frequency = 1000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/torque_boundary_box.prm
+++ b/applications_tests/dem/torque_boundary_box.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 1e-5
   set time end         = 2e-2
   set log frequency    = 10000
-  set output frequency = 10000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/dem/two_types_packing_in_circle.prm
+++ b/applications_tests/dem/two_types_packing_in_circle.prm
@@ -11,7 +11,7 @@ subsection simulation control
   set time step        = 0.00001
   set time end         = 0.3
   set log frequency    = 10000000
-  set output frequency = 10000000
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes/mms2d-unstructured_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms2d-unstructured_gd.prm
@@ -11,6 +11,7 @@ subsection simulation control
   set method            = steady
   set number mesh adapt = 2
   set output name       = mms2d-unstructured_
+  set output frequency  = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes/mms2d_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms2d_gd.prm
@@ -11,6 +11,7 @@ subsection simulation control
   set method            = steady
   set number mesh adapt = 2
   set output name       = mms2d_
+  set output frequency  = 0 
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes/mms2d_powerlaw_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms2d_powerlaw_gd.prm
@@ -11,6 +11,7 @@ subsection simulation control
   set method            = steady
   set number mesh adapt = 2
   set output name       = mms2d_powerlaw
+  set output frequency  = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes/mms3d_gd.prm
+++ b/applications_tests/gd_navier_stokes/mms3d_gd.prm
@@ -11,6 +11,7 @@ subsection simulation control
   set method            = steady
   set number mesh adapt = 1
   set output name       = mms3d_
+  set output frequency  = 0 
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes/poiseuille3d_gd.prm
+++ b/applications_tests/gd_navier_stokes/poiseuille3d_gd.prm
@@ -11,6 +11,7 @@ subsection simulation control
   set method            = steady
   set number mesh adapt = 1
   set output name       = poiseuille3d
+  set output frequency  = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gd_navier_stokes/poiseuille_gd.prm
+++ b/applications_tests/gd_navier_stokes/poiseuille_gd.prm
@@ -11,6 +11,7 @@ subsection simulation control
   set method            = steady
   set number mesh adapt = 0
   set output name       = poiseuille
+  set output frequency  = 0
 end
 
 #---------------------------------------------------

--- a/applications_tests/gls_sharp_navier_stokes/coupled_moving_stokes.prm
+++ b/applications_tests/gls_sharp_navier_stokes/coupled_moving_stokes.prm
@@ -12,7 +12,6 @@ subsection simulation control
   set time step         = 0.125
   set number mesh adapt = 2     # If steady, nb mesh adaptation
   set time end          = 0.125 # End time of simulation
-  set output name       = out   # Prefix for VTU outputs
   set output frequency  = 0     # Frequency of simulation output
   set log precision     = 12
 end

--- a/applications_tests/nitsche_navier_stokes/noslip33_simplex.prm
+++ b/applications_tests/nitsche_navier_stokes/noslip33_simplex.prm
@@ -8,9 +8,10 @@ set dimension = 3
 #---------------------------------------------------
 
 subsection simulation control
-  set method        = steady
-  set output name   = noslip33_simplex
-  set log precision = 0
+  set method           = steady
+  set output name      = noslip33_simplex
+  set log precision    = 0
+  set output frequency = 0
 end
 
 #---------------------------------------------------

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -223,6 +223,15 @@ public:
   print_progression(const ConditionalOStream &pcout) = 0;
 
   /**
+   * @brief Check if VTU/PVTU/PVD outputs are disabled
+   */
+  bool
+  output_enabled() const
+  {
+    return output_frequency != 0;
+  }
+
+  /**
    * @brief Check if the present iteration is an output iteration depending on the
    * output control chosen.
    */

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -2578,37 +2578,37 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
 
   // We only write the particle pvd when outputs are enabled
   if (this->simulation_control->output_enabled())
-  {
-  // If the processor id is id=0 we write the particles pvd
-  if (Utilities::MPI::this_mpi_process(this->mpi_communicator) == 0)
     {
-      Visualization_IB ib_particles_data;
-      ib_particles_data.build_patches(particles);
-      write_vtu_and_pvd<0, dim>(ib_particles_pvdhandler,
-                                ib_particles_data,
-                                folder,
-                                particles_solution_name,
-                                time,
-                                iter,
-                                group_files,
-                                this->mpi_communicator);
+      // If the processor id is id=0 we write the particles pvd
+      if (Utilities::MPI::this_mpi_process(this->mpi_communicator) == 0)
+        {
+          Visualization_IB ib_particles_data;
+          ib_particles_data.build_patches(particles);
+          write_vtu_and_pvd<0, dim>(ib_particles_pvdhandler,
+                                    ib_particles_data,
+                                    folder,
+                                    particles_solution_name,
+                                    time,
+                                    iter,
+                                    group_files,
+                                    this->mpi_communicator);
+        }
+      else
+        {
+          // If the processor id is not id=0 we add an empty particle vector.
+          Visualization_IB             ib_particles_data;
+          std::vector<IBParticle<dim>> empty_particle_vector(0);
+          ib_particles_data.build_patches(empty_particle_vector);
+          write_vtu_and_pvd<0, dim>(ib_particles_pvdhandler,
+                                    ib_particles_data,
+                                    folder,
+                                    particles_solution_name,
+                                    time,
+                                    iter,
+                                    group_files,
+                                    this->mpi_communicator);
+        }
     }
-  else
-    {
-      // If the processor id is not id=0 we add an empty particle vector.
-      Visualization_IB             ib_particles_data;
-      std::vector<IBParticle<dim>> empty_particle_vector(0);
-      ib_particles_data.build_patches(empty_particle_vector);
-      write_vtu_and_pvd<0, dim>(ib_particles_pvdhandler,
-                                ib_particles_data,
-                                folder,
-                                particles_solution_name,
-                                time,
-                                iter,
-                                group_files,
-                                this->mpi_communicator);
-    }
-  }
 
 
   table_all_p.clear();

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -2576,7 +2576,10 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
   const unsigned int group_files =
     this->simulation_parameters.simulation_control.group_files;
 
-  // If the processor id is id=0 we write the particles pvd.
+  // We only write the particle pvd when outputs are enabled
+  if (this->simulation_control->output_enabled())
+  {
+  // If the processor id is id=0 we write the particles pvd
   if (Utilities::MPI::this_mpi_process(this->mpi_communicator) == 0)
     {
       Visualization_IB ib_particles_data;
@@ -2605,6 +2608,7 @@ GLSSharpNavierStokesSolver<dim>::finish_time_step_particles()
                                 group_files,
                                 this->mpi_communicator);
     }
+  }
 
 
   table_all_p.clear();


### PR DESCRIPTION
# Description of the problem

- Many tests were still outputting VTU files
- The Sharp-Edge IB with moving particles would output files even when requested not to

# Description of the solution

- Normalize test output by removing all file output
- Force sharp-edge to not output particles when output are disabled

# How Has This Been Tested?

- All test still pass

# Comments

- Small maintenance, as usual
- 
