### PR TITLE
Manifolds gmsh

### DIFF
--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -60,18 +60,13 @@ attach_grid_to_triangulation(
           grid_in.read_msh(input_file);
 
           // Give a manifold id to the faces
-          // that corresponds to their boundary id. Loop throughout all the
-          // faces and set their manifold id.
-
+          // that corresponds to their boundary id. Otherwise all manifold IDs
+          // will be set to zero.
           triangulation.reset_all_manifolds();
           for (const auto &face : triangulation.active_face_iterators())
             {
               if (face->at_boundary())
-                {
-                  face->set_all_manifold_ids(face->boundary_id());
-                  std::cout << "Setting manifold is to " << face->boundary_id()
-                            << std::endl;
-                }
+                face->set_all_manifold_ids(face->boundary_id());
             }
         }
     }

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -58,6 +58,21 @@ attach_grid_to_triangulation(
           grid_in.attach_triangulation(triangulation);
           std::ifstream input_file(mesh_parameters.file_name);
           grid_in.read_msh(input_file);
+
+          // Give a manifold id to the faces
+          // that corresponds to their boundary id. Loop throughout all the
+          // faces and set their manifold id.
+
+          triangulation.reset_all_manifolds();
+          for (const auto &face : triangulation.active_face_iterators())
+            {
+              if (face->at_boundary())
+                {
+                  face->set_all_manifold_ids(face->boundary_id());
+                  std::cout << "Setting manifold is to " << face->boundary_id()
+                            << std::endl;
+                }
+            }
         }
     }
   // Dealii grids

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -275,8 +275,6 @@ attach_manifolds_to_triangulation(
           static const SphericalManifold<dim, spacedim> manifold_description(
             circleCenter);
           triangulation.set_manifold(manifolds.id[i], manifold_description);
-          triangulation.set_all_manifold_ids_on_boundary(manifolds.id[i],
-                                                         manifolds.id[i]);
         }
       else if (manifolds.types[i] == Parameters::Manifolds::ManifoldType::iges)
         {


### PR DESCRIPTION
# Description of the problem

- There was a slight bug with the spherical manifolds that would color the manifold everywhere which was not adequate for the flow around a sphere example

# Description of the solution

- Fixed it by attributing correctly the boundary ID as manifold IDs to GMSH mesh and not setting the spherical manifold everywhere.

# How Has This Been Tested?

- Tested on the example and the new flow around a sphere matrix free case.
