### PR TITLE
Add reference state temperature to linear surface tension model

### DIFF
--- a/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
+++ b/applications_tests/gls_navier_stokes/gls_droplet_marangoni_effect.prm
@@ -105,6 +105,7 @@ subsection physical properties
       set second fluid id                             = 1
       set surface tension model                       = linear
       set surface tension coefficient                 = 0.023
+      set reference state temperature                 = 0.0
       set temperature-driven surface tension gradient = 0.1
     end
   end

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -61,6 +61,7 @@ Physical Properties
         # Surface tension
         set surface tension model                       = constant
         set surface tension coefficient                 = 0
+        set reference state temperature                 = 0
         set temperature-driven surface tension gradient = 0
       end
     end
@@ -121,6 +122,8 @@ Physical Properties
           We = Re \cdot \frac{\mu_\text{ref} \; u_\text{ref}}{\sigma}
 
       where :math:`Re` is the Reynolds number, :math:`\mu_\text{ref}` and :math:`u_\text{ref}` are some reference viscosity and velocity characterizing the flow problem, and :math:`\sigma` is the surface tension coefficient.
+
+    * The ``reference state temperature`` parameter is the temperature of the reference state at which the surface ``surface tension coefficient`` is evaluated.
 
     * The ``temperature-driven surface tension gradient`` parameter is the surface tension gradient with respect to the temperature of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2} \cdot \text{Temperature}^{-1}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1} \cdot \text{K}^{-1}`. This parameter is used in the calculation of the surface tension using the ``linear`` surface tension model (see `Surface Tension Models`_).
       
@@ -500,9 +503,9 @@ Surface Tension Models
 Lethe supports two types of surface tension models: ``constant`` and ``linear``. A ``constant`` surface tension model assumes a constant value of surface tension, while a ``linear`` surface tension assumes that the surface tension evolves linearly with the temperature:
 
 .. math::
-  \sigma(T) = \sigma_0 + \frac{d\sigma}{dT} \cdot T
+  \sigma(T) = \sigma_0 + \frac{d\sigma}{dT} (T-T_0)
 
-where :math:`\sigma_0` is the ``surface tension coefficient`` evaluated at :math:`T = 0 \: \text{K}` and :math:`\frac{d\sigma}{dT}` is the ``surface tension gradient`` with respect to the temperature :math:`T`.
+where :math:`\sigma_0` is the ``surface tension coefficient`` evaluated at ``reference state temperature`` :math:`T_0` and :math:`\frac{d\sigma}{dT}` is the ``surface tension gradient`` with respect to the temperature :math:`T`.
 
 .. Warning::
     In Lethe, the ``linear`` surface tension model is only used to account for the thermocapillary effect known as the Marangoni effect. Therefore, to enable the Marangoni effect, the surface tension model must be set to ``linear`` and a ``surface tension gradient`` different from zero :math:`(\frac{d\sigma}{dT} \neq 0)` must be specified.

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -123,7 +123,7 @@ Physical Properties
 
       where :math:`Re` is the Reynolds number, :math:`\mu_\text{ref}` and :math:`u_\text{ref}` are some reference viscosity and velocity characterizing the flow problem, and :math:`\sigma` is the surface tension coefficient.
 
-    * The ``reference state temperature`` parameter is the temperature of the reference state at which the surface ``surface tension coefficient`` is evaluated.
+    * The ``reference state temperature`` parameter is the temperature of the reference state at which the ``surface tension coefficient`` is evaluated. This parameter is used in the calculation of the surface tension using the ``linear`` surface tension model (see `Surface Tension Models`_).
 
     * The ``temperature-driven surface tension gradient`` parameter is the surface tension gradient with respect to the temperature of the two interacting fluids in units of :math:`\text{Mass} \cdot \text{Time}^{-2} \cdot \text{Temperature}^{-1}`. In SI, this is :math:`\text{N} \cdot \text{m}^{-1} \cdot \text{K}^{-1}`. This parameter is used in the calculation of the surface tension using the ``linear`` surface tension model (see `Surface Tension Models`_).
       

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -295,8 +295,11 @@ namespace Parameters
    */
   struct SurfaceTensionParameters
   {
-    // Surface tension coefficient (sigma) in N/m
+    // Surface tension coefficient (sigma or sigma_0) in N/m
     double surface_tension_coefficient;
+    // Temperature of the reference state corresponding to the surface tension
+    // coefficient (T_0) in K
+    double T_0;
     // Surface tension gradient with respect to the temperature (dsigma/dT) in
     // N/(m*K)
     double surface_tension_gradient;

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -138,7 +138,7 @@ private:
 
 /**
  * @brief Linear surface tension. The surface tension is given by:
- * sigma_0 + dsimga/dT * T.
+ * sigma_0 + dsimga/dT * (T-T_0).
  */
 class SurfaceTensionLinear : public SurfaceTensionModel
 {
@@ -150,6 +150,7 @@ public:
     const Parameters::SurfaceTensionParameters &p_surface_tension_parameters)
     : surface_tension_coefficient(
         p_surface_tension_parameters.surface_tension_coefficient)
+    , T_0(p_surface_tension_parameters.T_0)
     , surface_tension_gradient(
         p_surface_tension_parameters.surface_tension_gradient)
   {
@@ -166,7 +167,8 @@ public:
   value(const std::map<field, double> &fields_value) override
   {
     const double temperature = fields_value.at(field::temperature);
-    return surface_tension_coefficient + surface_tension_gradient * temperature;
+    return surface_tension_coefficient +
+           surface_tension_gradient * (temperature - T_0);
   }
 
   /**
@@ -182,8 +184,8 @@ public:
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
-      property_vector[i] =
-        surface_tension_coefficient + surface_tension_gradient * temperature[i];
+      property_vector[i] = surface_tension_coefficient +
+                           surface_tension_gradient * (temperature[i] - T_0);
   }
 
   /**
@@ -231,6 +233,7 @@ public:
 
 private:
   const double surface_tension_coefficient;
+  const double T_0;
   const double surface_tension_gradient;
 };
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -422,6 +422,11 @@ namespace Parameters
       Patterns::Double(),
       "Surface tension coefficient for the corresponding pair of fluids or fluid-solid pair");
     prm.declare_entry(
+      "reference state temperature",
+      "0.0",
+      Patterns::Double(),
+      "Temperature of the reference state corresponding to the surface tension coefficient");
+    prm.declare_entry(
       "temperature-driven surface tension gradient",
       "0.0",
       Patterns::Double(),
@@ -432,6 +437,7 @@ namespace Parameters
   SurfaceTensionParameters::parse_parameters(ParameterHandler &prm)
   {
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
+    T_0                         = prm.get_double("reference state temperature");
     surface_tension_gradient =
       prm.get_double("temperature-driven surface tension gradient");
   }

--- a/tests/core/surface_tension_linear.cc
+++ b/tests/core/surface_tension_linear.cc
@@ -1,6 +1,6 @@
 /**
  * @brief Tests the linear surface tension model. This model should always
- * return sigma_0 + dsigma/dT * T.
+ * return sigma_0 + dsigma/dT * (T-T_0).
  */
 
 // Lethe
@@ -16,12 +16,13 @@ test()
 
   Parameters::SurfaceTensionParameters surface_tension_parameters;
   surface_tension_parameters.surface_tension_coefficient = 72.86;
+  surface_tension_parameters.T_0                         = 0.0;
   surface_tension_parameters.surface_tension_gradient    = 0.5;
 
   SurfaceTensionLinear surface_tension_model(surface_tension_parameters);
 
   deallog
-    << "Testing linear surface tension - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)"
+    << "Testing linear surface tension - sigma (sigma_0 = 72.86, T_0 = 0.0, dsigma/dT = 0.5)"
     << std::endl;
 
   // Field values must contain temperature
@@ -47,8 +48,25 @@ test()
                                                       field::temperature)
           << std::endl;
 
+  surface_tension_parameters.T_0 = 298.15;
+  SurfaceTensionLinear surface_tension_model_2(surface_tension_parameters);
   deallog
-    << "Surface tension vector values - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)"
+    << "Testing linear surface tension - sigma (sigma_0 = 72.86, T_0 = 298.15, dsigma/dT = 0.5)"
+    << std::endl;
+
+  field_values[field::temperature] = 300;
+  deallog << " T = 300, surface tension = "
+          << surface_tension_model_2.value(field_values)
+          << ", dsigma/dT analytical = "
+          << surface_tension_model_2.jacobian(field_values, field::temperature)
+          << ", dsigma/dT numerical = "
+          << surface_tension_model_2.numerical_jacobian(field_values,
+                                                        field::temperature)
+          << std::endl;
+
+  surface_tension_parameters.T_0 = 0.0;
+  deallog
+    << "Surface tension vector values - sigma (sigma_0 = 72.86, T_0 = 0.0, dsigma/dT = 0.5)"
     << std::endl;
   std::vector<double>                  temperature_vector({300, 400, 500, 600});
   std::map<field, std::vector<double>> field_vectors;

--- a/tests/core/surface_tension_linear.output
+++ b/tests/core/surface_tension_linear.output
@@ -1,9 +1,11 @@
 
 DEAL::Beginning
-DEAL::Testing linear surface tension - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)
+DEAL::Testing linear surface tension - sigma (sigma_0 = 72.86, T_0 = 0.0, dsigma/dT = 0.5)
 DEAL:: T = 0, surface tension = 72.86, dsigma/dT analytical = 0.500000, dsigma/dT numerical = 0.500000
 DEAL:: T = 300, surface tension = 222.860, dsigma/dT analytical = 0.500000, dsigma/dT numerical = 0.500000
-DEAL::Surface tension vector values - sigma (sigma_0 = 72.86, dsigma/dT = 0.5)
+DEAL::Testing linear surface tension - sigma (sigma_0 = 72.86, T_0 = 298.15, dsigma/dT = 0.5)
+DEAL:: T = 300, surface tension = 73.7850, dsigma/dT analytical = 0.500000, dsigma/dT numerical = 0.500000
+DEAL::Surface tension vector values - sigma (sigma_0 = 72.86, T_0 = 0.0, dsigma/dT = 0.5)
 DEAL:: T = {300, 400, 500, 600}
 DEAL:: sigma = {222.860, 272.860, 322.860, 372.860}
 DEAL:: dsigma/dT = {0.500000, 0.500000, 0.500000, 0.500000}


### PR DESCRIPTION
# Description of the problem

- When working on PR #854, it was noticed that the linear surface tension model could only be used with a surface tension coefficient evaluated at T = 0 K.

# Description of the solution

- A ``reference state temperature`` parameter was add to SurfaceTensionParameters.

# How Has This Been Tested?

- All tests have passed.
- Unit test with linear surface tension model was updated: tests/core/surface_tension_linear.cc (.output)

# Documentation

- Physical properties documentation was updated: doc/source/parameters/cfd/physical_properties.rst
