### PR TITLE
Migrate to clang format 16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 #
-# The clang-format (Clang 6) style file used by deal.II.
+# The clang-format (Clang 16) style file used by deal.II.
+# Slightly modified to be used in Lethe
 #
 
 AccessModifierOffset: -2
@@ -26,8 +27,9 @@ BinPackArguments: false
 BinPackParameters: false
 
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass: true
-  AfterControlStatement: true
+  AfterControlStatement: Always
   AfterEnum: true
   AfterExternBlock: true
   AfterFunction: true
@@ -36,6 +38,8 @@ BraceWrapping:
   AfterUnion: true
   BeforeCatch: true
   BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
   IndentBraces: true
   SplitEmptyFunction: false
   SplitEmptyRecord: false
@@ -175,7 +179,7 @@ SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 
-Standard: Cpp11
+Standard: c++20
 
 TabWidth: 2
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Executes the specified version of clang-format
       - name: clang-format lint
-        uses: DoozyX/clang-format-lint-action@v0.16.0
+        uses: DoozyX/clang-format-lint-action@v0.16
         with:
           source: 'applications source include'
           clangFormatVersion: ${{ env.CLANG_FORMAT_VERSION }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,4 +1,4 @@
-name: indent
+name: Check_indent
 
 on: [push, pull_request]
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,27 +1,28 @@
-# Independent workflow to allow greater flexibility in triggers and schedules
-name: clang-format
+name: indent
 
-on:
-  push:
-    paths-ignore:
-      - 'doc/**'
+on: [push, pull_request]
 
-env:
-  CLANG_FORMAT_VERSION: 16
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
+permissions:
+  contents: read
 
 jobs:
-  clang-format:
-    name: Run clang-format
-    runs-on: ubuntu-latest
+  indent:
+    # run the indent checks
+
+    name: indent
+    runs-on: [ubuntu-20.04]
 
     steps:
-      # Checks-out Lethe with branch of triggering commit
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      # Executes the specified version of clang-format
-      - name: clang-format lint
-        uses: DoozyX/clang-format-lint-action@v0.16
-        with:
-          source: 'applications source include'
-          clangFormatVersion: ${{ env.CLANG_FORMAT_VERSION }}
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 100
+    - name: setup
+      run: |
+        ./contrib/utilities/download_clang_format
+    - name: indent
+      run: |
+        ./contrib/utilities/check_indentation.sh

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Executes the specified version of clang-format
       - name: clang-format lint
-        uses: DoozyX/clang-format-lint-action@v0.16.0.0
+        uses: DoozyX/clang-format-lint-action@v0.16
         with:
           source: 'applications source include'
           clangFormatVersion: ${{ env.CLANG_FORMAT_VERSION }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Executes the specified version of clang-format
       - name: clang-format lint
-        uses: DoozyX/clang-format-lint-action@v0.16
+        uses: DoozyX/clang-format-lint-action@v0.16.0.0
         with:
           source: 'applications source include'
           clangFormatVersion: ${{ env.CLANG_FORMAT_VERSION }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,8 +7,7 @@ on:
       - 'doc/**'
 
 env:
-  # Supports version 5 up to version 12
-  CLANG_FORMAT_VERION: 11
+  CLANG_FORMAT_VERSION: 16
 
 jobs:
   clang-format:
@@ -25,4 +24,4 @@ jobs:
         uses: DoozyX/clang-format-lint-action@v0.12
         with:
           source: 'applications source include'
-          clangFormatVersion: ${{ env.CLANG_FORMAT_VERION }}
+          clangFormatVersion: ${{ env.CLANG_FORMAT_VERSION }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Executes the specified version of clang-format
       - name: clang-format lint
-        uses: DoozyX/clang-format-lint-action@v0.12
+        uses: DoozyX/clang-format-lint-action@v0.16.0
         with:
           source: 'applications source include'
           clangFormatVersion: ${{ env.CLANG_FORMAT_VERSION }}

--- a/applications/gls_navier_stokes/gls_navier_stokes.cc
+++ b/applications/gls_navier_stokes/gls_navier_stokes.cc
@@ -1,31 +1,31 @@
-i/* ---------------------------------------------------------------------
- *
- * Copyright (C) 2019 - by the Lethe authors
- *
- * This file is part of the Lethe library
- *
- * The Lethe library is free software; you can use it, redistribute
- * it, and/or modify it under the terms of the GNU Lesser General
- * Public License as published by the Free Software Foundation; either
- * version 3.1 of the License, or (at your option) any later version.
- * The full text of the license can be found in the file LICENSE at
- * the top level of the Lethe distribution.
- *
- * ---------------------------------------------------------------------
+i /* ---------------------------------------------------------------------
+  *
+  * Copyright (C) 2019 - by the Lethe authors
+  *
+  * This file is part of the Lethe library
+  *
+  * The Lethe library is free software; you can use it, redistribute
+  * it, and/or modify it under the terms of the GNU Lesser General
+  * Public License as published by the Free Software Foundation; either
+  * version 3.1 of the License, or (at your option) any later version.
+  * The full text of the license can be found in the file LICENSE at
+  * the top level of the Lethe distribution.
+  *
+  * ---------------------------------------------------------------------
 
-*
-* Author: Bruno Blais, Polytechnique Montreal, 2019-
-*/
+ *
+ * Author: Bruno Blais, Polytechnique Montreal, 2019-
+ */
 
 #include "solvers/gls_navier_stokes.h"
 
-int
-main(int argc, char *argv[])
+  int
+  main(int argc, char *argv[])
 {
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-                                                     argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, numbers::invalid_unsigned_int);
 
       if (argc != 2)
         {

--- a/applications/gls_navier_stokes/gls_navier_stokes.cc
+++ b/applications/gls_navier_stokes/gls_navier_stokes.cc
@@ -1,26 +1,26 @@
-i /* ---------------------------------------------------------------------
-  *
-  * Copyright (C) 2019 - by the Lethe authors
-  *
-  * This file is part of the Lethe library
-  *
-  * The Lethe library is free software; you can use it, redistribute
-  * it, and/or modify it under the terms of the GNU Lesser General
-  * Public License as published by the Free Software Foundation; either
-  * version 3.1 of the License, or (at your option) any later version.
-  * The full text of the license can be found in the file LICENSE at
-  * the top level of the Lethe distribution.
-  *
-  * ---------------------------------------------------------------------
-
+/* ---------------------------------------------------------------------
  *
- * Author: Bruno Blais, Polytechnique Montreal, 2019-
- */
+ * Copyright (C) 2019 - by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 3.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+
+*
+* Author: Bruno Blais, Polytechnique Montreal, 2019-
+*/
 
 #include "solvers/gls_navier_stokes.h"
 
-  int
-  main(int argc, char *argv[])
+int
+main(int argc, char *argv[])
 {
   try
     {

--- a/applications/gls_navier_stokes/gls_navier_stokes.cc
+++ b/applications/gls_navier_stokes/gls_navier_stokes.cc
@@ -1,4 +1,4 @@
-/* ---------------------------------------------------------------------
+i/* ---------------------------------------------------------------------
  *
  * Copyright (C) 2019 - by the Lethe authors
  *
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+                                                     argc, argv, numbers::invalid_unsigned_int);
 
       if (argc != 2)
         {

--- a/applications/initial_conditions/initial_conditions.cc
+++ b/applications/initial_conditions/initial_conditions.cc
@@ -21,7 +21,7 @@ public:
 template <int dim>
 void
 ExactInitialSolution<dim>::vector_value(const Point<dim> &p,
-                                        Vector<double> &  values) const
+                                        Vector<double>   &values) const
 {
   double x  = p[0];
   double y  = p[1];

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -24,23 +24,23 @@
 # This can be done with the compile_clang_format script.
 #
 
-VERSION=11
+VERSION=16
 PRG="$(cd "$(dirname "$0")" && pwd)/programs"
 CLANG_PATH="${PRG}/clang-${VERSION}"
 
-URL="https://github.com/dealii/dealii/releases/download/v9.3.0"
+URL="https://github.com/dealii/dealii/releases/download/v9.5.1"
 
 # Find out which kind of OS we are running and set the appropriate settings
 case "${OSTYPE}" in
   linux*)
     FILENAME="clang-format-${VERSION}-linux.tar.gz"
     CHECKSUM_CMD="sha256sum"
-    CHECKSUM="9420c4ed80268500ef357eb42b2e77dc55e807e559d6d9851f4808a9939fa47b  $FILENAME"
+    CHECKSUM="e6d92ab1b385f5e4392466a3cf651a9e403a5c212f4c1c3737ee173bc6d79d93  $FILENAME"
     ;;
   darwin*)
     FILENAME="clang-format-${VERSION}-darwin-intel.tar.gz"
     CHECKSUM_CMD="shasum"
-    CHECKSUM="5b8c310a660102a1aa46cc0242294fb14271797a4027883a698651411f8e51bf  $FILENAME"
+    CHECKSUM="edff4341fb3b9e25c670902227538be6348d3b91ff88aa676ff8e7bb589b2ae5  $FILENAME"
     ;;
   *)
     echo "unknown: ${OSTYPE}"

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -27,9 +27,9 @@
 #
 # The script can be invoked with DEAL_II_CLANG_FORMAT to change
 # the default version of clang-format. For example:
-#   DEAL_II_CLANG_FORMAT=clang-format-11.0 ./contrib/utilities/indent
+#   DEAL_II_CLANG_FORMAT=clang-format-16.0 ./contrib/utilities/indent
 # or,
-#   make DEAL_II_CLANG_FORMAT="clang-format-11.0" indent
+#   make DEAL_II_CLANG_FORMAT="clang-format-16.0" indent
 #
 # Note: If the script is invoked with REPORT_ONLY=true set,
 #   REPORT_ONLY=true ./contrib/utilities/indent

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -65,28 +65,28 @@ checks
 # Process all source and header files:
 #
 
-process "tests include source" ".*\.(cc|h)" format_file
+process "tests applications include source" ".*\.(cc|h)" format_file
 
 #
 # Fix permissions and convert to unix line ending if necessary:
 #
 
-process "tests include source examples" \
+process "tests applications include source examples" \
   ".*\.(cc|h|inst.in|output.*|cmake)" fix_permissions
 
-process "tests include source examples" \
+process "tests applications include source examples" \
   ".*\.(cc|h|inst.in|cmake)" dos_to_unix
 
 #
 # Removing trailing whitespace
 #
 
-process "tests include source doc" \
+process "tests applications include source doc" \
   ".*\.(cc|h|html|dox|txt)" remove_trailing_whitespace
 
 #
 # Ensure only a single newline at end of files
 #
 
-process "tests include source doc" \
+process "tests applications include source doc" \
   ".*\.(cc|h|html|dox|txt)" ensure_single_trailing_newline

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -31,9 +31,9 @@
 #
 # The script can be invoked with DEAL_II_CLANG_FORMAT to change
 # the default version of clang-format. For example:
-#   DEAL_II_CLANG_FORMAT=clang-format-11.0 ./contrib/utilities/indent-all
+#   DEAL_II_CLANG_FORMAT=clang-format-16.0 ./contrib/utilities/indent-all
 # or,
-#   make DEAL_II_CLANG_FORMAT="clang-format-11.0" indent-all
+#   make DEAL_II_CLANG_FORMAT="clang-format-16.0" indent-all
 #
 # Note: If the script is invoked with REPORT_ONLY=true set,
 #   REPORT_ONLY=true ./contrib/utilities/indent-all
@@ -66,28 +66,27 @@ checks
 #
 
 process "tests include source" ".*\.(cc|h)" format_file
-process "source" ".*\.inst.in" format_inst
 
 #
 # Fix permissions and convert to unix line ending if necessary:
 #
 
-process "tests include source examples " \
+process "tests include source examples" \
   ".*\.(cc|h|inst.in|output.*|cmake)" fix_permissions
 
-process "tests include source examples " \
+process "tests include source examples" \
   ".*\.(cc|h|inst.in|cmake)" dos_to_unix
 
 #
 # Removing trailing whitespace
 #
 
-process "tests include source examples " \
+process "tests include source doc" \
   ".*\.(cc|h|html|dox|txt)" remove_trailing_whitespace
 
 #
 # Ensure only a single newline at end of files
 #
 
-process "tests include source examples " \
+process "tests include source doc" \
   ".*\.(cc|h|html|dox|txt)" ensure_single_trailing_newline

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -39,7 +39,7 @@ checks() {
 
   # Add the location 'download_clang_format' or 'compile_clang_format'
   # installs clang-format to the local PATH.
-  CLANG_FORMAT_PATH="$(cd "$(dirname "$0")" && pwd)/programs/clang-11/bin"
+  CLANG_FORMAT_PATH="$(cd "$(dirname "$0")" && pwd)/programs/clang-16/bin"
   export PATH="${CLANG_FORMAT_PATH}:${PATH}"
 
   if ! [ -x "$(command -v "${DEAL_II_CLANG_FORMAT}")" ]; then
@@ -56,7 +56,7 @@ checks() {
   CLANG_FORMAT_MAJOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
   CLANG_FORMAT_MINOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*[0-9]*\.\([0-9]*\).*$/\1/g')
 
-  if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 11 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 1 ]; then
+  if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 16 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 0 ]; then
     echo "***   This indent script requires clang-format version 11.1,"
     echo "***   but version ${CLANG_FORMAT_MAJOR_VERSION}.${CLANG_FORMAT_MINOR_VERSION} was found instead."
     echo "***"

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -306,7 +306,8 @@ namespace ankerl::unordered_dense
                     see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
                     p += 48;
                     i -= 48;
-                } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 48));
+                  }
+                while (ANKERL_UNORDERED_DENSE_LIKELY(i > 48));
                 seed ^= see1 ^ see2;
               }
             while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16))

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -956,7 +956,7 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
         auto
         do_place_element(dist_and_fingerprint_type dist_and_fingerprint,
                          value_idx_type            bucket_idx,
-                         K &&                      key,
+                         K                       &&key,
                          Args &&...args) -> std::pair<iterator, bool>
         {
           // emplace the new value. If that throws an exception, no harm done;
@@ -1103,8 +1103,8 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
 
         explicit table(
           size_t                bucket_count,
-          Hash const &          hash               = Hash(),
-          KeyEqual const &      equal              = KeyEqual(),
+          Hash const           &hash               = Hash(),
+          KeyEqual const       &equal              = KeyEqual(),
           allocator_type const &alloc_or_container = allocator_type())
           : m_values(alloc_or_container)
           , m_hash(hash)
@@ -1121,7 +1121,7 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
         {}
 
         table(size_t                bucket_count,
-              Hash const &          hash,
+              Hash const           &hash,
               allocator_type const &alloc)
           : table(bucket_count, hash, KeyEqual(), alloc)
         {}
@@ -1134,8 +1134,8 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
         table(InputIt               first,
               InputIt               last,
               size_type             bucket_count = 0,
-              Hash const &          hash         = Hash(),
-              KeyEqual const &      equal        = KeyEqual(),
+              Hash const           &hash         = Hash(),
+              KeyEqual const       &equal        = KeyEqual(),
               allocator_type const &alloc        = allocator_type())
           : table(bucket_count, hash, equal, alloc)
         {
@@ -1154,7 +1154,7 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
         table(InputIt               first,
               InputIt               last,
               size_type             bucket_count,
-              Hash const &          hash,
+              Hash const           &hash,
               allocator_type const &alloc)
           : table(first, last, bucket_count, hash, KeyEqual(), alloc)
         {}
@@ -1192,9 +1192,9 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
 
         table(std::initializer_list<value_type> ilist,
               size_t                            bucket_count = 0,
-              Hash const &                      hash         = Hash(),
-              KeyEqual const &                  equal        = KeyEqual(),
-              allocator_type const &            alloc        = allocator_type())
+              Hash const                       &hash         = Hash(),
+              KeyEqual const                   &equal        = KeyEqual(),
+              allocator_type const             &alloc        = allocator_type())
           : table(bucket_count, hash, equal, alloc)
         {
           insert(ilist);
@@ -1202,14 +1202,14 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
 
         table(std::initializer_list<value_type> ilist,
               size_type                         bucket_count,
-              allocator_type const &            alloc)
+              allocator_type const             &alloc)
           : table(ilist, bucket_count, Hash(), KeyEqual(), alloc)
         {}
 
         table(std::initializer_list<value_type> init,
               size_type                         bucket_count,
-              Hash const &                      hash,
-              allocator_type const &            alloc)
+              Hash const                       &hash,
+              allocator_type const             &alloc)
           : table(init, bucket_count, hash, KeyEqual(), alloc)
         {}
 
@@ -1242,7 +1242,7 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
         auto
         operator=(table &&other) noexcept(noexcept(
           std::is_nothrow_move_assignable_v<value_container_type>
-            &&  std::is_nothrow_move_assignable_v<Hash>
+              &&std::is_nothrow_move_assignable_v<Hash>
               &&std::is_nothrow_move_assignable_v<KeyEqual>)) -> table &
         {
           if (&other != this)
@@ -1809,7 +1809,7 @@ constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& i
         void
         swap(table &other) noexcept(
           noexcept(std::is_nothrow_swappable_v<value_container_type>
-                     &&  std::is_nothrow_swappable_v<Hash>
+                       &&std::is_nothrow_swappable_v<Hash>
                        &&std::is_nothrow_swappable_v<KeyEqual>))
         {
           using std::swap;

--- a/include/core/bdf.h
+++ b/include/core/bdf.h
@@ -129,7 +129,7 @@ number_of_previous_solutions(
 
 template <typename DataType>
 inline void
-bdf_extrapolate(const std::vector<double> &               time_vector,
+bdf_extrapolate(const std::vector<double>                &time_vector,
                 const std::vector<std::vector<DataType>> &solution_vector,
                 const unsigned int     number_of_previous_solutions,
                 std::vector<DataType> &extrapolated_solution)

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -155,7 +155,7 @@ namespace BoundaryConditions
   {
   public:
     // Functions for (u,v,w) for all boundaries
-    NSBoundaryFunctions<dim> *        bcFunctions;
+    NSBoundaryFunctions<dim>         *bcFunctions;
     NSPressureBoundaryFunctions<dim> *bcPressureFunction;
 
     void
@@ -873,7 +873,7 @@ namespace BoundaryConditions
 
   template <int dim>
   void
-  CahnHilliardBoundaryConditions<dim>::parse_boundary(ParameterHandler & prm,
+  CahnHilliardBoundaryConditions<dim>::parse_boundary(ParameterHandler  &prm,
                                                       const unsigned int i_bc)
   {
     const std::string op = prm.get("type");
@@ -1116,7 +1116,7 @@ public:
  */
 template <int dim>
 double
-NavierStokesFunctionDefined<dim>::value(const Point<dim> & p,
+NavierStokesFunctionDefined<dim>::value(const Point<dim>  &p,
                                         const unsigned int component) const
 {
   Assert(component < this->n_components,
@@ -1165,7 +1165,7 @@ public:
 template <int dim>
 double
 NavierStokesPressureFunctionDefined<dim>::value(
-  const Point<dim> & point,
+  const Point<dim>  &point,
   const unsigned int component) const
 {
   if (component == dim)
@@ -1205,7 +1205,7 @@ public:
  */
 template <int dim>
 double
-CahnHilliardFunctionDefined<dim>::value(const Point<dim> & p,
+CahnHilliardFunctionDefined<dim>::value(const Point<dim>  &p,
                                         const unsigned int component) const
 {
   Assert(component < this->n_components,

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -42,7 +42,7 @@ template <int dim, int spacedim = dim>
 void
 attach_grid_to_triangulation(
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh &                               mesh_parameters);
+  const Parameters::Mesh                                &mesh_parameters);
 
 
 /**
@@ -55,7 +55,7 @@ attach_grid_to_triangulation(
 template <int dim, int spacedim = dim>
 void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<dim, spacedim> & triangulation,
+  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
 
 /**
@@ -72,10 +72,10 @@ setup_periodic_boundary_conditions(
 template <int dim, int spacedim = dim>
 void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<dim, spacedim> & triangulation,
-  const Parameters::Mesh &                                mesh_parameters,
-  const Parameters::Manifolds &                           manifolds_parameters,
-  const bool &                                            restart,
+  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
+  const Parameters::Mesh                                 &mesh_parameters,
+  const Parameters::Manifolds                            &manifolds_parameters,
+  const bool                                             &restart,
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
 
 

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -86,7 +86,7 @@ public:
    * is useful to reduce computation time
    */
   inline double
-  get_levelset(const Point<dim> &                                    p,
+  get_levelset(const Point<dim>                                     &p,
                const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
   {
     return shape->value_with_cell_guess(p, cell_guess);
@@ -113,8 +113,8 @@ public:
    */
   void
   closest_surface_point(
-    const Point<dim> &                                    p,
-    Point<dim> &                                          closest_point,
+    const Point<dim>                                     &p,
+    Point<dim>                                           &closest_point,
     const typename DoFHandler<dim>::active_cell_iterator &cell_guess);
 
   /**
@@ -138,7 +138,7 @@ public:
    */
   bool
   is_inside_crown(
-    const Point<dim> &                                    evaluation_point,
+    const Point<dim>                                     &evaluation_point,
     const double                                          outer_radius,
     const double                                          inside_radius,
     const bool                                            absolute_distance,

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -66,8 +66,8 @@ public:
   support_points_for_interpolation(
     const unsigned int                                    order,
     const double                                          length_ratio,
-    IBParticle<dim> &                                     p,
-    const Point<dim> &                                    dof_point,
+    IBParticle<dim>                                      &p,
+    const Point<dim>                                     &dof_point,
     const typename DoFHandler<dim>::active_cell_iterator &cell_guess);
 
   /**
@@ -76,8 +76,8 @@ public:
   virtual std::tuple<Point<dim>, std::vector<Point<dim>>>
   support_points_for_interpolation(const unsigned int order,
                                    const double       length_ratio,
-                                   IBParticle<dim> &  p,
-                                   const Point<dim> & dof_point);
+                                   IBParticle<dim>   &p,
+                                   const Point<dim>  &dof_point);
 
   /**
    * @brief
@@ -90,8 +90,8 @@ public:
    */
   virtual Point<dim>
   point_for_cell_detection(
-    IBParticle<dim> &                                     p,
-    const Point<dim> &                                    dof_point,
+    IBParticle<dim>                                      &p,
+    const Point<dim>                                     &dof_point,
     const typename DoFHandler<dim>::active_cell_iterator &cell_guess);
 
   /**
@@ -126,8 +126,8 @@ public:
    *  is useful to reduce computation time
    */
   virtual double
-  ib_velocity(IBParticle<dim> &                                     p,
-              const Point<dim> &                                    dof_point,
+  ib_velocity(IBParticle<dim>                                      &p,
+              const Point<dim>                                     &dof_point,
               const unsigned int                                    component,
               const typename DoFHandler<dim>::active_cell_iterator &cell_guess);
 
@@ -135,8 +135,8 @@ public:
    * See overloaded function
    */
   virtual double
-  ib_velocity(IBParticle<dim> &  p,
-              const Point<dim> & dof_point,
+  ib_velocity(IBParticle<dim>   &p,
+              const Point<dim>  &dof_point,
               const unsigned int component);
 
 private:

--- a/include/core/inexact_newton_non_linear_solver.h
+++ b/include/core/inexact_newton_non_linear_solver.h
@@ -57,7 +57,7 @@ private:
 
 template <typename VectorType>
 InexactNewtonNonLinearSolver<VectorType>::InexactNewtonNonLinearSolver(
-  PhysicsSolver<VectorType> *        physics_solver,
+  PhysicsSolver<VectorType>         *physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
   , matrix_requires_assembly(true)

--- a/include/core/interface_property_model.h
+++ b/include/core/interface_property_model.h
@@ -73,7 +73,7 @@ public:
    */
   virtual void
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
-               std::vector<double> &                       property_vector) = 0;
+               std::vector<double>                        &property_vector) = 0;
 
   /**
    * @brief jacobian Calculates the jacobian (the partial derivative) of the interface
@@ -133,7 +133,7 @@ public:
   vector_numerical_jacobian(
     const std::map<field, std::vector<double>> &field_vectors,
     const field                                 id,
-    std::vector<double> &                       jacobian_vector)
+    std::vector<double>                        &jacobian_vector)
   {
     const unsigned int n_pts = jacobian_vector.size();
 

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -40,7 +40,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
+  KinsolNewtonNonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
                               const Parameters::NonLinearSolver &param);
 
 
@@ -55,7 +55,7 @@ public:
 
 template <typename VectorType>
 KinsolNewtonNonLinearSolver<VectorType>::KinsolNewtonNonLinearSolver(
-  PhysicsSolver<VectorType> *        physics_solver,
+  PhysicsSolver<VectorType>         *physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
 {}
@@ -106,7 +106,7 @@ KinsolNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
   };
 
   nonlinear_solver.residual = [&](const VectorType &evaluation_point_for_kinsol,
-                                  VectorType &      residual) {
+                                  VectorType       &residual) {
     solver->pcout << "Computing residual vector..." << std::endl;
     evaluation_point = evaluation_point_for_kinsol;
     solver->apply_constraints();

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -78,7 +78,7 @@ namespace LetheGridTools
   template <int dim>
   typename DoFHandler<dim>::active_cell_iterator
   find_cell_around_point_with_tree(const DoFHandler<dim> &dof_handler,
-                                   const Point<dim> &     point);
+                                   const Point<dim>      &point);
 
   /**
    * @brief
@@ -96,9 +96,9 @@ namespace LetheGridTools
     const DoFHandler<dim> &dof_handler,
     std::map<unsigned int,
              std::set<typename DoFHandler<dim>::active_cell_iterator>>
-      &                                                   vertices_cell_map,
+                                                         &vertices_cell_map,
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const Point<dim> &                                    point);
+    const Point<dim>                                     &point);
 
   /**
    * @brief
@@ -113,7 +113,7 @@ namespace LetheGridTools
   find_cells_around_cell(
     std::map<unsigned int,
              std::set<typename DoFHandler<dim>::active_cell_iterator>>
-      &                                                   vertices_cell_map,
+                                                         &vertices_cell_map,
     const typename DoFHandler<dim>::active_cell_iterator &cell);
 
   /**
@@ -129,7 +129,7 @@ namespace LetheGridTools
   template <int dim>
   std::vector<typename DoFHandler<dim>::active_cell_iterator>
   find_cells_around_flat_cell(
-    const DoFHandler<dim> &                                        dof_handler,
+    const DoFHandler<dim>                                         &dof_handler,
     const typename DoFHandler<dim - 1, dim>::active_cell_iterator &cell,
     std::map<unsigned int,
              std::set<typename DoFHandler<dim>::active_cell_iterator>>
@@ -152,10 +152,10 @@ namespace LetheGridTools
     const DoFHandler<dim> &dof_handler,
     std::map<unsigned int,
              std::set<typename DoFHandler<dim>::active_cell_iterator>>
-      &                                                   vertices_cell_map,
+                                                         &vertices_cell_map,
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    Point<dim> &                                          point_1,
-    Point<dim> &                                          point_2);
+    Point<dim>                                           &point_1,
+    Point<dim>                                           &point_2);
 
   /**
    * @brief
@@ -167,7 +167,7 @@ namespace LetheGridTools
   template <int dim>
   std::vector<typename DoFHandler<dim>::active_cell_iterator>
   find_cells_in_cells(
-    const DoFHandler<dim> &                               dof_handler,
+    const DoFHandler<dim>                                &dof_handler,
     const typename DoFHandler<dim>::active_cell_iterator &cell);
 
   /**
@@ -181,7 +181,7 @@ namespace LetheGridTools
   template <int dim>
   bool
   cell_cut_by_flat(
-    const typename DoFHandler<dim>::active_cell_iterator &         cell,
+    const typename DoFHandler<dim>::active_cell_iterator          &cell,
     const typename DoFHandler<dim - 1, dim>::active_cell_iterator &cell_flat);
 
   /**
@@ -196,7 +196,7 @@ namespace LetheGridTools
   bool
   cell_pierced_by_edge(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const TriaIterator<CellAccessor<1, dim>> &            cell_edge);
+    const TriaIterator<CellAccessor<1, dim>>             &cell_edge);
 
   /**
    * @brief
@@ -230,7 +230,7 @@ namespace LetheGridTools
   std::pair<std::pair<Point<spacedim>, bool>, Tensor<1, spacedim>>
   project_to_d_linear_object(
     const typename DoFHandler<structdim, spacedim>::active_cell_iterator
-      &                    object,
+                          &object,
     const Point<spacedim> &trial_point);
 
   /**
@@ -248,7 +248,7 @@ namespace LetheGridTools
   template <int dim>
   std::vector<typename DoFHandler<dim>::active_cell_iterator>
   find_boundary_cells_in_sphere(const DoFHandler<dim> &dof_handler,
-                                const Point<dim> &     center,
+                                const Point<dim>      &center,
                                 const double           radius);
 
 
@@ -271,7 +271,7 @@ namespace LetheGridTools
     const DoFHandler<spacedim> &dof_handler,
     std::map<unsigned int,
              std::set<typename DoFHandler<spacedim>::active_cell_iterator>>
-      &                                            vertices_cell_map,
+                                                  &vertices_cell_map,
     std::vector<SerialSolid<structdim, spacedim>> &list_of_objects);
 
   /**
@@ -299,7 +299,7 @@ namespace LetheGridTools
   std::
     tuple<std::vector<bool>, std::vector<Point<3>>, std::vector<Tensor<1, 3>>>
     find_particle_triangle_projection(
-      const std::vector<Point<dim>> &                      triangle,
+      const std::vector<Point<dim>>                       &triangle,
       const std::vector<Particles::ParticleIterator<dim>> &particles,
       const unsigned int &n_particles_in_base_cell);
 
@@ -324,7 +324,7 @@ namespace LetheGridTools
   template <int dim>
   double
   find_point_triangle_distance(const std::vector<Point<dim>> &triangle_vertices,
-                               const Point<dim> &             point);
+                               const Point<dim>              &point);
 
   /**
    * @brief

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -39,7 +39,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  NewtonNonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
+  NewtonNonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
                         const Parameters::NonLinearSolver &param);
 
 
@@ -55,7 +55,7 @@ public:
 
 template <typename VectorType>
 NewtonNonLinearSolver<VectorType>::NewtonNonLinearSolver(
-  PhysicsSolver<VectorType> *        physics_solver,
+  PhysicsSolver<VectorType>         *physics_solver,
   const Parameters::NonLinearSolver &params)
   : NonLinearSolver<VectorType>(physics_solver, params)
 {}

--- a/include/core/non_linear_solver.h
+++ b/include/core/non_linear_solver.h
@@ -42,7 +42,7 @@ public:
    * @param param Non-linear solver parameters
    *
    */
-  NonLinearSolver(PhysicsSolver<VectorType> *        physics_solver,
+  NonLinearSolver(PhysicsSolver<VectorType>         *physics_solver,
                   const Parameters::NonLinearSolver &params);
 
   virtual ~NonLinearSolver()
@@ -58,13 +58,13 @@ public:
   solve(const bool is_initial_step) = 0;
 
 protected:
-  PhysicsSolver<VectorType> * physics_solver;
+  PhysicsSolver<VectorType>  *physics_solver;
   Parameters::NonLinearSolver params;
 };
 
 template <typename VectorType>
 NonLinearSolver<VectorType>::NonLinearSolver(
-  PhysicsSolver<VectorType> *        physics_solver,
+  PhysicsSolver<VectorType>         *physics_solver,
   const Parameters::NonLinearSolver &params)
   : physics_solver(physics_solver)
   , params(params)

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -342,7 +342,7 @@ namespace Parameters
                        std::string       material_prefix,
                        unsigned int      id);
     void
-    parse_parameters(ParameterHandler &   prm,
+    parse_parameters(ParameterHandler    &prm,
                      std::string          material_prefix,
                      const unsigned int   id,
                      const Dimensionality dimensions);
@@ -482,7 +482,7 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &   prm,
+    parse_parameters(ParameterHandler    &prm,
                      const Dimensionality dimensions = Dimensionality());
   };
 

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -20,8 +20,8 @@
 #ifndef lethe_parameters_lagrangian_h
 #define lethe_parameters_lagrangian_h
 
-//#include <deal.II/base/conditional_ostream.h>
-//#include <deal.II/base/function.h>
+// #include <deal.II/base/conditional_ostream.h>
+// #include <deal.II/base/function.h>
 #include <core/parameters.h>
 
 #include <deal.II/base/parameter_handler.h>
@@ -115,7 +115,7 @@ namespace Parameters
       declareDefaultEntry(ParameterHandler &prm);
       void
       parse_particle_properties(const unsigned int &particle_type,
-                                ParameterHandler &  prm);
+                                ParameterHandler   &prm);
 
     private:
       unsigned int particle_type_maximum_number = 5;
@@ -124,7 +124,7 @@ namespace Parameters
       initialize_containers(
         std::unordered_map<unsigned int, double> &particle_average_diameter,
         std::unordered_map<unsigned int, double> &particle_size_std,
-        std::unordered_map<unsigned int, int> &   number,
+        std::unordered_map<unsigned int, int>    &number,
         std::unordered_map<unsigned int, double> &density_particle,
         std::unordered_map<unsigned int, double> &youngs_modulus_particle,
         std::unordered_map<unsigned int, double> &poisson_ratio_particle,
@@ -384,7 +384,7 @@ namespace Parameters
           &boundary_translational_velocity,
         std::unordered_map<unsigned int, double> &boundary_rotational_speed,
         std::unordered_map<unsigned int, Tensor<1, 3>>
-          &                        boundary_rotational_vector,
+                                  &boundary_rotational_vector,
         std::vector<unsigned int> &outlet_boundaries);
     };
 

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -96,7 +96,7 @@ public:
 
   virtual void
   vector_value(const Point<spacedim> &np,
-               Vector<double> &       values) const override;
+               Vector<double>        &values) const override;
 
   virtual double
   value(const Point<spacedim> &np, const unsigned int component) const override;
@@ -160,7 +160,7 @@ template <int dim, int spacedim>
 void
 PeriodicHillsPushForward<dim, spacedim>::vector_value(
   const Point<spacedim> &op,
-  Vector<double> &       values) const
+  Vector<double>        &values) const
 {
   const Point<spacedim> np =
     PeriodicHillsGrid<dim, spacedim>::hill_geometry(op, spacing_y, alpha);

--- a/include/core/phase_change.h
+++ b/include/core/phase_change.h
@@ -31,7 +31,7 @@ using namespace dealii;
  */
 inline double
 calculate_liquid_fraction(
-  const double &                 T,
+  const double                  &T,
   const Parameters::PhaseChange &phase_change_parameters)
 {
   return std::min(std::max((T - phase_change_parameters.T_solidus) /

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -39,8 +39,8 @@ enum field : int
 };
 
 inline void
-set_field_vector(const field &                         id,
-                 const std::vector<double> &           data,
+set_field_vector(const field                          &id,
+                 const std::vector<double>            &data,
                  std::map<field, std::vector<double>> &fields)
 {
   std::vector<double> &target = fields.at(id);
@@ -102,7 +102,7 @@ public:
    */
   virtual void
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
-               std::vector<double> &                       property_vector) = 0;
+               std::vector<double>                        &property_vector) = 0;
 
   /**
    * @brief jacobian Calcualtes the jacobian (the partial derivative) of the physical
@@ -162,7 +162,7 @@ public:
   vector_numerical_jacobian(
     const std::map<field, std::vector<double>> &field_vectors,
     const field                                 id,
-    std::vector<double> &                       jacobian_vector)
+    std::vector<double>                        &jacobian_vector)
   {
     const unsigned int n_pts = jacobian_vector.size();
 

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -109,7 +109,7 @@ public:
    * depend.
    */
   virtual double
-  get_dynamic_viscosity(const double &                 p_density_ref,
+  get_dynamic_viscosity(const double                  &p_density_ref,
                         const std::map<field, double> &field_values) const = 0;
 
   /**
@@ -120,9 +120,9 @@ public:
    */
   virtual void
   get_dynamic_viscosity_vector(
-    const double &                              p_density_ref,
+    const double                               &p_density_ref,
     const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double> &                       property_vector) = 0;
+    std::vector<double>                        &property_vector) = 0;
 
   /**
    * @brief is_non_newtonian_rheological_model Returns a boolean indicating if
@@ -401,7 +401,7 @@ public:
    */
   double
   get_dynamic_viscosity(
-    const double &                 p_density_ref,
+    const double                  &p_density_ref,
     const std::map<field, double> &field_values) const override
   {
     const double shear_rate_magnitude = field_values.at(field::shear_rate);
@@ -416,9 +416,9 @@ public:
    */
   void
   get_dynamic_viscosity_vector(
-    const double &                              p_density_ref,
+    const double                               &p_density_ref,
     const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double> &                       property_vector) override
+    std::vector<double>                        &property_vector) override
   {
     const std::vector<double> &shear_rate_magnitude =
       field_vectors.at(field::shear_rate);
@@ -561,7 +561,7 @@ public:
 
   double
   get_dynamic_viscosity(
-    const double &                 p_density_ref,
+    const double                  &p_density_ref,
     const std::map<field, double> &field_values) const override
   {
     const double shear_rate_magnitude = field_values.at(field::shear_rate);
@@ -576,9 +576,9 @@ public:
    */
   void
   get_dynamic_viscosity_vector(
-    const double &                              p_density_ref,
+    const double                               &p_density_ref,
     const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double> &                       property_vector) override
+    std::vector<double>                        &property_vector) override
   {
     const std::vector<double> &shear_rate_magnitude =
       field_vectors.at(field::shear_rate);
@@ -697,7 +697,7 @@ public:
 
   double
   get_dynamic_viscosity(
-    const double &                 p_density_ref,
+    const double                  &p_density_ref,
     const std::map<field, double> &field_values) const override
   {
     const double temperature = field_values.at(field::temperature);
@@ -712,9 +712,9 @@ public:
    */
   void
   get_dynamic_viscosity_vector(
-    const double &                              p_density_ref,
+    const double                               &p_density_ref,
     const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double> &                       property_vector) override
+    std::vector<double>                        &property_vector) override
   {
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -95,7 +95,7 @@ public:
    * @param orientation The orientation to set the shape at
    */
   Shape(double              radius,
-        const Point<dim> &  position,
+        const Point<dim>   &position,
         const Tensor<1, 3> &orientation)
 
     : AutoDerivativeFunction<dim>(1e-8)
@@ -115,7 +115,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   virtual double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override = 0;
 
   /**
@@ -128,7 +128,7 @@ public:
    */
   virtual double
   value_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int                                   component = 0);
 
@@ -140,7 +140,7 @@ public:
    */
   virtual Tensor<1, dim>
   gradient_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int                                   component = 0);
 
@@ -164,8 +164,8 @@ public:
    */
   virtual void
   closest_surface_point(
-    const Point<dim> &                                    p,
-    Point<dim> &                                          closest_point,
+    const Point<dim>                                     &p,
+    Point<dim>                                           &closest_point,
     const typename DoFHandler<dim>::active_cell_iterator &cell_guess);
   virtual void
   closest_surface_point(const Point<dim> &p, Point<dim> &closest_point) const;
@@ -331,7 +331,7 @@ public:
    * @param orientation The sphere orientation
    */
   Sphere<dim>(double              radius,
-              const Point<dim> &  position,
+              const Point<dim>   &position,
               const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
   {
@@ -351,7 +351,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
 
@@ -367,7 +367,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   Tensor<1, dim>
-  gradient(const Point<dim> & evaluation_point,
+  gradient(const Point<dim>  &evaluation_point,
            const unsigned int component = 0) const override;
 
   /**
@@ -419,8 +419,8 @@ public:
   Superquadric<dim>(const Tensor<1, dim> half_lengths,
                     const Tensor<1, dim> exponents,
                     const double         epsilon,
-                    const Point<dim> &   position,
-                    const Tensor<1, 3> & orientation)
+                    const Point<dim>    &position,
+                    const Tensor<1, 3>  &orientation)
     : Shape<dim>(half_lengths.norm(), position, orientation)
     , half_lengths(half_lengths)
     , exponents(exponents)
@@ -435,7 +435,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -448,7 +448,7 @@ public:
    */
   double
   value_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int /*component = 0*/) override;
 
@@ -464,7 +464,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   Tensor<1, dim>
-  gradient(const Point<dim> & evaluation_point,
+  gradient(const Point<dim>  &evaluation_point,
            const unsigned int component = 0) const override;
 
   /**
@@ -475,7 +475,7 @@ public:
    */
   Tensor<1, dim>
   gradient_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int component = 0) override;
 
@@ -493,12 +493,12 @@ public:
    */
   void
   closest_surface_point(
-    const Point<dim> &                                    p,
-    Point<dim> &                                          closest_point,
+    const Point<dim>                                     &p,
+    Point<dim>                                           &closest_point,
     const typename DoFHandler<dim>::active_cell_iterator &cell_guess) override;
   void
   closest_surface_point(const Point<dim> &p,
-                        Point<dim> &      closest_point) const override;
+                        Point<dim>       &closest_point) const override;
 
   /**
    * @brief Return the sign of the parameter. To be removed once PR#794 is merged.
@@ -570,8 +570,8 @@ public:
    * @param orientation The hyper rectangle orientation
    */
   HyperRectangle<dim>(const Tensor<1, dim> &half_lengths,
-                      const Point<dim> &    position,
-                      const Tensor<1, 3> &  orientation)
+                      const Point<dim>     &position,
+                      const Tensor<1, 3>   &orientation)
     : Shape<dim>(half_lengths.norm(), position, orientation)
     , half_lengths(half_lengths)
   {}
@@ -584,7 +584,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -617,8 +617,8 @@ public:
    * @param orientation The ellipsoid orientation
    */
   Ellipsoid<dim>(const Tensor<1, dim> &radii,
-                 const Point<dim> &    position,
-                 const Tensor<1, 3> &  orientation)
+                 const Point<dim>     &position,
+                 const Tensor<1, 3>   &orientation)
     : Shape<dim>(radii.norm(), position, orientation)
     , radii(radii)
   {}
@@ -631,7 +631,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -667,7 +667,7 @@ public:
    */
   Torus<dim>(double              ring_radius,
              double              ring_thickness,
-             const Point<dim> &  position,
+             const Point<dim>   &position,
              const Tensor<1, 3> &orientation)
     : Shape<dim>(ring_thickness, position, orientation)
     , ring_radius(ring_radius)
@@ -682,7 +682,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -718,7 +718,7 @@ public:
    */
   Cone<dim>(double              tan_base_angle,
             double              height,
-            const Point<dim> &  position,
+            const Point<dim>   &position,
             const Tensor<1, 3> &orientation)
     : Shape<dim>(height, position, orientation)
     , tan_base_angle(tan_base_angle)
@@ -735,7 +735,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -777,7 +777,7 @@ public:
   CutHollowSphere<dim>(double              radius,
                        double              cut_depth,
                        double              shell_thickness,
-                       const Point<dim> &  position,
+                       const Point<dim>   &position,
                        const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
     , radius(radius)
@@ -794,7 +794,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -836,7 +836,7 @@ public:
   DeathStar<dim>(double              radius,
                  double              hole_radius,
                  double              spheres_distance,
-                 const Point<dim> &  position,
+                 const Point<dim>   &position,
                  const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
     , radius(radius)
@@ -857,7 +857,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -911,7 +911,7 @@ public:
     std::map<unsigned int,
              std::tuple<BooleanOperation, unsigned int, unsigned int>>
                         operations,
-    const Point<dim> &  position,
+    const Point<dim>   &position,
     const Tensor<1, 3> &orientation)
     : Shape<dim>(0., position, orientation)
     , constituents(constituents)
@@ -934,8 +934,8 @@ public:
    */
   CompositeShape<dim>(
     std::vector<std::shared_ptr<Shape<dim>>> constituents_vector,
-    const Point<dim> &                       position,
-    const Tensor<1, 3> &                     orientation)
+    const Point<dim>                        &position,
+    const Tensor<1, 3>                      &orientation)
     : Shape<dim>(0., position, orientation)
   {
     size_t number_of_constituents = constituents_vector.size();
@@ -973,7 +973,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -986,7 +986,7 @@ public:
    */
   double
   value_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int /*component = 0*/) override;
 
@@ -996,7 +996,7 @@ public:
    * @param component Not applicable
    */
   Tensor<1, dim>
-  gradient(const Point<dim> & evaluation_point,
+  gradient(const Point<dim>  &evaluation_point,
            const unsigned int component = 0) const override;
 
   /**
@@ -1007,7 +1007,7 @@ public:
    */
   Tensor<1, dim>
   gradient_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int component = 0) override;
 
@@ -1086,7 +1086,7 @@ public:
    * @param orientation The shape orientation
    */
   OpenCascadeShape<dim>(const std::string   file_name,
-                        const Point<dim> &  position,
+                        const Point<dim>   &position,
                         const Tensor<1, 3> &orientation)
     : Shape<dim>(0.1, position, orientation)
   {
@@ -1185,7 +1185,7 @@ public:
    * @param component Not applicable
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -1198,7 +1198,7 @@ public:
    */
   double
   value_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int component = 0) override;
 
@@ -1214,7 +1214,7 @@ public:
    * @param component Not applicable
    */
   Tensor<1, dim>
-  gradient(const Point<dim> & evaluation_point,
+  gradient(const Point<dim>  &evaluation_point,
            const unsigned int component = 0) const override;
 
   /**
@@ -1225,7 +1225,7 @@ public:
    */
   Tensor<1, dim>
   gradient_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int component = 0) override;
 
@@ -1324,7 +1324,7 @@ public:
    * axis
    */
   RBFShape<dim>(const std::string   shape_arguments_str,
-                const Point<dim> &  position,
+                const Point<dim>   &position,
                 const Tensor<1, 3> &orientation);
 
   /**
@@ -1356,7 +1356,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -1381,7 +1381,7 @@ public:
    */
   Tensor<1, dim>
   gradient_with_cell_guess(
-    const Point<dim> &                                   evaluation_point,
+    const Point<dim>                                    &evaluation_point,
     const typename DoFHandler<dim>::active_cell_iterator cell,
     const unsigned int component = 0) override;
 
@@ -1391,7 +1391,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   Tensor<1, dim>
-  gradient(const Point<dim> & evaluation_point,
+  gradient(const Point<dim>  &evaluation_point,
            const unsigned int component = 0) const override;
 
   /**
@@ -1861,7 +1861,7 @@ public:
    */
   Cylinder<dim>(double              radius,
                 double              half_length,
-                const Point<dim> &  position,
+                const Point<dim>   &position,
                 const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
     , radius(radius)
@@ -1876,7 +1876,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -1915,7 +1915,7 @@ public:
   CylindricalTube<dim>(double              radius_inside,
                        double              radius_outside,
                        double              half_length,
-                       const Point<dim> &  position,
+                       const Point<dim>   &position,
                        const Tensor<1, 3> &orientation)
     : Shape<dim>((radius_outside + radius_inside) / 2., position, orientation)
     , radius((radius_outside + radius_inside) / 2.)
@@ -1931,7 +1931,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**
@@ -1974,7 +1974,7 @@ public:
                         double              radius_disk,
                         double              height,
                         double              pitch,
-                        const Point<dim> &  position,
+                        const Point<dim>   &position,
                         const Tensor<1, 3> &orientation)
     : Shape<dim>(radius_disk, position, orientation)
     , radius(radius_helix)
@@ -1991,7 +1991,7 @@ public:
    * @param component This parameter is not used, but it is necessary because Shapes inherit from the Function class of deal.II.
    */
   double
-  value(const Point<dim> & evaluation_point,
+  value(const Point<dim>  &evaluation_point,
         const unsigned int component = 0) const override;
 
   /**

--- a/include/core/shape_parsing.h
+++ b/include/core/shape_parsing.h
@@ -35,7 +35,7 @@ namespace ShapeGenerator
   std::shared_ptr<Shape<dim>>
   initialize_shape(const std::string   type,
                    const std::string   shape_arguments_str,
-                   const Point<dim> &  position,
+                   const Point<dim>   &position,
                    const Tensor<1, 3> &orientation);
 
   /**
@@ -49,8 +49,8 @@ namespace ShapeGenerator
   std::shared_ptr<Shape<dim>>
   initialize_shape_from_vector(const std::string         type,
                                const std::vector<double> shape_arguments,
-                               const Point<dim> &        position,
-                               const Tensor<1, 3> &      orientation);
+                               const Point<dim>         &position,
+                               const Tensor<1, 3>       &orientation);
 
   /**
    * Initializes the shape from its type and a text file that contains the real
@@ -64,7 +64,7 @@ namespace ShapeGenerator
   std::shared_ptr<Shape<dim>>
   initialize_shape_from_file(const std::string   type,
                              const std::string   file_name,
-                             const Point<dim> &  position,
+                             const Point<dim>   &position,
                              const Tensor<1, 3> &orientation);
 } // namespace ShapeGenerator
 

--- a/include/core/solutions_output.h
+++ b/include/core/solutions_output.h
@@ -56,14 +56,14 @@ using namespace dealii;
  */
 template <int dim, int spacedim = dim>
 void
-write_vtu_and_pvd(PVDHandler &                           pvd_handler,
+write_vtu_and_pvd(PVDHandler                            &pvd_handler,
                   const DataOutInterface<dim, spacedim> &data_out,
                   const std::string                      folder,
                   const std::string                      file_prefix,
                   const double                           time,
                   const unsigned int                     iter,
                   const unsigned int                     group_files,
-                  const MPI_Comm &                       mpi_communicator,
+                  const MPI_Comm                        &mpi_communicator,
                   const unsigned int                     digits = 4);
 
 /**
@@ -86,7 +86,7 @@ write_boundaries_vtu(const DataOutFaces<dim> &data_out,
                      const std::string        folder,
                      const double             time,
                      const unsigned int       iter,
-                     const MPI_Comm &         mpi_communicator,
+                     const MPI_Comm          &mpi_communicator,
                      const std::string  file_prefix = std::string("boundaries"),
                      const unsigned int digits      = 4);
 #endif

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -65,7 +65,7 @@ public:
 inline void
 add_statistics_to_table_handler(const std::string variable,
                                 const statistics  stats,
-                                TableHandler &    table)
+                                TableHandler     &table)
 {
   table.add_value("Variable", variable);
   table.add_value("Min", stats.min);
@@ -92,20 +92,20 @@ add_statistics_to_table_handler(const std::string variable,
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T> &             independent_values,
-  const std::string &                independent_column_name,
+  const std::vector<T>              &independent_values,
+  const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string> &   dependent_column_name,
+  const std::vector<std::string>    &dependent_column_name,
   const unsigned int                 display_precision);
 
 
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T> &                          independent_values,
-  const std::string &                             independent_column_name,
+  const std::vector<T>                           &independent_values,
+  const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vector,
-  const std::vector<std::string> &                dependent_column_name,
+  const std::vector<std::string>                 &dependent_column_name,
   const unsigned int                              display_precision);
 
 /**
@@ -129,9 +129,9 @@ template <int dim>
 TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string> &   independent_column_name,
+  const std::vector<std::string>    &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string> &   dependent_column_name,
+  const std::vector<std::string>    &dependent_column_name,
   const unsigned int                 display_precision);
 
 
@@ -154,9 +154,9 @@ template <int dim>
 TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string> &   independent_column_name,
-  const std::vector<double> &        dependent_values,
-  const std::string &                dependent_column_name,
+  const std::vector<std::string>    &independent_column_name,
+  const std::vector<double>         &dependent_values,
+  const std::string                 &dependent_column_name,
   const unsigned int                 display_precision);
 
 
@@ -246,7 +246,7 @@ calculate_point_property_cahn_hilliard(const double phase_cahn_hilliard,
  *   @param delimiter The delimiter used to read the table.
  */
 void
-fill_table_from_file(TableHandler &    table,
+fill_table_from_file(TableHandler     &table,
                      const std::string file_name,
                      const std::string delimiter = " ");
 

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -97,14 +97,14 @@ private:
   unsigned int
   cell_weight(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &                                                                  cell,
+                                                                        &cell,
     const typename parallel::distributed::Triangulation<dim>::CellStatus status)
     const;
 #  else
   unsigned int
   cell_weight(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &              cell,
+                    &cell,
     const CellStatus status) const;
 #  endif
 
@@ -131,14 +131,14 @@ private:
   unsigned int
   cell_weight_with_mobility_status(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &                                                                  cell,
+                                                                        &cell,
     const typename parallel::distributed::Triangulation<dim>::CellStatus status)
     const;
 #  else
   unsigned int
   cell_weight_with_mobility_status(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &              cell,
+                    &cell,
     const CellStatus status) const;
 #  endif
 
@@ -209,7 +209,7 @@ private:
   void
   update_moment_of_inertia(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    std::vector<double> &                    MOI);
+    std::vector<double>                     &MOI);
 
 
   /**

--- a/include/dem/dem_contact_manager.h
+++ b/include/dem/dem_contact_manager.h
@@ -159,7 +159,7 @@ public:
   void
   execute_particle_particle_broad_search(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    const DisableContacts<dim> &             disable_particle_contact_object,
+    const DisableContacts<dim>              &disable_particle_contact_object,
     const bool                               has_periodic_boundaries = false);
 
   /**
@@ -179,7 +179,7 @@ public:
   void
   execute_particle_wall_broad_search(
     const Particles::ParticleHandler<dim> &particle_handler,
-    BoundaryCellsInformation<dim> &        boundary_cell_object,
+    BoundaryCellsInformation<dim>         &boundary_cell_object,
     const typename dem_data_structures<dim>::floating_mesh_information
                                                       floating_mesh_info,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
@@ -203,7 +203,7 @@ public:
   void
   execute_particle_wall_broad_search(
     const Particles::ParticleHandler<dim> &particle_handler,
-    BoundaryCellsInformation<dim> &        boundary_cell_object,
+    BoundaryCellsInformation<dim>         &boundary_cell_object,
     const typename dem_data_structures<dim>::floating_mesh_information
                                                       floating_mesh_info,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,

--- a/include/dem/disable_contacts.h
+++ b/include/dem/disable_contacts.h
@@ -173,7 +173,7 @@ public:
    */
   void
   identify_mobility_status(
-    const DoFHandler<dim> &                background_dh,
+    const DoFHandler<dim>                 &background_dh,
     const Particles::ParticleHandler<dim> &particle_handler,
     const unsigned int                     n_active_cells,
     MPI_Comm                               mpi_communicator);
@@ -259,7 +259,7 @@ private:
   calculate_granular_temperature_and_solid_fraction(
     const Particles::ParticleHandler<dim> &particle_handler,
     const std::set<typename DoFHandler<dim>::active_cell_iterator>
-      &             local_and_ghost_cells_with_particles,
+                   &local_and_ghost_cells_with_particles,
     Vector<double> &cell_granular_temperature,
     Vector<double> &cell_solid_fraction);
 

--- a/include/dem/explicit_euler_integrator.h
+++ b/include/dem/explicit_euler_integrator.h
@@ -62,11 +62,11 @@ public:
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
-    const Tensor<1, 3> &             body_force,
+    const Tensor<1, 3>              &body_force,
     const double                     time_step,
     const std::vector<Tensor<1, 3>> &torque,
     const std::vector<Tensor<1, 3>> &force,
-    const std::vector<double> &      MOI) override;
+    const std::vector<double>       &MOI) override;
 
   /**
    * Carries out integration of the motion of all
@@ -82,19 +82,19 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            const Tensor<1, 3> &             body_force,
+            const Tensor<1, 3>              &body_force,
             const double                     time_step,
-            std::vector<Tensor<1, 3>> &      torque,
-            std::vector<Tensor<1, 3>> &      force,
-            const std::vector<double> &      MOI) override;
+            std::vector<Tensor<1, 3>>       &torque,
+            std::vector<Tensor<1, 3>>       &force,
+            const std::vector<double>       &MOI) override;
 
   virtual void
-  integrate(Particles::ParticleHandler<dim> &                particle_handler,
-            const Tensor<1, 3> &                             body_force,
+  integrate(Particles::ParticleHandler<dim>                 &particle_handler,
+            const Tensor<1, 3>                              &body_force,
             const double                                     time_step,
-            std::vector<Tensor<1, 3>> &                      torque,
-            std::vector<Tensor<1, 3>> &                      force,
-            const std::vector<double> &                      MOI,
+            std::vector<Tensor<1, 3>>                       &torque,
+            std::vector<Tensor<1, 3>>                       &force,
+            const std::vector<double>                       &MOI,
             const parallel::distributed::Triangulation<dim> &triangulation,
             typename DEM::dem_data_structures<dim>::cell_index_int_map
               &cell_mobility_status_map) override;

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -75,18 +75,18 @@ public:
    */
   void
   build(
-    const parallel::distributed::Triangulation<dim> & triangulation,
+    const parallel::distributed::Triangulation<dim>  &triangulation,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-    const std::vector<unsigned int> &                 outlet_boundaries,
-    const bool &                                      check_diamond_cells,
-    const bool &              expand_particle_wall_contact_search,
+    const std::vector<unsigned int>                  &outlet_boundaries,
+    const bool                                       &check_diamond_cells,
+    const bool               &expand_particle_wall_contact_search,
     const ConditionalOStream &pcout);
 
   void
   build(const parallel::distributed::Triangulation<dim> &triangulation,
-        const std::vector<unsigned int> &                outlet_boundaries,
-        const bool &                                     check_diamond_cells,
-        const ConditionalOStream &                       pcout);
+        const std::vector<unsigned int>                 &outlet_boundaries,
+        const bool                                      &check_diamond_cells,
+        const ConditionalOStream                        &pcout);
 
   std::map<int, boundary_cells_info_struct<dim>> &
   get_boundary_cells_information()
@@ -144,7 +144,7 @@ private:
   void
   find_boundary_cells_information(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int> &                outlet_boundaries);
+    const std::vector<unsigned int>                 &outlet_boundaries);
 
   /**
    * Loops over all the cells to find boundary cells, find the global boundary
@@ -158,7 +158,7 @@ private:
   void
   find_global_boundary_cells_with_faces(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int> &                outlet_boundaries);
+    const std::vector<unsigned int>                 &outlet_boundaries);
 
   /**
    * Loops over all the cells to find cells which should be searched for
@@ -195,9 +195,9 @@ private:
   void
   add_cells_with_boundary_lines_to_boundary_cells(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int> &                outlet_boundaries,
-    const bool &                                     check_diamond_cells,
-    const ConditionalOStream &                       pcout);
+    const std::vector<unsigned int>                 &outlet_boundaries,
+    const bool                                      &check_diamond_cells,
+    const ConditionalOStream                        &pcout);
 
   /**
    * Loops over all the cells to find cells which should be searched for
@@ -212,7 +212,7 @@ private:
    */
   void
   find_boundary_cells_for_floating_walls(
-    const parallel::distributed::Triangulation<dim> & triangulation,
+    const parallel::distributed::Triangulation<dim>  &triangulation,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double                                      maximum_cell_diameter);
 
@@ -234,8 +234,8 @@ private:
   void
   add_boundary_neighbors_of_boundary_cells(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int> &                outlet_boundaries,
-    std::map<int, boundary_cells_info_struct<dim>> & boundary_cells_information,
+    const std::vector<unsigned int>                 &outlet_boundaries,
+    std::map<int, boundary_cells_info_struct<dim>>  &boundary_cells_information,
     const std::map<int, boundary_cells_info_struct<dim>>
       &global_boundary_cells_information);
 

--- a/include/dem/find_contact_detection_step.h
+++ b/include/dem/find_contact_detection_step.h
@@ -57,9 +57,9 @@ find_particle_contact_detection_step(
   Particles::ParticleHandler<dim> &particle_handler,
   const double                     dt,
   const double                     smallest_contact_search_criterion,
-  MPI_Comm &                       mpi_communicator,
+  MPI_Comm                        &mpi_communicator,
   const bool                       sorting_in_subdomains_step,
-  std::vector<double> &            displacement,
+  std::vector<double>             &displacement,
   const bool                       parallel_update = true);
 
 /**

--- a/include/dem/find_maximum_particle_size.h
+++ b/include/dem/find_maximum_particle_size.h
@@ -42,7 +42,7 @@
 double
 find_maximum_particle_size(
   const Parameters::Lagrangian::LagrangianPhysicalProperties
-    &          lagrangian_physical_properties,
+              &lagrangian_physical_properties,
   const double standard_deviation_multiplier);
 
 #endif

--- a/include/dem/gear3_integrator.h
+++ b/include/dem/gear3_integrator.h
@@ -80,11 +80,11 @@ public:
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
-    const Tensor<1, 3> &             body_force,
+    const Tensor<1, 3>              &body_force,
     const double                     time_step,
     const std::vector<Tensor<1, 3>> &torque,
     const std::vector<Tensor<1, 3>> &force,
-    const std::vector<double> &      MOI) override;
+    const std::vector<double>       &MOI) override;
 
   /**
    * Carries out the integration of the motion of all
@@ -100,19 +100,19 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            const Tensor<1, 3> &             body_force,
+            const Tensor<1, 3>              &body_force,
             const double                     time_step,
-            std::vector<Tensor<1, 3>> &      torque,
-            std::vector<Tensor<1, 3>> &      force,
-            const std::vector<double> &      MOI) override;
+            std::vector<Tensor<1, 3>>       &torque,
+            std::vector<Tensor<1, 3>>       &force,
+            const std::vector<double>       &MOI) override;
 
   virtual void
-  integrate(Particles::ParticleHandler<dim> &                particle_handler,
-            const Tensor<1, 3> &                             body_force,
+  integrate(Particles::ParticleHandler<dim>                 &particle_handler,
+            const Tensor<1, 3>                              &body_force,
             const double                                     time_step,
-            std::vector<Tensor<1, 3>> &                      torque,
-            std::vector<Tensor<1, 3>> &                      force,
-            const std::vector<double> &                      MOI,
+            std::vector<Tensor<1, 3>>                       &torque,
+            std::vector<Tensor<1, 3>>                       &force,
+            const std::vector<double>                       &MOI,
             const parallel::distributed::Triangulation<dim> &triangulation,
             typename DEM::dem_data_structures<dim>::cell_index_int_map
               &cell_mobility_status_map) override;

--- a/include/dem/input_parameter_inspection.h
+++ b/include/dem/input_parameter_inspection.h
@@ -40,7 +40,7 @@ using namespace std;
 template <int dim>
 void
 input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
-                           const ConditionalOStream &      pcout,
+                           const ConditionalOStream       &pcout,
                            const double standard_deviation_multiplier);
 
 #endif /* input_parameter_inspection_h */

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -68,9 +68,9 @@ public:
    * @param dem_parameters DEM parameters declared in the .prm file
    */
   virtual void
-  insert(Particles::ParticleHandler<dim> &                particle_handler,
+  insert(Particles::ParticleHandler<dim>                 &particle_handler,
          const parallel::distributed::Triangulation<dim> &triangulation,
-         const DEMSolverParameters<dim> &                 dem_parameters) = 0;
+         const DEMSolverParameters<dim>                  &dem_parameters) = 0;
 
 protected:
   /**
@@ -84,9 +84,9 @@ protected:
    * @param pcout Printing in parallel
    */
   void
-  print_insertion_info(const unsigned int &      inserted_this_step,
-                       const unsigned int &      remained_particles,
-                       const unsigned int &      particle_type,
+  print_insertion_info(const unsigned int       &inserted_this_step,
+                       const unsigned int       &remained_particles,
+                       const unsigned int       &particle_type,
                        const ConditionalOStream &pcout);
 
   /**
@@ -101,9 +101,9 @@ protected:
    */
   void
   assign_particle_properties(
-    const DEMSolverParameters<dim> &  dem_parameters,
-    const unsigned int &              inserted_this_step_this_proc,
-    const unsigned int &              current_inserting_particle_type,
+    const DEMSolverParameters<dim>   &dem_parameters,
+    const unsigned int               &inserted_this_step_this_proc,
+    const unsigned int               &current_inserting_particle_type,
     std::vector<std::vector<double>> &particle_properties);
 
   /**
@@ -118,7 +118,7 @@ protected:
   void
   calculate_insertion_domain_maximum_particle_number(
     const DEMSolverParameters<dim> &dem_parameters,
-    const ConditionalOStream &      pcout);
+    const ConditionalOStream       &pcout);
 
   // Number of particles that is going to be inserted at each insetion step.This
   // value can change in the last insertion step to reach the desired number of

--- a/include/dem/integrator.h
+++ b/include/dem/integrator.h
@@ -63,11 +63,11 @@ public:
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
-    const Tensor<1, 3> &             body_force,
+    const Tensor<1, 3>              &body_force,
     const double                     time_step,
     const std::vector<Tensor<1, 3>> &torque,
     const std::vector<Tensor<1, 3>> &force,
-    const std::vector<double> &      MOI) = 0;
+    const std::vector<double>       &MOI) = 0;
 
   /**
    * Carries out integrating of particles' velocity and position.
@@ -82,19 +82,19 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            const Tensor<1, 3> &             body_force,
+            const Tensor<1, 3>              &body_force,
             const double                     time_step,
-            std::vector<Tensor<1, 3>> &      torque,
-            std::vector<Tensor<1, 3>> &      force,
-            const std::vector<double> &      MOI) = 0;
+            std::vector<Tensor<1, 3>>       &torque,
+            std::vector<Tensor<1, 3>>       &force,
+            const std::vector<double>       &MOI) = 0;
 
   virtual void
-  integrate(Particles::ParticleHandler<dim> &                particle_handler,
-            const Tensor<1, 3> &                             body_force,
+  integrate(Particles::ParticleHandler<dim>                 &particle_handler,
+            const Tensor<1, 3>                              &body_force,
             const double                                     time_step,
-            std::vector<Tensor<1, 3>> &                      torque,
-            std::vector<Tensor<1, 3>> &                      force,
-            const std::vector<double> &                      MOI,
+            std::vector<Tensor<1, 3>>                       &torque,
+            std::vector<Tensor<1, 3>>                       &force,
+            const std::vector<double>                       &MOI,
             const parallel::distributed::Triangulation<dim> &triangulation,
             typename DEM::dem_data_structures<dim>::cell_index_int_map
               &cell_mobility_status_map) = 0;

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -67,14 +67,14 @@ public:
   void
   write_post_processing_results(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    PVDHandler &                                     grid_pvdhandler,
-    const DoFHandler<dim> &                          background_dh,
-    const Particles::ParticleHandler<dim> &          particle_handler,
-    const DEMSolverParameters<dim> &                 dem_parameters,
+    PVDHandler                                      &grid_pvdhandler,
+    const DoFHandler<dim>                           &background_dh,
+    const Particles::ParticleHandler<dim>           &particle_handler,
+    const DEMSolverParameters<dim>                  &dem_parameters,
     const double                                     current_time,
     const unsigned int                               step_number,
-    const MPI_Comm &                                 mpi_communicator,
-    DisableContacts<dim> &                           disable_contacts_object);
+    const MPI_Comm                                  &mpi_communicator,
+    DisableContacts<dim>                            &disable_contacts_object);
 
 private:
   /**
@@ -89,7 +89,7 @@ private:
   void
   calculate_average_particles_velocity(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const Particles::ParticleHandler<dim> &          particle_handler);
+    const Particles::ParticleHandler<dim>           &particle_handler);
 
   /**
    * Carries out the calculation of the granular temperature in each local cell.
@@ -103,7 +103,7 @@ private:
   void
   calculate_average_granular_temperature(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const Particles::ParticleHandler<dim> &          particle_handler);
+    const Particles::ParticleHandler<dim>           &particle_handler);
 
   /**
    * Carries out the calculation of average particles velocity for a single
@@ -118,7 +118,7 @@ private:
   Tensor<1, dim>
   calculate_cell_average_particles_velocity(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &                                    cell,
+                                          &cell,
     const Particles::ParticleHandler<dim> &particle_handler);
 
   Vector<double> velocity_average_x;

--- a/include/dem/list_insertion.h
+++ b/include/dem/list_insertion.h
@@ -58,7 +58,7 @@ public:
    * @param dem_parameters DEM parameters declared in the .prm file
    */
   virtual void
-  insert(Particles::ParticleHandler<dim> &                particle_handler,
+  insert(Particles::ParticleHandler<dim>                 &particle_handler,
          const parallel::distributed::Triangulation<dim> &triangulation,
          const DEMSolverParameters<dim> &dem_parameters) override;
 
@@ -78,9 +78,9 @@ public:
    */
   void
   assign_particle_properties_for_list_insertion(
-    const DEMSolverParameters<dim> &  dem_parameters,
-    const unsigned int &              inserted_this_step_this_proc,
-    const unsigned int &              current_inserting_particle_type,
+    const DEMSolverParameters<dim>   &dem_parameters,
+    const unsigned int               &inserted_this_step_this_proc,
+    const unsigned int               &current_inserting_particle_type,
     std::vector<std::vector<double>> &particle_properties);
 
   // Number of remaining particles of each type that should be inserted in the

--- a/include/dem/non_uniform_insertion.h
+++ b/include/dem/non_uniform_insertion.h
@@ -65,7 +65,7 @@ public:
    *
    */
   virtual void
-  insert(Particles::ParticleHandler<dim> &                particle_handler,
+  insert(Particles::ParticleHandler<dim>                 &particle_handler,
          const parallel::distributed::Triangulation<dim> &triangulation,
          const DEMSolverParameters<dim> &dem_parameters) override;
 
@@ -96,7 +96,7 @@ private:
    */
   void
   find_insertion_location_nonuniform(
-    Point<dim> &                                 insertion_location,
+    Point<dim>                                  &insertion_location,
     const unsigned int                           id,
     const double                                 random_number1,
     const double                                 random_number2,

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -65,7 +65,7 @@ public:
   void
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContactManager<dim> &                 container_manager);
+    DEMContactManager<dim>                  &container_manager);
 
   /**
    * @brief Finds a vector of pairs (particle_particle_candidates) which shows the
@@ -86,8 +86,8 @@ public:
   void
   find_particle_particle_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContactManager<dim> &                 container_manager,
-    const DisableContacts<dim> &             disable_contacts_object);
+    DEMContactManager<dim>                  &container_manager,
+    const DisableContacts<dim>              &disable_contacts_object);
 
   /**
    * @brief Finds a vector of pairs (particle_particle_candidates) which contains the
@@ -104,7 +104,7 @@ public:
   void
   find_particle_particle_periodic_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContactManager<dim> &                 container_manager);
+    DEMContactManager<dim>                  &container_manager);
 
   /**
    * @brief Finds a vector of pairs (particle_particle_candidates) which contains the
@@ -125,8 +125,8 @@ public:
   void
   find_particle_particle_periodic_contact_pairs(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    DEMContactManager<dim> &                 container_manager,
-    const DisableContacts<dim> &             disable_contacts_object);
+    DEMContactManager<dim>                  &container_manager,
+    const DisableContacts<dim>              &disable_contacts_object);
 
 private:
   /**
@@ -148,7 +148,7 @@ private:
     const typename Particles::ParticleHandler<
       dim>::particle_iterator_range::iterator &particle_begin,
     const typename Particles::ParticleHandler<dim>::particle_iterator_range
-      &                                 particles_to_evaluate,
+                                       &particles_to_evaluate,
     std::vector<types::particle_index> &contact_pair_candidates_container)
   {
     // Create a arbitrary temporary empty container

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -71,7 +71,7 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    DEMContactManager<dim> &   container_manager,
+    DEMContactManager<dim>    &container_manager,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -105,15 +105,15 @@ public:
   calculate_IB_particle_particle_contact_force(
     const double                         normal_overlap,
     particle_particle_contact_info<dim> &contact_info,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque,
-    IBParticle<dim> &                    particle_one,
-    IBParticle<dim> &                    particle_two,
-    const Point<dim> &                   particle_one_location,
-    const Point<dim> &                   particle_two_location,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque,
+    IBParticle<dim>                     &particle_one,
+    IBParticle<dim>                     &particle_two,
+    const Point<dim>                    &particle_one_location,
+    const Point<dim>                    &particle_two_location,
     const double                         dt,
     const double                         particle_one_radius,
     const double                         particle_two_radius,
@@ -167,7 +167,7 @@ public:
    */
   virtual void
   calculate_particle_particle_contact_force(
-    DEMContactManager<dim> &   container_manager,
+    DEMContactManager<dim>    &container_manager,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -200,15 +200,15 @@ public:
   calculate_IB_particle_particle_contact_force(
     const double                         normal_overlap,
     particle_particle_contact_info<dim> &contact_info,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque,
-    IBParticle<dim> &                    particle_one,
-    IBParticle<dim> &                    particle_two,
-    const Point<dim> &                   particle_one_location,
-    const Point<dim> &                   particle_two_location,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque,
+    IBParticle<dim>                     &particle_one,
+    IBParticle<dim>                     &particle_two,
+    const Point<dim>                    &particle_one_location,
+    const Point<dim>                    &particle_two_location,
     const double                         dt,
     const double                         particle_one_radius,
     const double                         particle_two_radius,
@@ -232,12 +232,12 @@ protected:
   inline void
   update_contact_information(
     particle_particle_contact_info<dim> &contact_info,
-    double &                             normal_relative_velocity_value,
-    Tensor<1, 3> &                       normal_unit_vector,
-    const ArrayView<const double> &      particle_one_properties,
-    const ArrayView<const double> &      particle_two_properties,
-    const Point<3> &                     particle_one_location,
-    const Point<3> &                     particle_two_location,
+    double                              &normal_relative_velocity_value,
+    Tensor<1, 3>                        &normal_unit_vector,
+    const ArrayView<const double>       &particle_one_properties,
+    const ArrayView<const double>       &particle_two_properties,
+    const Point<3>                      &particle_one_location,
+    const Point<3>                      &particle_two_location,
     const double                         dt)
   {
     // Calculation of the contact vector from particle one to particle two
@@ -329,10 +329,10 @@ protected:
     const Tensor<1, 3> &particle_one_tangential_torque,
     const Tensor<1, 3> &particle_two_tangential_torque,
     const Tensor<1, 3> &rolling_resistance_torque,
-    Tensor<1, 3> &      particle_one_torque,
-    Tensor<1, 3> &      particle_two_torque,
-    Tensor<1, 3> &      particle_one_force,
-    Tensor<1, 3> &      particle_two_force)
+    Tensor<1, 3>       &particle_one_torque,
+    Tensor<1, 3>       &particle_two_torque,
+    Tensor<1, 3>       &particle_one_force,
+    Tensor<1, 3>       &particle_two_force)
   {
     // Calculation of total force
     Tensor<1, 3> total_force = normal_force + tangential_force;
@@ -364,8 +364,8 @@ protected:
     const Tensor<1, 3> &tangential_force,
     const Tensor<1, 3> &particle_one_tangential_torque,
     const Tensor<1, 3> &rolling_resistance_torque,
-    Tensor<1, 3> &      particle_one_torque,
-    Tensor<1, 3> &      particle_one_force)
+    Tensor<1, 3>       &particle_one_torque,
+    Tensor<1, 3>       &particle_one_force)
   {
     // Updating the force and torque acting on particles in the particle handler
     particle_one_force -= normal_force + tangential_force;
@@ -419,15 +419,15 @@ protected:
   calculate_linear_contact(
     particle_particle_contact_info<dim> &contact_info,
     const double                         normal_relative_velocity_value,
-    const Tensor<1, 3> &                 normal_unit_vector,
+    const Tensor<1, 3>                  &normal_unit_vector,
     const double                         normal_overlap,
-    const ArrayView<const double> &      particle_one_properties,
-    const ArrayView<const double> &      particle_two_properties,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque)
+    const ArrayView<const double>       &particle_one_properties,
+    const ArrayView<const double>       &particle_two_properties,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque)
   {
     // Calculation of effective radius and mass
     this->find_effective_radius_and_mass(particle_one_properties,
@@ -572,15 +572,15 @@ protected:
   calculate_hertz_mindlin_limit_overlap_contact(
     particle_particle_contact_info<dim> &contact_info,
     const double                         normal_relative_velocity_value,
-    const Tensor<1, 3> &                 normal_unit_vector,
+    const Tensor<1, 3>                  &normal_unit_vector,
     const double                         normal_overlap,
-    const ArrayView<const double> &      particle_one_properties,
-    const ArrayView<const double> &      particle_two_properties,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque)
+    const ArrayView<const double>       &particle_one_properties,
+    const ArrayView<const double>       &particle_two_properties,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque)
   {
     // Calculation of effective radius and mass
     this->find_effective_radius_and_mass(particle_one_properties,
@@ -723,15 +723,15 @@ protected:
   calculate_hertz_mindlin_limit_force_contact(
     particle_particle_contact_info<dim> &contact_info,
     const double                         normal_relative_velocity_value,
-    const Tensor<1, 3> &                 normal_unit_vector,
+    const Tensor<1, 3>                  &normal_unit_vector,
     const double                         normal_overlap,
-    const ArrayView<const double> &      particle_one_properties,
-    const ArrayView<const double> &      particle_two_properties,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque)
+    const ArrayView<const double>       &particle_one_properties,
+    const ArrayView<const double>       &particle_two_properties,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque)
   {
     // Calculation of effective radius and mass
     this->find_effective_radius_and_mass(particle_one_properties,
@@ -867,15 +867,15 @@ protected:
   calculate_hertz_contact(
     particle_particle_contact_info<dim> &contact_info,
     const double                         normal_relative_velocity_value,
-    const Tensor<1, 3> &                 normal_unit_vector,
+    const Tensor<1, 3>                  &normal_unit_vector,
     const double                         normal_overlap,
-    const ArrayView<const double> &      particle_one_properties,
-    const ArrayView<const double> &      particle_two_properties,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque)
+    const ArrayView<const double>       &particle_one_properties,
+    const ArrayView<const double>       &particle_two_properties,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque)
   {
     // Calculation of effective radius and mass
     this->find_effective_radius_and_mass(particle_one_properties,

--- a/include/dem/particle_particle_fine_search.h
+++ b/include/dem/particle_particle_fine_search.h
@@ -86,7 +86,7 @@ public:
     typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
       &adjacent_particles,
     const typename DEM::dem_data_structures<dim>::particle_particle_candidates
-      &                  contact_pair_candidates,
+                        &contact_pair_candidates,
     const double         neighborhood_threshold,
     const Tensor<1, dim> periodic_offset = Tensor<1, dim>());
 };

--- a/include/dem/particle_point_line_broad_search.h
+++ b/include/dem/particle_point_line_broad_search.h
@@ -74,7 +74,7 @@ public:
     const std::unordered_map<
       std::string,
       std::pair<typename Triangulation<dim>::active_cell_iterator, Point<dim>>>
-      &                         boundary_cells_with_points,
+                               &boundary_cells_with_points,
     const DisableContacts<dim> &disable_contacts_object);
 
   /**
@@ -107,7 +107,7 @@ public:
       std::string,
       std::tuple<typename Triangulation<dim>::active_cell_iterator,
                  Point<dim>,
-                 Point<dim>>> & boundary_cells_with_lines,
+                 Point<dim>>>  &boundary_cells_with_lines,
     const DisableContacts<dim> &disable_contacts_object);
 };
 

--- a/include/dem/particle_point_line_contact_force.h
+++ b/include/dem/particle_point_line_contact_force.h
@@ -64,7 +64,7 @@ public:
     const typename DEM::dem_data_structures<dim>::
       particle_point_line_contact_info *particle_point_line_pairs_in_contact,
     const Parameters::Lagrangian::LagrangianPhysicalProperties
-      &                        lagrangian_physical_properties,
+                              &lagrangian_physical_properties,
     std::vector<Tensor<1, 3>> &force);
 
   /**
@@ -82,7 +82,7 @@ public:
     const typename DEM::dem_data_structures<
       dim>::particle_point_line_contact_info *particle_line_pairs_in_contact,
     const Parameters::Lagrangian::LagrangianPhysicalProperties
-      &                        lagrangian_physical_properties,
+                              &lagrangian_physical_properties,
     std::vector<Tensor<1, 3>> &force);
 
 private:

--- a/include/dem/particle_point_line_fine_search.h
+++ b/include/dem/particle_point_line_fine_search.h
@@ -66,7 +66,7 @@ public:
   typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
   particle_point_fine_search(
     const typename DEM::dem_data_structures<dim>::particle_point_candidates
-      &          particle_point_contact_candidates,
+                &particle_point_contact_candidates,
     const double neighborhood_threshold);
 
   /**
@@ -86,7 +86,7 @@ public:
   typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
   particle_line_fine_search(
     const typename DEM::dem_data_structures<dim>::particle_line_candidates
-      &          particle_line_contact_candidates,
+                &particle_line_contact_candidates,
     const double neighborhood_threshold);
 
 private:

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -74,7 +74,7 @@ public:
   void
   find_particle_wall_contact_pairs(
     const std::map<int, boundary_cells_info_struct<dim>>
-      &                                    boundary_cells_information,
+                                          &boundary_cells_information,
     const Particles::ParticleHandler<dim> &particle_handler,
     typename DEM::dem_data_structures<dim>::particle_wall_candidates
       &particle_wall_contact_candidates);
@@ -82,10 +82,10 @@ public:
   void
   find_particle_wall_contact_pairs(
     const std::map<int, boundary_cells_info_struct<dim>>
-      &                                    boundary_cells_information,
+                                          &boundary_cells_information,
     const Particles::ParticleHandler<dim> &particle_handler,
     typename DEM::dem_data_structures<dim>::particle_wall_candidates
-      &                         particle_wall_contact_candidates,
+                               &particle_wall_contact_candidates,
     const DisableContacts<dim> &disable_contacts_object);
 
   /**
@@ -110,7 +110,7 @@ public:
     const std::unordered_map<
       unsigned int,
       std::set<typename Triangulation<dim>::active_cell_iterator>>
-      &                                    boundary_cells_for_floating_walls,
+                                          &boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double                                      simulation_time,
@@ -122,12 +122,12 @@ public:
     const std::unordered_map<
       unsigned int,
       std::set<typename Triangulation<dim>::active_cell_iterator>>
-      &                                    boundary_cells_for_floating_walls,
+                                          &boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
     const double                                      simulation_time,
     typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates
-      &                         particle_floating_wall_candidates,
+                               &particle_floating_wall_candidates,
     const DisableContacts<dim> &disable_contacts_object);
 
   /**
@@ -149,7 +149,7 @@ public:
   void
   particle_floating_mesh_contact_search(
     const typename DEM::dem_data_structures<dim>::floating_mesh_information
-      &                                    floating_mesh_information,
+                                          &floating_mesh_information,
     const Particles::ParticleHandler<dim> &particle_handler,
     typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
       &particle_floating_mesh_contact_candidates,
@@ -159,12 +159,12 @@ public:
   void
   particle_floating_mesh_contact_search(
     const typename DEM::dem_data_structures<dim>::floating_mesh_information
-      &                                    floating_mesh_information,
+                                          &floating_mesh_information,
     const Particles::ParticleHandler<dim> &particle_handler,
     typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
       &particle_floating_mesh_contact_candidates,
     typename DEM::dem_data_structures<dim>::cells_total_neighbor_list
-      &                         cells_total_neighbor_list,
+                               &cells_total_neighbor_list,
     const DisableContacts<dim> &disable_contacts_object);
 };
 

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -73,7 +73,7 @@ public:
   virtual void
   calculate_particle_wall_contact_force(
     typename DEM::dem_data_structures<dim>::particle_wall_in_contact
-      &                        particle_wall_pairs_in_contact,
+                              &particle_wall_pairs_in_contact,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force) = 0;
@@ -92,7 +92,7 @@ public:
   virtual void
   calculate_particle_floating_wall_contact_force(
     typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
-      &                        particle_floating_mesh_in_contact,
+                              &particle_floating_mesh_in_contact,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -133,11 +133,11 @@ public:
   virtual void
   calculate_IB_particle_wall_contact_force(
     particle_wall_contact_info<dim> &contact_info,
-    Tensor<1, 3> &                   normal_force,
-    Tensor<1, 3> &                   tangential_force,
-    Tensor<1, 3> &                   tangential_torque,
-    Tensor<1, 3> &                   rolling_resistance_torque,
-    IBParticle<dim> &                particle,
+    Tensor<1, 3>                    &normal_force,
+    Tensor<1, 3>                    &tangential_force,
+    Tensor<1, 3>                    &tangential_torque,
+    Tensor<1, 3>                    &rolling_resistance_torque,
+    IBParticle<dim>                 &particle,
     const double                     wall_youngs_modulus,
     const double                     wall_poisson_ratio,
     const double                     wall_restitution_coefficient,
@@ -175,7 +175,7 @@ protected:
   void
   update_contact_information(
     particle_wall_contact_info<dim> &contact_pair_information,
-    const ArrayView<const double> &  particle_properties,
+    const ArrayView<const double>   &particle_properties,
     const double                     dt);
 
   /**
@@ -194,10 +194,10 @@ protected:
   void
   update_particle_floating_wall_contact_information(
     particle_wall_contact_info<dim> &contact_pair_information,
-    const ArrayView<const double> &  particle_properties,
+    const ArrayView<const double>   &particle_properties,
     const double                     dt,
-    const Tensor<1, 3> &             cut_cell_translational_velocity,
-    const Tensor<1, 3> &             cut_cell_rotational_velocity,
+    const Tensor<1, 3>              &cut_cell_translational_velocity,
+    const Tensor<1, 3>              &cut_cell_rotational_velocity,
     const double                     center_of_rotation_particle_distance);
 
   /**
@@ -216,9 +216,9 @@ protected:
   inline void
   apply_force_and_torque(
     const std::tuple<Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>>
-      &             forces_and_torques,
-    Tensor<1, 3> &  particle_torque,
-    Tensor<1, 3> &  particle_force,
+                   &forces_and_torques,
+    Tensor<1, 3>   &particle_torque,
+    Tensor<1, 3>   &particle_force,
     const Point<3> &point_on_boundary,
     int             boundary_id = 0)
   {

--- a/include/dem/particle_wall_contact_info.h
+++ b/include/dem/particle_wall_contact_info.h
@@ -48,8 +48,8 @@ public:
    */
 
   particle_wall_contact_info(const Particles::ParticleIterator<dim> &particle,
-                             const Tensor<1, 3> &      normal_vector,
-                             const Point<3> &          point_on_boundary,
+                             const Tensor<1, 3>       &normal_vector,
+                             const Point<3>           &point_on_boundary,
                              const types::boundary_id &boundary_id)
     : particle(particle)
     , normal_vector(normal_vector)

--- a/include/dem/particle_wall_linear_force.h
+++ b/include/dem/particle_wall_linear_force.h
@@ -62,7 +62,7 @@ public:
     const std::unordered_map<unsigned int, Tensor<1, 3>>
                                           boundary_rotational_vector,
     const double                          triangulation_radius,
-    const DEMSolverParameters<dim> &      dem_parameters,
+    const DEMSolverParameters<dim>       &dem_parameters,
     const std::vector<types::boundary_id> boundary_index = {});
 
   /**
@@ -79,7 +79,7 @@ public:
   virtual void
   calculate_particle_wall_contact_force(
     typename DEM::dem_data_structures<dim>::particle_wall_in_contact
-      &                        particle_wall_pairs_in_contact,
+                              &particle_wall_pairs_in_contact,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force) override;
@@ -98,7 +98,7 @@ public:
   virtual void
   calculate_particle_floating_wall_contact_force(
     typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
-      &                        particle_floating_mesh_in_contact,
+                              &particle_floating_mesh_in_contact,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -130,11 +130,11 @@ public:
   virtual void
   calculate_IB_particle_wall_contact_force(
     particle_wall_contact_info<dim> &contact_info,
-    Tensor<1, 3> &                   normal_force,
-    Tensor<1, 3> &                   tangential_force,
-    Tensor<1, 3> &                   tangential_torque,
-    Tensor<1, 3> &                   rolling_resistance_torque,
-    IBParticle<dim> &                particle,
+    Tensor<1, 3>                    &normal_force,
+    Tensor<1, 3>                    &tangential_force,
+    Tensor<1, 3>                    &tangential_torque,
+    Tensor<1, 3>                    &rolling_resistance_torque,
+    IBParticle<dim>                 &particle,
     const double                     wall_youngs_modulus,
     const double                     wall_poisson_ratio,
     const double                     wall_restitution_coefficient,
@@ -270,7 +270,7 @@ private:
   std::tuple<Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>>
   calculate_linear_contact_force_and_torque(
     particle_wall_contact_info<dim> &contact_info,
-    const ArrayView<const double> &  particle_properties);
+    const ArrayView<const double>   &particle_properties);
 };
 
 #endif

--- a/include/dem/particle_wall_nonlinear_force.h
+++ b/include/dem/particle_wall_nonlinear_force.h
@@ -62,7 +62,7 @@ public:
     const std::unordered_map<unsigned int, Tensor<1, 3>>
                                           boundary_rotational_vector,
     const double                          triangulation_radius,
-    const DEMSolverParameters<dim> &      dem_parameters,
+    const DEMSolverParameters<dim>       &dem_parameters,
     const std::vector<types::boundary_id> boundary_index = {});
 
   /**
@@ -79,7 +79,7 @@ public:
   virtual void
   calculate_particle_wall_contact_force(
     typename DEM::dem_data_structures<dim>::particle_wall_in_contact
-      &                        particle_wall_pairs_in_contact,
+                              &particle_wall_pairs_in_contact,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force) override;
@@ -98,7 +98,7 @@ public:
   virtual void
   calculate_particle_floating_wall_contact_force(
     typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
-      &                        particle_floating_mesh_in_contact,
+                              &particle_floating_mesh_in_contact,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -126,11 +126,11 @@ public:
   virtual void
   calculate_IB_particle_wall_contact_force(
     particle_wall_contact_info<dim> &contact_info,
-    Tensor<1, 3> &                   normal_force,
-    Tensor<1, 3> &                   tangential_force,
-    Tensor<1, 3> &                   tangential_torque,
-    Tensor<1, 3> &                   rolling_resistance_torque,
-    IBParticle<dim> &                particle,
+    Tensor<1, 3>                    &normal_force,
+    Tensor<1, 3>                    &tangential_force,
+    Tensor<1, 3>                    &tangential_torque,
+    Tensor<1, 3>                    &rolling_resistance_torque,
+    IBParticle<dim>                 &particle,
     const double                     wall_youngs_modulus,
     const double                     wall_poisson_ratio,
     const double                     wall_restitution_coefficient,
@@ -266,7 +266,7 @@ private:
   std::tuple<Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>>
   calculate_nonlinear_contact_force_and_torque(
     particle_wall_contact_info<dim> &contact_info,
-    const ArrayView<const double> &  particle_properties);
+    const ArrayView<const double>   &particle_properties);
 };
 
 #endif

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -142,7 +142,7 @@ private:
   check_and_move_particles(
     const periodic_boundaries_cells_info_struct<dim> &boundaries_cells_content,
     typename Particles::ParticleHandler<dim>::particle_iterator_range
-      &        particles_in_cell,
+              &particles_in_cell,
     const bool particles_in_pb0_cell);
 
   types::boundary_id periodic_boundary_0;

--- a/include/dem/plane_insertion.h
+++ b/include/dem/plane_insertion.h
@@ -55,7 +55,7 @@ public:
    * @param triangulation Triangulation object used in the simulation.
    */
   PlaneInsertion<dim>(
-    const DEMSolverParameters<dim> &                 dem_parameters,
+    const DEMSolverParameters<dim>                  &dem_parameters,
     const parallel::distributed::Triangulation<dim> &triangulation);
 
   /**
@@ -67,7 +67,7 @@ public:
    * @param dem_parameters DEM parameters declared in the .prm file.
    */
   virtual void
-  insert(Particles::ParticleHandler<dim> &                particle_handler,
+  insert(Particles::ParticleHandler<dim>                 &particle_handler,
          const parallel::distributed::Triangulation<dim> &triangulation,
          const DEMSolverParameters<dim> &dem_parameters) override;
 

--- a/include/dem/post_processing.h
+++ b/include/dem/post_processing.h
@@ -55,7 +55,7 @@ namespace DEM
   statistics
   calculate_granular_statistics(
     const Particles::ParticleHandler<dim> &particle_handler,
-    const MPI_Comm &                       mpi_communicator);
+    const MPI_Comm                        &mpi_communicator);
 
 
 } // namespace DEM

--- a/include/dem/print_initial_information.h
+++ b/include/dem/print_initial_information.h
@@ -35,6 +35,6 @@ using namespace std;
 
 void
 print_initial_information(const ConditionalOStream &pcout,
-                          const unsigned int &      n_mpi_processes);
+                          const unsigned int       &n_mpi_processes);
 
 #endif /* print_initial_information_h */

--- a/include/dem/read_checkpoint.h
+++ b/include/dem/read_checkpoint.h
@@ -52,12 +52,12 @@ using namespace std;
  */
 template <int dim>
 void
-read_checkpoint(TimerOutput &                              computing_timer,
-                const DEMSolverParameters<dim> &           dem_parameters,
-                std::shared_ptr<SimulationControl> &       simulation_control,
-                PVDHandler &                               particles_pvdhandler,
-                PVDHandler &                               grid_pvdhandler,
+read_checkpoint(TimerOutput                               &computing_timer,
+                const DEMSolverParameters<dim>            &dem_parameters,
+                std::shared_ptr<SimulationControl>        &simulation_control,
+                PVDHandler                                &particles_pvdhandler,
+                PVDHandler                                &grid_pvdhandler,
                 parallel::distributed::Triangulation<dim> &triangulation,
-                Particles::ParticleHandler<dim> &          particle_handler);
+                Particles::ParticleHandler<dim>           &particle_handler);
 
 #endif /* read_checkpoint_h */

--- a/include/dem/read_mesh.h
+++ b/include/dem/read_mesh.h
@@ -45,11 +45,11 @@ using namespace std;
  */
 template <int dim, int spacedim = dim>
 void
-read_mesh(const Parameters::Mesh &  mesh_parameters,
+read_mesh(const Parameters::Mesh   &mesh_parameters,
           const bool                restart,
           const ConditionalOStream &pcout,
           parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-          double &                             triangulation_cell_diameter,
+          double                              &triangulation_cell_diameter,
           const Parameters::Lagrangian::BCDEM &bc_params);
 
 /**
@@ -61,7 +61,7 @@ read_mesh(const Parameters::Mesh &  mesh_parameters,
  */
 template <int dim, int spacedim>
 void
-match_periodic_boundaries(Triangulation<dim, spacedim> &       triangulation,
+match_periodic_boundaries(Triangulation<dim, spacedim>        &triangulation,
                           const Parameters::Lagrangian::BCDEM &bc_params);
 
 #endif /* read_mesh_h */

--- a/include/dem/rolling_resistance_torque_models.h
+++ b/include/dem/rolling_resistance_torque_models.h
@@ -93,7 +93,7 @@ viscous_rolling_resistance_torque(
   const ArrayView<const double> &particle_two_properties,
   const double                   effective_rolling_friction_coefficient,
   const double                   normal_force_norm,
-  const Tensor<1, 3> &           normal_contact_vector)
+  const Tensor<1, 3>            &normal_contact_vector)
 
 {
   // For calculation of rolling resistance torque, we need to obtain

--- a/include/dem/set_particle_wall_contact_force_model.h
+++ b/include/dem/set_particle_wall_contact_force_model.h
@@ -40,7 +40,7 @@ using namespace std;
 template <int dim>
 std::shared_ptr<ParticleWallContactForce<dim>>
 set_particle_wall_contact_force_model(
-  const DEMSolverParameters<dim> &                 dem_parameters,
+  const DEMSolverParameters<dim>                  &dem_parameters,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const double                                     triangulation_cell_diameter);
 

--- a/include/dem/uniform_insertion.h
+++ b/include/dem/uniform_insertion.h
@@ -57,7 +57,7 @@ public:
    * @param dem_parameters DEM parameters declared in the .prm file
    */
   virtual void
-  insert(Particles::ParticleHandler<dim> &                particle_handler,
+  insert(Particles::ParticleHandler<dim>                 &particle_handler,
          const parallel::distributed::Triangulation<dim> &triangulation,
          const DEMSolverParameters<dim> &dem_parameters) override;
 
@@ -72,8 +72,8 @@ private:
    */
   void
   find_insertion_location_uniform(
-    Point<dim> &                                 insertion_location,
-    const unsigned int &                         id,
+    Point<dim>                                  &insertion_location,
+    const unsigned int                          &id,
     const Parameters::Lagrangian::InsertionInfo &insertion_information);
 
   // Number of remained particles of each type that should be inserted in the

--- a/include/dem/update_fine_search_candidates.h
+++ b/include/dem/update_fine_search_candidates.h
@@ -51,7 +51,7 @@ template <int dim,
           typename candidates_structure,
           ContactType contact_type>
 void
-update_fine_search_candidates(pairs_structure &     pairs_in_contact,
+update_fine_search_candidates(pairs_structure      &pairs_in_contact,
                               candidates_structure &contact_candidates);
 
 #endif /* localize_contacts_h */

--- a/include/dem/update_local_particle_containers.h
+++ b/include/dem/update_local_particle_containers.h
@@ -44,7 +44,7 @@ template <int dim>
 void
 update_particle_container(
   typename DEM::dem_data_structures<dim>::particle_index_iterator_map
-    &                                    particle_container,
+                                        &particle_container,
   const Particles::ParticleHandler<dim> *particle_handler);
 
 /**
@@ -64,7 +64,7 @@ void
 update_contact_container_iterators(
   pairs_structure &pairs_in_contact,
   typename DEM::dem_data_structures<dim>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures = false);
 
 

--- a/include/dem/velocity_verlet_integrator.h
+++ b/include/dem/velocity_verlet_integrator.h
@@ -68,11 +68,11 @@ public:
   virtual void
   integrate_half_step_location(
     Particles::ParticleHandler<dim> &particle_handler,
-    const Tensor<1, 3> &             body_force,
+    const Tensor<1, 3>              &body_force,
     const double                     time_step,
     const std::vector<Tensor<1, 3>> &torque,
     const std::vector<Tensor<1, 3>> &force,
-    const std::vector<double> &      MOI) override;
+    const std::vector<double>       &MOI) override;
 
   /**
    * Carries out the correction integration of the motion of all
@@ -88,19 +88,19 @@ public:
    */
   virtual void
   integrate(Particles::ParticleHandler<dim> &particle_handler,
-            const Tensor<1, 3> &             body_force,
+            const Tensor<1, 3>              &body_force,
             const double                     time_step,
-            std::vector<Tensor<1, 3>> &      torque,
-            std::vector<Tensor<1, 3>> &      force,
-            const std::vector<double> &      MOI) override;
+            std::vector<Tensor<1, 3>>       &torque,
+            std::vector<Tensor<1, 3>>       &force,
+            const std::vector<double>       &MOI) override;
 
   virtual void
-  integrate(Particles::ParticleHandler<dim> &                particle_handler,
-            const Tensor<1, 3> &                             body_force,
+  integrate(Particles::ParticleHandler<dim>                 &particle_handler,
+            const Tensor<1, 3>                              &body_force,
             const double                                     time_step,
-            std::vector<Tensor<1, 3>> &                      torque,
-            std::vector<Tensor<1, 3>> &                      force,
-            const std::vector<double> &                      MOI,
+            std::vector<Tensor<1, 3>>                       &torque,
+            std::vector<Tensor<1, 3>>                       &force,
+            const std::vector<double>                       &MOI,
             const parallel::distributed::Triangulation<dim> &triangulation,
             typename DEM::dem_data_structures<dim>::cell_index_int_map
               &cell_mobility_status_map) override;

--- a/include/dem/visualization.h
+++ b/include/dem/visualization.h
@@ -61,7 +61,7 @@ public:
    * dimension
    */
   void
-  build_patches(Particles::ParticleHandler<dim> &        particle_handler,
+  build_patches(Particles::ParticleHandler<dim>         &particle_handler,
                 std::vector<std::pair<std::string, int>> properties);
 
   /**
@@ -72,8 +72,8 @@ public:
    */
   void
   print_xyz(dealii::Particles::ParticleHandler<dim> &particle_handler,
-            const MPI_Comm &                         mpi_communicator,
-            const ConditionalOStream &               pcout);
+            const MPI_Comm                          &mpi_communicator,
+            const ConditionalOStream                &pcout);
 
   /**
    * Prints the data of particles in the deal.II intermediate format
@@ -83,9 +83,9 @@ public:
    * @param pcout Printing in parallel
    */
   void
-  print_intermediate_format(const Vector<float> &  data_to_print,
+  print_intermediate_format(const Vector<float>   &data_to_print,
                             const DoFHandler<dim> &background_dh,
-                            const MPI_Comm &       mpi_communicator);
+                            const MPI_Comm        &mpi_communicator);
 
   ~Visualization();
 

--- a/include/dem/write_checkpoint.h
+++ b/include/dem/write_checkpoint.h
@@ -55,14 +55,14 @@ using namespace std;
 
 template <int dim>
 void
-write_checkpoint(TimerOutput &                       computing_timer,
-                 const DEMSolverParameters<dim> &    dem_parameters,
+write_checkpoint(TimerOutput                        &computing_timer,
+                 const DEMSolverParameters<dim>     &dem_parameters,
                  std::shared_ptr<SimulationControl> &simulation_control,
-                 PVDHandler &                        particles_pvdhandler,
-                 PVDHandler &                        grid_pvdhandler,
+                 PVDHandler                         &particles_pvdhandler,
+                 PVDHandler                         &grid_pvdhandler,
                  parallel::distributed::Triangulation<dim> &triangulation,
-                 Particles::ParticleHandler<dim> &          particle_handler,
-                 const ConditionalOStream &                 pcout,
-                 MPI_Comm &                                 mpi_communicator);
+                 Particles::ParticleHandler<dim>           &particle_handler,
+                 const ConditionalOStream                  &pcout,
+                 MPI_Comm                                  &mpi_communicator);
 
 #endif /* write_checkpoint_h */

--- a/include/fem-dem/cfd_dem_coupling.h
+++ b/include/fem-dem/cfd_dem_coupling.h
@@ -80,14 +80,14 @@ public:
   unsigned int
   cell_weight(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &                                                                  cell,
+                                                                        &cell,
     const typename parallel::distributed::Triangulation<dim>::CellStatus status)
     const;
 #else
   unsigned int
   cell_weight(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
-      &              cell,
+                    &cell,
     const CellStatus status) const;
 #endif
 
@@ -161,7 +161,7 @@ private:
   void
   update_moment_of_inertia(
     dealii::Particles::ParticleHandler<dim> &particle_handler,
-    std::vector<double> &                    MOI);
+    std::vector<double>                     &MOI);
 
   /**
    * Sets the chosen integration method in the parameter handler file

--- a/include/fem-dem/gls_sharp_navier_stokes.h
+++ b/include/fem-dem/gls_sharp_navier_stokes.h
@@ -94,8 +94,8 @@ private:
   void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data) override;
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data) override;
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -113,8 +113,8 @@ private:
   void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data) override;
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data) override;
 
   /**
    * @brief sets up the vector of assembler functions
@@ -361,7 +361,7 @@ private:
    */
   std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
   cell_cut(const typename DoFHandler<dim>::active_cell_iterator &cell,
-           std::vector<types::global_dof_index> &         local_dof_indices,
+           std::vector<types::global_dof_index>          &local_dof_indices,
            std::map<types::global_dof_index, Point<dim>> &support_points);
 
   /**
@@ -380,7 +380,7 @@ private:
   bool
   cell_cut_by_p_absolute_distance(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    std::map<types::global_dof_index, Point<dim>> &       support_points,
+    std::map<types::global_dof_index, Point<dim>>        &support_points,
     unsigned int                                          p);
 
   /**
@@ -398,7 +398,7 @@ private:
    */
   std::tuple<bool, unsigned int, std::vector<types::global_dof_index>>
   cell_inside(const typename DoFHandler<dim>::active_cell_iterator &cell,
-              std::vector<types::global_dof_index> &         local_dof_indices,
+              std::vector<types::global_dof_index>          &local_dof_indices,
               std::map<types::global_dof_index, Point<dim>> &support_points);
 
 

--- a/include/fem-dem/gls_vans.h
+++ b/include/fem-dem/gls_vans.h
@@ -269,8 +269,8 @@ protected:
   void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data) override;
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data) override;
 
   /**
    * @brief Assembles the local rhs for a given cell
@@ -288,8 +288,8 @@ protected:
   void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data) override;
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data) override;
 
   /**
    * @brief sets up the vector of assembler functions

--- a/include/fem-dem/ib_particles_dem.h
+++ b/include/fem-dem/ib_particles_dem.h
@@ -69,7 +69,7 @@ public:
   initialize(const std::shared_ptr<Parameters::IBParticles<dim>> &p_nsparam,
              const std::shared_ptr<Parameters::Lagrangian::FloatingWalls<dim>>
                                                  floating_walls_parameters,
-             const MPI_Comm &                    mpi_communicator_input,
+             const MPI_Comm                     &mpi_communicator_input,
              const std::vector<IBParticle<dim>> &particles);
 
 
@@ -211,9 +211,9 @@ public:
   void
   update_particles_boundary_contact(
     const std::vector<IBParticle<dim>> &particles,
-    const DoFHandler<dim> &             dof_handler,
-    const Quadrature<dim - 1> &         face_quadrature_formula,
-    const Mapping<dim> &                mapping);
+    const DoFHandler<dim>              &dof_handler,
+    const Quadrature<dim - 1>          &face_quadrature_formula,
+    const Mapping<dim>                 &mapping);
 
 
   std::vector<IBParticle<dim>> dem_particles;

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -78,7 +78,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -87,7 +87,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   const bool SUPG = true;
@@ -120,7 +120,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -129,7 +129,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   const bool SUPG = true;
@@ -166,7 +166,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -175,7 +175,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -689,7 +689,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -698,7 +698,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::CFDDEM cfd_dem;

--- a/include/rpt/detector.h
+++ b/include/rpt/detector.h
@@ -45,8 +45,8 @@ public:
    */
   Detector(Parameters::DetectorParameters &detector_parameters,
            int                             n,
-           Point<dim> &                    face_point,
-           Point<dim> &                    middle_point)
+           Point<dim>                     &face_point,
+           Point<dim>                     &middle_point)
     : radius(detector_parameters.radius)
     , length(detector_parameters.length)
     , id(n)

--- a/include/rpt/particle_detector_interactions.h
+++ b/include/rpt/particle_detector_interactions.h
@@ -50,8 +50,8 @@ public:
    *
    * @param attenuation_coefficient_reactor Attenuation_coefficient_reactor defines the homogeneous attenuation coefficient of the reactor with respect to the reactor
    */
-  ParticleDetectorInteractions(RadioParticle<dim> &       particle,
-                               Detector<dim> &            detector,
+  ParticleDetectorInteractions(RadioParticle<dim>        &particle,
+                               Detector<dim>             &detector,
                                Parameters::RPTParameters &rpt_parameters)
     : particle_position(particle.get_position())
     , detector_face_position(detector.get_face_position())

--- a/include/rpt/particle_visualization.h
+++ b/include/rpt/particle_visualization.h
@@ -37,8 +37,8 @@ template <int dim>
 class ParticleVisualization
 {
 public:
-  ParticleVisualization(Triangulation<dim> &     background_triangulation,
-                        std::string &            filename,
+  ParticleVisualization(Triangulation<dim>      &background_triangulation,
+                        std::string             &filename,
                         std::vector<Point<dim>> &positions,
                         std::vector<std::vector<double>> &counts);
 

--- a/include/rpt/rpt_cell_reconstruction.h
+++ b/include/rpt/rpt_cell_reconstruction.h
@@ -54,9 +54,9 @@ public:
    *
    */
   RPTCellReconstruction(
-    Parameters::RPTParameters &              rpt_parameters,
+    Parameters::RPTParameters               &rpt_parameters,
     Parameters::RPTReconstructionParameters &rpt_reconstruction_parameters,
-    Parameters::DetectorParameters &         rpt_detector_parameters);
+    Parameters::DetectorParameters          &rpt_detector_parameters);
 
   /**
    * @brief Set up grid and find positions for every unknown particle positions.

--- a/include/rpt/rpt_fem_reconstruction.h
+++ b/include/rpt/rpt_fem_reconstruction.h
@@ -248,8 +248,8 @@ private:
   double
   calculate_cost(
     const TriaActiveIterator<DoFCellAccessor<dim, dim, false>> &cell,
-    Vector<double> &     reference_location,
-    const double &       last_constraint,
+    Vector<double>      &reference_location,
+    const double        &last_constraint,
     std::vector<double> &experimental_count);
 
   /**
@@ -265,7 +265,7 @@ private:
    */
   double
   calculate_reference_location_error(Vector<double> &reference_location,
-                                     const double &  last_constraint);
+                                     const double   &last_constraint);
 
   /**
    * @brief Searches in the reference space the position of the particle.
@@ -291,13 +291,13 @@ private:
   void
   search_position_in_reference_space(
     std::vector<std::vector<double>> &count_from_all_detectors,
-    std::vector<double> &             experimental_count,
+    std::vector<double>              &experimental_count,
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const double &  tol_reference_location,
-    double &        max_cost,
+    const double   &tol_reference_location,
+    double         &max_cost,
     Vector<double> &reference_location,
-    bool &          position_found,
-    Point<dim> &    real_location);
+    bool           &position_found,
+    Point<dim>     &real_location);
 
   /**
    * @brief Finds and saves the position of the particle in system coordinates.
@@ -398,7 +398,7 @@ template <int dim>
 Vector<double>
 assemble_matrix_and_rhs(
   std::vector<std::vector<double>> &vertex_count,
-  std::vector<double> &             experimental_count,
+  std::vector<double>              &experimental_count,
   Parameters::RPTFEMReconstructionParameters::FEMCostFunction
     &cost_function_type);
 

--- a/include/rpt/rpt_utilities.h
+++ b/include/rpt/rpt_utilities.h
@@ -38,7 +38,7 @@ using namespace dealii;
  */
 template <int dim>
 void
-attach_grid_to_triangulation(Triangulation<dim> &             triangulation,
+attach_grid_to_triangulation(Triangulation<dim>              &triangulation,
                              const Parameters::RPTParameters &parameters,
                              const unsigned int               n_refinement)
 {

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -58,7 +58,7 @@ template <int dim>
 class CahnHilliard : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  CahnHilliard<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
+  CahnHilliard<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
                     const SimulationParameters<dim> &p_simulation_parameters,
                     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                        p_triangulation,
@@ -333,8 +333,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    CahnHilliardScratchData<dim> &                        scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    CahnHilliardScratchData<dim>                         &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -352,8 +352,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    CahnHilliardScratchData<dim> &                        scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    CahnHilliardScratchData<dim>                         &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions

--- a/include/solvers/cahn_hilliard_assemblers.h
+++ b/include/solvers/cahn_hilliard_assemblers.h
@@ -52,7 +52,7 @@ public:
 
   virtual void
   assemble_matrix(CahnHilliardScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) = 0;
+                  StabilizedMethodsCopyData    &copy_data) = 0;
 
 
   /**
@@ -66,7 +66,7 @@ public:
 
   virtual void
   assemble_rhs(CahnHilliardScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) = 0;
+               StabilizedMethodsCopyData    &copy_data) = 0;
 
 protected:
   std::shared_ptr<SimulationControl> simulation_control;
@@ -107,7 +107,7 @@ public:
    */
   virtual void
   assemble_matrix(CahnHilliardScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
 
   /**
@@ -117,7 +117,7 @@ public:
    */
   virtual void
   assemble_rhs(CahnHilliardScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
   Parameters::CahnHilliard cahn_hilliard_parameters;
   MobilityModel            mobility_model;
@@ -153,7 +153,7 @@ public:
    */
   virtual void
   assemble_matrix(CahnHilliardScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
 
   /**
@@ -163,7 +163,7 @@ public:
    */
   virtual void
   assemble_rhs(CahnHilliardScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
 
   Parameters::MaterialInteractions material_interaction_parameters;
@@ -200,7 +200,7 @@ public:
 
   virtual void
   assemble_matrix(CahnHilliardScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -209,7 +209,7 @@ public:
    */
   virtual void
   assemble_rhs(CahnHilliardScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 };
 
 

--- a/include/solvers/cahn_hilliard_scratch_data.h
+++ b/include/solvers/cahn_hilliard_scratch_data.h
@@ -85,11 +85,11 @@ public:
    *
    */
   CahnHilliardScratchData(const PhysicalPropertiesManager &properties_manager,
-                          const FESystem<dim> &            fe_cahn_hilliard,
-                          const Quadrature<dim> &          quadrature,
-                          const Mapping<dim> &             mapping,
-                          const FiniteElement<dim> &       fe_fd,
-                          const Quadrature<dim - 1> &      face_quadrature)
+                          const FESystem<dim>             &fe_cahn_hilliard,
+                          const Quadrature<dim>           &quadrature,
+                          const Mapping<dim>              &mapping,
+                          const FiniteElement<dim>        &fe_fd,
+                          const Quadrature<dim - 1>       &face_quadrature)
     : properties_manager(properties_manager)
     , fe_values_cahn_hilliard(mapping,
                               fe_cahn_hilliard,
@@ -171,9 +171,9 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
-         Function<dim> *                source_function,
+         Function<dim>                 *source_function,
          Parameters::CahnHilliard       cahn_hilliard_parameters)
   {
     this->phase_order.component        = 0;

--- a/include/solvers/flow_control.h
+++ b/include/solvers/flow_control.h
@@ -57,8 +57,8 @@ public:
    * @param step_number. The current step
    */
   void
-  calculate_beta(const double &      average_velocity,
-                 const double &      dt,
+  calculate_beta(const double       &average_velocity,
+                 const double       &dt,
                  const unsigned int &step_number);
 
   /**

--- a/include/solvers/gd_navier_stokes.h
+++ b/include/solvers/gd_navier_stokes.h
@@ -44,13 +44,13 @@ public:
   BlockSchurPreconditioner(double gamma,
                            double kinematic_viscosity,
                            const TrilinosWrappers::BlockSparseMatrix &S,
-                           const TrilinosWrappers::SparseMatrix &     P,
-                           const BSPreconditioner * p_amat_preconditioner,
-                           const BSPreconditioner * p_pmass_preconditioner,
+                           const TrilinosWrappers::SparseMatrix      &P,
+                           const BSPreconditioner  *p_amat_preconditioner,
+                           const BSPreconditioner  *p_pmass_preconditioner,
                            Parameters::LinearSolver solver_parameters);
 
   void
-  vmult(TrilinosWrappers::MPI::BlockVector &      dst,
+  vmult(TrilinosWrappers::MPI::BlockVector       &dst,
         const TrilinosWrappers::MPI::BlockVector &src) const;
 
 private:
@@ -58,9 +58,9 @@ private:
   const double                               kinematic_viscosity;
   const Parameters::LinearSolver             linear_solver_parameters;
   const TrilinosWrappers::BlockSparseMatrix &stokes_matrix;
-  const TrilinosWrappers::SparseMatrix &     pressure_mass_matrix;
-  const BSPreconditioner *                   amat_preconditioner;
-  const BSPreconditioner *                   pmass_preconditioner;
+  const TrilinosWrappers::SparseMatrix      &pressure_mass_matrix;
+  const BSPreconditioner                    *amat_preconditioner;
+  const BSPreconditioner                    *pmass_preconditioner;
 };
 
 /**
@@ -126,8 +126,8 @@ private:
   void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data);
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -145,8 +145,8 @@ private:
   void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data);
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -268,9 +268,9 @@ BlockSchurPreconditioner<BSPreconditioner>::BlockSchurPreconditioner(
   double                                     gamma,
   double                                     kinematic_viscosity,
   const TrilinosWrappers::BlockSparseMatrix &S,
-  const TrilinosWrappers::SparseMatrix &     P,
-  const BSPreconditioner *                   p_amat_preconditioner,
-  const BSPreconditioner *                   p_pmass_preconditioner,
+  const TrilinosWrappers::SparseMatrix      &P,
+  const BSPreconditioner                    *p_amat_preconditioner,
+  const BSPreconditioner                    *p_pmass_preconditioner,
   Parameters::LinearSolver                   p_solver_parameters)
   : gamma(gamma)
   , kinematic_viscosity(kinematic_viscosity)
@@ -284,7 +284,7 @@ BlockSchurPreconditioner<BSPreconditioner>::BlockSchurPreconditioner(
 template <class BSPreconditioner>
 void
 BlockSchurPreconditioner<BSPreconditioner>::vmult(
-  TrilinosWrappers::MPI::BlockVector &      dst,
+  TrilinosWrappers::MPI::BlockVector       &dst,
   const TrilinosWrappers::MPI::BlockVector &src) const
 {
   //    TimerOutput computing_timer(std::cout,
@@ -348,25 +348,25 @@ class BlockDiagPreconditioner : public Subscriptor
 public:
   BlockDiagPreconditioner(const TrilinosWrappers::BlockSparseMatrix &S,
                           const PreconditionerMp &Mppreconditioner,
-                          SolverControl &         A_parameters);
+                          SolverControl          &A_parameters);
 
   void
-  vmult(TrilinosWrappers::MPI::BlockVector &      dst,
+  vmult(TrilinosWrappers::MPI::BlockVector       &dst,
         const TrilinosWrappers::MPI::BlockVector &src) const;
 
 private:
-  const TrilinosWrappers::BlockSparseMatrix & stokes_matrix;
+  const TrilinosWrappers::BlockSparseMatrix  &stokes_matrix;
   TrilinosWrappers::PreconditionILU           amat_preconditioner;
   TrilinosWrappers::PreconditionILU           pmat_preconditioner;
-  const PreconditionerMp &                    mp_preconditioner;
+  const PreconditionerMp                     &mp_preconditioner;
   SolverFGMRES<TrilinosWrappers::MPI::Vector> A_inverse;
 };
 
 template <class PreconditionerMp>
 BlockDiagPreconditioner<PreconditionerMp>::BlockDiagPreconditioner(
   const TrilinosWrappers::BlockSparseMatrix &S,
-  const PreconditionerMp &                   Mppreconditioner,
-  SolverControl &                            A_parameters)
+  const PreconditionerMp                    &Mppreconditioner,
+  SolverControl                             &A_parameters)
   : stokes_matrix(S)
   , mp_preconditioner(Mppreconditioner)
   , A_inverse(A_parameters)
@@ -388,7 +388,7 @@ BlockDiagPreconditioner<PreconditionerMp>::BlockDiagPreconditioner(
 template <class PreconditionerMp>
 void
 BlockDiagPreconditioner<PreconditionerMp>::vmult(
-  TrilinosWrappers::MPI::BlockVector &      dst,
+  TrilinosWrappers::MPI::BlockVector       &dst,
   const TrilinosWrappers::MPI::BlockVector &src) const
 {
   {

--- a/include/solvers/gls_navier_stokes.h
+++ b/include/solvers/gls_navier_stokes.h
@@ -151,8 +151,8 @@ protected:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data);
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -170,8 +170,8 @@ protected:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    NavierStokesScratchData<dim> &                        scratch_data,
-    StabilizedMethodsTensorCopyData<dim> &                copy_data);
+    NavierStokesScratchData<dim>                         &scratch_data,
+    StabilizedMethodsTensorCopyData<dim>                 &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -54,7 +54,7 @@ template <int dim>
 class HeatTransfer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  HeatTransfer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
+  HeatTransfer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
                     const SimulationParameters<dim> &p_simulation_parameters,
                     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                        p_triangulation,
@@ -321,8 +321,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    HeatTransferScratchData<dim> &                        scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    HeatTransferScratchData<dim>                         &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -340,8 +340,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    HeatTransferScratchData<dim> &                        scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    HeatTransferScratchData<dim>                         &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions
@@ -440,7 +440,7 @@ private:
     const bool                       gather_vof,
     const Parameters::FluidIndicator monitored_fluid,
     const std::string                domain_name,
-    const VectorType &               current_solution_fd);
+    const VectorType                &current_solution_fd);
 
   /**
    * @brief Post-processing. Write the heat transfer values to an output file.

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -59,7 +59,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) = 0;
+                  StabilizedMethodsCopyData    &copy_data) = 0;
 
   /**
    * @brief assemble_matrix Interface for the call to rhs
@@ -71,7 +71,7 @@ public:
 
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) = 0;
+               StabilizedMethodsCopyData    &copy_data) = 0;
 
 protected:
   std::shared_ptr<SimulationControl> simulation_control;
@@ -105,7 +105,7 @@ public:
    */
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
 
   /**
@@ -115,7 +115,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 };
 
 /**
@@ -143,7 +143,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -152,7 +152,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
   const bool GGLS = true;
 };
@@ -184,7 +184,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -193,7 +193,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
   const BoundaryConditions::HTBoundaryConditions<dim> &boundary_conditions_ht;
 };
@@ -218,7 +218,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -227,7 +227,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 };
 
 /**
@@ -254,7 +254,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -263,7 +263,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
 
 protected:
@@ -300,7 +300,7 @@ public:
 
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -309,7 +309,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
 protected:
   std::shared_ptr<Parameters::Laser<dim>> laser_parameters;
@@ -347,7 +347,7 @@ public:
    */
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -356,7 +356,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
 protected:
   std::shared_ptr<Parameters::Laser<dim>> laser_parameters;
@@ -396,7 +396,7 @@ public:
    */
   virtual void
   assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
-                  StabilizedMethodsCopyData &   copy_data) override;
+                  StabilizedMethodsCopyData    &copy_data) override;
 
   /**
    * @brief assemble_rhs Assembles the rhs
@@ -405,7 +405,7 @@ public:
    */
   virtual void
   assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
-               StabilizedMethodsCopyData &   copy_data) override;
+               StabilizedMethodsCopyData    &copy_data) override;
 
 protected:
   std::shared_ptr<Parameters::Laser<dim>> laser_parameters;

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -95,11 +95,11 @@ public:
    *
    */
   HeatTransferScratchData(const PhysicalPropertiesManager properties_manager,
-                          const FiniteElement<dim> &      fe_ht,
-                          const Quadrature<dim> &         quadrature,
-                          const Mapping<dim> &            mapping,
-                          const FiniteElement<dim> &      fe_fd,
-                          const Quadrature<dim - 1> &     face_quadrature)
+                          const FiniteElement<dim>       &fe_ht,
+                          const Quadrature<dim>          &quadrature,
+                          const Mapping<dim>             &mapping,
+                          const FiniteElement<dim>       &fe_fd,
+                          const Quadrature<dim - 1>      &face_quadrature)
     : properties_manager(properties_manager)
     , fe_values_T(mapping,
                   fe_ht,
@@ -182,9 +182,9 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<TrilinosWrappers::MPI::Vector> &previous_solutions,
-         Function<dim> *                                   source_function)
+         Function<dim>                                    *source_function)
   {
     material_id = cell->material_id();
     this->fe_values_T.reinit(cell);
@@ -332,9 +332,9 @@ public:
    */
 
   void
-  enable_vof(const FiniteElement<dim> &         fe,
-             const Quadrature<dim> &            quadrature,
-             const Mapping<dim> &               mapping,
+  enable_vof(const FiniteElement<dim>          &fe,
+             const Quadrature<dim>             &quadrature,
+             const Mapping<dim>                &mapping,
              const Parameters::VOF_PhaseFilter &phase_filter_parameters);
 
   /**
@@ -350,9 +350,9 @@ public:
    */
 
   void
-  enable_vof(const FiniteElement<dim> &                      fe,
-             const Quadrature<dim> &                         quadrature,
-             const Mapping<dim> &                            mapping,
+  enable_vof(const FiniteElement<dim>                       &fe,
+             const Quadrature<dim>                          &quadrature,
+             const Mapping<dim>                             &mapping,
              const std::shared_ptr<VolumeOfFluidFilterBase> &filter);
 
   /** @brief Reinitialize the content of the scratch for VOF.

--- a/include/solvers/isothermal_compressible_navier_stokes_assembler.h
+++ b/include/solvers/isothermal_compressible_navier_stokes_assembler.h
@@ -53,7 +53,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -62,7 +62,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -95,7 +95,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -104,7 +104,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
+++ b/include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
@@ -44,7 +44,7 @@ class GLSIsothermalCompressibleNavierStokesVOFAssemblerCore
 public:
   GLSIsothermalCompressibleNavierStokesVOFAssemblerCore(
     std::shared_ptr<SimulationControl> simulation_control,
-    const SimulationParameters<dim> &  nsparam)
+    const SimulationParameters<dim>   &nsparam)
     : simulation_control(simulation_control)
     , vof_parameters(nsparam.multiphysics.vof_parameters)
   {}
@@ -55,7 +55,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -64,7 +64,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -87,7 +87,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -96,7 +96,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -64,11 +64,11 @@ public:
    * @param kinematic_viscosity Kinematic viscosity.
    * @param mg_level Level of the operator in case of MG methods.
    */
-  NavierStokesOperatorBase(const Mapping<dim> &             mapping,
-                           const DoFHandler<dim> &          dof_handler,
+  NavierStokesOperatorBase(const Mapping<dim>              &mapping,
+                           const DoFHandler<dim>           &dof_handler,
                            const AffineConstraints<number> &constraints,
-                           const Quadrature<dim> &          quadrature,
-                           const Function<dim> *            forcing_function,
+                           const Quadrature<dim>           &quadrature,
+                           const Function<dim>             *forcing_function,
                            const double                     kinematic_viscosity,
                            const unsigned int               mg_level);
   /**
@@ -85,11 +85,11 @@ public:
    * @param mg_level Level of the operator in case of MG methods.
    */
   void
-  reinit(const Mapping<dim> &             mapping,
-         const DoFHandler<dim> &          dof_handler,
+  reinit(const Mapping<dim>              &mapping,
+         const DoFHandler<dim>           &dof_handler,
          const AffineConstraints<number> &constraints,
-         const Quadrature<dim> &          quadrature,
-         const Function<dim> *            forcing_function,
+         const Quadrature<dim>           &quadrature,
+         const Function<dim>             *forcing_function,
          const double                     kinematic_viscosity,
          const unsigned int               mg_level);
 
@@ -250,9 +250,9 @@ protected:
    */
   void
   do_cell_integral_range(
-    const MatrixFree<dim, number> &              matrix_free,
-    VectorType &                                 dst,
-    const VectorType &                           src,
+    const MatrixFree<dim, number>               &matrix_free,
+    VectorType                                  &dst,
+    const VectorType                            &src,
     const std::pair<unsigned int, unsigned int> &range) const;
 
 
@@ -268,9 +268,9 @@ protected:
    */
   virtual void
   local_evaluate_residual(
-    const MatrixFree<dim, number> &              matrix_free,
-    VectorType &                                 dst,
-    const VectorType &                           src,
+    const MatrixFree<dim, number>               &matrix_free,
+    VectorType                                  &dst,
+    const VectorType                            &src,
     const std::pair<unsigned int, unsigned int> &range) const;
 
 
@@ -291,7 +291,7 @@ protected:
   mutable TrilinosWrappers::SparseMatrix system_matrix;
   AlignedVector<VectorizedArray<number>> element_size;
   unsigned int                           fe_degree;
-  const Function<dim> *                  forcing_function;
+  const Function<dim>                   *forcing_function;
   double                                 kinematic_viscosity;
 
   // Variables needed from the last Newton step vector
@@ -353,9 +353,9 @@ private:
    */
   void
   local_evaluate_residual(
-    const MatrixFree<dim, number> &              matrix_free,
-    VectorType &                                 dst,
-    const VectorType &                           src,
+    const MatrixFree<dim, number>               &matrix_free,
+    VectorType                                  &dst,
+    const VectorType                            &src,
     const std::pair<unsigned int, unsigned int> &range) const override;
 };
 

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -59,7 +59,7 @@ public:
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
     std::shared_ptr<SimulationControl> p_simulation_control,
-    ConditionalOStream &               p_pcout);
+    ConditionalOStream                &p_pcout);
 
   std::vector<PhysicsID>
   get_active_physics()

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -46,7 +46,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 
 
@@ -60,7 +60,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) = 0;
 };
 
@@ -91,7 +91,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -101,7 +101,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -135,7 +135,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -145,7 +145,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -184,7 +184,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -193,7 +193,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   Parameters::VelocitySource velocity_sources;
@@ -276,7 +276,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -286,7 +286,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -326,7 +326,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -335,7 +335,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -371,7 +371,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -381,7 +381,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -407,7 +407,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -417,7 +417,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -449,7 +449,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -459,7 +459,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -493,7 +493,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -503,7 +503,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -539,7 +539,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -549,7 +549,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -586,7 +586,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -596,7 +596,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -632,7 +632,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -642,7 +642,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -676,7 +676,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -686,7 +686,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -191,7 +191,8 @@ protected:
             multiphysics->postprocess(true);
           }
         ref_iter++;
-    } while (
+      }
+    while (
       ref_iter <
         (this->simulation_parameters.mesh_adaptation.initial_refinement + 1) &&
       restart == false);

--- a/include/solvers/navier_stokes_cahn_hilliard_assemblers.h
+++ b/include/solvers/navier_stokes_cahn_hilliard_assemblers.h
@@ -44,7 +44,7 @@ class GLSNavierStokesCahnHilliardAssemblerCore
 public:
   GLSNavierStokesCahnHilliardAssemblerCore(
     std::shared_ptr<SimulationControl> simulation_control,
-    const SimulationParameters<dim> &  nsparam)
+    const SimulationParameters<dim>   &nsparam)
     : simulation_control(simulation_control)
     , cahn_hilliard_parameters(nsparam.multiphysics.cahn_hilliard_parameters)
   {}
@@ -55,7 +55,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -64,7 +64,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   const bool                         SUPG = true;
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -108,7 +108,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -85,9 +85,9 @@ public:
    *
    */
   NavierStokesScratchData(PhysicalPropertiesManager &properties_manager,
-                          const FESystem<dim> &      fe,
-                          const Quadrature<dim> &    quadrature,
-                          const Mapping<dim> &       mapping,
+                          const FESystem<dim>       &fe,
+                          const Quadrature<dim>     &quadrature,
+                          const Mapping<dim>        &mapping,
                           const Quadrature<dim - 1> &face_quadrature)
     : properties_manager(properties_manager)
     , fe_values(mapping,
@@ -223,9 +223,9 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
-         Function<dim> *                forcing_function,
+         Function<dim>                 *forcing_function,
          Tensor<1, dim>                 beta_force,
          const double                   pressure_scaling_factor)
   {
@@ -475,9 +475,9 @@ public:
    */
 
   void
-  enable_vof(const FiniteElement<dim> &         fe,
-             const Quadrature<dim> &            quadrature,
-             const Mapping<dim> &               mapping,
+  enable_vof(const FiniteElement<dim>          &fe,
+             const Quadrature<dim>             &quadrature,
+             const Mapping<dim>                &mapping,
              const Parameters::VOF_PhaseFilter &phase_filter_parameters);
 
   /**
@@ -493,21 +493,21 @@ public:
    */
 
   void
-  enable_vof(const FiniteElement<dim> &                      fe,
-             const Quadrature<dim> &                         quadrature,
-             const Mapping<dim> &                            mapping,
+  enable_vof(const FiniteElement<dim>                       &fe,
+             const Quadrature<dim>                          &quadrature,
+             const Mapping<dim>                             &mapping,
              const std::shared_ptr<VolumeOfFluidFilterBase> &filter);
 
   void
   enable_projected_phase_fraction_gradient(
     const FiniteElement<dim> &fe_projected_phase_fraction_gradient,
-    const Quadrature<dim> &   quadrature,
-    const Mapping<dim> &      mapping);
+    const Quadrature<dim>    &quadrature,
+    const Mapping<dim>       &mapping);
 
   void
   enable_curvature(const FiniteElement<dim> &fe_curvature,
-                   const Quadrature<dim> &   quadrature,
-                   const Mapping<dim> &      mapping);
+                   const Quadrature<dim>    &quadrature,
+                   const Mapping<dim>       &mapping);
 
   /** @brief Reinitialize the content of the scratch for the vof
    *
@@ -527,8 +527,8 @@ public:
   template <typename VectorType>
   void
   reinit_vof(const typename DoFHandler<dim>::active_cell_iterator &cell,
-             const VectorType &             current_solution,
-             const VectorType &             current_filtered_solution,
+             const VectorType              &current_solution,
+             const VectorType              &current_filtered_solution,
              const std::vector<VectorType> &previous_solutions)
   {
     this->fe_values_vof->reinit(cell);
@@ -552,7 +552,7 @@ public:
   void
   reinit_projected_phase_fraction_gradient(
     const typename DoFHandler<dim>::active_cell_iterator
-      &               projected_phase_fraction_gradient_cell,
+                     &projected_phase_fraction_gradient_cell,
     const VectorType &current_projected_phase_fraction_gradient_solution)
   {
     this->fe_values_projected_phase_fraction_gradient->reinit(
@@ -590,8 +590,8 @@ public:
 
   void
   enable_void_fraction(const FiniteElement<dim> &fe,
-                       const Quadrature<dim> &   quadrature,
-                       const Mapping<dim> &      mapping);
+                       const Quadrature<dim>    &quadrature,
+                       const Mapping<dim>       &mapping);
 
   /** @brief Reinitialize the content of the scratch for the void fraction
    *
@@ -609,8 +609,8 @@ public:
   void
   reinit_void_fraction(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType &                                    current_solution,
-    const std::vector<VectorType> &                       previous_solutions)
+    const VectorType                                     &current_solution,
+    const std::vector<VectorType>                        &previous_solutions)
   {
     this->fe_values_void_fraction->reinit(cell);
 
@@ -663,8 +663,8 @@ public:
     const VectorType                       previous_solution,
     const VectorType                       void_fraction_solution,
     const Particles::ParticleHandler<dim> &particle_handler,
-    DoFHandler<dim> &                      dof_handler,
-    DoFHandler<dim> &                      void_fraction_dof_handler)
+    DoFHandler<dim>                       &dof_handler,
+    DoFHandler<dim>                       &void_fraction_dof_handler)
   {
     const FiniteElement<dim> &fe = this->fe_values.get_fe();
     const FiniteElement<dim> &fe_void_fraction =
@@ -874,8 +874,8 @@ public:
 
   void
   enable_heat_transfer(const FiniteElement<dim> &fe,
-                       const Quadrature<dim> &   quadrature,
-                       const Mapping<dim> &      mapping);
+                       const Quadrature<dim>    &quadrature,
+                       const Mapping<dim>       &mapping);
 
 
   /** @brief Reinitialize the content of the scratch for the heat transfer
@@ -895,7 +895,7 @@ public:
   void
   reinit_heat_transfer(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType &                                    current_solution)
+    const VectorType                                     &current_solution)
   {
     this->fe_values_temperature->reinit(cell);
 
@@ -920,8 +920,8 @@ public:
    */
   void
   enable_cahn_hilliard(const FiniteElement<dim> &fe,
-                       const Quadrature<dim> &   quadrature,
-                       const Mapping<dim> &      mapping);
+                       const Quadrature<dim>    &quadrature,
+                       const Mapping<dim>       &mapping);
 
 
   /** @brief Reinitialize the content of the scratch for CH
@@ -937,7 +937,7 @@ public:
   void
   reinit_cahn_hilliard(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    const VectorType &                                    current_solution,
+    const VectorType                                     &current_solution,
     Parameters::CahnHilliard cahn_hilliard_parameters)
   {
     this->fe_values_cahn_hilliard->reinit(cell);

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -43,7 +43,7 @@ class GLSNavierStokesVOFAssemblerCore : public NavierStokesAssemblerBase<dim>
 public:
   GLSNavierStokesVOFAssemblerCore(
     std::shared_ptr<SimulationControl> simulation_control,
-    const SimulationParameters<dim> &  nsparam)
+    const SimulationParameters<dim>   &nsparam)
     : simulation_control(simulation_control)
     , vof_parameters(nsparam.multiphysics.vof_parameters)
   {}
@@ -54,7 +54,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -63,7 +63,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   const bool SUPG = true;
@@ -99,7 +99,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -108,7 +108,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -130,7 +130,7 @@ class GLSNavierStokesVOFAssemblerSTF : public NavierStokesAssemblerBase<dim>
 public:
   GLSNavierStokesVOFAssemblerSTF(
     std::shared_ptr<SimulationControl> p_simulation_control,
-    const SimulationParameters<dim> &  nsparam)
+    const SimulationParameters<dim>   &nsparam)
     : simulation_control(p_simulation_control)
     , STF_parameters(nsparam.multiphysics.vof_parameters.surface_tension_force)
   {}
@@ -141,7 +141,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -150,7 +150,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -191,7 +191,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
@@ -200,7 +200,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
@@ -226,7 +226,7 @@ class GLSNavierStokesVOFAssemblerNonNewtonianCore
 public:
   GLSNavierStokesVOFAssemblerNonNewtonianCore(
     std::shared_ptr<SimulationControl> simulation_control,
-    const SimulationParameters<dim> &  nsparam)
+    const SimulationParameters<dim>   &nsparam)
     : simulation_control(simulation_control)
     , vof_parameters(nsparam.multiphysics.vof_parameters)
   {}
@@ -288,7 +288,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
                   StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
 
@@ -298,7 +298,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(NavierStokesScratchData<dim> &        scratch_data,
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -64,11 +64,11 @@
  */
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
+calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
                         std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType &            evaluation_point,
-                        const Quadrature<dim> &       cell_quadrature_formula,
-                        const Quadrature<dim - 1> &   face_quadrature_formula,
+                        const VectorType             &evaluation_point,
+                        const Quadrature<dim>        &cell_quadrature_formula,
+                        const Quadrature<dim - 1>    &face_quadrature_formula,
                         const unsigned int            inlet_boundary_id,
                         const unsigned int            outlet_boundary_id);
 
@@ -89,10 +89,10 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
 template <int dim, typename VectorType>
 double
 calculate_CFL(const DoFHandler<dim> &dof_handler,
-              const VectorType &     evaluation_point,
+              const VectorType      &evaluation_point,
               const double           time_step,
               const Quadrature<dim> &quadrature_formula,
-              const Mapping<dim> &   mapping);
+              const Mapping<dim>    &mapping);
 
 /**
  * @brief Calculate the average enstrophy in the simulation domain
@@ -111,9 +111,9 @@ calculate_CFL(const DoFHandler<dim> &dof_handler,
 template <int dim, typename VectorType>
 double
 calculate_enstrophy(const DoFHandler<dim> &dof_handler,
-                    const VectorType &     evaluation_point,
+                    const VectorType      &evaluation_point,
                     const Quadrature<dim> &quadrature_formula,
-                    const Mapping<dim> &   mapping);
+                    const Mapping<dim>    &mapping);
 
 /**
  * @brief Calculate the average kinetic energy in the simulation domain
@@ -132,9 +132,9 @@ calculate_enstrophy(const DoFHandler<dim> &dof_handler,
 template <int dim, typename VectorType>
 double
 calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
-                         const VectorType &     evaluation_point,
+                         const VectorType      &evaluation_point,
                          const Quadrature<dim> &quadrature_formula,
-                         const Mapping<dim> &   mapping);
+                         const Mapping<dim>    &mapping);
 
 /**
  * @brief Calculates the apparent viscosity of the fluid for non Newtonian flows.
@@ -153,10 +153,10 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
  */
 template <int dim, typename VectorType>
 double
-calculate_apparent_viscosity(const DoFHandler<dim> &    dof_handler,
-                             const VectorType &         evaluation_point,
-                             const Quadrature<dim> &    quadrature_formula,
-                             const Mapping<dim> &       mapping,
+calculate_apparent_viscosity(const DoFHandler<dim>     &dof_handler,
+                             const VectorType          &evaluation_point,
+                             const Quadrature<dim>     &quadrature_formula,
+                             const Mapping<dim>        &mapping,
                              PhysicalPropertiesManager &properties_manager);
 
 /**
@@ -182,12 +182,12 @@ calculate_apparent_viscosity(const DoFHandler<dim> &    dof_handler,
 template <int dim, typename VectorType>
 std::vector<std::vector<Tensor<1, dim>>>
 calculate_forces(
-  const DoFHandler<dim> &                              dof_handler,
-  const VectorType &                                   evaluation_point,
-  PhysicalPropertiesManager &                          properties_manager,
+  const DoFHandler<dim>                               &dof_handler,
+  const VectorType                                    &evaluation_point,
+  PhysicalPropertiesManager                           &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1> &                          face_quadrature_formula,
-  const Mapping<dim> &                                 mapping);
+  const Quadrature<dim - 1>                           &face_quadrature_formula,
+  const Mapping<dim>                                  &mapping);
 
 
 /**
@@ -213,12 +213,12 @@ calculate_forces(
 template <int dim, typename VectorType>
 std::vector<Tensor<1, 3>>
 calculate_torques(
-  const DoFHandler<dim> &                              dof_handler,
-  const VectorType &                                   evaluation_point,
-  PhysicalPropertiesManager &                          properties_manager,
+  const DoFHandler<dim>                               &dof_handler,
+  const VectorType                                    &evaluation_point,
+  PhysicalPropertiesManager                           &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1> &                          face_quadrature_formula,
-  const Mapping<dim> &                                 mapping);
+  const Quadrature<dim - 1>                           &face_quadrature_formula,
+  const Mapping<dim>                                  &mapping);
 
 
 /**
@@ -243,10 +243,10 @@ calculate_torques(
 template <int dim, typename VectorType>
 std::pair<double, double>
 calculate_L2_error(const DoFHandler<dim> &dof_handler,
-                   const VectorType &     evaluation_point,
-                   const Function<dim> *  exact_solution,
+                   const VectorType      &evaluation_point,
+                   const Function<dim>   *exact_solution,
                    const Quadrature<dim> &quadrature_formula,
-                   const Mapping<dim> &   mapping);
+                   const Mapping<dim>    &mapping);
 
 /**
  * @brief calculate_flow_rate. This function calculates the volumetric flow
@@ -267,11 +267,11 @@ calculate_L2_error(const DoFHandler<dim> &dof_handler,
  */
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
-                    const VectorType &         present_solution,
-                    const unsigned int &       boundary_id,
+calculate_flow_rate(const DoFHandler<dim>     &dof_handler,
+                    const VectorType          &present_solution,
+                    const unsigned int        &boundary_id,
                     const Quadrature<dim - 1> &face_quadrature_formula,
-                    const Mapping<dim> &       mapping);
+                    const Mapping<dim>        &mapping);
 
 /**
  * @brief calculate_average_velocity. This function calculates average velocity
@@ -290,11 +290,11 @@ calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
  */
 template <int dim, typename VectorType>
 double
-calculate_average_velocity(const DoFHandler<dim> &    dof_handler,
-                           const VectorType &         present_solution,
-                           const unsigned int &       boundary_id,
+calculate_average_velocity(const DoFHandler<dim>     &dof_handler,
+                           const VectorType          &present_solution,
+                           const unsigned int        &boundary_id,
                            const Quadrature<dim - 1> &face_quadrature_formula,
-                           const Mapping<dim> &       mapping);
+                           const Mapping<dim>        &mapping);
 
 /**
  * @brief calculate_average_velocity. This function calculates the average velocity of
@@ -323,11 +323,11 @@ template <int dim, typename VectorType>
 double
 calculate_average_velocity(const DoFHandler<dim> &dof_handler,
                            const DoFHandler<dim> &void_fraction_dof_handler,
-                           const VectorType &     present_solution,
-                           const VectorType &  present_void_fraction_solution,
+                           const VectorType      &present_solution,
+                           const VectorType   &present_void_fraction_solution,
                            const unsigned int &flow_direction,
                            const Quadrature<dim> &quadrature_formula,
-                           const Mapping<dim> &   mapping);
+                           const Mapping<dim>    &mapping);
 
 
 

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -69,10 +69,10 @@ public:
    */
   void
   calculate_average_velocities(
-    const VectorType &                local_evaluation_point,
+    const VectorType                 &local_evaluation_point,
     const Parameters::PostProcessing &post_processing,
-    const double &                    current_time,
-    const double &                    time_step);
+    const double                     &current_time,
+    const double                     &time_step);
 
 
   void
@@ -132,10 +132,10 @@ public:
    * @param mpi_communicator. The mpi communicator information
    */
   void
-  initialize_vectors(const DofsType &    locally_owned_dofs,
-                     const DofsType &    locally_relevant_dofs,
+  initialize_vectors(const DofsType     &locally_owned_dofs,
+                     const DofsType     &locally_relevant_dofs,
                      const unsigned int &dofs_per_vertex,
-                     const MPI_Comm &    mpi_communicator);
+                     const MPI_Comm     &mpi_communicator);
 
   /**
    * @brief initialize_checkpoint_vectors. This function initializes all the

--- a/include/solvers/postprocessors_smoothing.h
+++ b/include/solvers/postprocessors_smoothing.h
@@ -48,7 +48,7 @@ public:
   // Member functions
   PostProcessorSmoothing(
     const parallel::DistributedTriangulationBase<dim> &triangulation,
-    const SimulationParameters<dim> &                  simulation_parameters,
+    const SimulationParameters<dim>                   &simulation_parameters,
     const unsigned int &number_quadrature_points);
 
   /**
@@ -76,8 +76,8 @@ public:
    * @brief Returns the smoothed field solution.
    */
   const TrilinosWrappers::MPI::Vector &
-  calculate_smoothed_field(const VectorType &            solution,
-                           const DoFHandler<dim> &       dof_handler_velocity,
+  calculate_smoothed_field(const VectorType             &solution,
+                           const DoFHandler<dim>        &dof_handler_velocity,
                            std::shared_ptr<Mapping<dim>> mapping_velocity);
 
   /**
@@ -115,7 +115,7 @@ public:
   // Member functions
   QcriterionPostProcessorSmoothing(
     const parallel::DistributedTriangulationBase<dim> &triangulation,
-    const SimulationParameters<dim> &                  simulation_parameters,
+    const SimulationParameters<dim>                   &simulation_parameters,
     const unsigned int &number_quadrature_points);
 
   /**
@@ -126,8 +126,8 @@ public:
    * @param mapping_fluid The mapping of the fluid
    */
   void
-  generate_rhs(const VectorType &            solution,
-               const DoFHandler<dim> &       dof_handler_fluid,
+  generate_rhs(const VectorType             &solution,
+               const DoFHandler<dim>        &dof_handler_fluid,
                std::shared_ptr<Mapping<dim>> mapping_fluid) override;
 
 private:
@@ -146,7 +146,7 @@ public:
   // Member functions
   ContinuityPostProcessorSmoothing(
     const parallel::DistributedTriangulationBase<dim> &triangulation,
-    const SimulationParameters<dim> &                  simulation_parameters,
+    const SimulationParameters<dim>                   &simulation_parameters,
     const unsigned int &number_quadrature_points);
 
   /**
@@ -157,8 +157,8 @@ public:
    * @param mapping_fluid The mapping of the fluid
    */
   void
-  generate_rhs(const VectorType &            solution,
-               const DoFHandler<dim> &       dof_handler_fluid,
+  generate_rhs(const VectorType             &solution,
+               const DoFHandler<dim>        &dof_handler_fluid,
                std::shared_ptr<Mapping<dim>> mapping_fluid) override;
 
 private:

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -60,7 +60,7 @@ public:
                                       boundary_conditions_cahn_hilliard;
   Parameters::InitialConditions<dim> *initial_condition;
   AnalyticalSolutions::AnalyticalSolution<dim> *analytical_solution;
-  SourceTerms::SourceTerm<dim> *                source_term;
+  SourceTerms::SourceTerm<dim>                 *source_term;
   Parameters::VelocitySource                    velocity_sources;
   std::shared_ptr<Parameters::IBParticles<dim>> particlesParameters;
   Parameters::DynamicFlowControl                flow_control;

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -53,7 +53,7 @@ template <int dim>
 class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  Tracer<dim>(MultiphysicsInterface<dim> *     multiphysics_interface,
+  Tracer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
               const SimulationParameters<dim> &p_simulation_parameters,
               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                                  p_triangulation,
@@ -300,8 +300,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim> &                              scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    TracerScratchData<dim>                               &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -319,8 +319,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    TracerScratchData<dim> &                              scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    TracerScratchData<dim>                               &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -44,7 +44,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(TracerScratchData<dim> &   scratch_data,
+  assemble_matrix(TracerScratchData<dim>    &scratch_data,
                   StabilizedMethodsCopyData &copy_data) = 0;
 
 
@@ -57,7 +57,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(TracerScratchData<dim> &   scratch_data,
+  assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) = 0;
 };
 
@@ -88,7 +88,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(TracerScratchData<dim> &   scratch_data,
+  assemble_matrix(TracerScratchData<dim>    &scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
 
@@ -98,7 +98,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(TracerScratchData<dim> &   scratch_data,
+  assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   const bool DCDD = true;
@@ -131,7 +131,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(TracerScratchData<dim> &   scratch_data,
+  assemble_matrix(TracerScratchData<dim>    &scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
   /**
@@ -140,7 +140,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(TracerScratchData<dim> &   scratch_data,
+  assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -78,10 +78,10 @@ public:
    *
    */
   TracerScratchData(const PhysicalPropertiesManager &properties_manager,
-                    const FiniteElement<dim> &       fe_tracer,
-                    const Quadrature<dim> &          quadrature,
-                    const Mapping<dim> &             mapping,
-                    const FiniteElement<dim> &       fe_fd)
+                    const FiniteElement<dim>        &fe_tracer,
+                    const Quadrature<dim>           &quadrature,
+                    const Mapping<dim>              &mapping,
+                    const FiniteElement<dim>        &fe_fd)
     : properties_manager(properties_manager)
     , fe_values_tracer(mapping,
                        fe_tracer,
@@ -149,9 +149,9 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
-         Function<dim> *                source_function)
+         Function<dim>                 *source_function)
   {
     this->fe_values_tracer.reinit(cell);
 

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -61,7 +61,7 @@ public:
    * @brief VOF - Base constructor.
    */
   VolumeOfFluid<dim>(
-    MultiphysicsInterface<dim> *     multiphysics_interface,
+    MultiphysicsInterface<dim>      *multiphysics_interface,
     const SimulationParameters<dim> &p_simulation_parameters,
     std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
                                        p_triangulation,
@@ -429,8 +429,8 @@ private:
   virtual void
   assemble_local_system_matrix(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    VOFScratchData<dim> &                                 scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    VOFScratchData<dim>                                  &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief Assemble the local rhs for a given cell
@@ -448,8 +448,8 @@ private:
   virtual void
   assemble_local_system_rhs(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
-    VOFScratchData<dim> &                                 scratch_data,
-    StabilizedMethodsCopyData &                           copy_data);
+    VOFScratchData<dim>                                  &scratch_data,
+    StabilizedMethodsCopyData                            &copy_data);
 
   /**
    * @brief sets up the vector of assembler functions

--- a/include/solvers/vof_assemblers.h
+++ b/include/solvers/vof_assemblers.h
@@ -45,7 +45,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(VOFScratchData<dim> &      scratch_data,
+  assemble_matrix(VOFScratchData<dim>       &scratch_data,
                   StabilizedMethodsCopyData &copy_data) = 0;
 
 
@@ -58,7 +58,7 @@ public:
    */
 
   virtual void
-  assemble_rhs(VOFScratchData<dim> &      scratch_data,
+  assemble_rhs(VOFScratchData<dim>       &scratch_data,
                StabilizedMethodsCopyData &copy_data) = 0;
 };
 
@@ -94,7 +94,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_matrix(VOFScratchData<dim> &      scratch_data,
+  assemble_matrix(VOFScratchData<dim>       &scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
 
@@ -104,7 +104,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(VOFScratchData<dim> &      scratch_data,
+  assemble_rhs(VOFScratchData<dim>       &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   // enable/disable DCDD shock capturing model, for debugging purposes
@@ -143,7 +143,7 @@ public:
    */
 
   virtual void
-  assemble_matrix(VOFScratchData<dim> &      scratch_data,
+  assemble_matrix(VOFScratchData<dim>       &scratch_data,
                   StabilizedMethodsCopyData &copy_data) override;
 
   /**
@@ -152,7 +152,7 @@ public:
    * @param copy_data (see base class)
    */
   virtual void
-  assemble_rhs(VOFScratchData<dim> &      scratch_data,
+  assemble_rhs(VOFScratchData<dim>       &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -76,10 +76,10 @@ public:
    *
    */
   VOFScratchData(const PhysicalPropertiesManager properties_manager,
-                 const FiniteElement<dim> &      fe_vof,
-                 const Quadrature<dim> &         quadrature,
-                 const Mapping<dim> &            mapping,
-                 const FiniteElement<dim> &      fe_fd)
+                 const FiniteElement<dim>       &fe_vof,
+                 const Quadrature<dim>          &quadrature,
+                 const Mapping<dim>             &mapping,
+                 const FiniteElement<dim>       &fe_fd)
     : properties_manager(properties_manager)
     , fe_values_vof(mapping,
                     fe_vof,
@@ -144,7 +144,7 @@ public:
   template <typename VectorType>
   void
   reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-         const VectorType &                                    current_solution,
+         const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions)
   {
     fe_values_vof.reinit(cell);
@@ -204,7 +204,7 @@ public:
   template <typename VectorType>
   void
   reinit_velocity(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                  const VectorType &             current_solution,
+                  const VectorType              &current_solution,
                   const std::vector<VectorType> &previous_solutions)
   {
     fe_values_fd.reinit(cell);

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -20,7 +20,7 @@ template <int dim, int spacedim>
 void
 attach_grid_to_triangulation(
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh &                               mesh_parameters)
+  const Parameters::Mesh                                &mesh_parameters)
 
 {
   // GMSH input
@@ -272,7 +272,7 @@ attach_grid_to_triangulation(
 template <int dim, int spacedim>
 void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<dim, spacedim> & triangulation,
+  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions)
 
 {
@@ -301,10 +301,10 @@ setup_periodic_boundary_conditions(
 template <int dim, int spacedim>
 void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<dim, spacedim> & triangulation,
-  const Parameters::Mesh &                                mesh_parameters,
-  const Parameters::Manifolds &                           manifolds_parameters,
-  const bool &                                            restart,
+  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
+  const Parameters::Mesh                                 &mesh_parameters,
+  const Parameters::Manifolds                            &manifolds_parameters,
+  const bool                                             &restart,
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions)
 {
   attach_grid_to_triangulation(triangulation, mesh_parameters);
@@ -339,48 +339,48 @@ read_mesh_and_manifolds(
 template void
 attach_grid_to_triangulation(
   parallel::DistributedTriangulationBase<2> &triangulation,
-  const Parameters::Mesh &                   mesh_parameters);
+  const Parameters::Mesh                    &mesh_parameters);
 template void
 attach_grid_to_triangulation(
   parallel::DistributedTriangulationBase<3> &triangulation,
-  const Parameters::Mesh &                   mesh_parameters);
+  const Parameters::Mesh                    &mesh_parameters);
 template void
 attach_grid_to_triangulation(
   parallel::DistributedTriangulationBase<2, 3> &triangulation,
-  const Parameters::Mesh &                      mesh_parameters);
+  const Parameters::Mesh                       &mesh_parameters);
 
 
 template void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<2, 2> &   triangulation,
+  parallel::DistributedTriangulationBase<2, 2>    &triangulation,
   const BoundaryConditions::BoundaryConditions<2> &boundary_conditions);
 template void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<2, 3> &   triangulation,
+  parallel::DistributedTriangulationBase<2, 3>    &triangulation,
   const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
 template void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<3, 3> &   triangulation,
+  parallel::DistributedTriangulationBase<3, 3>    &triangulation,
   const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
 
 template void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<2> &      triangulation,
-  const Parameters::Mesh &                         mesh_parameters,
-  const Parameters::Manifolds &                    manifolds_parameters,
-  const bool &                                     restart,
+  parallel::DistributedTriangulationBase<2>       &triangulation,
+  const Parameters::Mesh                          &mesh_parameters,
+  const Parameters::Manifolds                     &manifolds_parameters,
+  const bool                                      &restart,
   const BoundaryConditions::BoundaryConditions<2> &boundary_conditions);
 template void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<3> &      triangulation,
-  const Parameters::Mesh &                         mesh_parameters,
-  const Parameters::Manifolds &                    manifolds_parameters,
-  const bool &                                     restart,
+  parallel::DistributedTriangulationBase<3>       &triangulation,
+  const Parameters::Mesh                          &mesh_parameters,
+  const Parameters::Manifolds                     &manifolds_parameters,
+  const bool                                      &restart,
   const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
 template void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<2, 3> &   triangulation,
-  const Parameters::Mesh &                         mesh_parameters,
-  const Parameters::Manifolds &                    manifolds_parameters,
-  const bool &                                     restart,
+  parallel::DistributedTriangulationBase<2, 3>    &triangulation,
+  const Parameters::Mesh                          &mesh_parameters,
+  const Parameters::Manifolds                     &manifolds_parameters,
+  const bool                                      &restart,
   const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);

--- a/source/core/ib_particle.cc
+++ b/source/core/ib_particle.cc
@@ -176,8 +176,8 @@ IBParticle<dim>::initialize_shape(const std::string type,
 template <int dim>
 void
 IBParticle<dim>::closest_surface_point(
-  const Point<dim> &                                    p,
-  Point<dim> &                                          closest_point,
+  const Point<dim>                                     &p,
+  Point<dim>                                           &closest_point,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
   shape->closest_surface_point(p, closest_point, cell_guess);
@@ -186,7 +186,7 @@ IBParticle<dim>::closest_surface_point(
 template <int dim>
 void
 IBParticle<dim>::closest_surface_point(const Point<dim> &p,
-                                       Point<dim> &      closest_point)
+                                       Point<dim>       &closest_point)
 {
   shape->closest_surface_point(p, closest_point);
 }
@@ -194,7 +194,7 @@ IBParticle<dim>::closest_surface_point(const Point<dim> &p,
 template <int dim>
 bool
 IBParticle<dim>::is_inside_crown(
-  const Point<dim> &                                    evaluation_point,
+  const Point<dim>                                     &evaluation_point,
   const double                                          outer_radius,
   const double                                          inside_radius,
   const bool                                            absolute_distance,

--- a/source/core/ib_stencil.cc
+++ b/source/core/ib_stencil.cc
@@ -95,8 +95,8 @@ std::tuple<Point<dim>, std::vector<Point<dim>>>
 IBStencil<dim>::support_points_for_interpolation(
   const unsigned int                                    order,
   const double                                          length_ratio,
-  IBParticle<dim> &                                     p,
-  const Point<dim> &                                    dof_point,
+  IBParticle<dim>                                      &p,
+  const Point<dim>                                     &dof_point,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
   // Create the vector of points used for the stencil based on the order of the
@@ -141,7 +141,7 @@ template <int dim>
 std::tuple<Point<dim>, std::vector<Point<dim>>>
 IBStencil<dim>::support_points_for_interpolation(const unsigned int order,
                                                  const double      length_ratio,
-                                                 IBParticle<dim> & p,
+                                                 IBParticle<dim>  &p,
                                                  const Point<dim> &dof_point)
 {
   // Create the vector of points used for the stencil based on the order of the
@@ -185,8 +185,8 @@ IBStencil<dim>::support_points_for_interpolation(const unsigned int order,
 template <int dim>
 Point<dim>
 IBStencil<dim>::point_for_cell_detection(
-  IBParticle<dim> &                                     p,
-  const Point<dim> &                                    dof_point,
+  IBParticle<dim>                                      &p,
+  const Point<dim>                                     &dof_point,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
   // Create the vector of points used for the stencil based on the order of the
@@ -203,7 +203,7 @@ IBStencil<dim>::point_for_cell_detection(
 
 template <int dim>
 Point<dim>
-IBStencil<dim>::point_for_cell_detection(IBParticle<dim> & p,
+IBStencil<dim>::point_for_cell_detection(IBParticle<dim>  &p,
                                          const Point<dim> &dof_point)
 {
   // Create the vector of points used for the stencil based on the order of the
@@ -221,8 +221,8 @@ IBStencil<dim>::point_for_cell_detection(IBParticle<dim> & p,
 template <int dim>
 double
 IBStencil<dim>::ib_velocity(
-  IBParticle<dim> &                                     p,
-  const Point<dim> &                                    dof_point,
+  IBParticle<dim>                                      &p,
+  const Point<dim>                                     &dof_point,
   unsigned int                                          component,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
@@ -287,7 +287,7 @@ IBStencil<dim>::ib_velocity(
 
 template <int dim>
 double
-IBStencil<dim>::ib_velocity(IBParticle<dim> & p,
+IBStencil<dim>::ib_velocity(IBParticle<dim>  &p,
                             const Point<dim> &dof_point,
                             unsigned int      component)
 {

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -627,7 +627,8 @@ LetheGridTools::project_to_d_linear_object(
         {
           break;
         }
-  } while (true);
+    }
+  while (true);
   Tensor<1, spacedim> normal;
   if (spacedim == 3)
     {

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -139,7 +139,7 @@ template <int dim>
 typename DoFHandler<dim>::active_cell_iterator
 LetheGridTools::find_cell_around_point_with_tree(
   const DoFHandler<dim> &dof_handler,
-  const Point<dim> &     point)
+  const Point<dim>      &point)
 {
   // Define temporary variables to store search parameters and intermediate
   // results
@@ -246,11 +246,11 @@ template <int dim>
 std::vector<typename DoFHandler<dim>::active_cell_iterator>
 LetheGridTools::find_boundary_cells_in_sphere(
   const DoFHandler<dim> &dof_handler,
-  const Point<dim> &     center,
+  const Point<dim>      &center,
   const double           radius)
 {
   MappingQ1<dim> mapping;
-  const auto &   cell_iterator = dof_handler.cell_iterators_on_level(0);
+  const auto    &cell_iterator = dof_handler.cell_iterators_on_level(0);
   unsigned int   max_childs    = GeometryInfo<dim>::max_children_per_cell;
 
   std::set<typename DoFHandler<dim>::cell_iterator> boundary_cells_candidates;
@@ -335,9 +335,9 @@ LetheGridTools::find_cell_around_point_with_neighbors(
   const DoFHandler<dim> &dof_handler,
   std::map<unsigned int,
            std::set<typename DoFHandler<dim>::active_cell_iterator>>
-    &                                                   vertices_cell_map,
+                                                       &vertices_cell_map,
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  const Point<dim> &                                    point)
+  const Point<dim>                                     &point)
 {
   // Find the cells that share a vertex with the original cell.
   std::vector<typename DoFHandler<dim>::active_cell_iterator>
@@ -362,7 +362,7 @@ std::vector<typename DoFHandler<dim>::active_cell_iterator>
 LetheGridTools::find_cells_around_cell(
   std::map<unsigned int,
            std::set<typename DoFHandler<dim>::active_cell_iterator>>
-    &                                                   vertices_cell_map,
+                                                       &vertices_cell_map,
   const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
   // Find all the cells that share a vertex with a reference cell, including the
@@ -387,7 +387,7 @@ LetheGridTools::find_cells_around_cell(
 template <int dim>
 std::vector<typename DoFHandler<dim>::active_cell_iterator>
 LetheGridTools::find_cells_in_cells(
-  const DoFHandler<dim> &                               dof_handler,
+  const DoFHandler<dim>                                &dof_handler,
   const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
   std::vector<typename DoFHandler<dim>::active_cell_iterator> cells_inside;
@@ -424,7 +424,7 @@ template <int dim>
 bool
 LetheGridTools::cell_pierced_by_edge(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  const TriaIterator<CellAccessor<1, dim>> &            cell_edge)
+  const TriaIterator<CellAccessor<1, dim>>             &cell_edge)
 {
   std::vector<Point<dim>> manifold_points(GeometryInfo<1>::vertices_per_cell);
 
@@ -679,10 +679,10 @@ LetheGridTools::find_cells_around_edge(
   const DoFHandler<dim> &dof_handler,
   std::map<unsigned int,
            std::set<typename DoFHandler<dim>::active_cell_iterator>>
-    &                                                   vertices_cell_map,
+                                                       &vertices_cell_map,
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  Point<dim> &                                          point_1,
-  Point<dim> &                                          point_2)
+  Point<dim>                                           &point_1,
+  Point<dim>                                           &point_2)
 {
   std::set<typename DoFHandler<dim>::active_cell_iterator> cells_pierced_set;
   DoFHandler<1, dim>       local_edge_dof_handler;
@@ -785,7 +785,7 @@ LetheGridTools::find_cells_around_edge(
 template <int dim>
 bool
 LetheGridTools::cell_cut_by_flat(
-  const typename DoFHandler<dim>::active_cell_iterator &         cell,
+  const typename DoFHandler<dim>::active_cell_iterator          &cell,
   const typename DoFHandler<dim - 1, dim>::active_cell_iterator &cell_flat)
 {
   std::vector<Point<dim>> manifold_points(
@@ -908,7 +908,7 @@ LetheGridTools::cell_cut_by_flat(
 template <int dim>
 std::vector<typename DoFHandler<dim>::active_cell_iterator>
 LetheGridTools::find_cells_around_flat_cell(
-  const DoFHandler<dim> &                                        dof_handler,
+  const DoFHandler<dim>                                         &dof_handler,
   const typename DoFHandler<dim - 1, dim>::active_cell_iterator &cell,
   std::map<unsigned int,
            std::set<typename DoFHandler<dim>::active_cell_iterator>>
@@ -990,7 +990,7 @@ LetheGridTools::find_cells_cut_by_object(
   const DoFHandler<spacedim> &dof_handler,
   std::map<unsigned int,
            std::set<typename DoFHandler<spacedim>::active_cell_iterator>>
-    &                                            vertices_cell_map,
+                                                &vertices_cell_map,
   std::vector<SerialSolid<structdim, spacedim>> &list_of_objects)
 {
   std::map<
@@ -1055,11 +1055,11 @@ LetheGridTools::find_cells_cut_by_object(
 template typename DoFHandler<3>::active_cell_iterator
 LetheGridTools::find_cell_around_point_with_tree(
   const DoFHandler<3> &dof_handler,
-  const Point<3> &     point);
+  const Point<3>      &point);
 template typename DoFHandler<2>::active_cell_iterator
 LetheGridTools::find_cell_around_point_with_tree(
   const DoFHandler<2> &dof_handler,
-  const Point<2> &     point);
+  const Point<2>      &point);
 
 template void
 LetheGridTools::vertices_cell_mapping(
@@ -1087,61 +1087,61 @@ template typename DoFHandler<2>::active_cell_iterator
 LetheGridTools::find_cell_around_point_with_neighbors(
   const DoFHandler<2> &dof_handler,
   std::map<unsigned int, std::set<typename DoFHandler<2>::active_cell_iterator>>
-    &                                                 vertices_cell_map,
+                                                     &vertices_cell_map,
   const typename DoFHandler<2>::active_cell_iterator &cell,
-  const Point<2> &                                    point);
+  const Point<2>                                     &point);
 
 template typename DoFHandler<3>::active_cell_iterator
 LetheGridTools::find_cell_around_point_with_neighbors(
   const DoFHandler<3> &dof_handler,
   std::map<unsigned int, std::set<typename DoFHandler<3>::active_cell_iterator>>
-    &                                                 vertices_cell_map,
+                                                     &vertices_cell_map,
   const typename DoFHandler<3>::active_cell_iterator &cell,
-  const Point<3> &                                    point);
+  const Point<3>                                     &point);
 
 template typename std::vector<typename DoFHandler<2>::active_cell_iterator>
 LetheGridTools::find_cells_around_cell<2>(
   std::map<unsigned int, std::set<typename DoFHandler<2>::active_cell_iterator>>
-    &                                                 vertices_cell_map,
+                                                     &vertices_cell_map,
   const typename DoFHandler<2>::active_cell_iterator &cell);
 
 template typename std::vector<typename DoFHandler<3>::active_cell_iterator>
 LetheGridTools::find_cells_around_cell<3>(
   std::map<unsigned int, std::set<typename DoFHandler<3>::active_cell_iterator>>
-    &                                                 vertices_cell_map,
+                                                     &vertices_cell_map,
   const typename DoFHandler<3>::active_cell_iterator &cell);
 
 template std::vector<typename DoFHandler<2>::active_cell_iterator>
 LetheGridTools::find_cells_in_cells(
-  const DoFHandler<2> &                               dof_handler,
+  const DoFHandler<2>                                &dof_handler,
   const typename DoFHandler<2>::active_cell_iterator &cell);
 
 template std::vector<typename DoFHandler<3>::active_cell_iterator>
 LetheGridTools::find_cells_in_cells(
-  const DoFHandler<3> &                               dof_handler,
+  const DoFHandler<3>                                &dof_handler,
   const typename DoFHandler<3>::active_cell_iterator &cell);
 
 template bool
 LetheGridTools::cell_cut_by_flat<2>(
-  const typename DoFHandler<2>::active_cell_iterator &       cell,
+  const typename DoFHandler<2>::active_cell_iterator        &cell,
   const typename DoFHandler<2 - 1, 2>::active_cell_iterator &cell_flat);
 
 template bool
 LetheGridTools::cell_cut_by_flat<3>(
-  const typename DoFHandler<3>::active_cell_iterator &       cell,
+  const typename DoFHandler<3>::active_cell_iterator        &cell,
   const typename DoFHandler<3 - 1, 3>::active_cell_iterator &cell_flat);
 
 
 template std::vector<typename DoFHandler<2>::active_cell_iterator>
 LetheGridTools::find_cells_around_flat_cell(
-  const DoFHandler<2> &                                      dof_handler,
+  const DoFHandler<2>                                       &dof_handler,
   const typename DoFHandler<2 - 1, 2>::active_cell_iterator &cell,
   std::map<unsigned int, std::set<typename DoFHandler<2>::active_cell_iterator>>
     &vertices_cell_map);
 
 template std::vector<typename DoFHandler<3>::active_cell_iterator>
 LetheGridTools::find_cells_around_flat_cell(
-  const DoFHandler<3> &                                      dof_handler,
+  const DoFHandler<3>                                       &dof_handler,
   const typename DoFHandler<3 - 1, 3>::active_cell_iterator &cell,
   std::map<unsigned int, std::set<typename DoFHandler<3>::active_cell_iterator>>
     &vertices_cell_map);
@@ -1149,18 +1149,18 @@ LetheGridTools::find_cells_around_flat_cell(
 template std::pair<std::pair<Point<2>, bool>, Tensor<1, 2>>
 LetheGridTools::project_to_d_linear_object<2, 1>(
   const typename DoFHandler<1, 2>::active_cell_iterator &object,
-  const Point<2> &                                       trial_point);
+  const Point<2>                                        &trial_point);
 
 template std::pair<std::pair<Point<3>, bool>, Tensor<1, 3>>
 LetheGridTools::project_to_d_linear_object<3, 2>(
   const typename DoFHandler<2, 3>::active_cell_iterator &object,
-  const Point<3> &                                       trial_point);
+  const Point<3>                                        &trial_point);
 
 
 template bool
 LetheGridTools::cell_pierced_by_edge<3>(
   const typename DoFHandler<3>::active_cell_iterator &cell,
-  const TriaIterator<CellAccessor<1, 3>> &            cell_edge);
+  const TriaIterator<CellAccessor<1, 3>>             &cell_edge);
 
 template bool
 LetheGridTools::cell_pierced_by_edge<3>(
@@ -1170,11 +1170,11 @@ LetheGridTools::cell_pierced_by_edge<3>(
 
 template std::vector<typename DoFHandler<2>::active_cell_iterator>
 LetheGridTools::find_boundary_cells_in_sphere(const DoFHandler<2> &dof_handler,
-                                              const Point<2> &     center,
+                                              const Point<2>      &center,
                                               const double         radius);
 template std::vector<typename DoFHandler<3>::active_cell_iterator>
 LetheGridTools::find_boundary_cells_in_sphere(const DoFHandler<3> &dof_handler,
-                                              const Point<3> &     center,
+                                              const Point<3>      &center,
                                               const double         radius);
 
 
@@ -1184,7 +1184,7 @@ template std::map<
 LetheGridTools::find_cells_cut_by_object(
   const DoFHandler<3> &dof_handler,
   std::map<unsigned int, std::set<typename DoFHandler<3>::active_cell_iterator>>
-    &                             vertices_cell_map,
+                                 &vertices_cell_map,
   std::vector<SerialSolid<3, 3>> &list_of_objects);
 
 template std::map<
@@ -1193,7 +1193,7 @@ template std::map<
 LetheGridTools::find_cells_cut_by_object(
   const DoFHandler<2> &dof_handler,
   std::map<unsigned int, std::set<typename DoFHandler<2>::active_cell_iterator>>
-    &                             vertices_cell_map,
+                                 &vertices_cell_map,
   std::vector<SerialSolid<2, 2>> &list_of_objects);
 
 template std::map<
@@ -1202,7 +1202,7 @@ template std::map<
 LetheGridTools::find_cells_cut_by_object(
   const DoFHandler<3> &dof_handler,
   std::map<unsigned int, std::set<typename DoFHandler<3>::active_cell_iterator>>
-    &                             vertices_cell_map,
+                                 &vertices_cell_map,
   std::vector<SerialSolid<2, 3>> &list_of_objects);
 
 template std::map<
@@ -1211,16 +1211,16 @@ template std::map<
 LetheGridTools::find_cells_cut_by_object(
   const DoFHandler<2> &dof_handler,
   std::map<unsigned int, std::set<typename DoFHandler<2>::active_cell_iterator>>
-    &                             vertices_cell_map,
+                                 &vertices_cell_map,
   std::vector<SerialSolid<1, 2>> &list_of_objects);
 
 
 template <int dim>
 std::tuple<std::vector<bool>, std::vector<Point<3>>, std::vector<Tensor<1, 3>>>
 LetheGridTools::find_particle_triangle_projection(
-  const std::vector<Point<dim>> &                      triangle,
+  const std::vector<Point<dim>>                       &triangle,
   const std::vector<Particles::ParticleIterator<dim>> &particles,
-  const unsigned int &                                 n_particles_in_base_cell)
+  const unsigned int                                  &n_particles_in_base_cell)
 {
   std::vector<bool>         pass_distance_check(n_particles_in_base_cell);
   std::vector<Point<3>>     projection_points(n_particles_in_base_cell);
@@ -1461,13 +1461,13 @@ LetheGridTools::find_particle_triangle_projection(
 template std::
   tuple<std::vector<bool>, std::vector<Point<3>>, std::vector<Tensor<1, 3>>>
   LetheGridTools::find_particle_triangle_projection(
-    const std::vector<Point<2>> &                      triangle,
+    const std::vector<Point<2>>                       &triangle,
     const std::vector<Particles::ParticleIterator<2>> &particles,
     const unsigned int &n_particles_in_base_cell);
 template std::
   tuple<std::vector<bool>, std::vector<Point<3>>, std::vector<Tensor<1, 3>>>
   LetheGridTools::find_particle_triangle_projection(
-    const std::vector<Point<3>> &                      triangle,
+    const std::vector<Point<3>>                       &triangle,
     const std::vector<Particles::ParticleIterator<3>> &particles,
     const unsigned int &n_particles_in_base_cell);
 
@@ -1476,7 +1476,7 @@ template <int dim>
 double
 LetheGridTools::find_point_triangle_distance(
   const std::vector<Point<dim>> &triangle,
-  const Point<dim> &             point)
+  const Point<dim>              &point)
 {
   const Point<dim> &point_0 = triangle[0];
   const Point<dim> &point_1 = triangle[1];
@@ -1659,8 +1659,8 @@ LetheGridTools::find_point_triangle_distance(
 template double
 LetheGridTools::find_point_triangle_distance(
   const std::vector<Point<2>> &triangle,
-  const Point<2> &             point);
+  const Point<2>              &point);
 template double
 LetheGridTools::find_point_triangle_distance(
   const std::vector<Point<3>> &triangle,
-  const Point<3> &             point);
+  const Point<3>              &point);

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -285,7 +285,8 @@ attach_manifolds_to_triangulation(
                                  manifolds.id[i]);
         }
       else if (manifolds.types[i] == Parameters::Manifolds::ManifoldType::none)
-        {}
+        {
+        }
       else
         throw std::runtime_error("Unsupported manifolds type");
     }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -276,7 +276,7 @@ namespace Parameters
   }
 
   void
-  PowerLawParameters::parse_parameters(ParameterHandler &   prm,
+  PowerLawParameters::parse_parameters(ParameterHandler    &prm,
                                        const Dimensionality dimensions)
   {
     prm.enter_subsection("power-law");
@@ -316,7 +316,7 @@ namespace Parameters
   }
 
   void
-  CarreauParameters::parse_parameters(ParameterHandler &   prm,
+  CarreauParameters::parse_parameters(ParameterHandler    &prm,
                                       const Dimensionality dimensions)
   {
     prm.enter_subsection("carreau");
@@ -352,7 +352,7 @@ namespace Parameters
   }
 
   void
-  NonNewtonian::parse_parameters(ParameterHandler &   prm,
+  NonNewtonian::parse_parameters(ParameterHandler    &prm,
                                  const Dimensionality dimensions)
   {
     prm.enter_subsection("non newtonian");
@@ -392,7 +392,7 @@ namespace Parameters
 
   void
   IsothermalIdealGasDensityParameters::parse_parameters(
-    ParameterHandler &   prm,
+    ParameterHandler    &prm,
     const Dimensionality dimensions)
   {
     prm.enter_subsection("isothermal_ideal_gas");
@@ -511,7 +511,7 @@ namespace Parameters
   }
 
   void
-  PhaseChange::parse_parameters(ParameterHandler &   prm,
+  PhaseChange::parse_parameters(ParameterHandler    &prm,
                                 const Dimensionality dimensions)
   {
     prm.enter_subsection("phase change");
@@ -677,7 +677,7 @@ namespace Parameters
   }
 
   void
-  PhysicalProperties::parse_parameters(ParameterHandler &   prm,
+  PhysicalProperties::parse_parameters(ParameterHandler    &prm,
                                        const Dimensionality dimensions)
   {
     prm.enter_subsection("physical properties");
@@ -832,7 +832,7 @@ namespace Parameters
   }
 
   void
-  Material::parse_parameters(ParameterHandler &               prm,
+  Material::parse_parameters(ParameterHandler                &prm,
                              std::string                      material_prefix,
                              const unsigned int               id,
                              const Parameters::Dimensionality dimensions)
@@ -1666,7 +1666,7 @@ namespace Parameters
   }
 
   void
-  NonLinearSolver::declare_parameters(ParameterHandler & prm,
+  NonLinearSolver::declare_parameters(ParameterHandler  &prm,
                                       const std::string &physics_name)
   {
     prm.enter_subsection("non-linear solver");
@@ -1754,7 +1754,7 @@ namespace Parameters
   }
 
   void
-  NonLinearSolver::parse_parameters(ParameterHandler & prm,
+  NonLinearSolver::parse_parameters(ParameterHandler  &prm,
                                     const std::string &physics_name)
   {
     prm.enter_subsection("non-linear solver");
@@ -1981,7 +1981,7 @@ namespace Parameters
   }
 
   void
-  LinearSolver::declare_parameters(ParameterHandler & prm,
+  LinearSolver::declare_parameters(ParameterHandler  &prm,
                                    const std::string &physics_name)
   {
     prm.enter_subsection("linear solver");
@@ -2089,7 +2089,7 @@ namespace Parameters
     prm.leave_subsection();
   }
   void
-  LinearSolver::parse_parameters(ParameterHandler & prm,
+  LinearSolver::parse_parameters(ParameterHandler  &prm,
                                  const std::string &physics_name)
   {
     prm.enter_subsection("linear solver");

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -59,7 +59,7 @@ namespace Parameters
     void
     LagrangianPhysicalProperties::parse_particle_properties(
       const unsigned int &particle_type,
-      ParameterHandler &  prm)
+      ParameterHandler   &prm)
     {
       const std::string size_distribution_type =
         prm.get("size distribution type");
@@ -228,7 +228,7 @@ namespace Parameters
     LagrangianPhysicalProperties::initialize_containers(
       std::unordered_map<unsigned int, double> &particle_average_diameter,
       std::unordered_map<unsigned int, double> &particle_size_std,
-      std::unordered_map<unsigned int, int> &   number,
+      std::unordered_map<unsigned int, int>    &number,
       std::unordered_map<unsigned int, double> &density_particle,
       std::unordered_map<unsigned int, double> &youngs_modulus_particle,
       std::unordered_map<unsigned int, double> &poisson_ratio_particle,
@@ -1250,10 +1250,10 @@ namespace Parameters
     void
     BCDEM::initialize_containers(
       std::unordered_map<unsigned int, Tensor<1, 3>>
-        &                                       boundary_translational_velocity,
+                                               &boundary_translational_velocity,
       std::unordered_map<unsigned int, double> &boundary_rotational_speed,
       std::unordered_map<unsigned int, Tensor<1, 3>>
-        &                        boundary_rotational_vector,
+                                &boundary_rotational_vector,
       std::vector<unsigned int> &outlet_boundaries)
     {
       Tensor<1, 3> zero_tensor({0.0, 0.0, 0.0});

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -47,7 +47,7 @@ PowerLaw::value(const std::map<field, double> &field_values)
 void
 PowerLaw::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
-  std::vector<double> &                       property_vector)
+  std::vector<double>                        &property_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -69,7 +69,7 @@ void
 PowerLaw::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double> &                       jacobian_vector)
+  std::vector<double>                        &jacobian_vector)
 {
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
@@ -114,7 +114,7 @@ void
 Carreau::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double> &                       jacobian_vector)
+  std::vector<double>                        &jacobian_vector)
 {
   if (id == field::shear_rate)
     this->vector_numerical_jacobian(field_vectors,
@@ -137,7 +137,7 @@ PhaseChangeRheology::value(const std::map<field, double> &field_values)
 void
 PhaseChangeRheology::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
-  std::vector<double> &                       property_vector)
+  std::vector<double>                        &property_vector)
 {
   const std::vector<double> &temperature_vec =
     field_vectors.at(field::temperature);
@@ -162,7 +162,7 @@ void
 PhaseChangeRheology::vector_jacobian(
   const std::map<field, std::vector<double>> &field_vectors,
   const field                                 id,
-  std::vector<double> &                       jacobian_vector)
+  std::vector<double>                        &jacobian_vector)
 {
   vector_numerical_jacobian(field_vectors, id, jacobian_vector);
 }

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -483,7 +483,8 @@ SerialSolid<dim, spacedim>::write_output_results(
 }
 
 template <int dim, int spacedim>
-void SerialSolid<dim, spacedim>::write_checkpoint(std::string /*prefix*/)
+void
+SerialSolid<dim, spacedim>::write_checkpoint(std::string /*prefix*/)
 {
   // SolutionTransfer<dim, Vector<double>, spacedim> system_trans_vectors(
   //   this->displacement_dh);
@@ -502,7 +503,8 @@ void SerialSolid<dim, spacedim>::write_checkpoint(std::string /*prefix*/)
 }
 
 template <int dim, int spacedim>
-void SerialSolid<dim, spacedim>::read_checkpoint(std::string /*prefix*/)
+void
+SerialSolid<dim, spacedim>::read_checkpoint(std::string /*prefix*/)
 {
   throw(std::runtime_error(
     "Restarting DEM simulations with floating meshes is currently not possible."));

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -230,8 +230,8 @@ Shape<dim>::point_to_string(const Point<dim> &evaluation_point) const
 template <int dim>
 void
 Shape<dim>::closest_surface_point(
-  const Point<dim> &                                    p,
-  Point<dim> &                                          closest_point,
+  const Point<dim>                                     &p,
+  Point<dim>                                           &closest_point,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
   Tensor<1, dim> actual_gradient;
@@ -250,7 +250,7 @@ Shape<dim>::closest_surface_point(
 template <int dim>
 void
 Shape<dim>::closest_surface_point(const Point<dim> &p,
-                                  Point<dim> &      closest_point) const
+                                  Point<dim>       &closest_point) const
 {
   Tensor<1, dim> actual_gradient;
   double         distance_from_surface;
@@ -369,7 +369,7 @@ template <int dim>
 void
 Superquadric<dim>::closest_surface_point(
   const Point<dim> &p,
-  Point<dim> &      closest_point,
+  Point<dim>       &closest_point,
   const typename DoFHandler<dim>::active_cell_iterator & /*cell_guess*/)
 {
   auto point_in_string = this->point_to_string(p);
@@ -395,7 +395,7 @@ Superquadric<dim>::closest_surface_point(
 template <int dim>
 void
 Superquadric<dim>::closest_surface_point(const Point<dim> &p,
-                                         Point<dim> &      closest_point) const
+                                         Point<dim>       &closest_point) const
 {
   auto point_in_string = this->point_to_string(p);
   auto iterator        = this->closest_point_cache.find(point_in_string);
@@ -1173,7 +1173,7 @@ CompositeShape<dim>::value(const Point<dim> &evaluation_point,
 template <int dim>
 double
 CompositeShape<dim>::value_with_cell_guess(
-  const Point<dim> &                                   evaluation_point,
+  const Point<dim>                                    &evaluation_point,
   const typename DoFHandler<dim>::active_cell_iterator cell,
   const unsigned int /*component*/)
 {
@@ -1265,7 +1265,7 @@ CompositeShape<dim>::gradient(const Point<dim> &evaluation_point,
 template <int dim>
 Tensor<1, dim>
 CompositeShape<dim>::gradient_with_cell_guess(
-  const Point<dim> &                                   evaluation_point,
+  const Point<dim>                                    &evaluation_point,
   const typename DoFHandler<dim>::active_cell_iterator cell,
   const unsigned int /*component*/)
 {
@@ -1464,7 +1464,7 @@ CompositeShape<dim>::clear_cache()
 
 template <int dim>
 RBFShape<dim>::RBFShape(const std::string   shape_arguments_str,
-                        const Point<dim> &  position,
+                        const Point<dim>   &position,
                         const Tensor<1, 3> &orientation)
   : Shape<dim>(1, position, orientation)
   , number_of_nodes(1)
@@ -1485,7 +1485,7 @@ RBFShape<dim>::RBFShape(const std::string   shape_arguments_str,
 template <int dim>
 double
 RBFShape<dim>::value_with_cell_guess(
-  const Point<dim> &                                   evaluation_point,
+  const Point<dim>                                    &evaluation_point,
   const typename DoFHandler<dim>::active_cell_iterator cell,
   const unsigned int /*component*/)
 {
@@ -1515,7 +1515,7 @@ RBFShape<dim>::value_with_cell_guess(
 template <int dim>
 Tensor<1, dim>
 RBFShape<dim>::gradient_with_cell_guess(
-  const Point<dim> &                                   evaluation_point,
+  const Point<dim>                                    &evaluation_point,
   const typename DoFHandler<dim>::active_cell_iterator cell,
   const unsigned int /*component*/)
 {

--- a/source/core/shape_parsing.cc
+++ b/source/core/shape_parsing.cc
@@ -4,7 +4,7 @@ template <int dim>
 std::shared_ptr<Shape<dim>>
 ShapeGenerator::initialize_shape(const std::string   type,
                                  const std::string   shape_arguments_str,
-                                 const Point<dim> &  position,
+                                 const Point<dim>   &position,
                                  const Tensor<1, 3> &orientation)
 {
   std::shared_ptr<Shape<dim>> shape;
@@ -34,8 +34,8 @@ std::shared_ptr<Shape<dim>>
 ShapeGenerator::initialize_shape_from_vector(
   const std::string         type,
   const std::vector<double> shape_arguments,
-  const Point<dim> &        position,
-  const Tensor<1, 3> &      orientation)
+  const Point<dim>         &position,
+  const Tensor<1, 3>       &orientation)
 {
   std::shared_ptr<Shape<dim>> shape;
   if (type == "sphere")
@@ -147,7 +147,7 @@ template <int dim>
 std::shared_ptr<Shape<dim>>
 ShapeGenerator::initialize_shape_from_file(const std::string   type,
                                            const std::string   file_name,
-                                           const Point<dim> &  position,
+                                           const Point<dim>   &position,
                                            const Tensor<1, 3> &orientation)
 {
   std::shared_ptr<Shape<dim>> shape;
@@ -299,32 +299,32 @@ ShapeGenerator::initialize_shape_from_file(const std::string   type,
 template std::shared_ptr<Shape<2>>
 ShapeGenerator::initialize_shape(const std::string   type,
                                  const std::string   arguments,
-                                 const Point<2> &    position,
+                                 const Point<2>     &position,
                                  const Tensor<1, 3> &orientation);
 template std::shared_ptr<Shape<3>>
 ShapeGenerator::initialize_shape(const std::string   type,
                                  const std::string   arguments,
-                                 const Point<3> &    position,
+                                 const Point<3>     &position,
                                  const Tensor<1, 3> &orientation);
 template std::shared_ptr<Shape<2>>
 ShapeGenerator::initialize_shape_from_vector(
   const std::string         type,
   const std::vector<double> shape_arguments,
-  const Point<2> &          position,
-  const Tensor<1, 3> &      orientation);
+  const Point<2>           &position,
+  const Tensor<1, 3>       &orientation);
 template std::shared_ptr<Shape<3>>
 ShapeGenerator::initialize_shape_from_vector(
   const std::string         type,
   const std::vector<double> shape_arguments,
-  const Point<3> &          position,
-  const Tensor<1, 3> &      orientation);
+  const Point<3>           &position,
+  const Tensor<1, 3>       &orientation);
 template std::shared_ptr<Shape<2>>
 ShapeGenerator::initialize_shape_from_file(const std::string   type,
                                            const std::string   file_name,
-                                           const Point<2> &    position,
+                                           const Point<2>     &position,
                                            const Tensor<1, 3> &orientation);
 template std::shared_ptr<Shape<3>>
 ShapeGenerator::initialize_shape_from_file(const std::string   type,
                                            const std::string   file_name,
-                                           const Point<3> &    position,
+                                           const Point<3>     &position,
                                            const Tensor<1, 3> &orientation);

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -52,7 +52,7 @@
 
 template <int dim, int spacedim>
 SolidBase<dim, spacedim>::SolidBase(
-  std::shared_ptr<Parameters::NitscheObject<spacedim>> &            param,
+  std::shared_ptr<Parameters::NitscheObject<spacedim>>             &param,
   std::shared_ptr<parallel::DistributedTriangulationBase<spacedim>> fluid_tria,
   std::shared_ptr<Mapping<spacedim>> fluid_mapping)
   : mpi_communicator(MPI_COMM_WORLD)

--- a/source/core/solutions_output.cc
+++ b/source/core/solutions_output.cc
@@ -14,14 +14,14 @@
 
 template <int dim, int spacedim>
 void
-write_vtu_and_pvd(PVDHandler &                           pvd_handler,
+write_vtu_and_pvd(PVDHandler                            &pvd_handler,
                   const DataOutInterface<dim, spacedim> &data_out,
                   const std::string                      folder,
                   const std::string                      file_prefix,
                   const double                           time,
                   const unsigned int                     iter,
                   const unsigned int                     group_files,
-                  const MPI_Comm &                       mpi_communicator,
+                  const MPI_Comm                        &mpi_communicator,
                   const unsigned int                     digits)
 {
   const int my_id = Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -76,7 +76,7 @@ write_boundaries_vtu(const DataOutFaces<dim> &data_out_faces,
                      const std::string        folder,
                      const double,
                      const unsigned int iter,
-                     const MPI_Comm &   mpi_communicator,
+                     const MPI_Comm    &mpi_communicator,
                      const std::string  file_prefix,
                      const unsigned int digits)
 {
@@ -95,69 +95,69 @@ write_boundaries_vtu(const DataOutFaces<dim> &data_out_faces,
 }
 
 template void
-write_vtu_and_pvd(PVDHandler &                  pvd_handler,
+write_vtu_and_pvd(PVDHandler                   &pvd_handler,
                   const DataOutInterface<1, 2> &data_out,
                   const std::string             folder,
                   const std::string             file_prefix,
                   const double                  time,
                   const unsigned int            iter,
                   const unsigned int            group_files,
-                  const MPI_Comm &              mpi_communicator,
+                  const MPI_Comm               &mpi_communicator,
                   const unsigned int            digits);
 
 template void
-write_vtu_and_pvd(PVDHandler &                  pvd_handler,
+write_vtu_and_pvd(PVDHandler                   &pvd_handler,
                   const DataOutInterface<2, 2> &data_out,
                   const std::string             folder,
                   const std::string             file_prefix,
                   const double                  time,
                   const unsigned int            iter,
                   const unsigned int            group_files,
-                  const MPI_Comm &              mpi_communicator,
+                  const MPI_Comm               &mpi_communicator,
                   const unsigned int            digits);
 
 template void
-write_vtu_and_pvd(PVDHandler &                  pvd_handler,
+write_vtu_and_pvd(PVDHandler                   &pvd_handler,
                   const DataOutInterface<2, 3> &data_out,
                   const std::string             folder,
                   const std::string             file_prefix,
                   const double                  time,
                   const unsigned int            iter,
                   const unsigned int            group_files,
-                  const MPI_Comm &              mpi_communicator,
+                  const MPI_Comm               &mpi_communicator,
                   const unsigned int            digits);
 
 template void
-write_vtu_and_pvd(PVDHandler &                  pvd_handler,
+write_vtu_and_pvd(PVDHandler                   &pvd_handler,
                   const DataOutInterface<3, 3> &data_out,
                   const std::string             folder,
                   const std::string             file_prefix,
                   const double                  time,
                   const unsigned int            iter,
                   const unsigned int            group_files,
-                  const MPI_Comm &              mpi_communicator,
+                  const MPI_Comm               &mpi_communicator,
                   const unsigned int            digits);
 
 template void
-write_vtu_and_pvd(PVDHandler &                  pvd_handler,
+write_vtu_and_pvd(PVDHandler                   &pvd_handler,
                   const DataOutInterface<0, 2> &data_out,
                   const std::string             folder,
                   const std::string             file_prefix,
                   const double                  time,
                   const unsigned int            iter,
                   const unsigned int            group_files,
-                  const MPI_Comm &              mpi_communicator,
+                  const MPI_Comm               &mpi_communicator,
                   const unsigned int            digits);
 
 template void
-write_vtu_and_pvd(PVDHandler &                  pvd_handler,
+write_vtu_and_pvd(PVDHandler                   &pvd_handler,
                   const DataOutInterface<0, 3> &data_out,
                   const std::string             folder,
                   const std::string             file_prefix,
                   const double                  time,
                   const unsigned int            iter,
                   const unsigned int            group_files,
-                  const MPI_Comm &              mpi_communicator,
+                  const MPI_Comm               &mpi_communicator,
                   const unsigned int            digits);
 
 
@@ -166,7 +166,7 @@ write_boundaries_vtu(const DataOutFaces<2> &data_out_faces,
                      const std::string      folder,
                      const double           time,
                      const unsigned int     iter,
-                     const MPI_Comm &       mpi_communicator,
+                     const MPI_Comm        &mpi_communicator,
                      const std::string      file_prefix,
                      const unsigned int     digits);
 
@@ -175,6 +175,6 @@ write_boundaries_vtu(const DataOutFaces<3> &data_out_faces,
                      const std::string      folder,
                      const double           time,
                      const unsigned int     iter,
-                     const MPI_Comm &       mpi_communicator,
+                     const MPI_Comm        &mpi_communicator,
                      const std::string      file_prefix,
                      const unsigned int     digits);

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -8,10 +8,10 @@
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T> &             independent_vector,
-  const std::string &                independent_column_name,
+  const std::vector<T>              &independent_vector,
+  const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string> &   dependent_column_name,
+  const std::vector<std::string>    &dependent_column_name,
   const unsigned int                 display_precision)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
@@ -37,10 +37,10 @@ make_table_scalars_tensors(
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
-  const std::vector<T> &                          independent_vector,
-  const std::string &                             independent_column_name,
+  const std::vector<T>                           &independent_vector,
+  const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vectors,
-  const std::vector<std::string> &                dependent_column_name,
+  const std::vector<std::string>                 &dependent_column_name,
   const unsigned int                              display_precision)
 {
   AssertDimension(dependent_column_name.size(), 3 * dim);
@@ -77,9 +77,9 @@ template <int dim>
 TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string> &   independent_column_name,
+  const std::vector<std::string>    &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string> &   dependent_column_name,
+  const std::vector<std::string>    &dependent_column_name,
   const unsigned int                 display_precision)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
@@ -110,9 +110,9 @@ template <int dim>
 TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string> &   independent_column_name,
-  const std::vector<double> &        dependent_vector,
-  const std::string &                dependent_column_name,
+  const std::vector<std::string>    &independent_column_name,
+  const std::vector<double>         &dependent_vector,
+  const std::string                 &dependent_column_name,
   const unsigned int                 display_precision)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
@@ -136,7 +136,7 @@ make_table_tensors_scalars(
 }
 
 void
-fill_table_from_file(TableHandler &    table,
+fill_table_from_file(TableHandler     &table,
                      const std::string file_name,
                      const std::string delimiter)
 {
@@ -255,130 +255,130 @@ create_output_folder(const std::string &dirname)
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<double> &      independent_values,
-  const std::string &              independent_column_name,
+  const std::vector<double>       &independent_values,
+  const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<double> &      independent_values,
-  const std::string &              independent_column_name,
+  const std::vector<double>       &independent_values,
+  const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<double> &                   independent_values,
-  const std::string &                           independent_column_name,
+  const std::vector<double>                    &independent_values,
+  const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
-  const std::vector<std::string> &              dependent_column_name,
+  const std::vector<std::string>               &dependent_column_name,
   const unsigned int                            display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<double> &                   independent_values,
-  const std::string &                           independent_column_name,
+  const std::vector<double>                    &independent_values,
+  const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
-  const std::vector<std::string> &              dependent_column_name,
+  const std::vector<std::string>               &dependent_column_name,
   const unsigned int                            display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
   const std::vector<unsigned int> &independent_values,
-  const std::string &              independent_column_name,
+  const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
   const std::vector<unsigned int> &independent_values,
-  const std::string &              independent_column_name,
+  const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<unsigned int> &             independent_values,
-  const std::string &                           independent_column_name,
+  const std::vector<unsigned int>              &independent_values,
+  const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
-  const std::vector<std::string> &              dependent_column_name,
+  const std::vector<std::string>               &dependent_column_name,
   const unsigned int                            display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<unsigned int> &             independent_values,
-  const std::string &                           independent_column_name,
+  const std::vector<unsigned int>              &independent_values,
+  const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
-  const std::vector<std::string> &              dependent_column_name,
+  const std::vector<std::string>               &dependent_column_name,
   const unsigned int                            display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<int> &         independent_values,
-  const std::string &              independent_column_name,
+  const std::vector<int>          &independent_values,
+  const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<int> &         independent_values,
-  const std::string &              independent_column_name,
+  const std::vector<int>          &independent_values,
+  const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<int> &                      independent_values,
-  const std::string &                           independent_column_name,
+  const std::vector<int>                       &independent_values,
+  const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
-  const std::vector<std::string> &              dependent_column_name,
+  const std::vector<std::string>               &dependent_column_name,
   const unsigned int                            display_precision);
 
 template TableHandler
 make_table_scalars_tensors(
-  const std::vector<int> &                      independent_values,
-  const std::string &                           independent_column_name,
+  const std::vector<int>                       &independent_values,
+  const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
-  const std::vector<std::string> &              dependent_column_name,
+  const std::vector<std::string>               &dependent_column_name,
   const unsigned int                            display_precision);
 
 template TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, 2>> &independent_values,
-  const std::vector<std::string> & independent_column_name,
+  const std::vector<std::string>  &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, 3>> &independent_values,
-  const std::vector<std::string> & independent_column_name,
+  const std::vector<std::string>  &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string> & dependent_column_name,
+  const std::vector<std::string>  &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, 2>> &independent_vector,
-  const std::vector<std::string> & independent_column_name,
-  const std::vector<double> &      dependent_values,
-  const std::string &              dependent_column_name,
+  const std::vector<std::string>  &independent_column_name,
+  const std::vector<double>       &dependent_values,
+  const std::string               &dependent_column_name,
   const unsigned int               display_precision);
 
 template TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, 3>> &independent_vector,
-  const std::vector<std::string> & independent_column_name,
-  const std::vector<double> &      dependent_values,
-  const std::string &              dependent_column_name,
+  const std::vector<std::string>  &independent_column_name,
+  const std::vector<double>       &dependent_values,
+  const std::string               &dependent_column_name,
   const unsigned int               display_precision);
 
 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -136,7 +136,7 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
 
   triangulation.signals.weight.connect(
     [&](const typename parallel::distributed::Triangulation<dim>::cell_iterator
-          &              cell,
+                        &cell,
         const CellStatus status) -> unsigned int {
       return this->cell_weight(cell, status);
     });
@@ -662,7 +662,7 @@ DEMSolver<dim>::check_load_balance_with_disabled_contacts()
 
   triangulation.signals.weight.connect(
     [&](const typename parallel::distributed::Triangulation<dim>::cell_iterator
-          &cell,
+                        &cell,
         const CellStatus status) -> unsigned int {
       return this->cell_weight_with_mobility_status(cell, status);
     });
@@ -748,7 +748,7 @@ template <int dim>
 void
 DEMSolver<dim>::update_moment_of_inertia(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  std::vector<double> &                    MOI)
+  std::vector<double>                     &MOI)
 {
   MOI.resize(torque.size());
 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -311,9 +311,9 @@ DEMSolver<dim>::cell_weight(
 #endif
 
 #if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-        case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
+      case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
 #else
-        case CellStatus::children_will_be_coarsened:
+      case CellStatus::children_will_be_coarsened:
 #endif
         {
           unsigned int n_particles_in_cell = 0;
@@ -378,10 +378,10 @@ DEMSolver<dim>::cell_weight_with_mobility_status(
     {
 #if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
       case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
-        case parallel::distributed::Triangulation<dim>::CELL_REFINE:
+      case parallel::distributed::Triangulation<dim>::CELL_REFINE:
 #else
       case dealii::CellStatus::cell_will_persist:
-        case dealii::CellStatus::cell_will_be_refined:
+      case dealii::CellStatus::cell_will_be_refined:
 
 #endif
         {
@@ -400,9 +400,9 @@ DEMSolver<dim>::cell_weight_with_mobility_status(
 #endif
 
 #if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-        case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
+      case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
 #else
-        case dealii::CellStatus::children_will_be_coarsened:
+      case dealii::CellStatus::children_will_be_coarsened:
 #endif
         {
           unsigned int n_particles_in_cell = 0;
@@ -834,13 +834,15 @@ DEMSolver<dim>::finish_simulation()
     {
       switch (parameters.test.test_type)
         {
-            case Parameters::Testing::TestType::particles: {
+          case Parameters::Testing::TestType::particles:
+            {
               visualization_object.print_xyz(particle_handler,
                                              mpi_communicator,
                                              pcout);
               break;
             }
-            case Parameters::Testing::TestType::mobility_status: {
+          case Parameters::Testing::TestType::mobility_status:
+            {
               // Get mobility status vector sorted by cell id
               Vector<float> mobility_status(triangulation.n_active_cells());
               disable_contacts_object.get_mobility_status_vector(
@@ -852,7 +854,8 @@ DEMSolver<dim>::finish_simulation()
                                                              mpi_communicator);
               break;
             }
-            case Parameters::Testing::TestType::subdomain: {
+          case Parameters::Testing::TestType::subdomain:
+            {
               // Get mobility status vector sorted by cell id
               Vector<float> subdomain(triangulation.n_active_cells());
               for (unsigned int i = 0; i < subdomain.size(); ++i)

--- a/source/dem/dem_contact_manager.cc
+++ b/source/dem/dem_contact_manager.cc
@@ -265,7 +265,7 @@ template <int dim>
 void
 DEMContactManager<dim>::execute_particle_particle_broad_search(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  const DisableContacts<dim> &             disable_contacts_object,
+  const DisableContacts<dim>              &disable_contacts_object,
   const bool                               has_periodic_boundaries)
 {
   particle_particle_broad_search_object.find_particle_particle_contact_pairs(
@@ -284,7 +284,7 @@ template <int dim>
 void
 DEMContactManager<dim>::execute_particle_wall_broad_search(
   const Particles::ParticleHandler<dim> &particle_handler,
-  BoundaryCellsInformation<dim> &        boundary_cell_object,
+  BoundaryCellsInformation<dim>         &boundary_cell_object,
   const typename dem_data_structures<dim>::floating_mesh_information
                                                     floating_mesh_info,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
@@ -337,12 +337,12 @@ template <int dim>
 void
 DEMContactManager<dim>::execute_particle_wall_broad_search(
   const Particles::ParticleHandler<dim> &particle_handler,
-  BoundaryCellsInformation<dim> &        boundary_cell_object,
+  BoundaryCellsInformation<dim>         &boundary_cell_object,
   const typename dem_data_structures<dim>::floating_mesh_information
                                                     floating_mesh_info,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_walls,
   const double                                      simulation_time,
-  const DisableContacts<dim> &                      disable_contacts_object,
+  const DisableContacts<dim>                       &disable_contacts_object,
   const bool                                        has_floating_mesh)
 {
   // Particle-wall contact candidates

--- a/source/dem/disable_contacts.cc
+++ b/source/dem/disable_contacts.cc
@@ -46,7 +46,7 @@ void
 DisableContacts<dim>::calculate_granular_temperature_and_solid_fraction(
   const Particles::ParticleHandler<dim> &particle_handler,
   const std::set<typename DoFHandler<dim>::active_cell_iterator>
-    &             local_and_ghost_cells_with_particles,
+                 &local_and_ghost_cells_with_particles,
   Vector<double> &granular_temperature_average,
   Vector<double> &solid_fractions)
 {
@@ -136,7 +136,7 @@ DisableContacts<dim>::calculate_granular_temperature_and_solid_fraction(
 template <int dim>
 void
 DisableContacts<dim>::identify_mobility_status(
-  const DoFHandler<dim> &                background_dh,
+  const DoFHandler<dim>                 &background_dh,
   const Particles::ParticleHandler<dim> &particle_handler,
   const unsigned int                     n_active_cells,
   MPI_Comm                               mpi_communicator)

--- a/source/dem/explicit_euler_integrator.cc
+++ b/source/dem/explicit_euler_integrator.cc
@@ -21,11 +21,11 @@ template <int dim>
 void
 ExplicitEulerIntegrator<dim>::integrate(
   Particles::ParticleHandler<dim> &particle_handler,
-  const Tensor<1, 3> &             g,
+  const Tensor<1, 3>              &g,
   const double                     dt,
-  std::vector<Tensor<1, 3>> &      torque,
-  std::vector<Tensor<1, 3>> &      force,
-  const std::vector<double> &      MOI)
+  std::vector<Tensor<1, 3>>       &torque,
+  std::vector<Tensor<1, 3>>       &force,
+  const std::vector<double>       &MOI)
 {
   for (auto particle = particle_handler.begin();
        particle != particle_handler.end();

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -24,11 +24,11 @@ BoundaryCellsInformation<dim>::BoundaryCellsInformation()
 template <int dim>
 void
 BoundaryCellsInformation<dim>::build(
-  const parallel::distributed::Triangulation<dim> & triangulation,
+  const parallel::distributed::Triangulation<dim>  &triangulation,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-  const std::vector<unsigned int> &                 outlet_boundaries,
-  const bool &                                      check_diamond_cells,
-  const bool &              expand_particle_wall_contact_search,
+  const std::vector<unsigned int>                  &outlet_boundaries,
+  const bool                                       &check_diamond_cells,
+  const bool               &expand_particle_wall_contact_search,
   const ConditionalOStream &pcout)
 {
   boundary_cells_with_faces.clear();
@@ -97,9 +97,9 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::build(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int> &                outlet_boundaries,
-  const bool &                                     check_diamond_cells,
-  const ConditionalOStream &                       pcout)
+  const std::vector<unsigned int>                 &outlet_boundaries,
+  const bool                                      &check_diamond_cells,
+  const ConditionalOStream                        &pcout)
 {
   boundary_cells_with_faces.clear();
   global_boundary_cells_with_faces.clear();
@@ -129,7 +129,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::find_boundary_cells_information(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int> &                outlet_boundaries)
+  const std::vector<unsigned int>                 &outlet_boundaries)
 {
   // Initializing output_vector and a search_vector (containing boundary_id and
   // cell) to avoid replication of a boundary face. All the found boundary faces
@@ -438,7 +438,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::find_global_boundary_cells_with_faces(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int> &                outlet_boundaries)
+  const std::vector<unsigned int>                 &outlet_boundaries)
 {
   // Iterating over the active cells in the triangulation
   for (const auto &cell : triangulation.active_cell_iterators())
@@ -466,9 +466,9 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int> &                outlet_boundaries,
-  const bool &                                     check_diamond_cells,
-  const ConditionalOStream &                       pcout)
+  const std::vector<unsigned int>                 &outlet_boundaries,
+  const bool                                      &check_diamond_cells,
+  const ConditionalOStream                        &pcout)
 {
   std::vector<typename Triangulation<dim>::active_cell_iterator>
     boundary_neighbor_cells;
@@ -638,7 +638,7 @@ BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(
 template <int dim>
 void
 BoundaryCellsInformation<dim>::find_boundary_cells_for_floating_walls(
-  const parallel::distributed::Triangulation<dim> & triangulation,
+  const parallel::distributed::Triangulation<dim>  &triangulation,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double                                      maximum_cell_diameter)
 {
@@ -689,8 +689,8 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::add_boundary_neighbors_of_boundary_cells(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int> &                outlet_boundaries,
-  std::map<int, boundary_cells_info_struct<dim>> & boundary_cells_information,
+  const std::vector<unsigned int>                 &outlet_boundaries,
+  std::map<int, boundary_cells_info_struct<dim>>  &boundary_cells_information,
   const std::map<int, boundary_cells_info_struct<dim>>
     &global_boundary_cells_information)
 {

--- a/source/dem/find_cell_neighbors.cc
+++ b/source/dem/find_cell_neighbors.cc
@@ -322,10 +322,10 @@ void
 FindCellNeighbors<dim>::get_periodic_neighbor_list(
   const typename Triangulation<dim>::active_cell_iterator &cell,
   const std::map<unsigned int, std::vector<unsigned int>>
-    &                                         coinciding_vertex_groups,
+                                             &coinciding_vertex_groups,
   const std::map<unsigned int, unsigned int> &vertex_to_coinciding_vertex_group,
   const std::vector<std::set<typename Triangulation<dim>::active_cell_iterator>>
-    &                                                  v_to_c,
+                                                      &v_to_c,
   typename DEM::dem_data_structures<dim>::cell_vector &periodic_neighbor_list)
 {
   // Loop over vertices of the cell

--- a/source/dem/find_contact_detection_step.cc
+++ b/source/dem/find_contact_detection_step.cc
@@ -8,9 +8,9 @@ find_particle_contact_detection_step(
   Particles::ParticleHandler<dim> &particle_handler,
   const double                     dt,
   const double                     smallest_contact_search_criterion,
-  MPI_Comm &                       mpi_communicator,
+  MPI_Comm                        &mpi_communicator,
   const bool                       sorting_in_subdomains_step,
-  std::vector<double> &            displacement,
+  std::vector<double>             &displacement,
   const bool                       parallel_update)
 {
   if (sorting_in_subdomains_step)
@@ -61,9 +61,9 @@ find_particle_contact_detection_step(
   Particles::ParticleHandler<2> &particle_handler,
   const double                   dt,
   const double                   smallest_contact_search_criterion,
-  MPI_Comm &                     mpi_communicator,
+  MPI_Comm                      &mpi_communicator,
   bool                           sorting_in_subdomains_step,
-  std::vector<double> &          displacement,
+  std::vector<double>           &displacement,
   const bool                     parallel_update);
 
 template bool
@@ -71,9 +71,9 @@ find_particle_contact_detection_step(
   Particles::ParticleHandler<3> &particle_handler,
   const double                   dt,
   const double                   smallest_contact_search_criterion,
-  MPI_Comm &                     mpi_communicator,
+  MPI_Comm                      &mpi_communicator,
   const bool                     sorting_in_subdomains_step,
-  std::vector<double> &          displacement,
+  std::vector<double>           &displacement,
   const bool                     parallel_update);
 
 

--- a/source/dem/find_maximum_particle_size.cc
+++ b/source/dem/find_maximum_particle_size.cc
@@ -3,7 +3,7 @@
 double
 find_maximum_particle_size(
   const Parameters::Lagrangian::LagrangianPhysicalProperties
-    &          physical_properties,
+              &physical_properties,
   const double standard_deviation_multiplier)
 {
   double maximum_particle_size = 0;

--- a/source/dem/input_parameter_inspection.cc
+++ b/source/dem/input_parameter_inspection.cc
@@ -6,7 +6,7 @@ using namespace dealii;
 template <int dim>
 void
 input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
-                           const ConditionalOStream &      pcout,
+                           const ConditionalOStream       &pcout,
                            const double standard_deviation_multiplier)
 {
   // Getting the input parameters as local variable
@@ -101,10 +101,10 @@ input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
 
 template void
 input_parameter_inspection(const DEMSolverParameters<2> &dem_parameters,
-                           const ConditionalOStream &    pcout,
+                           const ConditionalOStream     &pcout,
                            const double standard_deviation_multiplier);
 
 template void
 input_parameter_inspection(const DEMSolverParameters<3> &dem_parameters,
-                           const ConditionalOStream &    pcout,
+                           const ConditionalOStream     &pcout,
                            const double standard_deviation_multiplier);

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -43,9 +43,9 @@ Insertion<dim>::print_insertion_info(const unsigned int &inserted_this_step,
 template <int dim>
 void
 Insertion<dim>::assign_particle_properties(
-  const DEMSolverParameters<dim> &  dem_parameters,
-  const unsigned int &              inserted_this_step_this_proc,
-  const unsigned int &              current_inserting_particle_type,
+  const DEMSolverParameters<dim>   &dem_parameters,
+  const unsigned int               &inserted_this_step_this_proc,
+  const unsigned int               &current_inserting_particle_type,
   std::vector<std::vector<double>> &particle_properties)
 {
   // Clearing and resizing particle_properties
@@ -136,7 +136,7 @@ template <int dim>
 void
 Insertion<dim>::calculate_insertion_domain_maximum_particle_number(
   const DEMSolverParameters<dim> &dem_parameters,
-  const ConditionalOStream &      pcout)
+  const ConditionalOStream       &pcout)
 {
   // Getting properties as local parameters
   const auto insertion_information = dem_parameters.insertion_info;

--- a/source/dem/lagrangian_post_processing.cc
+++ b/source/dem/lagrangian_post_processing.cc
@@ -20,7 +20,7 @@ template <int dim>
 void
 LagrangianPostProcessing<dim>::calculate_average_particles_velocity(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const Particles::ParticleHandler<dim> &          particle_handler)
+  const Particles::ParticleHandler<dim>           &particle_handler)
 {
   velocity_average_x.reinit(triangulation.n_active_cells());
   velocity_average_y.reinit(triangulation.n_active_cells());
@@ -61,7 +61,7 @@ template <int dim>
 void
 LagrangianPostProcessing<dim>::calculate_average_granular_temperature(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const Particles::ParticleHandler<dim> &          particle_handler)
+  const Particles::ParticleHandler<dim>           &particle_handler)
 {
   granular_temperature_average.reinit(triangulation.n_active_cells());
 
@@ -175,14 +175,14 @@ template <int dim>
 void
 LagrangianPostProcessing<dim>::write_post_processing_results(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  PVDHandler &                                     grid_pvdhandler,
-  const DoFHandler<dim> &                          background_dh,
-  const Particles::ParticleHandler<dim> &          particle_handler,
-  const DEMSolverParameters<dim> &                 dem_parameters,
+  PVDHandler                                      &grid_pvdhandler,
+  const DoFHandler<dim>                           &background_dh,
+  const Particles::ParticleHandler<dim>           &particle_handler,
+  const DEMSolverParameters<dim>                  &dem_parameters,
   const double                                     current_time,
   const unsigned int                               step_number,
-  const MPI_Comm &                                 mpi_communicator,
-  DisableContacts<dim> &                           disable_contacts_object)
+  const MPI_Comm                                  &mpi_communicator,
+  DisableContacts<dim>                            &disable_contacts_object)
 {
   const std::string folder = dem_parameters.simulation_control.output_folder;
   const std::string particles_solution_name =

--- a/source/dem/list_insertion.cc
+++ b/source/dem/list_insertion.cc
@@ -61,9 +61,9 @@ ListInsertion<dim>::ListInsertion(
 template <int dim>
 void
 ListInsertion<dim>::insert(
-  Particles::ParticleHandler<dim> &                particle_handler,
+  Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const DEMSolverParameters<dim> &                 dem_parameters)
+  const DEMSolverParameters<dim>                  &dem_parameters)
 {
   // TODO refactor into a function call
   if (remaining_particles_of_each_type == 0 &&
@@ -139,9 +139,9 @@ ListInsertion<dim>::insert(
 template <int dim>
 void
 ListInsertion<dim>::assign_particle_properties_for_list_insertion(
-  const DEMSolverParameters<dim> &  dem_parameters,
-  const unsigned int &              inserted_this_step_this_proc,
-  const unsigned int &              current_inserting_particle_type,
+  const DEMSolverParameters<dim>   &dem_parameters,
+  const unsigned int               &inserted_this_step_this_proc,
+  const unsigned int               &current_inserting_particle_type,
   std::vector<std::vector<double>> &particle_properties)
 {
   // Clearing and resizing particle_properties

--- a/source/dem/non_uniform_insertion.cc
+++ b/source/dem/non_uniform_insertion.cc
@@ -27,9 +27,9 @@ NonUniformInsertion<dim>::NonUniformInsertion(
 template <int dim>
 void
 NonUniformInsertion<dim>::insert(
-  Particles::ParticleHandler<dim> &                particle_handler,
+  Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const DEMSolverParameters<dim> &                 dem_parameters)
+  const DEMSolverParameters<dim>                  &dem_parameters)
 {
   if (particles_of_each_type_remaining == 0 &&
       current_inserting_particle_type !=
@@ -160,7 +160,7 @@ NonUniformInsertion<dim>::create_random_number_container(
 template <>
 void
 NonUniformInsertion<2>::find_insertion_location_nonuniform(
-  Point<2> &                                   insertion_location,
+  Point<2>                                    &insertion_location,
   const unsigned int                           id,
   const double                                 random_number1,
   const double                                 random_number2,
@@ -195,7 +195,7 @@ NonUniformInsertion<2>::find_insertion_location_nonuniform(
 template <>
 void
 NonUniformInsertion<3>::find_insertion_location_nonuniform(
-  Point<3> &                                   insertion_location,
+  Point<3>                                    &insertion_location,
   const unsigned int                           id,
   const double                                 random_number1,
   const double                                 random_number2,

--- a/source/dem/particle_particle_broad_search.cc
+++ b/source/dem/particle_particle_broad_search.cc
@@ -11,7 +11,7 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContactManager<dim> &                 container_manager)
+  DEMContactManager<dim>                  &container_manager)
 {
   // Pre-fetch and clear containers
   auto &local_contact_pair_candidates =
@@ -136,8 +136,8 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContactManager<dim> &                 container_manager,
-  const DisableContacts<dim> &             disable_contacts_object)
+  DEMContactManager<dim>                  &container_manager,
+  const DisableContacts<dim>              &disable_contacts_object)
 {
   // Pre-fetch and clear containers
   auto &local_contact_pair_candidates =
@@ -295,7 +295,7 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_periodic_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContactManager<dim> &                 container_manager)
+  DEMContactManager<dim>                  &container_manager)
 {
   // Pre-fetch and clear containers
   auto &local_contact_pair_periodic_candidates =
@@ -471,8 +471,8 @@ template <int dim>
 void
 ParticleParticleBroadSearch<dim>::find_particle_particle_periodic_contact_pairs(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  DEMContactManager<dim> &                 container_manager,
-  const DisableContacts<dim> &             disable_contacts_object)
+  DEMContactManager<dim>                  &container_manager,
+  const DisableContacts<dim>              &disable_contacts_object)
 {
   // Pre-fetch and clear containers
   auto &local_contact_pair_periodic_candidates =

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -112,7 +112,7 @@ template <
 void
 ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
   calculate_particle_particle_contact_force(
-    DEMContactManager<dim> &   container_manager,
+    DEMContactManager<dim>    &container_manager,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
@@ -998,15 +998,15 @@ ParticleParticleContactForce<dim, contact_model, rolling_friction_model>::
   calculate_IB_particle_particle_contact_force(
     const double                         normal_overlap,
     particle_particle_contact_info<dim> &contact_info,
-    Tensor<1, 3> &                       normal_force,
-    Tensor<1, 3> &                       tangential_force,
-    Tensor<1, 3> &                       particle_one_tangential_torque,
-    Tensor<1, 3> &                       particle_two_tangential_torque,
-    Tensor<1, 3> &                       rolling_resistance_torque,
-    IBParticle<dim> &                    particle_one,
-    IBParticle<dim> &                    particle_two,
-    const Point<dim> &                   particle_one_location,
-    const Point<dim> &                   particle_two_location,
+    Tensor<1, 3>                        &normal_force,
+    Tensor<1, 3>                        &tangential_force,
+    Tensor<1, 3>                        &particle_one_tangential_torque,
+    Tensor<1, 3>                        &particle_two_tangential_torque,
+    Tensor<1, 3>                        &rolling_resistance_torque,
+    IBParticle<dim>                     &particle_one,
+    IBParticle<dim>                     &particle_two,
+    const Point<dim>                    &particle_one_location,
+    const Point<dim>                    &particle_two_location,
     const double                         dt,
     const double                         particle_one_radius,
     const double                         particle_two_radius,

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -15,7 +15,7 @@ ParticleParticleFineSearch<dim>::particle_particle_fine_search(
   typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
     &adjacent_particles,
   const typename DEM::dem_data_structures<dim>::particle_particle_candidates
-    &                  contact_pair_candidates,
+                      &contact_pair_candidates,
   const double         neighborhood_threshold,
   const Tensor<1, dim> periodic_offset)
 {

--- a/source/dem/particle_point_line_broad_search.cc
+++ b/source/dem/particle_point_line_broad_search.cc
@@ -72,7 +72,7 @@ ParticlePointLineBroadSearch<dim>::find_particle_point_contact_pairs(
   const std::unordered_map<
     std::string,
     std::pair<typename Triangulation<dim>::active_cell_iterator, Point<dim>>>
-    &                         boundary_cells_with_points,
+                             &boundary_cells_with_points,
   const DisableContacts<dim> &disable_contacts_object)
 {
   std::unordered_map<types::particle_index,
@@ -204,7 +204,7 @@ ParticlePointLineBroadSearch<dim>::find_particle_line_contact_pairs(
     std::string,
     std::tuple<typename Triangulation<dim>::active_cell_iterator,
                Point<dim>,
-               Point<dim>>> & boundary_cells_with_lines,
+               Point<dim>>>  &boundary_cells_with_lines,
   const DisableContacts<dim> &disable_contacts_object)
 {
   std::unordered_map<

--- a/source/dem/particle_point_line_contact_force.cc
+++ b/source/dem/particle_point_line_contact_force.cc
@@ -17,7 +17,7 @@ ParticlePointLineForce<dim>::calculate_particle_point_contact_force(
   const typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
     *particle_point_pairs_in_contact,
   const Parameters::Lagrangian::LagrangianPhysicalProperties
-    &                        physical_properties,
+                            &physical_properties,
   std::vector<Tensor<1, 3>> &force)
 
 {
@@ -141,7 +141,7 @@ ParticlePointLineForce<dim>::calculate_particle_line_contact_force(
   const typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
     *particle_line_pairs_in_contact,
   const Parameters::Lagrangian::LagrangianPhysicalProperties
-    &                        physical_properties,
+                            &physical_properties,
   std::vector<Tensor<1, 3>> &force)
 {
   // Looping over particle_point_line_pairs_in_contact

--- a/source/dem/particle_point_line_fine_search.cc
+++ b/source/dem/particle_point_line_fine_search.cc
@@ -17,7 +17,7 @@ template <int dim>
 typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
 ParticlePointLineFineSearch<dim>::particle_point_fine_search(
   const typename DEM::dem_data_structures<dim>::particle_point_candidates
-    &          particle_point_contact_candidates,
+              &particle_point_contact_candidates,
   const double neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,
@@ -88,7 +88,7 @@ template <int dim>
 typename DEM::dem_data_structures<dim>::particle_point_line_contact_info
 ParticlePointLineFineSearch<dim>::particle_line_fine_search(
   const typename DEM::dem_data_structures<dim>::particle_line_candidates
-    &          particle_line_contact_candidates,
+              &particle_line_contact_candidates,
   const double neighborhood_threshold)
 {
   std::unordered_map<types::particle_index,

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -10,7 +10,7 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::find_particle_wall_contact_pairs(
   const std::map<int, boundary_cells_info_struct<dim>>
-    &                                    boundary_cells_information,
+                                        &boundary_cells_information,
   const Particles::ParticleHandler<dim> &particle_handler,
   typename DEM::dem_data_structures<dim>::particle_wall_candidates
     &particle_wall_contact_candidates)
@@ -69,7 +69,7 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
     unsigned int,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
-    &                                    boundary_cells_for_floating_walls,
+                                        &boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double                                      simulation_time,
@@ -137,7 +137,7 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::particle_floating_mesh_contact_search(
   const typename DEM::dem_data_structures<dim>::floating_mesh_information
-    &                                    floating_mesh_information,
+                                        &floating_mesh_information,
   const Particles::ParticleHandler<dim> &particle_handler,
   typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates,
@@ -224,10 +224,10 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::find_particle_wall_contact_pairs(
   const std::map<int, boundary_cells_info_struct<dim>>
-    &                                    boundary_cells_information,
+                                        &boundary_cells_information,
   const Particles::ParticleHandler<dim> &particle_handler,
   typename DEM::dem_data_structures<dim>::particle_wall_candidates
-    &                         particle_wall_contact_candidates,
+                             &particle_wall_contact_candidates,
   const DisableContacts<dim> &disable_contacts_object)
 {
   // Clearing particle_wall_contact_candidates (output of this function)
@@ -281,12 +281,12 @@ ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
     unsigned int,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
-    &                                    boundary_cells_for_floating_walls,
+                                        &boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
   const double                                      simulation_time,
   typename DEM::dem_data_structures<dim>::particle_floating_wall_candidates
-    &                         particle_floating_wall_candidates,
+                             &particle_floating_wall_candidates,
   const DisableContacts<dim> &disable_contacts_object)
 {
   // Clearing particle_floating_wall_candidates(output of this function)
@@ -348,12 +348,12 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::particle_floating_mesh_contact_search(
   const typename DEM::dem_data_structures<dim>::floating_mesh_information
-    &                                    floating_mesh_information,
+                                        &floating_mesh_information,
   const Particles::ParticleHandler<dim> &particle_handler,
   typename DEM::dem_data_structures<dim>::particle_floating_mesh_candidates
     &particle_floating_mesh_contact_candidates,
   typename DEM::dem_data_structures<dim>::cells_total_neighbor_list
-    &                         cells_total_neighbor_list,
+                             &cells_total_neighbor_list,
   const DisableContacts<dim> &disable_contacts_object)
 {
   // Clear the candidate container

--- a/source/dem/particle_wall_contact_force.cc
+++ b/source/dem/particle_wall_contact_force.cc
@@ -25,7 +25,7 @@ template <int dim>
 void
 ParticleWallContactForce<dim>::update_contact_information(
   particle_wall_contact_info<dim> &contact_info,
-  const ArrayView<const double> &  particle_properties,
+  const ArrayView<const double>   &particle_properties,
   const double                     dt)
 {
   auto               normal_vector = contact_info.normal_vector;
@@ -89,10 +89,10 @@ void
 ParticleWallContactForce<dim>::
   update_particle_floating_wall_contact_information(
     particle_wall_contact_info<dim> &contact_info,
-    const ArrayView<const double> &  particle_properties,
+    const ArrayView<const double>   &particle_properties,
     const double                     dt,
-    const Tensor<1, 3> &             cut_cell_translational_velocity,
-    const Tensor<1, 3> &             cut_cell_rotational_velocity,
+    const Tensor<1, 3>              &cut_cell_translational_velocity,
+    const Tensor<1, 3>              &cut_cell_rotational_velocity,
     const double                     center_of_rotation_particle_distance)
 {
   const Tensor<1, 3> normal_vector = contact_info.normal_vector;

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -13,7 +13,7 @@ ParticleWallLinearForce<dim>::ParticleWallLinearForce(
   const std::unordered_map<unsigned int, Tensor<1, 3>>
                                         boundary_rotational_vector,
   const double                          triangulation_radius,
-  const DEMSolverParameters<dim> &      dem_parameters,
+  const DEMSolverParameters<dim>       &dem_parameters,
   const std::vector<types::boundary_id> boundary_index)
   : ParticleWallContactForce<dim>(dem_parameters)
 {
@@ -116,7 +116,7 @@ template <int dim>
 void
 ParticleWallLinearForce<dim>::calculate_particle_wall_contact_force(
   typename DEM::dem_data_structures<dim>::particle_wall_in_contact
-    &                        particle_wall_pairs_in_contact,
+                            &particle_wall_pairs_in_contact,
   const double               dt,
   std::vector<Tensor<1, 3>> &torque,
   std::vector<Tensor<1, 3>> &force)
@@ -214,7 +214,7 @@ template <int dim>
 void
 ParticleWallLinearForce<dim>::calculate_particle_floating_wall_contact_force(
   typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
-    &                        particle_floating_mesh_in_contact,
+                            &particle_floating_mesh_in_contact,
   const double               dt,
   std::vector<Tensor<1, 3>> &torque,
   std::vector<Tensor<1, 3>> &force,
@@ -379,7 +379,7 @@ template <int dim>
 std::tuple<Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>>
 ParticleWallLinearForce<dim>::calculate_linear_contact_force_and_torque(
   particle_wall_contact_info<dim> &contact_info,
-  const ArrayView<const double> &  particle_properties)
+  const ArrayView<const double>   &particle_properties)
 {
   const unsigned int particle_type =
     particle_properties[DEM::PropertiesIndex::type];

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -13,7 +13,7 @@ ParticleWallNonLinearForce<dim>::ParticleWallNonLinearForce(
   const std::unordered_map<unsigned int, Tensor<1, 3>>
                                         boundary_rotational_vector,
   const double                          triangulation_radius,
-  const DEMSolverParameters<dim> &      dem_parameters,
+  const DEMSolverParameters<dim>       &dem_parameters,
   const std::vector<types::boundary_id> boundary_index)
   : ParticleWallContactForce<dim>(dem_parameters)
 {
@@ -121,7 +121,7 @@ template <int dim>
 void
 ParticleWallNonLinearForce<dim>::calculate_particle_wall_contact_force(
   typename DEM::dem_data_structures<dim>::particle_wall_in_contact
-    &                        particle_wall_pairs_in_contact,
+                            &particle_wall_pairs_in_contact,
   const double               dt,
   std::vector<Tensor<1, 3>> &torque,
   std::vector<Tensor<1, 3>> &force)
@@ -222,7 +222,7 @@ template <int dim>
 void
 ParticleWallNonLinearForce<dim>::calculate_particle_floating_wall_contact_force(
   typename DEM::dem_data_structures<dim>::particle_floating_mesh_in_contact
-    &                        particle_floating_mesh_in_contact,
+                            &particle_floating_mesh_in_contact,
   const double               dt,
   std::vector<Tensor<1, 3>> &torque,
   std::vector<Tensor<1, 3>> &force,
@@ -389,7 +389,7 @@ template <int dim>
 std::tuple<Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>, Tensor<1, 3>>
 ParticleWallNonLinearForce<dim>::calculate_nonlinear_contact_force_and_torque(
   particle_wall_contact_info<dim> &contact_info,
-  const ArrayView<const double> &  particle_properties)
+  const ArrayView<const double>   &particle_properties)
 {
   const unsigned int particle_type =
     particle_properties[DEM::PropertiesIndex::type];
@@ -469,11 +469,11 @@ template <int dim>
 void
 ParticleWallNonLinearForce<dim>::calculate_IB_particle_wall_contact_force(
   particle_wall_contact_info<dim> &contact_info,
-  Tensor<1, 3> &                   normal_force,
-  Tensor<1, 3> &                   tangential_force,
-  Tensor<1, 3> &                   tangential_torque,
-  Tensor<1, 3> &                   rolling_resistance_torque,
-  IBParticle<dim> &                particle,
+  Tensor<1, 3>                    &normal_force,
+  Tensor<1, 3>                    &tangential_force,
+  Tensor<1, 3>                    &tangential_torque,
+  Tensor<1, 3>                    &rolling_resistance_torque,
+  IBParticle<dim>                 &particle,
   const double                     wall_youngs_modulus,
   const double                     wall_poisson_ratio,
   const double                     wall_restitution_coefficient,

--- a/source/dem/periodic_boundaries_manipulator.cc
+++ b/source/dem/periodic_boundaries_manipulator.cc
@@ -123,7 +123,7 @@ void
 PeriodicBoundariesManipulator<dim>::check_and_move_particles(
   const periodic_boundaries_cells_info_struct<dim> &boundaries_cells_content,
   typename Particles::ParticleHandler<dim>::particle_iterator_range
-    &        particles_in_cell,
+            &particles_in_cell,
   const bool particles_in_pb0_cell)
 {
   for (auto particle = particles_in_cell.begin();

--- a/source/dem/plane_insertion.cc
+++ b/source/dem/plane_insertion.cc
@@ -9,7 +9,7 @@ using namespace DEM;
 // those cells.
 template <int dim>
 PlaneInsertion<dim>::PlaneInsertion(
-  const DEMSolverParameters<dim> &                 dem_parameters,
+  const DEMSolverParameters<dim>                  &dem_parameters,
   const parallel::distributed::Triangulation<dim> &triangulation)
   : particles_of_each_type_remaining(
       dem_parameters.lagrangian_physical_properties.number.at(0))
@@ -103,9 +103,9 @@ PlaneInsertion<dim>::find_centers_of_inplane_cells()
 template <int dim>
 void
 PlaneInsertion<dim>::insert(
-  Particles::ParticleHandler<dim> &                particle_handler,
+  Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const DEMSolverParameters<dim> &                 dem_parameters)
+  const DEMSolverParameters<dim>                  &dem_parameters)
 {
   if (particles_of_each_type_remaining == 0 &&
       this->current_inserting_particle_type !=

--- a/source/dem/post_processing.cc
+++ b/source/dem/post_processing.cc
@@ -8,7 +8,7 @@ namespace DEM
   statistics
   calculate_granular_statistics(
     const Particles::ParticleHandler<dim> &particle_handler,
-    const MPI_Comm &                       mpi_communicator)
+    const MPI_Comm                        &mpi_communicator)
   {
     double total_variable = 0;
     double max_variable   = DBL_MIN;
@@ -110,48 +110,48 @@ namespace DEM
     2,
     dem_statistic_variable::translational_kinetic_energy>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<
     3,
     dem_statistic_variable::translational_kinetic_energy>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<
     2,
     dem_statistic_variable::rotational_kinetic_energy>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<
     3,
     dem_statistic_variable::rotational_kinetic_energy>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<2, dem_statistic_variable::velocity>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<3, dem_statistic_variable::velocity>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<2, dem_statistic_variable::omega>(
     const Particles::ParticleHandler<2, 2> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
   template statistics
   calculate_granular_statistics<3, dem_statistic_variable::omega>(
     const Particles::ParticleHandler<3, 3> &particle_handler,
-    const MPI_Comm &                        mpi_communicator);
+    const MPI_Comm                         &mpi_communicator);
 
 
 

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -4,13 +4,13 @@ using namespace dealii;
 
 template <int dim>
 void
-read_checkpoint(TimerOutput &                              computing_timer,
-                const DEMSolverParameters<dim> &           parameters,
-                std::shared_ptr<SimulationControl> &       simulation_control,
-                PVDHandler &                               particles_pvdhandler,
-                PVDHandler &                               grid_pvdhandler,
+read_checkpoint(TimerOutput                               &computing_timer,
+                const DEMSolverParameters<dim>            &parameters,
+                std::shared_ptr<SimulationControl>        &simulation_control,
+                PVDHandler                                &particles_pvdhandler,
+                PVDHandler                                &grid_pvdhandler,
                 parallel::distributed::Triangulation<dim> &triangulation,
-                Particles::ParticleHandler<dim> &          particle_handler)
+                Particles::ParticleHandler<dim>           &particle_handler)
 {
   TimerOutput::Scope timer(computing_timer, "read_checkpoint");
   std::string        prefix = parameters.restart.filename;
@@ -61,19 +61,19 @@ read_checkpoint(TimerOutput &                              computing_timer,
 }
 
 template void
-read_checkpoint(TimerOutput &                            computing_timer,
-                const DEMSolverParameters<2> &           parameters,
-                std::shared_ptr<SimulationControl> &     simulation_control,
-                PVDHandler &                             particles_pvdhandler,
-                PVDHandler &                             grid_pvdhandler,
+read_checkpoint(TimerOutput                             &computing_timer,
+                const DEMSolverParameters<2>            &parameters,
+                std::shared_ptr<SimulationControl>      &simulation_control,
+                PVDHandler                              &particles_pvdhandler,
+                PVDHandler                              &grid_pvdhandler,
                 parallel::distributed::Triangulation<2> &triangulation,
-                Particles::ParticleHandler<2> &          particle_handler);
+                Particles::ParticleHandler<2>           &particle_handler);
 
 template void
-read_checkpoint(TimerOutput &                            computing_timer,
-                const DEMSolverParameters<3> &           parameters,
-                std::shared_ptr<SimulationControl> &     simulation_control,
-                PVDHandler &                             particles_pvdhandler,
-                PVDHandler &                             grid_pvdhandler,
+read_checkpoint(TimerOutput                             &computing_timer,
+                const DEMSolverParameters<3>            &parameters,
+                std::shared_ptr<SimulationControl>      &simulation_control,
+                PVDHandler                              &particles_pvdhandler,
+                PVDHandler                              &grid_pvdhandler,
                 parallel::distributed::Triangulation<3> &triangulation,
-                Particles::ParticleHandler<3> &          particle_handler);
+                Particles::ParticleHandler<3>           &particle_handler);

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -5,11 +5,11 @@
 
 template <int dim, int spacedim>
 void
-read_mesh(const Parameters::Mesh &  mesh_parameters,
+read_mesh(const Parameters::Mesh   &mesh_parameters,
           const bool                restart,
           const ConditionalOStream &pcout,
           parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-          double &                             triangulation_cell_diameter,
+          double                              &triangulation_cell_diameter,
           const Parameters::Lagrangian::BCDEM &bc_params)
 {
   pcout << "Reading triangulation" << std::endl;
@@ -51,7 +51,7 @@ read_mesh(const Parameters::Mesh &  mesh_parameters,
 
 template <int dim, int spacedim>
 void
-match_periodic_boundaries(Triangulation<dim, spacedim> &       triangulation,
+match_periodic_boundaries(Triangulation<dim, spacedim>        &triangulation,
                           const Parameters::Lagrangian::BCDEM &bc_param)
 {
   std::vector<GridTools::PeriodicFacePair<
@@ -67,25 +67,25 @@ match_periodic_boundaries(Triangulation<dim, spacedim> &       triangulation,
 }
 
 template void
-read_mesh<2, 2>(const Parameters::Mesh &                      mesh_parameters,
+read_mesh<2, 2>(const Parameters::Mesh                       &mesh_parameters,
                 const bool                                    restart,
-                const ConditionalOStream &                    pcout,
+                const ConditionalOStream                     &pcout,
                 parallel::DistributedTriangulationBase<2, 2> &triangulation,
                 double &triangulation_cell_diameter,
                 const Parameters::Lagrangian::BCDEM &bc_params);
 
 template void
-read_mesh<2, 3>(const Parameters::Mesh &                      mesh_parameters,
+read_mesh<2, 3>(const Parameters::Mesh                       &mesh_parameters,
                 const bool                                    restart,
-                const ConditionalOStream &                    pcout,
+                const ConditionalOStream                     &pcout,
                 parallel::DistributedTriangulationBase<2, 3> &triangulation,
                 double &triangulation_cell_diameter,
                 const Parameters::Lagrangian::BCDEM &bc_params);
 
 template void
-read_mesh<3, 3>(const Parameters::Mesh &                      mesh_parameters,
+read_mesh<3, 3>(const Parameters::Mesh                       &mesh_parameters,
                 const bool                                    restart,
-                const ConditionalOStream &                    pcout,
+                const ConditionalOStream                     &pcout,
                 parallel::DistributedTriangulationBase<3, 3> &triangulation,
                 double &triangulation_cell_diameter,
                 const Parameters::Lagrangian::BCDEM &bc_params);

--- a/source/dem/set_particle_particle_contact_force_model.cc
+++ b/source/dem/set_particle_particle_contact_force_model.cc
@@ -15,8 +15,8 @@ set_particle_particle_contact_force_model(
     {
       switch (dem_parameters.model_parameters.rolling_resistance_method)
         {
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              no_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -26,8 +26,9 @@ set_particle_particle_contact_force_model(
                     no_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              constant_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -37,8 +38,9 @@ set_particle_particle_contact_force_model(
                     constant_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              viscous_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -60,8 +62,8 @@ set_particle_particle_contact_force_model(
     {
       switch (dem_parameters.model_parameters.rolling_resistance_method)
         {
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              no_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -71,8 +73,9 @@ set_particle_particle_contact_force_model(
                     no_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              constant_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -82,8 +85,9 @@ set_particle_particle_contact_force_model(
                     constant_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              viscous_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -105,8 +109,8 @@ set_particle_particle_contact_force_model(
     {
       switch (dem_parameters.model_parameters.rolling_resistance_method)
         {
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              no_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -116,8 +120,9 @@ set_particle_particle_contact_force_model(
                     no_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              constant_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -127,8 +132,9 @@ set_particle_particle_contact_force_model(
                     constant_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              viscous_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -149,8 +155,8 @@ set_particle_particle_contact_force_model(
     {
       switch (dem_parameters.model_parameters.rolling_resistance_method)
         {
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              no_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::no_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -160,8 +166,9 @@ set_particle_particle_contact_force_model(
                     no_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              constant_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            constant_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,
@@ -171,8 +178,9 @@ set_particle_particle_contact_force_model(
                     constant_resistance>>(dem_parameters);
               break;
             }
-            case Parameters::Lagrangian::RollingResistanceMethod::
-              viscous_resistance: {
+          case Parameters::Lagrangian::RollingResistanceMethod::
+            viscous_resistance:
+            {
               particle_particle_contact_force_object =
                 std::make_shared<ParticleParticleContactForce<
                   dim,

--- a/source/dem/set_particle_wall_contact_force_model.cc
+++ b/source/dem/set_particle_wall_contact_force_model.cc
@@ -5,7 +5,7 @@ using namespace dealii;
 template <int dim>
 std::shared_ptr<ParticleWallContactForce<dim>>
 set_particle_wall_contact_force_model(
-  const DEMSolverParameters<dim> &                 dem_parameters,
+  const DEMSolverParameters<dim>                  &dem_parameters,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const double                                     triangulation_cell_diameter)
 {
@@ -49,12 +49,12 @@ set_particle_wall_contact_force_model(
 
 template std::shared_ptr<ParticleWallContactForce<2>>
 set_particle_wall_contact_force_model(
-  const DEMSolverParameters<2> &                 dem_parameters,
+  const DEMSolverParameters<2>                  &dem_parameters,
   const parallel::distributed::Triangulation<2> &triangulation,
   const double                                   triangulation_cell_diameter);
 
 template std::shared_ptr<ParticleWallContactForce<3>>
 set_particle_wall_contact_force_model(
-  const DEMSolverParameters<3> &                 dem_parameters,
+  const DEMSolverParameters<3>                  &dem_parameters,
   const parallel::distributed::Triangulation<3> &triangulation,
   const double                                   triangulation_cell_diameter);

--- a/source/dem/uniform_insertion.cc
+++ b/source/dem/uniform_insertion.cc
@@ -27,9 +27,9 @@ UniformInsertion<dim>::UniformInsertion(
 template <int dim>
 void
 UniformInsertion<dim>::insert(
-  Particles::ParticleHandler<dim> &                particle_handler,
+  Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const DEMSolverParameters<dim> &                 dem_parameters)
+  const DEMSolverParameters<dim>                  &dem_parameters)
 {
   if (particles_of_each_type_remaining == 0 &&
       current_inserting_particle_type !=
@@ -130,8 +130,8 @@ UniformInsertion<dim>::insert(
 template <>
 void
 UniformInsertion<2>::find_insertion_location_uniform(
-  Point<2> &                                   insertion_location,
-  const unsigned int &                         id,
+  Point<2>                                    &insertion_location,
+  const unsigned int                          &id,
   const Parameters::Lagrangian::InsertionInfo &insertion_information)
 {
   std::vector<int> insertion_index;
@@ -161,8 +161,8 @@ UniformInsertion<2>::find_insertion_location_uniform(
 template <>
 void
 UniformInsertion<3>::find_insertion_location_uniform(
-  Point<3> &                                   insertion_location,
-  const unsigned int &                         id,
+  Point<3>                                    &insertion_location,
+  const unsigned int                          &id,
   const Parameters::Lagrangian::InsertionInfo &insertion_information)
 {
   std::vector<int> insertion_index;

--- a/source/dem/update_fine_search_candidates.cc
+++ b/source/dem/update_fine_search_candidates.cc
@@ -8,7 +8,7 @@ template <int dim,
           typename candidates_structure,
           ContactType contact_type>
 void
-update_fine_search_candidates(pairs_structure &     pairs_in_contact,
+update_fine_search_candidates(pairs_structure      &pairs_in_contact,
                               candidates_structure &contact_candidates)
 {
   for (auto pairs_in_contact_iterator = pairs_in_contact.begin();

--- a/source/dem/update_local_particle_containers.cc
+++ b/source/dem/update_local_particle_containers.cc
@@ -6,7 +6,7 @@ template <int dim>
 void
 update_particle_container(
   typename DEM::dem_data_structures<dim>::particle_index_iterator_map
-    &                                    particle_container,
+                                        &particle_container,
   const Particles::ParticleHandler<dim> *particle_handler)
 {
   // Clear the current particle container
@@ -34,7 +34,7 @@ void
 update_contact_container_iterators(
   pairs_structure &pairs_in_contact,
   typename DEM::dem_data_structures<dim>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures)
 {
   // Loop over particle-object (particle/wall/line/point) pairs in contact
@@ -138,13 +138,13 @@ update_contact_container_iterators(
 template void
 update_particle_container(
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &                                  particle_container,
+                                      &particle_container,
   const Particles::ParticleHandler<2> *particle_handler);
 
 template void
 update_particle_container(
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &                                  particle_container,
+                                      &particle_container,
   const Particles::ParticleHandler<3> *particle_handler);
 
 // Local particle-particle contact container
@@ -156,7 +156,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -167,7 +167,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Ghost particle-particle contact container
@@ -179,7 +179,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -190,7 +190,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Local-local particle-particle periodic contact container
@@ -202,7 +202,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -213,7 +213,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Local-ghost particle-particle periodic contact container
@@ -225,7 +225,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -236,7 +236,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Ghost-local particle-particle periodic contact container
@@ -248,7 +248,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -259,7 +259,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::adjacent_particle_pairs
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Particle-wall contact container
@@ -271,7 +271,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -282,7 +282,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Particle-floating wall contact container
@@ -294,7 +294,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::particle_wall_in_contact
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -305,7 +305,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::particle_wall_in_contact
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Particle-floating mesh contact container
@@ -318,7 +318,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<
     2>::particle_floating_wall_from_mesh_in_contact &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -330,7 +330,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<
     3>::particle_floating_wall_from_mesh_in_contact &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Particle-point contact container
@@ -342,7 +342,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::particle_point_line_contact_info
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -353,7 +353,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::particle_point_line_contact_info
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 // Particle-line contact container
@@ -365,7 +365,7 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<2>::particle_point_line_contact_info
     &pairs_in_contact,
   typename DEM::dem_data_structures<2>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);
 
 template void
@@ -376,5 +376,5 @@ update_contact_container_iterators<
   typename DEM::dem_data_structures<3>::particle_point_line_contact_info
     &pairs_in_contact,
   typename DEM::dem_data_structures<3>::particle_index_iterator_map
-    &        particle_container,
+            &particle_container,
   const bool clear_contact_structures);

--- a/source/dem/velocity_verlet_integrator.cc
+++ b/source/dem/velocity_verlet_integrator.cc
@@ -10,11 +10,11 @@ template <int dim>
 void
 VelocityVerletIntegrator<dim>::integrate_half_step_location(
   Particles::ParticleHandler<dim> &particle_handler,
-  const Tensor<1, 3> &             g,
+  const Tensor<1, 3>              &g,
   const double                     dt,
   const std::vector<Tensor<1, 3>> &torque,
   const std::vector<Tensor<1, 3>> &force,
-  const std::vector<double> &      MOI)
+  const std::vector<double>       &MOI)
 {
   Tensor<1, dim> particle_acceleration;
 
@@ -55,11 +55,11 @@ template <int dim>
 void
 VelocityVerletIntegrator<dim>::integrate(
   Particles::ParticleHandler<dim> &particle_handler,
-  const Tensor<1, 3> &             g,
+  const Tensor<1, 3>              &g,
   const double                     dt,
-  std::vector<Tensor<1, 3>> &      torque,
-  std::vector<Tensor<1, 3>> &      force,
-  const std::vector<double> &      MOI)
+  std::vector<Tensor<1, 3>>       &torque,
+  std::vector<Tensor<1, 3>>       &force,
+  const std::vector<double>       &MOI)
 {
   Point<3>           particle_position;
   const Tensor<1, 3> dt_g = g * dt;
@@ -134,12 +134,12 @@ VelocityVerletIntegrator<dim>::integrate(
 template <int dim>
 void
 VelocityVerletIntegrator<dim>::integrate(
-  Particles::ParticleHandler<dim> &                particle_handler,
-  const Tensor<1, 3> &                             g,
+  Particles::ParticleHandler<dim>                 &particle_handler,
+  const Tensor<1, 3>                              &g,
   const double                                     dt,
-  std::vector<Tensor<1, 3>> &                      torque,
-  std::vector<Tensor<1, 3>> &                      force,
-  const std::vector<double> &                      MOI,
+  std::vector<Tensor<1, 3>>                       &torque,
+  std::vector<Tensor<1, 3>>                       &force,
+  const std::vector<double>                       &MOI,
   const parallel::distributed::Triangulation<dim> &triangulation,
   typename DEM::dem_data_structures<dim>::cell_index_int_map
     &cell_mobility_status_map)

--- a/source/dem/visualization.cc
+++ b/source/dem/visualization.cc
@@ -83,8 +83,8 @@ template <int dim>
 void
 Visualization<dim>::print_xyz(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  const MPI_Comm &                         mpi_communicator,
-  const ConditionalOStream &               pcout)
+  const MPI_Comm                          &mpi_communicator,
+  const ConditionalOStream                &pcout)
 {
   pcout << "id, type, dp, x, y, z " << std::endl;
   usleep(100);
@@ -135,9 +135,9 @@ Visualization<dim>::print_xyz(
 template <int dim>
 void
 Visualization<dim>::print_intermediate_format(
-  const Vector<float> &  data_to_print,
+  const Vector<float>   &data_to_print,
   const DoFHandler<dim> &background_dh,
-  const MPI_Comm &       mpi_communicator)
+  const MPI_Comm        &mpi_communicator)
 {
   unsigned int n_mpi_processes(
     Utilities::MPI::n_mpi_processes(mpi_communicator));

--- a/source/dem/write_checkpoint.cc
+++ b/source/dem/write_checkpoint.cc
@@ -4,15 +4,15 @@ using namespace dealii;
 
 template <int dim>
 void
-write_checkpoint(TimerOutput &                       computing_timer,
-                 const DEMSolverParameters<dim> &    parameters,
+write_checkpoint(TimerOutput                        &computing_timer,
+                 const DEMSolverParameters<dim>     &parameters,
                  std::shared_ptr<SimulationControl> &simulation_control,
-                 PVDHandler &                        particles_pvdhandler,
-                 PVDHandler &                        grid_pvdhandler,
+                 PVDHandler                         &particles_pvdhandler,
+                 PVDHandler                         &grid_pvdhandler,
                  parallel::distributed::Triangulation<dim> &triangulation,
-                 Particles::ParticleHandler<dim> &          particle_handler,
-                 const ConditionalOStream &                 pcout,
-                 MPI_Comm &                                 mpi_communicator)
+                 Particles::ParticleHandler<dim>           &particle_handler,
+                 const ConditionalOStream                  &pcout,
+                 MPI_Comm                                  &mpi_communicator)
 {
   TimerOutput::Scope timer(computing_timer, "write_checkpoint");
 
@@ -46,23 +46,23 @@ write_checkpoint(TimerOutput &                       computing_timer,
 }
 
 template void
-write_checkpoint(TimerOutput &                            computing_timer,
-                 const DEMSolverParameters<2> &           parameters,
-                 std::shared_ptr<SimulationControl> &     simulation_control,
-                 PVDHandler &                             particles_pvdhandler,
-                 PVDHandler &                             grid_pvdhandler,
+write_checkpoint(TimerOutput                             &computing_timer,
+                 const DEMSolverParameters<2>            &parameters,
+                 std::shared_ptr<SimulationControl>      &simulation_control,
+                 PVDHandler                              &particles_pvdhandler,
+                 PVDHandler                              &grid_pvdhandler,
                  parallel::distributed::Triangulation<2> &triangulation,
-                 Particles::ParticleHandler<2> &          particle_handler,
-                 const ConditionalOStream &               pcout,
-                 MPI_Comm &                               mpi_communicator);
+                 Particles::ParticleHandler<2>           &particle_handler,
+                 const ConditionalOStream                &pcout,
+                 MPI_Comm                                &mpi_communicator);
 
 template void
-write_checkpoint(TimerOutput &                            computing_timer,
-                 const DEMSolverParameters<3> &           parameters,
-                 std::shared_ptr<SimulationControl> &     simulation_control,
-                 PVDHandler &                             particles_pvdhandler,
-                 PVDHandler &                             grid_pvdhandler,
+write_checkpoint(TimerOutput                             &computing_timer,
+                 const DEMSolverParameters<3>            &parameters,
+                 std::shared_ptr<SimulationControl>      &simulation_control,
+                 PVDHandler                              &particles_pvdhandler,
+                 PVDHandler                              &grid_pvdhandler,
                  parallel::distributed::Triangulation<3> &triangulation,
-                 Particles::ParticleHandler<3> &          particle_handler,
-                 const ConditionalOStream &               pcout,
-                 MPI_Comm &                               mpi_communicator);
+                 Particles::ParticleHandler<3>           &particle_handler,
+                 const ConditionalOStream                &pcout,
+                 MPI_Comm                                &mpi_communicator);

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -17,8 +17,8 @@ template <int dim>
 bool
 check_contact_detection_method(
   unsigned int                          counter,
-  CFDDEMSimulationParameters<dim> &     param,
-  std::vector<double> &                 displacement,
+  CFDDEMSimulationParameters<dim>      &param,
+  std::vector<double>                  &displacement,
   Particles::ParticleHandler<dim, dim> &particle_handler,
   MPI_Comm                              mpi_communicator,
   std::shared_ptr<SimulationControl>    simulation_control,
@@ -68,9 +68,9 @@ check_contact_detection_method(
 template <int dim>
 bool
 check_load_balance_method(
-  CFDDEMSimulationParameters<dim> &     param,
+  CFDDEMSimulationParameters<dim>      &param,
   Particles::ParticleHandler<dim, dim> &particle_handler,
-  const MPI_Comm &                      mpi_communicator,
+  const MPI_Comm                       &mpi_communicator,
   const unsigned int                    n_mpi_processes,
   std::shared_ptr<SimulationControl>    simulation_control)
 { // Setting load-balance method (single-step, frequent or dynamic)
@@ -743,7 +743,7 @@ template <int dim>
 void
 CFDDEMSolver<dim>::update_moment_of_inertia(
   dealii::Particles::ParticleHandler<dim> &particle_handler,
-  std::vector<double> &                    MOI)
+  std::vector<double>                     &MOI)
 {
   MOI.resize(torque.size());
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -122,14 +122,14 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
                                  this->mpi_communicator);
     }
 
-  const auto &       cell_iterator = this->dof_handler.active_cell_iterators();
+  const auto        &cell_iterator = this->dof_handler.active_cell_iterators();
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
   const unsigned int dofs_per_face = this->fe->dofs_per_face;
 
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
   std::vector<types::global_dof_index> local_face_dof_indices(dofs_per_face);
 
-  auto &             v_x_fe                  = this->fe->get_sub_fe(0, 1);
+  auto              &v_x_fe                  = this->fe->get_sub_fe(0, 1);
   const unsigned int dofs_per_cell_local_v_x = v_x_fe.dofs_per_cell;
   // // Loop on all the cells and check if they are cut.
   for (const auto &cell : cell_iterator)
@@ -276,8 +276,8 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
             }
 
           cut_cells_map[cell]    = {cell_is_cut,
-                                 particle_id_which_cuts_this_cell,
-                                 number_of_particles_cutting_this_cell};
+                                    particle_id_which_cuts_this_cell,
+                                    number_of_particles_cutting_this_cell};
           cells_inside_map[cell] = {cell_is_inside,
                                     particle_id_in_which_this_cell_is_embedded};
         }
@@ -440,7 +440,7 @@ template <int dim>
 bool
 GLSSharpNavierStokesSolver<dim>::cell_cut_by_p_absolute_distance(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  std::map<types::global_dof_index, Point<dim>> &       support_points,
+  std::map<types::global_dof_index, Point<dim>>        &support_points,
   unsigned int                                          p)
 {
   // This function aims at defining if a cell is cut when the level set used to
@@ -1637,7 +1637,7 @@ GLSSharpNavierStokesSolver<dim>::output_field_hook(DataOut<dim> &data_out)
         ->enable_extra_sharp_interface_vtu_output_field)
     {
       // Define cell iterator
-      const auto & cell_iterator = this->dof_handler.active_cell_iterators();
+      const auto  &cell_iterator = this->dof_handler.active_cell_iterators();
       unsigned int i             = 0;
 
       for (const auto &cell : cell_iterator)
@@ -3779,8 +3779,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 
@@ -3872,8 +3872,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
 

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1578,8 +1578,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -1685,8 +1685,8 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/fem-dem/ib_particles_dem.cc
+++ b/source/fem-dem/ib_particles_dem.cc
@@ -38,7 +38,7 @@ IBParticlesDEM<dim>::initialize(
   const std::shared_ptr<Parameters::IBParticles<dim>> &p_nsparam,
   const std::shared_ptr<Parameters::Lagrangian::FloatingWalls<dim>>
                                       fw_parameters,
-  const MPI_Comm &                    mpi_communicator_input,
+  const MPI_Comm                     &mpi_communicator_input,
   const std::vector<IBParticle<dim>> &particles)
 {
   parameters                = p_nsparam;
@@ -335,7 +335,7 @@ IBParticlesDEM<dim>::calculate_pp_lubrication_force(
            ++particle_contact_candidates_id)
         {
           const auto &particle_contact_id = *particle_contact_candidates_id;
-          auto &      particle_two        = dem_particles[particle_contact_id];
+          auto       &particle_two        = dem_particles[particle_contact_id];
           if (particle_one.particle_id != particle_two.particle_id and
               particle_one.particle_id < particle_two.particle_id)
             {
@@ -394,9 +394,9 @@ template <int dim>
 void
 IBParticlesDEM<dim>::update_particles_boundary_contact(
   const std::vector<IBParticle<dim>> &particles,
-  const DoFHandler<dim> &             dof_handler,
-  const Quadrature<dim - 1> &         face_quadrature_formula,
-  const Mapping<dim> &                mapping)
+  const DoFHandler<dim>              &dof_handler,
+  const Quadrature<dim - 1>          &face_quadrature_formula,
+  const Mapping<dim>                 &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -10,7 +10,7 @@
 template <int dim>
 void
 GLSVansAssemblerCoreModelB<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Kinematic viscosity at Gauss points
@@ -18,7 +18,7 @@ GLSVansAssemblerCoreModelB<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -194,7 +194,7 @@ GLSVansAssemblerCoreModelB<dim>::assemble_matrix(
 template <int dim>
 void
 GLSVansAssemblerCoreModelB<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -202,7 +202,7 @@ GLSVansAssemblerCoreModelB<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -350,7 +350,7 @@ template class GLSVansAssemblerCoreModelB<3>;
 template <int dim>
 void
 GLSVansAssemblerCoreModelA<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -358,7 +358,7 @@ GLSVansAssemblerCoreModelA<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -543,7 +543,7 @@ GLSVansAssemblerCoreModelA<dim>::assemble_matrix(
 template <int dim>
 void
 GLSVansAssemblerCoreModelA<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -551,7 +551,7 @@ GLSVansAssemblerCoreModelA<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -702,11 +702,11 @@ template class GLSVansAssemblerCoreModelA<3>;
 template <int dim>
 void
 GLSVansAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -764,7 +764,7 @@ GLSVansAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSVansAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Physical properties
@@ -773,7 +773,7 @@ GLSVansAssemblerBDF<dim>::assemble_rhs(
 
   // Loop and quadrature informations
   const double       h          = scratch_data.cell_size;
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -873,7 +873,7 @@ GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   const auto &relative_velocity =
     scratch_data.fluid_particle_relative_velocity_at_particle_location;
   const auto &Re_p      = scratch_data.Re_particle;
-  auto &      beta_drag = scratch_data.beta_drag;
+  auto       &beta_drag = scratch_data.beta_drag;
 
   Tensor<1, dim> drag_force;
 
@@ -944,7 +944,7 @@ GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   const auto &relative_velocity =
     scratch_data.fluid_particle_relative_velocity_at_particle_location;
   const auto &Re_p      = scratch_data.Re_particle;
-  auto &      beta_drag = scratch_data.beta_drag;
+  auto       &beta_drag = scratch_data.beta_drag;
 
   Tensor<1, dim> drag_force;
 
@@ -1012,7 +1012,7 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   const auto &relative_velocity =
     scratch_data.fluid_particle_relative_velocity_at_particle_location;
   const auto &Re_p      = scratch_data.Re_particle;
-  auto &      beta_drag = scratch_data.beta_drag;
+  auto       &beta_drag = scratch_data.beta_drag;
 
   Tensor<1, dim> drag_force;
 
@@ -1074,7 +1074,7 @@ GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   const auto &relative_velocity =
     scratch_data.fluid_particle_relative_velocity_at_particle_location;
   const auto &Re_p      = scratch_data.Re_particle;
-  auto &      beta_drag = scratch_data.beta_drag;
+  auto       &beta_drag = scratch_data.beta_drag;
 
   Tensor<1, dim> drag_force;
 
@@ -1164,7 +1164,7 @@ GLSVansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   const auto &relative_velocity =
     scratch_data.fluid_particle_relative_velocity_at_particle_location;
   const auto &Re_p      = scratch_data.Re_particle;
-  auto &      beta_drag = scratch_data.beta_drag;
+  auto       &beta_drag = scratch_data.beta_drag;
 
 
   Tensor<1, dim> drag_force;
@@ -1246,7 +1246,7 @@ GLSVansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   const auto &relative_velocity =
     scratch_data.fluid_particle_relative_velocity_at_particle_location;
   const auto &Re_p      = scratch_data.Re_particle;
-  auto &      beta_drag = scratch_data.beta_drag;
+  auto       &beta_drag = scratch_data.beta_drag;
 
   Tensor<1, dim> drag_force;
 
@@ -1778,7 +1778,7 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto pic                    = scratch_data.pic;
-  auto &     undisturbed_flow_force = scratch_data.undisturbed_flow_force;
+  auto      &undisturbed_flow_force = scratch_data.undisturbed_flow_force;
   auto       pressure_gradients =
     scratch_data.fluid_pressure_gradients_at_particle_location;
   Tensor<1, dim> pressure_force;
@@ -1833,8 +1833,8 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto pic                    = scratch_data.pic;
-  auto &     undisturbed_flow_force = scratch_data.undisturbed_flow_force;
-  auto &     velocity_laplacians =
+  auto      &undisturbed_flow_force = scratch_data.undisturbed_flow_force;
+  auto      &velocity_laplacians =
     scratch_data.fluid_velocity_laplacian_at_particle_location;
   Tensor<1, dim> shear_force;
 
@@ -1894,11 +1894,11 @@ template class GLSVansAssemblerShearForce<3>;
 template <int dim>
 void
 GLSVansAssemblerFPI<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1962,11 +1962,11 @@ GLSVansAssemblerFPI<dim>::assemble_matrix(
 template <int dim>
 void
 GLSVansAssemblerFPI<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/rpt/particle_visualization.cc
+++ b/source/rpt/particle_visualization.cc
@@ -11,9 +11,9 @@
 
 template <int dim>
 ParticleVisualization<dim>::ParticleVisualization(
-  Triangulation<dim> &              background_triangulation,
-  std::string &                     filename,
-  std::vector<Point<dim>> &         positions,
+  Triangulation<dim>               &background_triangulation,
+  std::string                      &filename,
+  std::vector<Point<dim>>          &positions,
   std::vector<std::vector<double>> &counts)
   : particle_positions(positions)
   , particle_counts(counts)

--- a/source/rpt/rpt_cell_reconstruction.cc
+++ b/source/rpt/rpt_cell_reconstruction.cc
@@ -13,9 +13,9 @@
 
 template <int dim>
 RPTCellReconstruction<dim>::RPTCellReconstruction(
-  Parameters::RPTParameters &              rpt_parameters,
+  Parameters::RPTParameters               &rpt_parameters,
   Parameters::RPTReconstructionParameters &rpt_reconstruction_parameters,
-  Parameters::DetectorParameters &         rpt_detector_parameters)
+  Parameters::DetectorParameters          &rpt_detector_parameters)
   : parameters(rpt_parameters)
   , reconstruction_parameters(rpt_reconstruction_parameters)
   , detector_parameters(rpt_detector_parameters)

--- a/source/rpt/rpt_fem_reconstruction.cc
+++ b/source/rpt/rpt_fem_reconstruction.cc
@@ -495,7 +495,7 @@ template <int dim>
 Vector<double>
 assemble_matrix_and_rhs(
   std::vector<std::vector<double>> &vertex_count,
-  std::vector<double> &             experimental_count,
+  std::vector<double>              &experimental_count,
   Parameters::RPTFEMReconstructionParameters::FEMCostFunction
     &cost_function_type)
 {
@@ -590,7 +590,7 @@ template <int dim>
 double
 RPTFEMReconstruction<dim>::calculate_reference_location_error(
   Vector<double> &reference_location,
-  const double &  last_constraint)
+  const double   &last_constraint)
 {
   std::vector<double> err_coordinates(dim + 1, 0);
   double              norm_error_coordinates = 0;
@@ -633,8 +633,8 @@ template <int dim>
 double
 RPTFEMReconstruction<dim>::calculate_cost(
   const TriaActiveIterator<DoFCellAccessor<dim, dim, false>> &cell,
-  Vector<double> &     reference_location,
-  const double &       last_constraint,
+  Vector<double>      &reference_location,
+  const double        &last_constraint,
   std::vector<double> &experimental_count)
 {
   double cost  = 0;
@@ -695,13 +695,13 @@ template <int dim>
 void
 RPTFEMReconstruction<dim>::search_position_in_reference_space(
   std::vector<std::vector<double>> &count_from_all_detectors,
-  std::vector<double> &             experimental_count,
+  std::vector<double>              &experimental_count,
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  const double &                                        tol_reference_location,
-  double &                                              max_cost,
-  Vector<double> &                                      reference_location,
-  bool &                                                position_found,
-  Point<dim> &                                          real_location)
+  const double                                         &tol_reference_location,
+  double                                               &max_cost,
+  Vector<double>                                       &reference_location,
+  bool                                                 &position_found,
+  Point<dim>                                           &real_location)
 {
   double last_constraint_reference_location;
   double norm_error_coordinates;

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -100,8 +100,8 @@ template <int dim>
 void
 CahnHilliard<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  CahnHilliardScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  CahnHilliardScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!copy_data.cell_is_local)
@@ -196,8 +196,8 @@ template <int dim>
 void
 CahnHilliard<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  CahnHilliardScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  CahnHilliardScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!copy_data.cell_is_local)

--- a/source/solvers/cahn_hilliard_assemblers.cc
+++ b/source/solvers/cahn_hilliard_assemblers.cc
@@ -9,7 +9,7 @@ template <int dim>
 void
 CahnHilliardAssemblerCore<dim>::assemble_matrix(
   CahnHilliardScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Gather physical properties
   const double well_height       = this->cahn_hilliard_parameters.well_height;
@@ -17,7 +17,7 @@ CahnHilliardAssemblerCore<dim>::assemble_matrix(
   const double epsilon           = scratch_data.epsilon;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -142,7 +142,7 @@ template <int dim>
 void
 CahnHilliardAssemblerCore<dim>::assemble_rhs(
   CahnHilliardScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Gather physical properties
   const double well_height       = this->cahn_hilliard_parameters.well_height;
@@ -150,7 +150,7 @@ CahnHilliardAssemblerCore<dim>::assemble_rhs(
   const double epsilon           = scratch_data.epsilon;
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -262,7 +262,7 @@ template <int dim>
 void
 CahnHilliardAssemblerAngleOfContact<dim>::assemble_matrix(
   CahnHilliardScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
@@ -323,7 +323,7 @@ template <int dim>
 void
 CahnHilliardAssemblerAngleOfContact<dim>::assemble_rhs(
   CahnHilliardScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
@@ -379,10 +379,10 @@ template <int dim>
 void
 CahnHilliardAssemblerBDF<dim>::assemble_matrix(
   CahnHilliardScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -423,10 +423,10 @@ template <int dim>
 void
 CahnHilliardAssemblerBDF<dim>::assemble_rhs(
   CahnHilliardScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/solvers/flow_control.cc
+++ b/source/solvers/flow_control.cc
@@ -17,8 +17,8 @@ FlowControl<dim>::FlowControl(
 
 template <int dim>
 void
-FlowControl<dim>::calculate_beta(const double &      average_velocity_n,
-                                 const double &      dt,
+FlowControl<dim>::calculate_beta(const double       &average_velocity_n,
+                                 const double       &dt,
                                  const unsigned int &step_number)
 {
   double beta_n1;

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -224,8 +224,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -351,8 +351,8 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -120,7 +120,7 @@ GLSNavierStokesSolver<dim>::setup_dofs_fd()
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);
   this->local_evaluation_point.reinit(this->locally_owned_dofs,
                                       this->mpi_communicator);
-  auto &                 nonzero_constraints = this->get_nonzero_constraints();
+  auto                  &nonzero_constraints = this->get_nonzero_constraints();
   DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
@@ -679,8 +679,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -889,8 +889,8 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  NavierStokesScratchData<dim> &                        scratch_data,
-  StabilizedMethodsTensorCopyData<dim> &                copy_data)
+  NavierStokesScratchData<dim>                         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim>                 &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -1365,8 +1365,8 @@ GLSNavierStokesSolver<dim>::setup_AMG()
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .amg_smoother_overlap;
   const bool                                        output_details = false;
-  const char *                                      smoother_type  = "ILU";
-  const char *                                      coarse_type    = "ILU";
+  const char                                       *smoother_type  = "ILU";
+  const char                                       *coarse_type    = "ILU";
   TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
     elliptic,
     higher_order_elements,

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -409,8 +409,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  HeatTransferScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -560,8 +560,8 @@ template <int dim>
 void
 HeatTransfer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  HeatTransferScratchData<dim> &                        scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  HeatTransferScratchData<dim>                         &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -1201,7 +1201,7 @@ HeatTransfer<dim>::postprocess_temperature_statistics(
                              update_values | update_JxW_values);
 
   // Initialize VOF information
-  const DoFHandler<dim> *        dof_handler_vof = NULL;
+  const DoFHandler<dim>         *dof_handler_vof = NULL;
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            filtered_phase_values(n_q_points);
 
@@ -1401,7 +1401,7 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
                                       update_values);
 
   // Initialize VOF information
-  DoFHandler<dim> *                  dof_handler_vof = NULL;
+  DoFHandler<dim>                   *dof_handler_vof = NULL;
   std::shared_ptr<FEFaceValues<dim>> fe_face_values_vof;
   std::vector<double>                filtered_phase_values(n_q_points_face);
 
@@ -1677,7 +1677,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
   const bool                       gather_vof,
   const Parameters::FluidIndicator monitored_fluid,
   const std::string                domain_name,
-  const VectorType &               current_solution_fd)
+  const VectorType                &current_solution_fd)
 {
   const unsigned int n_q_points       = this->cell_quadrature->size();
   const MPI_Comm     mpi_communicator = this->dof_handler.get_communicator();
@@ -1701,7 +1701,7 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
                              update_values);
 
   // Initialize VOF information
-  const DoFHandler<dim> *        dof_handler_vof = NULL;
+  const DoFHandler<dim>         *dof_handler_vof = NULL;
   std::shared_ptr<FEValues<dim>> fe_values_vof;
   std::vector<double>            filtered_phase_values(n_q_points);
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -791,15 +791,18 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
       gather_vof = true;
       switch (monitored_fluid)
         {
-            default: {
+          default:
+            {
               domain_name = "fluid";
               break;
             }
-            case Parameters::FluidIndicator::fluid0: {
+          case Parameters::FluidIndicator::fluid0:
+            {
               domain_name = "fluid_0";
               break;
             }
-            case Parameters::FluidIndicator::fluid1: {
+          case Parameters::FluidIndicator::fluid1:
+            {
               domain_name = "fluid_1";
               break;
             }
@@ -1433,7 +1436,8 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
 
   switch (properties_manager.get_number_of_fluids())
     {
-        default: {
+      default:
+        {
           // Get values for monophase flow
           const auto density_model = properties_manager.get_density();
           const auto specific_heat_model =
@@ -1447,7 +1451,8 @@ HeatTransfer<dim>::postprocess_heat_flux_on_bc(
 
           break;
         }
-        case 2: {
+      case 2:
+        {
           // Get prm values for multiphase flow - will be blended in the
           // integration loop
           const auto density_models = properties_manager.get_density_vector();
@@ -1728,7 +1733,8 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
 
   switch (properties_manager.get_number_of_fluids())
     {
-        default: {
+      default:
+        {
           // Get values for monophase flow
           const auto density_model = properties_manager.get_density();
           const auto specific_heat_model =
@@ -1739,7 +1745,8 @@ HeatTransfer<dim>::postprocess_thermal_energy_in_fluid(
 
           break;
         }
-        case 2: {
+      case 2:
+        {
           // Get prm values for multiphase flow - will be blended in the
           // integration loop
           const auto density_models = properties_manager.get_density_vector();
@@ -1906,13 +1913,15 @@ HeatTransfer<dim>::set_phase_coefficient(
 
   switch (monitored_fluid)
     {
-        default: {
+      default:
+        {
           // Parameters::FluidIndicator::both
           phase_coefficient               = 1.;
           point_is_in_postprocessed_fluid = true;
           break;
         }
-        case Parameters::FluidIndicator::fluid0: {
+      case Parameters::FluidIndicator::fluid0:
+        {
           if (gather_vof)
             {
               phase_coefficient = 1. - phase_value_q;
@@ -1928,7 +1937,8 @@ HeatTransfer<dim>::set_phase_coefficient(
             }
           break;
         }
-        case Parameters::FluidIndicator::fluid1: {
+      case Parameters::FluidIndicator::fluid1:
+        {
           if (gather_vof)
             {
               phase_coefficient = phase_value_q;

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -10,7 +10,7 @@ template <int dim>
 void
 HeatTransferAssemblerCore<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
@@ -21,7 +21,7 @@ HeatTransferAssemblerCore<dim>::assemble_matrix(
 
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const double       h          = scratch_data.cell_size;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -112,7 +112,7 @@ template <int dim>
 void
 HeatTransferAssemblerCore<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   const auto         method = this->simulation_control->get_assembly_method();
   const unsigned int n_q_points = scratch_data.n_q_points;
@@ -201,10 +201,10 @@ template <int dim>
 void
 HeatTransferAssemblerBDF<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -296,7 +296,7 @@ template <int dim>
 void
 HeatTransferAssemblerBDF<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Gather physical properties in case of mono fluids simulations (to be
   // modified by cell in case of multiple fluids simulations)
@@ -305,7 +305,7 @@ HeatTransferAssemblerBDF<dim>::assemble_rhs(
 
 
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -381,11 +381,11 @@ template <int dim>
 void
 HeatTransferAssemblerRobinBC<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
-  auto &       local_matrix = copy_data.local_matrix;
+  auto        &local_matrix = copy_data.local_matrix;
   const double Stefan_Boltzmann_constant =
     this->boundary_conditions_ht.Stefan_Boltzmann_constant;
 
@@ -436,12 +436,12 @@ template <int dim>
 void
 HeatTransferAssemblerRobinBC<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
     return;
 
-  auto &       local_rhs = copy_data.local_rhs;
+  auto        &local_rhs = copy_data.local_rhs;
   const double Stefan_Boltzmann_constant =
     this->boundary_conditions_ht.Stefan_Boltzmann_constant;
 
@@ -509,7 +509,7 @@ template <int dim>
 void
 HeatTransferAssemblerViscousDissipation<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -566,7 +566,7 @@ template <int dim>
 void
 HeatTransferAssemblerViscousDissipationVOF<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
@@ -654,7 +654,7 @@ template <int dim>
 void
 HeatTransferAssemblerLaser<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Laser parameters
   const double concentration_factor = laser_parameters->concentration_factor;
@@ -802,7 +802,7 @@ template <int dim>
 void
 HeatTransferAssemblerLaserVOF<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Laser parameters
   const double concentration_factor = laser_parameters->concentration_factor;
@@ -949,7 +949,7 @@ template <int dim>
 void
 HeatTransferAssemblerFreeSurfaceRadiationVOF<dim>::assemble_matrix(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Loop and quadrature informations
   const unsigned int n_q_points = scratch_data.n_q_points;
@@ -1003,7 +1003,7 @@ template <int dim>
 void
 HeatTransferAssemblerFreeSurfaceRadiationVOF<dim>::assemble_rhs(
   HeatTransferScratchData<dim> &scratch_data,
-  StabilizedMethodsCopyData &   copy_data)
+  StabilizedMethodsCopyData    &copy_data)
 {
   // Loop and quadrature informations
   const unsigned int n_q_points = scratch_data.n_q_points;

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -71,9 +71,9 @@ HeatTransferScratchData<dim>::allocate()
 template <int dim>
 void
 HeatTransferScratchData<dim>::enable_vof(
-  const FiniteElement<dim> &         fe,
-  const Quadrature<dim> &            quadrature,
-  const Mapping<dim> &               mapping,
+  const FiniteElement<dim>          &fe,
+  const Quadrature<dim>             &quadrature,
+  const Mapping<dim>                &mapping,
   const Parameters::VOF_PhaseFilter &phase_filter_parameters)
 {
   gather_vof    = true;
@@ -105,9 +105,9 @@ HeatTransferScratchData<dim>::enable_vof(
 template <int dim>
 void
 HeatTransferScratchData<dim>::enable_vof(
-  const FiniteElement<dim> &                      fe,
-  const Quadrature<dim> &                         quadrature,
-  const Mapping<dim> &                            mapping,
+  const FiniteElement<dim>                       &fe,
+  const Quadrature<dim>                          &quadrature,
+  const Mapping<dim>                             &mapping,
   const std::shared_ptr<VolumeOfFluidFilterBase> &filter)
 {
   gather_vof    = true;

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -170,7 +170,8 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
     {
       switch (properties_manager.get_number_of_fluids())
         {
-            case 1: {
+          case 1:
+            {
               const auto density_model = properties_manager.get_density();
               const auto specific_heat_model =
                 properties_manager.get_specific_heat();
@@ -189,7 +190,8 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
 
               break;
             }
-            case 2: {
+          case 2:
+            {
               const auto density_models =
                 properties_manager.get_density_vector();
               const auto specific_heat_models =

--- a/source/solvers/isothermal_compressible_navier_stokes_assembler.cc
+++ b/source/solvers/isothermal_compressible_navier_stokes_assembler.cc
@@ -8,7 +8,7 @@
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Physical properties
@@ -18,7 +18,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerCore<dim>::assemble_matrix(
   const double density_psi = scratch_data.density_psi;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -198,7 +198,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Physical properties
@@ -208,7 +208,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerCore<dim>::assemble_rhs(
   const double density_psi = scratch_data.density_psi;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -318,7 +318,7 @@ template class GLSIsothermalCompressibleNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Physical properties
@@ -326,7 +326,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerBDF<dim>::assemble_matrix(
   const double               density_psi    = scratch_data.density_psi;
 
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -370,7 +370,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerBDF<dim>::assemble_matrix(
           const Tensor<1, dim> &phi_u_i = scratch_data.phi_u[q][i];
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const double &        phi_p_j = scratch_data.phi_p[q][j];
+              const double         &phi_p_j = scratch_data.phi_p[q][j];
               const Tensor<1, dim> &phi_u_j = scratch_data.phi_u[q][j];
 
               local_matrix(i, j) +=
@@ -385,7 +385,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Physical properties
@@ -393,7 +393,7 @@ GLSIsothermalCompressibleNavierStokesAssemblerBDF<dim>::assemble_rhs(
   const double               density_psi    = scratch_data.density_psi;
 
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/solvers/isothermal_compressible_navier_stokes_vof_assembler.cc
+++ b/source/solvers/isothermal_compressible_navier_stokes_vof_assembler.cc
@@ -7,11 +7,11 @@
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -177,11 +177,11 @@ GLSIsothermalCompressibleNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -307,11 +307,11 @@ template class GLSIsothermalCompressibleNavierStokesVOFAssemblerCore<3>;
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -375,11 +375,11 @@ GLSIsothermalCompressibleNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSIsothermalCompressibleNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -26,7 +26,7 @@
  */
 template <int dim, typename Number>
 VectorizedArray<Number>
-evaluate_function(const Function<dim> &                      function,
+evaluate_function(const Function<dim>                       &function,
                   const Point<dim, VectorizedArray<Number>> &p_vectorized)
 {
   VectorizedArray<Number> result;
@@ -52,7 +52,7 @@ evaluate_function(const Function<dim> &                      function,
  */
 template <int dim, typename Number, int components>
 Tensor<1, components, VectorizedArray<Number>>
-evaluate_function(const Function<dim> &                      function,
+evaluate_function(const Function<dim>                       &function,
                   const Point<dim, VectorizedArray<Number>> &p_vectorized)
 {
   Tensor<1, components, VectorizedArray<Number>> result;
@@ -73,11 +73,11 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase()
 
 template <int dim, typename number>
 NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
-  const Mapping<dim> &             mapping,
-  const DoFHandler<dim> &          dof_handler,
+  const Mapping<dim>              &mapping,
+  const DoFHandler<dim>           &dof_handler,
   const AffineConstraints<number> &constraints,
-  const Quadrature<dim> &          quadrature,
-  const Function<dim> *            forcing_function,
+  const Quadrature<dim>           &quadrature,
+  const Function<dim>             *forcing_function,
   const double                     kinematic_viscosity,
   const unsigned int               mg_level)
 {
@@ -93,11 +93,11 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
 template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::reinit(
-  const Mapping<dim> &             mapping,
-  const DoFHandler<dim> &          dof_handler,
+  const Mapping<dim>              &mapping,
+  const DoFHandler<dim>           &dof_handler,
   const AffineConstraints<number> &constraints,
-  const Quadrature<dim> &          quadrature,
-  const Function<dim> *            forcing_function,
+  const Quadrature<dim>           &quadrature,
+  const Function<dim>             *forcing_function,
   const double                     kinematic_viscosity,
   const unsigned int               mg_level)
 {
@@ -264,7 +264,7 @@ NavierStokesOperatorBase<dim, number>::initialize_dof_vector(
 
 template <int dim, typename number>
 void
-NavierStokesOperatorBase<dim, number>::vmult(VectorType &      dst,
+NavierStokesOperatorBase<dim, number>::vmult(VectorType       &dst,
                                              const VectorType &src) const
 {
   // save values for edge constrained dofs and set them to 0 in src vector
@@ -299,7 +299,7 @@ NavierStokesOperatorBase<dim, number>::vmult(VectorType &      dst,
 
 template <int dim, typename number>
 void
-NavierStokesOperatorBase<dim, number>::Tvmult(VectorType &      dst,
+NavierStokesOperatorBase<dim, number>::Tvmult(VectorType       &dst,
                                               const VectorType &src) const
 {
   this->vmult(dst, src);
@@ -308,7 +308,7 @@ NavierStokesOperatorBase<dim, number>::Tvmult(VectorType &      dst,
 template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::vmult_interface_down(
-  VectorType &      dst,
+  VectorType       &dst,
   VectorType const &src) const
 {
   this->matrix_free.cell_loop(
@@ -323,7 +323,7 @@ NavierStokesOperatorBase<dim, number>::vmult_interface_down(
 template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::vmult_interface_up(
-  VectorType &      dst,
+  VectorType       &dst,
   VectorType const &src) const
 {
   if (has_edge_constrained_indices == false)
@@ -432,7 +432,7 @@ NavierStokesOperatorBase<dim, number>::evaluate_non_linear_term(
 
 template <int dim, typename number>
 void
-NavierStokesOperatorBase<dim, number>::evaluate_residual(VectorType &      dst,
+NavierStokesOperatorBase<dim, number>::evaluate_residual(VectorType       &dst,
                                                          const VectorType &src)
 {
   this->matrix_free.cell_loop(
@@ -474,9 +474,9 @@ NavierStokesOperatorBase<dim, number>::do_cell_integral_local(
 template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::local_evaluate_residual(
-  const MatrixFree<dim, number> &              matrix_free,
-  VectorType &                                 dst,
-  const VectorType &                           src,
+  const MatrixFree<dim, number>               &matrix_free,
+  VectorType                                  &dst,
+  const VectorType                            &src,
   const std::pair<unsigned int, unsigned int> &range) const
 {
   (void)matrix_free;
@@ -493,9 +493,9 @@ NavierStokesOperatorBase<dim, number>::local_evaluate_residual(
 template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::do_cell_integral_range(
-  const MatrixFree<dim, number> &              matrix_free,
-  VectorType &                                 dst,
-  const VectorType &                           src,
+  const MatrixFree<dim, number>               &matrix_free,
+  VectorType                                  &dst,
+  const VectorType                            &src,
   const std::pair<unsigned int, unsigned int> &range) const
 {
   FECellIntegrator integrator(matrix_free, range);
@@ -704,9 +704,9 @@ NavierStokesSUPGPSPGOperator<dim, number>::do_cell_integral_local(
 template <int dim, typename number>
 void
 NavierStokesSUPGPSPGOperator<dim, number>::local_evaluate_residual(
-  const MatrixFree<dim, number> &              matrix_free,
-  VectorType &                                 dst,
-  const VectorType &                           src,
+  const MatrixFree<dim, number>               &matrix_free,
+  VectorType                                  &dst,
+  const VectorType                            &src,
   const std::pair<unsigned int, unsigned int> &range) const
 {
   FECellIntegrator integrator(matrix_free);

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -65,10 +65,10 @@ DeclException1(
 
 template <int dim>
 MultiphysicsInterface<dim>::MultiphysicsInterface(
-  const SimulationParameters<dim> &                            nsparam,
+  const SimulationParameters<dim>                             &nsparam,
   std::shared_ptr<parallel::DistributedTriangulationBase<dim>> p_triangulation,
   std::shared_ptr<SimulationControl> p_simulation_control,
-  ConditionalOStream &               p_pcout)
+  ConditionalOStream                &p_pcout)
   : multiphysics_parameters(nsparam.multiphysics)
   // ,
   // verbosity(nsparam.non_linear_solver.at(PhysicsID::fluid_dynamics).verbosity)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -9,7 +9,7 @@
 template <int dim>
 void
 PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -17,7 +17,7 @@ PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -185,7 +185,7 @@ PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -193,7 +193,7 @@ PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -302,7 +302,7 @@ template class PSPGSUPGNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -310,7 +310,7 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -486,7 +486,7 @@ GLSNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -494,7 +494,7 @@ GLSNavierStokesAssemblerCore<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -614,7 +614,7 @@ template class GLSNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -622,7 +622,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -804,7 +804,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -812,7 +812,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -941,11 +941,11 @@ template class GLSNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1028,12 +1028,12 @@ GLSNavierStokesAssemblerSRF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerSRF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW               = scratch_data.JxW;
-  const auto &       quadrature_points = scratch_data.quadrature_points;
+  const auto        &JxW               = scratch_data.JxW;
+  const auto        &quadrature_points = scratch_data.quadrature_points;
   const unsigned int n_q_points        = scratch_data.n_q_points;
   const unsigned int n_dofs            = scratch_data.n_dofs;
 
@@ -1116,11 +1116,11 @@ template class GLSNavierStokesAssemblerSRF<3>;
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1174,11 +1174,11 @@ GLSNavierStokesAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1230,7 +1230,7 @@ template class GLSNavierStokesAssemblerBDF<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -1238,7 +1238,7 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1318,7 +1318,7 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -1326,7 +1326,7 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1392,7 +1392,7 @@ template class GDNavierStokesAssemblerNonNewtonianCore<3>;
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -1400,7 +1400,7 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1479,7 +1479,7 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GDNavierStokesAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Scheme and physical properties
@@ -1487,7 +1487,7 @@ GDNavierStokesAssemblerCore<dim>::assemble_rhs(
     scratch_data.kinematic_viscosity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1551,11 +1551,11 @@ template class GDNavierStokesAssemblerCore<3>;
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec       = scratch_data.JxW;
+  const auto        &JxW_vec       = scratch_data.JxW;
   const unsigned int n_q_points    = scratch_data.n_q_points;
   const unsigned int n_dofs        = scratch_data.n_dofs;
   const double kinematic_viscosity = scratch_data.kinematic_viscosity_scale;
@@ -1611,14 +1611,14 @@ LaplaceAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 LaplaceAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec       = scratch_data.JxW;
+  const auto        &JxW_vec       = scratch_data.JxW;
   const unsigned int n_q_points    = scratch_data.n_q_points;
   const unsigned int n_dofs        = scratch_data.n_dofs;
-  auto &             local_rhs     = copy_data.local_rhs;
+  auto              &local_rhs     = copy_data.local_rhs;
   const double kinematic_viscosity = scratch_data.kinematic_viscosity_scale;
   const double h                   = scratch_data.cell_size;
 
@@ -1680,11 +1680,11 @@ BuoyancyAssembly<dim>::assemble_matrix(
 template <int dim>
 void
 BuoyancyAssembly<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -1727,7 +1727,7 @@ template class BuoyancyAssembly<3>;
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1810,7 +1810,7 @@ PressureBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PressureBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1894,7 +1894,7 @@ template class PressureBoundaryCondition<3>;
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -1999,7 +1999,7 @@ WeakDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 WeakDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -2104,7 +2104,7 @@ template class WeakDirichletBoundaryCondition<3>;
 template <int dim>
 void
 PartialSlipDirichletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -2242,7 +2242,7 @@ PartialSlipDirichletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 PartialSlipDirichletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -2378,7 +2378,7 @@ template class PartialSlipDirichletBoundaryCondition<3>;
 template <int dim>
 void
 OutletBoundaryCondition<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)
@@ -2459,7 +2459,7 @@ OutletBoundaryCondition<dim>::assemble_matrix(
 template <int dim>
 void
 OutletBoundaryCondition<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!scratch_data.is_boundary_cell)

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -860,7 +860,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   Vector<float> estimated_error_per_cell(tria.n_active_cells());
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  auto &                           present_solution = this->present_solution;
+  auto                            &present_solution = this->present_solution;
 
   // Global flags
   // Their dimension is consistent with the dimension returned by
@@ -2014,7 +2014,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
             1, DataComponentInterpretation::component_is_scalar);
 
         std::vector<std::string> qcriterion_name = {"qcriterion"};
-        const DoFHandler<dim> &  dof_handler_qcriterion =
+        const DoFHandler<dim>   &dof_handler_qcriterion =
           qcriterion_smoothing.get_dof_handler();
         data_out.add_data_vector(dof_handler_qcriterion,
                                  qcriterion_field,
@@ -2033,7 +2033,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
             1, DataComponentInterpretation::component_is_scalar);
 
         std::vector<std::string> continuity_name = {"velocity_divergence"};
-        const DoFHandler<dim> &  dof_handler_qcriterion =
+        const DoFHandler<dim>   &dof_handler_qcriterion =
           continuity_smoothing.get_dof_handler();
         data_out.add_data_vector(dof_handler_qcriterion,
                                  continuity_field,

--- a/source/solvers/navier_stokes_cahn_hilliard_assemblers.cc
+++ b/source/solvers/navier_stokes_cahn_hilliard_assemblers.cc
@@ -9,7 +9,7 @@
 template <int dim>
 void
 GLSNavierStokesCahnHilliardAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   const double well_height  = scratch_data.well_height;
@@ -17,7 +17,7 @@ GLSNavierStokesCahnHilliardAssemblerCore<dim>::assemble_matrix(
   const double density_diff = scratch_data.density_diff;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -200,7 +200,7 @@ GLSNavierStokesCahnHilliardAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesCahnHilliardAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   const double well_height  = scratch_data.well_height;
@@ -209,7 +209,7 @@ GLSNavierStokesCahnHilliardAssemblerCore<dim>::assemble_rhs(
   const double h            = scratch_data.cell_size;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -357,11 +357,11 @@ template class GLSNavierStokesCahnHilliardAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesCahnHilliardAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -418,11 +418,11 @@ GLSNavierStokesCahnHilliardAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesCahnHilliardAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -332,7 +332,8 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
 
   switch (properties_manager.get_number_of_fluids())
     {
-        case 1: {
+      case 1:
+        {
           // In the case of an incompressible flow, viscosity is the only
           // required property
           const auto rheology_model = properties_manager.get_rheology();
@@ -369,7 +370,8 @@ NavierStokesScratchData<dim>::calculate_physical_properties()
             }
           break;
         }
-        case 2: {
+      case 2:
+        {
           // We need both density and viscosity
           const auto density_model_0  = properties_manager.get_density(0);
           const auto rheology_model_0 = properties_manager.get_rheology(0);

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -90,9 +90,9 @@ NavierStokesScratchData<dim>::allocate()
 template <int dim>
 void
 NavierStokesScratchData<dim>::enable_vof(
-  const FiniteElement<dim> &         fe,
-  const Quadrature<dim> &            quadrature,
-  const Mapping<dim> &               mapping,
+  const FiniteElement<dim>          &fe,
+  const Quadrature<dim>             &quadrature,
+  const Mapping<dim>                &mapping,
   const Parameters::VOF_PhaseFilter &phase_filter_parameters)
 {
   gather_vof    = true;
@@ -128,9 +128,9 @@ NavierStokesScratchData<dim>::enable_vof(
 template <int dim>
 void
 NavierStokesScratchData<dim>::enable_vof(
-  const FiniteElement<dim> &                      fe,
-  const Quadrature<dim> &                         quadrature,
-  const Mapping<dim> &                            mapping,
+  const FiniteElement<dim>                       &fe,
+  const Quadrature<dim>                          &quadrature,
+  const Mapping<dim>                             &mapping,
   const std::shared_ptr<VolumeOfFluidFilterBase> &filter)
 {
   gather_vof    = true;
@@ -167,8 +167,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_cahn_hilliard(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim> &   quadrature,
-  const Mapping<dim> &      mapping)
+  const Quadrature<dim>    &quadrature,
+  const Mapping<dim>       &mapping)
 {
   gather_cahn_hilliard    = true;
   fe_values_cahn_hilliard = std::make_shared<FEValues<dim>>(
@@ -206,8 +206,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_projected_phase_fraction_gradient(
   const FiniteElement<dim> &fe_projected_phase_fraction_gradient,
-  const Quadrature<dim> &   quadrature,
-  const Mapping<dim> &      mapping)
+  const Quadrature<dim>    &quadrature,
+  const Mapping<dim>       &mapping)
 {
   gather_projected_phase_fraction_gradient = true;
   fe_values_projected_phase_fraction_gradient =
@@ -226,8 +226,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_curvature(
   const FiniteElement<dim> &fe_curvature,
-  const Quadrature<dim> &   quadrature,
-  const Mapping<dim> &      mapping)
+  const Quadrature<dim>    &quadrature,
+  const Mapping<dim>       &mapping)
 {
   gather_curvature    = true;
   fe_values_curvature = std::make_shared<FEValues<dim>>(
@@ -242,8 +242,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_void_fraction(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim> &   quadrature,
-  const Mapping<dim> &      mapping)
+  const Quadrature<dim>    &quadrature,
+  const Mapping<dim>       &mapping)
 {
   gather_void_fraction    = true;
   fe_values_void_fraction = std::make_shared<FEValues<dim>>(
@@ -284,8 +284,8 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::enable_heat_transfer(
   const FiniteElement<dim> &fe,
-  const Quadrature<dim> &   quadrature,
-  const Mapping<dim> &      mapping)
+  const Quadrature<dim>    &quadrature,
+  const Mapping<dim>       &mapping)
 {
   gather_temperature    = true;
   fe_values_temperature = std::make_shared<FEValues<dim>>(

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -9,11 +9,11 @@
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -180,11 +180,11 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -317,11 +317,11 @@ template class GLSNavierStokesVOFAssemblerCore<3>;
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -379,11 +379,11 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -445,11 +445,11 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -464,7 +464,7 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
       const double surface_tension_coef = scratch_data.surface_tension[q];
 
       // Gather pfg and curvature values
-      const double &        curvature_value = scratch_data.curvature_values[q];
+      const double         &curvature_value = scratch_data.curvature_values[q];
       const Tensor<1, dim> &phase_gradient_value =
         scratch_data.filtered_phase_gradient_values[q];
       const double JxW_value = JxW[q];
@@ -499,7 +499,7 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Densities of phases
@@ -508,7 +508,7 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
            "GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs"));
 
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -573,11 +573,11 @@ template class GLSNavierStokesVOFAssemblerMarangoni<3>;
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -766,11 +766,11 @@ GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_matrix(
 template <int dim>
 void
 GLSNavierStokesVOFAssemblerNonNewtonianCore<dim>::assemble_rhs(
-  NavierStokesScratchData<dim> &        scratch_data,
+  NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -34,11 +34,11 @@ using namespace dealii;
 
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
+calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
                         std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType &            evaluation_point,
-                        const Quadrature<dim> &       cell_quadrature_formula,
-                        const Quadrature<dim - 1> &   face_quadrature_formula,
+                        const VectorType             &evaluation_point,
+                        const Quadrature<dim>        &cell_quadrature_formula,
+                        const Quadrature<dim - 1>    &face_quadrature_formula,
                         const unsigned int            inlet_boundary_id,
                         const unsigned int            outlet_boundary_id)
 {
@@ -165,71 +165,71 @@ calculate_pressure_drop(const DoFHandler<dim> &       dof_handler,
 
 template std::pair<double, double>
 calculate_pressure_drop<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   std::shared_ptr<Mapping<2>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                cell_quadrature_formula,
-  const Quadrature<1> &                face_quadrature_formula,
+  const Quadrature<2>                 &cell_quadrature_formula,
+  const Quadrature<1>                 &face_quadrature_formula,
   const unsigned int                   inlet_boundary_id,
   const unsigned int                   outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   std::shared_ptr<Mapping<3>>          mapping,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                cell_quadrature_formula,
-  const Quadrature<2> &                face_quadrature_formula,
+  const Quadrature<3>                 &cell_quadrature_formula,
+  const Quadrature<2>                 &face_quadrature_formula,
   const unsigned int                   inlet_boundary_id,
   const unsigned int                   outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   std::shared_ptr<Mapping<2>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     cell_quadrature_formula,
-  const Quadrature<1> &                     face_quadrature_formula,
+  const Quadrature<2>                      &cell_quadrature_formula,
+  const Quadrature<1>                      &face_quadrature_formula,
   const unsigned int                        inlet_boundary_id,
   const unsigned int                        outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   std::shared_ptr<Mapping<3>>               mapping,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     cell_quadrature_formula,
-  const Quadrature<2> &                     face_quadrature_formula,
+  const Quadrature<3>                      &cell_quadrature_formula,
+  const Quadrature<2>                      &face_quadrature_formula,
   const unsigned int                        inlet_boundary_id,
   const unsigned int                        outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   std::shared_ptr<Mapping<2>>                       mapping,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<2> &                             cell_quadrature_formula,
-  const Quadrature<1> &                             face_quadrature_formula,
+  const Quadrature<2>                              &cell_quadrature_formula,
+  const Quadrature<1>                              &face_quadrature_formula,
   const unsigned int                                inlet_boundary_id,
   const unsigned int                                outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   std::shared_ptr<Mapping<3>>                       mapping,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<3> &                             cell_quadrature_formula,
-  const Quadrature<2> &                             face_quadrature_formula,
+  const Quadrature<3>                              &cell_quadrature_formula,
+  const Quadrature<2>                              &face_quadrature_formula,
   const unsigned int                                inlet_boundary_id,
   const unsigned int                                outlet_boundary_id);
 
 template <int dim, typename VectorType>
 double
 calculate_CFL(const DoFHandler<dim> &dof_handler,
-              const VectorType &     evaluation_point,
+              const VectorType      &evaluation_point,
               const double           time_step,
               const Quadrature<dim> &quadrature_formula,
-              const Mapping<dim> &   mapping)
+              const Mapping<dim>    &mapping)
 {
   FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>      fe_values(mapping,
@@ -279,59 +279,59 @@ calculate_CFL(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_CFL<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
   const double                         time_step,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_CFL<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
   const double                         time_step,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_CFL<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const double                              time_step,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_CFL<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
   const double                              time_step,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 template double
 calculate_CFL<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
   const double                                      time_step,
-  const Quadrature<2> &                             quadrature_formula,
-  const Mapping<2> &                                mapping);
+  const Quadrature<2>                              &quadrature_formula,
+  const Mapping<2>                                 &mapping);
 
 template double
 calculate_CFL<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
   const double                                      time_step,
-  const Quadrature<3> &                             quadrature_formula,
-  const Mapping<3> &                                mapping);
+  const Quadrature<3>                              &quadrature_formula,
+  const Mapping<3>                                 &mapping);
 
 
 template <int dim, typename VectorType>
 double
 calculate_enstrophy(const DoFHandler<dim> &dof_handler,
-                    const VectorType &     evaluation_point,
+                    const VectorType      &evaluation_point,
                     const Quadrature<dim> &quadrature_formula,
-                    const Mapping<dim> &   mapping)
+                    const Mapping<dim>    &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -393,52 +393,52 @@ calculate_enstrophy(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_enstrophy<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_enstrophy<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_enstrophy<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_enstrophy<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 template double
 calculate_enstrophy<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<2> &                             quadrature_formula,
-  const Mapping<2> &                                mapping);
+  const Quadrature<2>                              &quadrature_formula,
+  const Mapping<2>                                 &mapping);
 
 template double
 calculate_enstrophy<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<3> &                             quadrature_formula,
-  const Mapping<3> &                                mapping);
+  const Quadrature<3>                              &quadrature_formula,
+  const Mapping<3>                                 &mapping);
 
 template <int dim, typename VectorType>
 double
 calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
-                         const VectorType &     evaluation_point,
+                         const VectorType      &evaluation_point,
                          const Quadrature<dim> &quadrature_formula,
-                         const Mapping<dim> &   mapping)
+                         const Mapping<dim>    &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -488,53 +488,53 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_kinetic_energy<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_kinetic_energy<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_kinetic_energy<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_kinetic_energy<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 template double
 calculate_kinetic_energy<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<2> &                             quadrature_formula,
-  const Mapping<2> &                                mapping);
+  const Quadrature<2>                              &quadrature_formula,
+  const Mapping<2>                                 &mapping);
 
 template double
 calculate_kinetic_energy<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<3> &                             quadrature_formula,
-  const Mapping<3> &                                mapping);
+  const Quadrature<3>                              &quadrature_formula,
+  const Mapping<3>                                 &mapping);
 
 
 template <int dim, typename VectorType>
 double
-calculate_apparent_viscosity(const DoFHandler<dim> &    dof_handler,
-                             const VectorType &         evaluation_point,
-                             const Quadrature<dim> &    quadrature_formula,
-                             const Mapping<dim> &       mapping,
+calculate_apparent_viscosity(const DoFHandler<dim>     &dof_handler,
+                             const VectorType          &evaluation_point,
+                             const Quadrature<dim>     &quadrature_formula,
+                             const Mapping<dim>        &mapping,
                              PhysicalPropertiesManager &properties_manager)
 {
   double         integral_viscosity_x_shear_rate = 0;
@@ -606,61 +606,61 @@ calculate_apparent_viscosity(const DoFHandler<dim> &    dof_handler,
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping,
-  PhysicalPropertiesManager &          properties_manager);
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping,
+  PhysicalPropertiesManager           &properties_manager);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &evaluation_point,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping,
-  PhysicalPropertiesManager &          properties_manager);
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping,
+  PhysicalPropertiesManager           &properties_manager);
 
 template double
 calculate_apparent_viscosity<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<2> &                     quadrature_formula,
-  const Mapping<2> &                        mapping,
-  PhysicalPropertiesManager &               properties_manager);
+  const Quadrature<2>                      &quadrature_formula,
+  const Mapping<2>                         &mapping,
+  PhysicalPropertiesManager                &properties_manager);
 
 template double
 calculate_apparent_viscosity<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &evaluation_point,
-  const Quadrature<3> &                     quadrature_formula,
-  const Mapping<3> &                        mapping,
-  PhysicalPropertiesManager &               properties_manager);
+  const Quadrature<3>                      &quadrature_formula,
+  const Mapping<3>                         &mapping,
+  PhysicalPropertiesManager                &properties_manager);
 
 template double
 calculate_apparent_viscosity<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<2> &                             quadrature_formula,
-  const Mapping<2> &                                mapping,
-  PhysicalPropertiesManager &                       properties_manager);
+  const Quadrature<2>                              &quadrature_formula,
+  const Mapping<2>                                 &mapping,
+  PhysicalPropertiesManager                        &properties_manager);
 
 template double
 calculate_apparent_viscosity<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
-  const Quadrature<3> &                             quadrature_formula,
-  const Mapping<3> &                                mapping,
-  PhysicalPropertiesManager &                       properties_manager);
+  const Quadrature<3>                              &quadrature_formula,
+  const Mapping<3>                                 &mapping,
+  PhysicalPropertiesManager                        &properties_manager);
 
 template <int dim, typename VectorType>
 std::vector<std::vector<Tensor<1, dim>>>
 calculate_forces(
-  const DoFHandler<dim> &                              dof_handler,
-  const VectorType &                                   evaluation_point,
-  PhysicalPropertiesManager &                          properties_manager,
+  const DoFHandler<dim>                               &dof_handler,
+  const VectorType                                    &evaluation_point,
+  PhysicalPropertiesManager                           &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1> &                          face_quadrature_formula,
-  const Mapping<dim> &                                 mapping)
+  const Quadrature<dim - 1>                           &face_quadrature_formula,
+  const Mapping<dim>                                  &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -779,66 +779,66 @@ calculate_forces(
 
 template std::vector<std::vector<Tensor<1, 2>>>
 calculate_forces<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 template std::vector<std::vector<Tensor<1, 3>>>
 calculate_forces<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template std::vector<std::vector<Tensor<1, 2>>>
 calculate_forces<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 
 template std::vector<std::vector<Tensor<1, 3>>>
 calculate_forces<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template std::vector<std::vector<Tensor<1, 2>>>
 calculate_forces<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                              dof_handler,
-  const LinearAlgebra::distributed::Vector<double> & evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<2>                               &dof_handler,
+  const LinearAlgebra::distributed::Vector<double>  &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 
 template std::vector<std::vector<Tensor<1, 3>>>
 calculate_forces<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                              dof_handler,
-  const LinearAlgebra::distributed::Vector<double> & evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<3>                               &dof_handler,
+  const LinearAlgebra::distributed::Vector<double>  &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template <int dim, typename VectorType>
 std::vector<Tensor<1, 3>>
 calculate_torques(
-  const DoFHandler<dim> &                              dof_handler,
-  const VectorType &                                   evaluation_point,
-  PhysicalPropertiesManager &                          properties_manager,
+  const DoFHandler<dim>                               &dof_handler,
+  const VectorType                                    &evaluation_point,
+  PhysicalPropertiesManager                           &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
-  const Quadrature<dim - 1> &                          face_quadrature_formula,
-  const Mapping<dim> &                                 mapping)
+  const Quadrature<dim - 1>                           &face_quadrature_formula,
+  const Mapping<dim>                                  &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -945,56 +945,56 @@ calculate_torques(
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::Vector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::Vector &              evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::Vector               &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<2> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<2>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, TrilinosWrappers::MPI::BlockVector>(
-  const DoFHandler<3> &                              dof_handler,
-  const TrilinosWrappers::MPI::BlockVector &         evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<3>                               &dof_handler,
+  const TrilinosWrappers::MPI::BlockVector          &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<2, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<2> &                              dof_handler,
-  const LinearAlgebra::distributed::Vector<double> & evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<2>                               &dof_handler,
+  const LinearAlgebra::distributed::Vector<double>  &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<2> &boundary_conditions,
-  const Quadrature<1> &                              face_quadrature_formula,
-  const Mapping<2> &                                 mapping);
+  const Quadrature<1>                               &face_quadrature_formula,
+  const Mapping<2>                                  &mapping);
 
 template std::vector<Tensor<1, 3>>
 calculate_torques<3, LinearAlgebra::distributed::Vector<double>>(
-  const DoFHandler<3> &                              dof_handler,
-  const LinearAlgebra::distributed::Vector<double> & evaluation_point,
-  PhysicalPropertiesManager &                        properties_manager,
+  const DoFHandler<3>                               &dof_handler,
+  const LinearAlgebra::distributed::Vector<double>  &evaluation_point,
+  PhysicalPropertiesManager                         &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<3> &boundary_conditions,
-  const Quadrature<2> &                              face_quadrature_formula,
-  const Mapping<3> &                                 mapping);
+  const Quadrature<2>                               &face_quadrature_formula,
+  const Mapping<3>                                  &mapping);
 
 
 // Find the l2 norm of the error between the finite element sol'n and the exact
@@ -1003,10 +1003,10 @@ calculate_torques<3, LinearAlgebra::distributed::Vector<double>>(
 template <int dim, typename VectorType>
 std::pair<double, double>
 calculate_L2_error(const DoFHandler<dim> &dof_handler,
-                   const VectorType &     evaluation_point,
-                   const Function<dim> *  exact_solution,
+                   const VectorType      &evaluation_point,
+                   const Function<dim>   *exact_solution,
                    const Quadrature<dim> &quadrature_formula,
-                   const Mapping<dim> &   mapping)
+                   const Mapping<dim>    &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
   FEValues<dim>            fe_values(mapping,
@@ -1114,56 +1114,56 @@ calculate_L2_error(const DoFHandler<dim> &dof_handler,
 }
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<2> &                dof_handler,
+calculate_L2_error(const DoFHandler<2>                 &dof_handler,
                    const TrilinosWrappers::MPI::Vector &present_solution,
-                   const Function<2> *                  l_exact_solution,
-                   const Quadrature<2> &                quadrature_formula,
-                   const Mapping<2> &                   mapping);
+                   const Function<2>                   *l_exact_solution,
+                   const Quadrature<2>                 &quadrature_formula,
+                   const Mapping<2>                    &mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<3> &                dof_handler,
+calculate_L2_error(const DoFHandler<3>                 &dof_handler,
                    const TrilinosWrappers::MPI::Vector &present_solution,
-                   const Function<3> *                  l_exact_solution,
-                   const Quadrature<3> &                quadrature_formula,
-                   const Mapping<3> &                   mapping);
+                   const Function<3>                   *l_exact_solution,
+                   const Quadrature<3>                 &quadrature_formula,
+                   const Mapping<3>                    &mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<2> &                     dof_handler,
+calculate_L2_error(const DoFHandler<2>                      &dof_handler,
                    const TrilinosWrappers::MPI::BlockVector &present_solution,
-                   const Function<2> *                       l_exact_solution,
-                   const Quadrature<2> &                     quadrature_formula,
-                   const Mapping<2> &                        mapping);
+                   const Function<2>                        *l_exact_solution,
+                   const Quadrature<2>                      &quadrature_formula,
+                   const Mapping<2>                         &mapping);
 
 template std::pair<double, double>
-calculate_L2_error(const DoFHandler<3> &                     dof_handler,
+calculate_L2_error(const DoFHandler<3>                      &dof_handler,
                    const TrilinosWrappers::MPI::BlockVector &present_solution,
-                   const Function<3> *                       l_exact_solution,
-                   const Quadrature<3> &                     quadrature_formula,
-                   const Mapping<3> &                        mapping);
+                   const Function<3>                        *l_exact_solution,
+                   const Quadrature<3>                      &quadrature_formula,
+                   const Mapping<3>                         &mapping);
 
 template std::pair<double, double>
 calculate_L2_error(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &present_solution,
-  const Function<2> *                               l_exact_solution,
-  const Quadrature<2> &                             quadrature_formula,
-  const Mapping<2> &                                mapping);
+  const Function<2>                                *l_exact_solution,
+  const Quadrature<2>                              &quadrature_formula,
+  const Mapping<2>                                 &mapping);
 
 template std::pair<double, double>
 calculate_L2_error(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &present_solution,
-  const Function<3> *                               l_exact_solution,
-  const Quadrature<3> &                             quadrature_formula,
-  const Mapping<3> &                                mapping);
+  const Function<3>                                *l_exact_solution,
+  const Quadrature<3>                              &quadrature_formula,
+  const Mapping<3>                                 &mapping);
 
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
-                    const VectorType &         present_solution,
-                    const unsigned int &       boundary_id,
+calculate_flow_rate(const DoFHandler<dim>     &dof_handler,
+                    const VectorType          &present_solution,
+                    const unsigned int        &boundary_id,
                     const Quadrature<dim - 1> &face_quadrature_formula,
-                    const Mapping<dim> &       mapping)
+                    const Mapping<dim>        &mapping)
 {
   const FESystem<dim, dim> fe = dof_handler.get_fe();
 
@@ -1217,56 +1217,56 @@ calculate_flow_rate(const DoFHandler<dim> &    dof_handler,
 }
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<2> &                dof_handler,
+calculate_flow_rate(const DoFHandler<2>                 &dof_handler,
                     const TrilinosWrappers::MPI::Vector &present_solution,
-                    const unsigned int &                 boundary_id,
+                    const unsigned int                  &boundary_id,
                     const Quadrature<1> &face_quadrature_formula,
-                    const Mapping<2> &   mapping);
+                    const Mapping<2>    &mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<3> &                dof_handler,
+calculate_flow_rate(const DoFHandler<3>                 &dof_handler,
                     const TrilinosWrappers::MPI::Vector &present_solution,
-                    const unsigned int &                 boundary_id,
+                    const unsigned int                  &boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
-                    const Mapping<3> &   mapping);
+                    const Mapping<3>    &mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<2> &                     dof_handler,
+calculate_flow_rate(const DoFHandler<2>                      &dof_handler,
                     const TrilinosWrappers::MPI::BlockVector &present_solution,
-                    const unsigned int &                      boundary_id,
+                    const unsigned int                       &boundary_id,
                     const Quadrature<1> &face_quadrature_formula,
-                    const Mapping<2> &   mapping);
+                    const Mapping<2>    &mapping);
 
 template std::pair<double, double>
-calculate_flow_rate(const DoFHandler<3> &                     dof_handler,
+calculate_flow_rate(const DoFHandler<3>                      &dof_handler,
                     const TrilinosWrappers::MPI::BlockVector &present_solution,
-                    const unsigned int &                      boundary_id,
+                    const unsigned int                       &boundary_id,
                     const Quadrature<2> &face_quadrature_formula,
-                    const Mapping<3> &   mapping);
+                    const Mapping<3>    &mapping);
 
 template std::pair<double, double>
 calculate_flow_rate(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &present_solution,
-  const unsigned int &                              boundary_id,
-  const Quadrature<1> &                             face_quadrature_formula,
-  const Mapping<2> &                                mapping);
+  const unsigned int                               &boundary_id,
+  const Quadrature<1>                              &face_quadrature_formula,
+  const Mapping<2>                                 &mapping);
 
 template std::pair<double, double>
 calculate_flow_rate(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &present_solution,
-  const unsigned int &                              boundary_id,
-  const Quadrature<2> &                             face_quadrature_formula,
-  const Mapping<3> &                                mapping);
+  const unsigned int                               &boundary_id,
+  const Quadrature<2>                              &face_quadrature_formula,
+  const Mapping<3>                                 &mapping);
 
 template <int dim, typename VectorType>
 double
-calculate_average_velocity(const DoFHandler<dim> &    dof_handler,
-                           const VectorType &         present_solution,
-                           const unsigned int &       boundary_id,
+calculate_average_velocity(const DoFHandler<dim>     &dof_handler,
+                           const VectorType          &present_solution,
+                           const unsigned int        &boundary_id,
                            const Quadrature<dim - 1> &face_quadrature_formula,
-                           const Mapping<dim> &       mapping)
+                           const Mapping<dim>        &mapping)
 {
   std::pair<double, double> flow_rate_and_area =
     calculate_flow_rate(dof_handler,
@@ -1283,64 +1283,64 @@ calculate_average_velocity(const DoFHandler<dim> &    dof_handler,
 
 template double
 calculate_average_velocity(
-  const DoFHandler<2> &                dof_handler,
+  const DoFHandler<2>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &present_solution,
-  const unsigned int &                 boundary_id,
-  const Quadrature<1> &                face_quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const unsigned int                  &boundary_id,
+  const Quadrature<1>                 &face_quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_average_velocity(
-  const DoFHandler<3> &                dof_handler,
+  const DoFHandler<3>                 &dof_handler,
   const TrilinosWrappers::MPI::Vector &present_solution,
-  const unsigned int &                 boundary_id,
-  const Quadrature<2> &                face_quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const unsigned int                  &boundary_id,
+  const Quadrature<2>                 &face_quadrature_formula,
+  const Mapping<3>                    &mapping);
 
 template double
 calculate_average_velocity(
-  const DoFHandler<2> &                     dof_handler,
+  const DoFHandler<2>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &present_solution,
-  const unsigned int &                      boundary_id,
-  const Quadrature<1> &                     face_quadrature_formula,
-  const Mapping<2> &                        mapping);
+  const unsigned int                       &boundary_id,
+  const Quadrature<1>                      &face_quadrature_formula,
+  const Mapping<2>                         &mapping);
 
 template double
 calculate_average_velocity(
-  const DoFHandler<3> &                     dof_handler,
+  const DoFHandler<3>                      &dof_handler,
   const TrilinosWrappers::MPI::BlockVector &present_solution,
-  const unsigned int &                      boundary_id,
-  const Quadrature<2> &                     face_quadrature_formula,
-  const Mapping<3> &                        mapping);
+  const unsigned int                       &boundary_id,
+  const Quadrature<2>                      &face_quadrature_formula,
+  const Mapping<3>                         &mapping);
 
 template double
 calculate_average_velocity(
-  const DoFHandler<2> &                             dof_handler,
+  const DoFHandler<2>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &present_solution,
-  const unsigned int &                              boundary_id,
-  const Quadrature<1> &                             face_quadrature_formula,
-  const Mapping<2> &                                mapping);
+  const unsigned int                               &boundary_id,
+  const Quadrature<1>                              &face_quadrature_formula,
+  const Mapping<2>                                 &mapping);
 
 template double
 calculate_average_velocity(
-  const DoFHandler<3> &                             dof_handler,
+  const DoFHandler<3>                              &dof_handler,
   const LinearAlgebra::distributed::Vector<double> &present_solution,
-  const unsigned int &                              boundary_id,
-  const Quadrature<2> &                             face_quadrature_formula,
-  const Mapping<3> &                                mapping);
+  const unsigned int                               &boundary_id,
+  const Quadrature<2>                              &face_quadrature_formula,
+  const Mapping<3>                                 &mapping);
 
 template <int dim, typename VectorType>
 double
 calculate_average_velocity(const DoFHandler<dim> &dof_handler,
                            const DoFHandler<dim> &void_fraction_dof_handler,
-                           const VectorType &     present_solution,
-                           const VectorType &  present_void_fraction_solution,
+                           const VectorType      &present_solution,
+                           const VectorType   &present_void_fraction_solution,
                            const unsigned int &flow_direction,
                            const Quadrature<dim> &quadrature_formula,
-                           const Mapping<dim> &   mapping)
+                           const Mapping<dim>    &mapping)
 {
   // Set up for velocity fe values
-  const auto &                     tria       = dof_handler.get_triangulation();
+  const auto                      &tria       = dof_handler.get_triangulation();
   const FESystem<dim, dim>         fe         = dof_handler.get_fe();
   const unsigned int               n_q_points = quadrature_formula.size();
   const FEValuesExtractors::Vector velocities(0);
@@ -1411,20 +1411,20 @@ calculate_average_velocity(const DoFHandler<dim> &dof_handler,
 
 template double
 calculate_average_velocity(
-  const DoFHandler<2> &                dof_handler,
-  const DoFHandler<2> &                void_fraction_dof_handler,
+  const DoFHandler<2>                 &dof_handler,
+  const DoFHandler<2>                 &void_fraction_dof_handler,
   const TrilinosWrappers::MPI::Vector &present_solution,
   const TrilinosWrappers::MPI::Vector &present_void_fraction_solution,
-  const unsigned int &                 flow_direction,
-  const Quadrature<2> &                quadrature_formula,
-  const Mapping<2> &                   mapping);
+  const unsigned int                  &flow_direction,
+  const Quadrature<2>                 &quadrature_formula,
+  const Mapping<2>                    &mapping);
 
 template double
 calculate_average_velocity(
-  const DoFHandler<3> &                dof_handler,
-  const DoFHandler<3> &                void_fraction_dof_handler,
+  const DoFHandler<3>                 &dof_handler,
+  const DoFHandler<3>                 &void_fraction_dof_handler,
   const TrilinosWrappers::MPI::Vector &present_solution,
   const TrilinosWrappers::MPI::Vector &present_void_fraction_solution,
-  const unsigned int &                 flow_direction,
-  const Quadrature<3> &                quadrature_formula,
-  const Mapping<3> &                   mapping);
+  const unsigned int                  &flow_direction,
+  const Quadrature<3>                 &quadrature_formula,
+  const Mapping<3>                    &mapping);

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -15,10 +15,10 @@ AverageVelocities<dim, VectorType, DofsType>::AverageVelocities(
 template <int dim, typename VectorType, typename DofsType>
 void
 AverageVelocities<dim, VectorType, DofsType>::calculate_average_velocities(
-  const VectorType &                local_evaluation_point,
+  const VectorType                 &local_evaluation_point,
   const Parameters::PostProcessing &post_processing,
-  const double &                    current_time,
-  const double &                    time_step)
+  const double                     &current_time,
+  const double                     &time_step)
 {
   const double epsilon      = 1e-6;
   const double initial_time = post_processing.initial_time;
@@ -96,7 +96,7 @@ AverageVelocities<dim, VectorType, DofsType>::calculate_reynolds_stresses(
       };
 
       const TrilinosWrappers::MPI::Vector *local_solution, *local_average;
-      TrilinosWrappers::MPI::Vector *      rns_dt, *rss_dt, *k_dt;
+      TrilinosWrappers::MPI::Vector       *rns_dt, *rss_dt, *k_dt;
 
       if constexpr (std::is_same_v<VectorType, TrilinosWrappers::MPI::Vector>)
         {
@@ -177,10 +177,10 @@ AverageVelocities<dim, VectorType, DofsType>::calculate_reynolds_stresses(
 template <int dim, typename VectorType, typename DofsType>
 void
 AverageVelocities<dim, VectorType, DofsType>::initialize_vectors(
-  const DofsType &    locally_owned_dofs,
-  const DofsType &    locally_relevant_dofs,
+  const DofsType     &locally_owned_dofs,
+  const DofsType     &locally_relevant_dofs,
   const unsigned int &dofs_per_vertex,
-  const MPI_Comm &    mpi_communicator)
+  const MPI_Comm     &mpi_communicator)
 {
   // Save the number of dofs per vertex. If solution is in block vectors,
   // this is the number of dofs about velocity, dim.

--- a/source/solvers/postprocessors_smoothing.cc
+++ b/source/solvers/postprocessors_smoothing.cc
@@ -3,8 +3,8 @@
 template <int dim, typename VectorType>
 PostProcessorSmoothing<dim, VectorType>::PostProcessorSmoothing(
   const parallel::DistributedTriangulationBase<dim> &triangulation,
-  const SimulationParameters<dim> &                  simulation_parameters,
-  const unsigned int &                               number_quadrature_points)
+  const SimulationParameters<dim>                   &simulation_parameters,
+  const unsigned int                                &number_quadrature_points)
   : fe_q(1)
   , dof_handler(triangulation)
   , simulation_parameters(simulation_parameters)
@@ -149,8 +149,8 @@ PostProcessorSmoothing<dim, VectorType>::solve_L2_projection()
 template <int dim, typename VectorType>
 const TrilinosWrappers::MPI::Vector &
 PostProcessorSmoothing<dim, VectorType>::calculate_smoothed_field(
-  const VectorType &            solution,
-  const DoFHandler<dim> &       dof_handler_velocity,
+  const VectorType             &solution,
+  const DoFHandler<dim>        &dof_handler_velocity,
   std::shared_ptr<Mapping<dim>> mapping_velocity)
 {
   generate_mass_matrix();
@@ -181,8 +181,8 @@ template <int dim, typename VectorType>
 QcriterionPostProcessorSmoothing<dim, VectorType>::
   QcriterionPostProcessorSmoothing(
     const parallel::DistributedTriangulationBase<dim> &triangulation,
-    const SimulationParameters<dim> &                  simulation_parameters,
-    const unsigned int &                               number_quadrature_points)
+    const SimulationParameters<dim>                   &simulation_parameters,
+    const unsigned int                                &number_quadrature_points)
   : PostProcessorSmoothing<dim, VectorType>(triangulation,
                                             simulation_parameters,
                                             number_quadrature_points)
@@ -191,8 +191,8 @@ QcriterionPostProcessorSmoothing<dim, VectorType>::
 template <int dim, typename VectorType>
 void
 QcriterionPostProcessorSmoothing<dim, VectorType>::generate_rhs(
-  const VectorType &            solution,
-  const DoFHandler<dim> &       dof_handler_velocity,
+  const VectorType             &solution,
+  const DoFHandler<dim>        &dof_handler_velocity,
   std::shared_ptr<Mapping<dim>> mapping_velocity)
 {
   QGauss<dim> quadrature_formula(this->number_quadrature_points);
@@ -311,8 +311,8 @@ template <int dim, typename VectorType>
 ContinuityPostProcessorSmoothing<dim, VectorType>::
   ContinuityPostProcessorSmoothing(
     const parallel::DistributedTriangulationBase<dim> &triangulation,
-    const SimulationParameters<dim> &                  simulation_parameters,
-    const unsigned int &                               number_quadrature_points)
+    const SimulationParameters<dim>                   &simulation_parameters,
+    const unsigned int                                &number_quadrature_points)
   : PostProcessorSmoothing<dim, VectorType>(triangulation,
                                             simulation_parameters,
                                             number_quadrature_points)
@@ -321,8 +321,8 @@ ContinuityPostProcessorSmoothing<dim, VectorType>::
 template <int dim, typename VectorType>
 void
 ContinuityPostProcessorSmoothing<dim, VectorType>::generate_rhs(
-  const VectorType &            solution,
-  const DoFHandler<dim> &       dof_handler_velocity,
+  const VectorType             &solution,
+  const DoFHandler<dim>        &dof_handler_velocity,
   std::shared_ptr<Mapping<dim>> mapping_velocity)
 {
   this->system_rhs.reinit(this->locally_owned_dofs, this->mpi_communicator);

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -77,8 +77,8 @@ template <int dim>
 void
 Tracer<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  TracerScratchData<dim> &                              scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  TracerScratchData<dim>                               &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -199,8 +199,8 @@ template <int dim>
 void
 Tracer<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  TracerScratchData<dim> &                              scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  TracerScratchData<dim>                               &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -16,7 +16,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
   const auto method = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -127,7 +127,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
 
 template <int dim>
 void
-TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim> &   scratch_data,
+TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
                                        StabilizedMethodsCopyData &copy_data)
 {
   // Scheme and physical properties
@@ -136,7 +136,7 @@ TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim> &   scratch_data,
   const auto method = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature informations
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -234,7 +234,7 @@ TracerAssemblerBDF<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
                                          StabilizedMethodsCopyData &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -286,11 +286,11 @@ TracerAssemblerBDF<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
 
 template <int dim>
 void
-TracerAssemblerBDF<dim>::assemble_rhs(TracerScratchData<dim> &   scratch_data,
+TracerAssemblerBDF<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
                                       StabilizedMethodsCopyData &copy_data)
 {
   // Loop and quadrature informations
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/source/solvers/tracer_scratch_data.cc
+++ b/source/solvers/tracer_scratch_data.cc
@@ -54,14 +54,16 @@ TracerScratchData<dim>::calculate_physical_properties()
   // Case where you have one fluid
   switch (properties_manager.get_number_of_fluids())
     {
-        case 1: {
+      case 1:
+        {
           // In this case, only viscosity is the required property
           const auto diffusivity_model =
             properties_manager.get_tracer_diffusivity();
           diffusivity_model->vector_value(fields, tracer_diffusivity);
           break;
         }
-        case 2: {
+      case 2:
+        {
           // In this case, we need both density and viscosity
           const auto diffusivity_models =
             properties_manager.get_tracer_diffusivity_vector();

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -97,8 +97,8 @@ template <int dim>
 void
 VolumeOfFluid<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  VOFScratchData<dim> &                                 scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  VOFScratchData<dim>                                  &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -217,8 +217,8 @@ template <int dim>
 void
 VolumeOfFluid<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  VOFScratchData<dim> &                                 scratch_data,
-  StabilizedMethodsCopyData &                           copy_data)
+  VOFScratchData<dim>                                  &scratch_data,
+  StabilizedMethodsCopyData                            &copy_data)
 {
   copy_data.cell_is_local = cell->is_locally_owned();
   if (!cell->is_locally_owned())
@@ -389,7 +389,7 @@ template <typename VectorType>
 std::pair<Tensor<1, dim>, Tensor<1, dim>>
 VolumeOfFluid<dim>::calculate_barycenter(
   const TrilinosWrappers::MPI::Vector &solution,
-  const VectorType &                   solution_fd)
+  const VectorType                    &solution_fd)
 {
   const MPI_Comm mpi_communicator = this->triangulation->get_communicator();
 
@@ -482,13 +482,13 @@ VolumeOfFluid<3>::calculate_barycenter<TrilinosWrappers::MPI::Vector>(
 
 template std::pair<Tensor<1, 2>, Tensor<1, 2>>
 VolumeOfFluid<2>::calculate_barycenter<TrilinosWrappers::MPI::BlockVector>(
-  const TrilinosWrappers::MPI::Vector &     solution,
+  const TrilinosWrappers::MPI::Vector      &solution,
   const TrilinosWrappers::MPI::BlockVector &current_solution_fd);
 
 
 template std::pair<Tensor<1, 3>, Tensor<1, 3>>
 VolumeOfFluid<3>::calculate_barycenter<TrilinosWrappers::MPI::BlockVector>(
-  const TrilinosWrappers::MPI::Vector &     solution,
+  const TrilinosWrappers::MPI::Vector      &solution,
   const TrilinosWrappers::MPI::BlockVector &current_solution_fd);
 
 
@@ -497,7 +497,7 @@ template <typename VectorType>
 void
 VolumeOfFluid<dim>::calculate_volume_and_mass(
   const TrilinosWrappers::MPI::Vector &solution,
-  const VectorType &                   current_solution_fd,
+  const VectorType                    &current_solution_fd,
   const Parameters::FluidIndicator     monitored_fluid)
 {
   const MPI_Comm mpi_communicator = this->triangulation->get_communicator();

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -565,7 +565,8 @@ VolumeOfFluid<dim>::calculate_volume_and_mass(
             {
               switch (monitored_fluid)
                 {
-                    case Parameters::FluidIndicator::fluid0: {
+                  case Parameters::FluidIndicator::fluid0:
+                    {
                       this->volume_monitored +=
                         fe_values_vof.JxW(q) * (1 - phase_values[q]);
                       this->mass_monitored += fe_values_vof.JxW(q) *
@@ -573,7 +574,8 @@ VolumeOfFluid<dim>::calculate_volume_and_mass(
                                               density_0[q];
                       break;
                     }
-                    case Parameters::FluidIndicator::fluid1: {
+                  case Parameters::FluidIndicator::fluid1:
+                    {
                       this->volume_monitored +=
                         fe_values_vof.JxW(q) * phase_values[q];
                       this->mass_monitored +=
@@ -1026,8 +1028,9 @@ VolumeOfFluid<dim>::find_sharpening_threshold()
           st_min             = st_avg;
           mass_deviation_min = mass_deviation_avg;
         }
-  } while (std::abs(mass_deviation_avg) > mass_deviation_tol &&
-           nb_search_ite < max_iterations);
+    }
+  while (std::abs(mass_deviation_avg) > mass_deviation_tol &&
+         nb_search_ite < max_iterations);
 
   // Take minimum deviation in between the two endpoints of the last
   // interval searched, if out of the do-while loop because max_iterations is

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -8,14 +8,14 @@
 
 template <int dim>
 void
-VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim> &      scratch_data,
+VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
                                        StabilizedMethodsCopyData &copy_data)
 {
   // Scheme and physical properties
   const auto method = this->simulation_control->get_assembly_method();
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -158,7 +158,7 @@ VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim> &      scratch_data,
 
 template <int dim>
 void
-VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim> &      scratch_data,
+VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
                                     StabilizedMethodsCopyData &copy_data)
 {
   // Scheme and physical properties
@@ -168,7 +168,7 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim> &      scratch_data,
   const double diffusivity = this->vof_parameters.diffusivity;
 
   // Loop and quadrature information
-  const auto &       JxW_vec    = scratch_data.JxW;
+  const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
   const double       h          = scratch_data.cell_size;
@@ -289,11 +289,11 @@ template class VOFAssemblerCore<3>;
 
 template <int dim>
 void
-VOFAssemblerBDF<dim>::assemble_matrix(VOFScratchData<dim> &      scratch_data,
+VOFAssemblerBDF<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
                                       StabilizedMethodsCopyData &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 
@@ -355,11 +355,11 @@ VOFAssemblerBDF<dim>::assemble_matrix(VOFScratchData<dim> &      scratch_data,
 
 template <int dim>
 void
-VOFAssemblerBDF<dim>::assemble_rhs(VOFScratchData<dim> &      scratch_data,
+VOFAssemblerBDF<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
                                    StabilizedMethodsCopyData &copy_data)
 {
   // Loop and quadrature information
-  const auto &       JxW        = scratch_data.JxW;
+  const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
 

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -55,8 +55,8 @@ using namespace dealii;
 template <int dim>
 void
 reinitialize_force(Particles::ParticleHandler<dim> &particle_handler,
-                   std::vector<Tensor<1, 3>> &      torque,
-                   std::vector<Tensor<1, 3>> &      force)
+                   std::vector<Tensor<1, 3>>       &torque,
+                   std::vector<Tensor<1, 3>>       &force)
 {
   torque.resize(particle_handler.n_locally_owned_particles());
   force.resize(particle_handler.n_locally_owned_particles());

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -29,8 +29,8 @@ using namespace dealii;
 template <int dim>
 void
 reinitialize_force(Particles::ParticleHandler<dim> &particle_handler,
-                   std::vector<Tensor<1, 3>> &      torque,
-                   std::vector<Tensor<1, 3>> &      force)
+                   std::vector<Tensor<1, 3>>       &torque,
+                   std::vector<Tensor<1, 3>>       &force)
 {
   for (auto particle = particle_handler.begin();
        particle != particle_handler.end();

--- a/tests/rpt/count.cc
+++ b/tests/rpt/count.cc
@@ -48,9 +48,9 @@ test()
 
   const unsigned int n_particle = 4;
   RadioParticle<3>   particle_positions[n_particle]{position0,
-                                                  position1,
-                                                  position2,
-                                                  position3};
+                                                    position1,
+                                                    position2,
+                                                    position3};
 
   // Detector positions
   Parameters::DetectorParameters detector_param;

--- a/tests/rpt/position_parameters.cc
+++ b/tests/rpt/position_parameters.cc
@@ -49,9 +49,9 @@ test()
 
   const unsigned int n_particle = 4;
   RadioParticle<3>   particle_positions[n_particle]{position0,
-                                                  position1,
-                                                  position2,
-                                                  position3};
+                                                    position1,
+                                                    position2,
+                                                    position3};
 
   // Detector position
   Parameters::DetectorParameters detector_param;

--- a/tests/rpt/reactor_detector_path_lengths.cc
+++ b/tests/rpt/reactor_detector_path_lengths.cc
@@ -47,9 +47,9 @@ test()
 
   const unsigned int n_particle = 4;
   RadioParticle<3>   particle_positions[n_particle]{position0,
-                                                  position1,
-                                                  position2,
-                                                  position3};
+                                                    position1,
+                                                    position2,
+                                                    position3};
 
   // Detector positions
   Parameters::DetectorParameters detector_param;

--- a/tests/rpt/solid_angle.cc
+++ b/tests/rpt/solid_angle.cc
@@ -48,9 +48,9 @@ test()
 
   const unsigned int n_particle = 4;
   RadioParticle<3>   particle_positions[n_particle]{position0,
-                                                  position1,
-                                                  position2,
-                                                  position3};
+                                                    position1,
+                                                    position2,
+                                                    position3};
 
   // Detector positions
   Parameters::DetectorParameters detector_param;

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -34,7 +34,7 @@ public:
 template <int dim>
 void
 ExactSolutionMMS<dim>::vector_value(const Point<dim> &p,
-                                    Vector<double> &  values) const
+                                    Vector<double>   &values) const
 {
   assert(dim == 2);
   const double a = M_PI;
@@ -58,7 +58,7 @@ public:
 template <int dim>
 void
 MMSSineForcingFunction<dim>::vector_value(const Point<dim> &p,
-                                          Vector<double> &  values) const
+                                          Vector<double>   &values) const
 {
   assert(dim == 2);
   const double a = M_PI;


### PR DESCRIPTION
# Description of the problem

- Deal.II uses clang format 16. It is important to maintain our clang format in a similar fashion that they do, for my sanity's sake.

# Description of the solution

- Migrate to clang format 16

# How Has This Been Tested?

- All tests should still pass. Barely any changes to files actually

