### PR TITLE
Remove unused AdditionalData object in the AMG preconditioner

### DIFF
--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1345,9 +1345,6 @@ GLSNavierStokesSolver<dim>::setup_AMG()
                                    components,
                                    constant_modes);
 
-  TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
-  amg_data.constant_modes = constant_modes;
-
   const bool elliptic              = false;
   bool       higher_order_elements = false;
   if (this->velocity_fem_degree > 1)


### PR DESCRIPTION
# Description of the problem

There was an Additional Data object being allocated for the AMG preconditioner that was not being used. 

# Description of the solution

The object was removed.

# How Has This Been Tested?

This change should not affect any tests.
