### PR TITLE
Fix if condition in preconditioner setup

### DIFF
--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1460,7 +1460,7 @@ GLSNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
     {
       try
         {
-          if (!ilu_preconditioner || !amg_preconditioner)
+          if (!ilu_preconditioner && !amg_preconditioner)
             setup_preconditioner();
 
           TrilinosWrappers::SolverGMRES solver(solver_control,


### PR DESCRIPTION
# Description of the problem

The preconditioner was being setup more than it should for the gls navier stokes solver.

# Description of the solution

Fix if condition and built the preconditioner only when really needed.

# Comments

The bug was introduced when the preconditioner parameter was introduced for the linear solver in PR #856.
