### PR TITLE
Check if file exist when reading dim

### DIFF
--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -389,6 +389,8 @@ get_last_value_of_parameter(const std::string &file_name,
   std::string return_value;
 
   std::ifstream x_file(file_name);
+  AssertThrow(x_file.fail() == false, ExcIO());
+
   while (x_file)
     {
       // Get one line and then match a regex to it that matches the parameter


### PR DESCRIPTION
# Description of the problem

- When we added the tool to read the dimension first, it broke the check for the existence of the file itself

# Description of the solution

- Add a new assertion within the dimension parsing to actually Assert if the file itself exists. This way if you get an error message because the file is missing, the error message will match that.

# How Has This Been Tested?

- tested on my machine and it works well.

# Comments

- Generic maintenance is always fun
-
