### PR TITLE
Fix dynamic viscosity output

### DIFF
--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1963,14 +1963,16 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
 
       // Only output the kinematic viscosity for non-newtonian rheology
       if (rheological_models[f_id]->is_non_newtonian_rheological_model())
-        data_out.add_data_vector(solution,
-                                 kinematic_viscosity_postprocessors[f_id]);
+        {
+          data_out.add_data_vector(solution,
+                                   kinematic_viscosity_postprocessors[f_id]);
 
-      // Only output the dynamic viscosity for multiphase flows
-      if (this->simulation_parameters.multiphysics.VOF ||
-          this->simulation_parameters.multiphysics.cahn_hilliard)
-        data_out.add_data_vector(solution,
-                                 dynamic_viscosity_postprocessors[f_id]);
+          // Only output the dynamic viscosity for multiphase flows
+          if (this->simulation_parameters.multiphysics.VOF ||
+              this->simulation_parameters.multiphysics.cahn_hilliard)
+            data_out.add_data_vector(solution,
+                                     dynamic_viscosity_postprocessors[f_id]);
+        }
     }
 
   ShearRatePostprocessor<dim> shear_rate_processor;


### PR DESCRIPTION
# Description of the problem

- When outputting results of a simulation with a ``phase change`` rheological model, an exception was thrown by deal.II.

# Description of the solution

- A temporary fix was made: only when the dynamic viscosity is non-newtonian the dynamic viscosity is outputted.

# How Has This Been Tested?

- All tests have passed

# Future changes

- To avoid similar mistakes, add an indicator to physics to determine if the physical property is owned by the physics (not dependent on other auxiliary physics' solution).
- Eventually, make our own post-processor to output properties dependent of multiple physics (multiple dof handlers).
