### PR TITLE
Deprecate conservative fluid parameter

### DIFF
--- a/applications_tests/gls_navier_stokes/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
+++ b/applications_tests/gls_navier_stokes/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
@@ -33,7 +33,6 @@ subsection VOF
   end
 
   subsection mass conservation
-    set conservative fluid = both
     set monitoring         = true
     set monitored fluid    = fluid 1
     # parameters used with adaptative sharpening

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -186,7 +186,7 @@ The following procedure is recommended to choose proper values for the ``phase f
 Mass Conservation
 ~~~~~~~~~~~~~~~~~~~~~
 
-* ``subsection mass conservation``: By default, mass conservation (continuity) equations are solved on the whole domain, i.e. on both fluids (``set conservative fluid = both``).  This subsection defines parameters that can be used to solve mass conservation in one fluid instead of both, and to monitor the surface/volume (2D/3D) occupied by the other fluid of interest.
+* ``subsection mass conservation``: By default, mass conservation (continuity) equations are solved on the whole domain, i.e. on both fluids. This subsection defines parameters that are used to solve mass conservation in both fluids, and to monitor the surface/volume (2D/3D) occupied by the fluid of interest (``monitored fluid``).
 
   * ``monitoring``: controls if conservation is monitored at each iteration, through the volume (3D) or surface (2D) computation of the fluid given as ``monitored fluid`` (``fluid 1`` (default) or ``fluid 0``). Results are outputted in a data table (`VOF_monitoring_fluid_0.dat` or `VOF_monitoring_fluid_1.dat`).
 

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -55,7 +55,6 @@ The default values of the VOF parameters are given in the text box below.
     end
 
     subsection mass conservation
-      set conservative fluid = both
       set monitoring         = false
       set monitored fluid    = fluid 1
 
@@ -188,10 +187,6 @@ Mass Conservation
 ~~~~~~~~~~~~~~~~~~~~~
 
 * ``subsection mass conservation``: By default, mass conservation (continuity) equations are solved on the whole domain, i.e. on both fluids (``set conservative fluid = both``).  This subsection defines parameters that can be used to solve mass conservation in one fluid instead of both, and to monitor the surface/volume (2D/3D) occupied by the other fluid of interest.
-
-  * ``conservative fluid``: defines fluid(s) for which conservation is solved. 
-
-    Choices are: ``fluid 0``, ``fluid 1`` or ``both`` (default), with the fluid IDs defined in :ref:`Physical properties - Two Phase Simulations<two phase simulations>`.
 
   * ``monitoring``: controls if conservation is monitored at each iteration, through the volume (3D) or surface (2D) computation of the fluid given as ``monitored fluid`` (``fluid 1`` (default) or ``fluid 0``). Results are outputted in a data table (`VOF_monitoring_fluid_0.dat` or `VOF_monitoring_fluid_1.dat`).
 

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -70,11 +70,11 @@ namespace Parameters
   struct VOF_MassConservation
   {
     bool monitoring;
+
     // Conservation tolerance on the fluid monitored,
     // used with adaptative Sharpening
     double tolerance;
 
-    Parameters::FluidIndicator conservative_fluid;
     Parameters::FluidIndicator monitored_fluid;
 
     // Type of verbosity for the mass conservation algorithm

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -181,7 +181,7 @@ Parameters::VOF::parse_parameters(ParameterHandler &prm)
     if (sharpening.type == Parameters::SharpeningType::adaptative)
       {
         AssertThrow(conservation.monitoring,
-               AdaptativeSharpeningError(conservation.monitoring));
+                    AdaptativeSharpeningError(conservation.monitoring));
       }
   }
   prm.leave_subsection();

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -180,13 +180,8 @@ Parameters::VOF::parse_parameters(ParameterHandler &prm)
     // Error definitions
     if (sharpening.type == Parameters::SharpeningType::adaptative)
       {
-        Assert(conservation.monitoring == true,
+        AssertThrow(conservation.monitoring,
                AdaptativeSharpeningError(conservation.monitoring));
-        Assert((conservation.conservative_fluid ==
-                Parameters::FluidIndicator::both) or
-                 (conservation.conservative_fluid ==
-                  conservation.monitored_fluid),
-               MonitoringConservationError(conservation.monitoring));
       }
   }
   prm.leave_subsection();
@@ -208,12 +203,6 @@ Parameters::VOF_MassConservation::declare_parameters(ParameterHandler &prm)
       "1e-6",
       Patterns::Double(),
       "Tolerance on the mass conservation of the monitored fluid, used with adaptative sharpening");
-
-    prm.declare_entry(
-      "conservative fluid",
-      "both",
-      Patterns::Selection("fluid 0|fluid 1|both"),
-      "Fluid for which conservation is solved <fluid 0|fluid 1|both>. ");
 
     prm.declare_entry(
       "monitored fluid",
@@ -238,18 +227,6 @@ Parameters::VOF_MassConservation::parse_parameters(ParameterHandler &prm)
   {
     monitoring = prm.get_bool("monitoring");
     tolerance  = prm.get_double("tolerance");
-
-    // Conservative fluid
-    const std::string op_cf = prm.get("conservative fluid");
-    if (op_cf == "fluid 1")
-      conservative_fluid = Parameters::FluidIndicator::fluid1;
-    else if (op_cf == "fluid 0")
-      conservative_fluid = Parameters::FluidIndicator::fluid0;
-    else if (op_cf == "both")
-      conservative_fluid = Parameters::FluidIndicator::both;
-    else
-      throw(std::runtime_error("Invalid conservative fluid. "
-                               "Options are 'fluid 0', 'fluid 1' or 'both'."));
 
     // Monitored fluid
     const std::string op_mf = prm.get("monitored fluid");

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -33,15 +33,6 @@ DeclException1(
   << "Adaptative sharpening requires to set 'monitoring = true', and to define"
   << " the 'fluid monitored' and the 'tolerance' to reach. See documentation for further details.");
 
-DeclException1(
-  MonitoringConservationError,
-  bool,
-  << "Sharpening type is set to 'adaptative' and monitoring is set to " << arg1
-  << " but " << std::endl
-  << "conservative fluid (choices are <fluid 0, fluid 1, both>) does not include the monitored fluid. "
-  << std::endl
-  << "Conservation must be solved on the monitored fluid for adaptative sharpening to work properly.");
-
 void
 Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
 {


### PR DESCRIPTION
# Description of the problem

- The conservative fluid parameter was used to neglect mass conservation in one of the fluid. It generally led to very poor results and added weird if statements everywhere in the VOF solver

# Description of the solution

- Deprecate it. Better results can be obtained with the equation of state module instead

# How Has This Been Tested?

- Tests results remain unchanged

# Documentation

- Documentation elements were removed.
