### PR TITLE
Replace 'adaptative' by 'adaptive' in interface sharpening methods

### DIFF
--- a/applications_tests/lethe-fluid/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
+++ b/applications_tests/lethe-fluid/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
@@ -28,14 +28,14 @@ subsection VOF
     set threshold           = 0.5
     set interface sharpness = 2
     set frequency           = 2
-    set type                = adaptative
+    set type                = adaptive
     set max iterations      = 50
   end
 
   subsection mass conservation
     set monitoring         = true
     set monitored fluid    = fluid 1
-    # parameters used with adaptative sharpening
+    # parameters used with adaptive sharpening
     set tolerance = 1e-8
     set verbosity = verbose
   end

--- a/doc/source/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.rst
+++ b/doc/source/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.rst
@@ -223,7 +223,7 @@ The boundary conditions applied on the left and right boundaries are ``periodic`
 VOF
 ~~~
 
-In the ``VOF`` subsection, we enable ``interface sharpening`` to reconstruct the interface and keep it sharp during the simulation. Note that here we use the ``constant`` and ``adaptive`` methods for interface sharpening. The ``mass conservation`` results show that choosing a ``constant`` method does not affect the mass conservation significantly. Hence, the results of both methods are almost identical. For the ``constant`` refinement we use
+In the ``VOF`` subsection, we enable ``interface sharpening`` to reconstruct the interface and keep it sharp during the simulation. Note that here we use the ``constant`` and ``adaptive`` methods for interface sharpening. The ``mass conservation`` results show that choosing a ``constant`` method does not affect the mass conservation significantly. Hence, the results of both methods are almost identical. For the ``constant`` sharpening we use
 
 
 .. code-block:: text
@@ -252,7 +252,7 @@ In the ``VOF`` subsection, we enable ``interface sharpening`` to reconstruct the
    end
 
 
-and for the ``adaptive`` refinement
+and for the ``adaptive`` sharpening
 
 
 .. code-block:: text
@@ -263,7 +263,7 @@ and for the ``adaptive`` refinement
        set threshold               = 0.5
        set interface sharpness     = 1.5
        set frequency               = 25
-       set type                    = adaptative
+       set type                    = adaptive
        set threshold max deviation = 0.2
        set max iterations          = 50
      end

--- a/doc/source/parameters/cfd/volume_of_fluid.rst
+++ b/doc/source/parameters/cfd/volume_of_fluid.rst
@@ -30,7 +30,7 @@ The default values of the VOF parameters are given in the text box below.
       # parameter for constant sharpening
       set threshold               = 0.5
 
-      # parameters for adaptative sharpening
+      # parameters for adaptive sharpening
       set threshold max deviation = 0.20
       set max iterations          = 20
 
@@ -58,7 +58,7 @@ The default values of the VOF parameters are given in the text box below.
       set monitoring         = false
       set monitored fluid    = fluid 1
 
-      # parameters used with adaptative sharpening
+      # parameters used with adaptive sharpening
       set tolerance          = 1e-6
       set verbosity          = quiet
     end
@@ -84,21 +84,21 @@ Interface Sharpening
   * ``frequency``: sets the frequency (in number of iterations) for the interface sharpening computation.
   * ``interface sharpness``: sharpness of the moving interface (parameter :math:`a` in the `interface sharpening model <https://www.researchgate.net/publication/287118331_Development_of_efficient_interface_sharpening_procedure_for_viscous_incompressible_flows>`_). This parameter must be larger than 1 for interface sharpening. Choosing values less than 1 leads to interface smoothing instead of sharpening. A good value would be around 1.5.
 
-  * ``type``: defines the interface sharpening type, either ``constant`` or ``adaptative``
+  * ``type``: defines the interface sharpening type, either ``constant`` or ``adaptive``
 
     * ``set type = constant``: the sharpening ``threshold`` is the same throughout the simulation. This ``threshold``, between ``0`` and ``1`` (``0.5`` by default), corresponds to the phase fraction at which the interface is located.
-    * ``set type = adaptative``: the sharpening threshold is searched in the range :math:`\left[0.5-c_\text{dev} \; ; 0.5+c_\text{dev}\right]`, with :math:`c_\text{dev}` the ``threshold max deviation`` (``0.2`` by default), to ensure mass conservation. The search algorithm will stop either if the mass conservation ``tolerance`` is reached (see ``subsection mass conservation``), or if the number of search steps reach the number of ``max iterations``. If the ``tolerance`` is not reached, a warning message will be printed.
+    * ``set type = adaptive``: the sharpening threshold is searched in the range :math:`\left[0.5-c_\text{dev} \; ; 0.5+c_\text{dev}\right]`, with :math:`c_\text{dev}` the ``threshold max deviation`` (``0.2`` by default), to ensure mass conservation. The search algorithm will stop either if the mass conservation ``tolerance`` is reached (see ``subsection mass conservation``), or if the number of search steps reach the number of ``max iterations``. If the ``tolerance`` is not reached, a warning message will be printed.
 
     .. warning::
 
-      In case of adaptative interface sharpening (``set type = adaptative``), mass conservation must be monitored (``set monitoring = true`` in ``mass conservation`` subsection).
+      In case of adaptive interface sharpening (``set type = adaptive``), mass conservation must be monitored (``set monitoring = true`` in ``mass conservation`` subsection).
 
-    .. admonition:: Example of a warning message if sharpening is adaptative but the mass conservation tolerance is not reached:
+    .. admonition:: Example of a warning message if sharpening is adaptive but the mass conservation tolerance is not reached:
 
       .. code-block:: text
 
         WARNING: Maximum number of iterations (5) reached in the
-        adaptative sharpening threshold algorithm, remaining error
+        adaptive sharpening threshold algorithm, remaining error
         on mass conservation is: 0.02
         Consider increasing the sharpening threshold range or the
         number of iterations to reach the mass conservation tolerance.
@@ -212,7 +212,7 @@ Mass Conservation
         0.0450     4.9144e-01   3.8185e+02               0.5000 
         0.0500     5.0639e-01   3.9346e+02               0.5000 
 
-  * ``tolerance``: value for the tolerance on the mass conservation of the monitored fluid, used with adaptative sharpening (see the ``subsection sharpening``). 
+  * ``tolerance``: value for the tolerance on the mass conservation of the monitored fluid, used with adaptive sharpening (see the ``subsection sharpening``).
   
     For instance, with ``set tolerance = 0.02`` the sharpening threshold will be adapted so that the mass of the ``monitored fluid`` varies less than :math:`\pm 2\%` from the initial mass (at :math:`t = 0.0` sec).
 

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
@@ -109,7 +109,7 @@ subsection VOF
     set threshold               = 0.5
     set interface sharpness     = 1.5
     set frequency               = 25
-    set type                    = adaptative
+    set type                    = adaptive
     set threshold max deviation = 0.2
     set max iterations          = 50
   end

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -37,13 +37,13 @@ namespace Parameters
   /** @brief Class to account for different sharpening types:
    *  - constant: the sharpening threshold is the same throughout the
    * simulation,
-   *  - adaptative: the sharpening threshold is determined by binary search, to
+   *  - adaptive: the sharpening threshold is determined by binary search, to
    * ensure mass conservation of the monitored phase
    */
   enum class SharpeningType
   {
     constant,
-    adaptative
+    adaptive
   };
 
   /** @brief Class to account for different phase fraction filtering types:
@@ -64,7 +64,7 @@ namespace Parameters
   };
 
   /**
-   * @brief Defines the subparameters for free surface mass conservation.
+   * @brief Defines the sub-parameters for free surface mass conservation.
    * Has to be declared before member creation in VOF structure.
    */
   struct VOF_MassConservation
@@ -72,7 +72,7 @@ namespace Parameters
     bool monitoring;
 
     // Conservation tolerance on the fluid monitored,
-    // used with adaptative Sharpening
+    // used with adaptive Sharpening
     double tolerance;
 
     Parameters::FluidIndicator monitored_fluid;
@@ -103,7 +103,7 @@ namespace Parameters
     // Parameters for constant sharpening
     double threshold;
 
-    // Parameters for adaptative sharpening
+    // Parameters for adaptive sharpening
     double threshold_max_deviation;
     int    max_iterations;
 

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -187,11 +187,11 @@ public:
       }
 
     if (multiphysics.vof_parameters.sharpening.type ==
-          Parameters::SharpeningType::adaptative &&
+          Parameters::SharpeningType::adaptive &&
         not(multiphysics.vof_parameters.conservation.monitoring))
       {
         throw std::logic_error(
-          "Inconsistency in .prm!\n in subsection VOF, with sharpening type = adaptative\n "
+          "Inconsistency in .prm!\n in subsection VOF, with sharpening type = adaptive\n "
           "use: monitoring = true");
       }
 

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -544,7 +544,7 @@ private:
    * @brief Calculate the mass deviation of the monitored fluid, between the current
    * iteration and the mass at first iteration (mass_first_iteration). Used to
    * test multiple sharpening threshold in the binary search algorithm
-   * (adaptative sharpening).
+   * (adaptive sharpening).
    *
    * @param monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding to
    * the phase of interest.

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -15,7 +15,7 @@ DeclException1(
   double,
   << "Sharpening threshold max deviation : " << arg1
   << " is smaller than 0 or larger than 0.5." << std::endl
-  << "Adaptative interface sharpening requires a maximum deviation of the"
+  << "Adaptive interface sharpening requires a maximum deviation of the"
   << " sharpening threshold between 0.0 and 0.5. See documentation for further details");
 
 DeclException1(
@@ -26,11 +26,11 @@ DeclException1(
   << "Interface sharpening model requires an integer sharpening frequency larger than 0.");
 
 DeclException1(
-  AdaptativeSharpeningError,
+  AdaptiveSharpeningError,
   bool,
-  << "Sharpening type is set to 'adaptative' but monitoring is : " << arg1
+  << "Sharpening type is set to 'adaptive' but monitoring is : " << arg1
   << std::endl
-  << "Adaptative sharpening requires to set 'monitoring = true', and to define"
+  << "Adaptive sharpening requires to set 'monitoring = true', and to define"
   << " the 'fluid monitored' and the 'tolerance' to reach. See documentation for further details.");
 
 void
@@ -169,10 +169,10 @@ Parameters::VOF::parse_parameters(ParameterHandler &prm)
 
 
     // Error definitions
-    if (sharpening.type == Parameters::SharpeningType::adaptative)
+    if (sharpening.type == Parameters::SharpeningType::adaptive)
       {
         AssertThrow(conservation.monitoring,
-                    AdaptativeSharpeningError(conservation.monitoring));
+                    AdaptiveSharpeningError(conservation.monitoring));
       }
   }
   prm.leave_subsection();
@@ -193,7 +193,7 @@ Parameters::VOF_MassConservation::declare_parameters(ParameterHandler &prm)
       "tolerance",
       "1e-6",
       Patterns::Double(),
-      "Tolerance on the mass conservation of the monitored fluid, used with adaptative sharpening");
+      "Tolerance on the mass conservation of the monitored fluid, used with adaptive sharpening");
 
     prm.declare_entry(
       "monitored fluid",
@@ -258,10 +258,10 @@ Parameters::VOF_InterfaceSharpening::declare_parameters(ParameterHandler &prm)
     prm.declare_entry(
       "type",
       "constant",
-      Patterns::Selection("constant|adaptative"),
+      Patterns::Selection("constant|adaptive"),
       "VOF interface sharpening type, "
       "if constant the sharpening threshold is the same throughout the simulation, "
-      "if adaptative the sharpening threshold is determined by binary search, "
+      "if adaptive the sharpening threshold is determined by binary search, "
       "to ensure mass conservation of the monitored phase");
 
     // Parameters for constant sharpening
@@ -272,7 +272,7 @@ Parameters::VOF_InterfaceSharpening::declare_parameters(ParameterHandler &prm)
       "Interface sharpening threshold that represents the phase fraction at which "
       "the interphase is considered located");
 
-    // Parameters for adaptative sharpening
+    // Parameters for adaptive sharpening
     prm.declare_entry(
       "threshold max deviation",
       "0.20",
@@ -323,13 +323,13 @@ Parameters::VOF_InterfaceSharpening::parse_parameters(ParameterHandler &prm)
     const std::string t = prm.get("type");
     if (t == "constant")
       type = Parameters::SharpeningType::constant;
-    if (t == "adaptative")
-      type = Parameters::SharpeningType::adaptative;
+    if (t == "adaptive")
+      type = Parameters::SharpeningType::adaptive;
 
     // Parameters for constant sharpening
     threshold = prm.get_double("threshold");
 
-    // Parameters for adaptative sharpening
+    // Parameters for adaptive sharpening
     threshold_max_deviation = prm.get_double("threshold max deviation");
     max_iterations          = prm.get_double("max iterations");
 

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -167,7 +167,6 @@ Parameters::VOF::parse_parameters(ParameterHandler &prm)
 
     compressible = prm.get_bool("compressible");
 
-
     // Error definitions
     if (sharpening.type == Parameters::SharpeningType::adaptive)
       {

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -938,7 +938,7 @@ VolumeOfFluid<dim>::handle_interface_sharpening()
                   << this->simulation_control->get_step_number() << std::endl;
     }
   if (this->simulation_parameters.multiphysics.vof_parameters.sharpening.type ==
-      Parameters::SharpeningType::adaptative)
+      Parameters::SharpeningType::adaptive)
     {
       if (this->simulation_parameters.multiphysics.vof_parameters.conservation
             .verbosity != Parameters::Verbosity::quiet)
@@ -1060,7 +1060,7 @@ VolumeOfFluid<dim>::find_sharpening_threshold()
           this->pcout
             << "  WARNING: Maximum number of iterations (" << nb_search_ite
             << ") reached in the " << std::endl
-            << "  adaptative sharpening threshold algorithm, remaining error"
+            << "  adaptive sharpening threshold algorithm, remaining error"
             << std::endl
             << "  on mass conservation is: "
             << (this->mass_monitored - this->mass_first_iteration) /


### PR DESCRIPTION
# Description of the problem

- In VOF, the adaptive sharpening method was named "adaptative" and both terms were used in the documentation leading to unnecessary confusion.

# Description of the solution

- The "adaptative" sharpening method was renamed "adaptive" sharpening method.

# How Has This Been Tested?

- All tests passed and ``applications_tests/lethe-fluid/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm`` was updated.

# Documentation

- All relevant documentation was modified.
