### PR TITLE
Add concurrency

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   indent:
-    # run the indent checks
 
     name: indent
     runs-on: [ubuntu-20.04]

--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -2,6 +2,11 @@ name: Publish doc to GitHub Pages
 
 on: push
 
+# Cancels running instances when a pull request is updated by a commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   SPHINX_VERSION: 4.3.1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,3 @@
-#Generates a docker image for Lethe
 name: Docker Image Build & Push
 
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,4 @@
+# Comment comment  comment
 name: Docker Image Build & Push
 
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,4 @@
+#Generates a docker image for Lethe
 name: Docker Image Build & Push
 
 on:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -11,8 +11,9 @@ on:
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -5,9 +5,6 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
-  pull_request_target:
-    paths-ignore:
-      - 'doc/**'
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -11,8 +11,8 @@ on:
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
+  pull_request_target:
+    paths-ignore:
+      - 'doc/**'
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -8,6 +8,10 @@ on:
   pull_request_target:
     paths-ignore:
       - 'doc/**'
+    
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - 'doc/**'
     
+# Cancels running instances when a pull request is updated by a commit
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -1,7 +1,7 @@
 name: CI-Debug
 
-on: [push, pull_request]
-  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
+on: 
+# Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -1,6 +1,6 @@
 name: CI-Debug
 
-on:
+on: [push, pull_request]
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     paths-ignore:
@@ -11,8 +11,8 @@ on:
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -11,8 +11,8 @@ on:
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
 
 
 env:

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -11,7 +11,7 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - 'doc/**'
 
+# Cancels running instances when a pull request is updated by a commit
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -9,6 +9,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
 env:
   COMPILE_JOBS: 2
   MULTI_CORE_TESTS_REGEX: "mpirun=2"

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -1,6 +1,6 @@
 name: CI-Release
 
-on:
+on: [push, pull_request]
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     paths-ignore:
@@ -11,8 +11,8 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -1,6 +1,6 @@
 name: CI-Release
 
-on: [push, pull_request]
+on:
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     paths-ignore:

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -11,8 +11,8 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -11,8 +11,8 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -9,6 +9,11 @@ on:
     paths-ignore:
       - 'doc/**'
 
+
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
 env:
   COMPILE_JOBS: 2
   MULTI_CORE_TESTS_REGEX: "mpirun=2"

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -11,7 +11,7 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -1,6 +1,6 @@
 name: CI-Warnings
 
-on:
+on: [push, pull_request]
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     paths-ignore:

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -11,8 +11,8 @@ on: [push, pull_request]
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore:
       - 'doc/**'
 
-
+# Cancels running instances when a pull request is updated by a commit
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -11,8 +11,8 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -11,8 +11,8 @@ on:
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:
   COMPILE_JOBS: 2

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -1,6 +1,6 @@
 name: CI-Warnings
 
-on: [push, pull_request]
+on: 
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     paths-ignore:


### PR DESCRIPTION
# Description of the problem

- The CI would not cancel jobs in an active pull requests after additional commits were made on top of them. This wastes ressources

# Description of the solution

- Add a step to cancel concurrent tasks in the github actions

# How Has This Been Tested?

- Testing it on this PR. CI stuff is always tough to test
