### PR TITLE
Correct typo in static bubble prm file

### DIFF
--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -162,7 +162,7 @@ subsection linear solver
     set minimum residual  = 1e-10
     set preconditioner    = ilu
   end
-  subsection fVOF
+  subsection VOF
     set verbosity         = verbose
     set method            = gmres
     set relative residual = 1e-3


### PR DESCRIPTION
# Description of the problem

- There was a typo in the ``linear solver`` subsection of the ``.prm`` file.

# Description of the solution

- The typo was corrected

# How Has This Been Tested?

- All tests have passed
