### PR TITLE
Remove dumb warning

### DIFF
--- a/source/solvers/navier_stokes_cahn_hilliard_assemblers.cc
+++ b/source/solvers/navier_stokes_cahn_hilliard_assemblers.cc
@@ -247,7 +247,6 @@ GLSNavierStokesCahnHilliardAssemblerCore<dim>::assemble_rhs(
         scratch_data.velocity_gradients[q];
       const Tensor<1, dim> velocity_laplacian =
         scratch_data.velocity_laplacians[q];
-      scratch_data.velocity_gradients[q];
       const Tensor<3, dim> &velocity_hessian =
         scratch_data.velocity_hessians[q];
       // From hessian, calculate grad (div (u)) term needed for CH problems


### PR DESCRIPTION
# Description of the problem

- There was a weird warning remaining in the CHN code assembler because a variable was called but not used

# Description of the solution

- Removed it
