### PR TITLE
Fix 64bit compilation

### DIFF
--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -269,7 +269,7 @@ private:
 
   // Structure that contains the boundary cells with floating walls
   std::unordered_map<
-    unsigned int,
+    types::global_dof_index,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
     boundary_cells_for_floating_walls;
 

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -108,7 +108,7 @@ public:
   void
   find_particle_floating_wall_contact_pairs(
     const std::unordered_map<
-      unsigned int,
+      types::global_dof_index,
       std::set<typename Triangulation<dim>::active_cell_iterator>>
                                           &boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,
@@ -120,7 +120,7 @@ public:
   void
   find_particle_floating_wall_contact_pairs(
     const std::unordered_map<
-      unsigned int,
+      types::global_dof_index,
       std::set<typename Triangulation<dim>::active_cell_iterator>>
                                           &boundary_cells_for_floating_walls,
     const Particles::ParticleHandler<dim> &particle_handler,

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -294,9 +294,9 @@ BoundaryCellsInformation<dim>::find_particle_point_and_line_contact_cells(
   // Boundary lines only exist in three-dimensional cases
   if (dim == 3)
     {
-      std::unordered_map<
-        std::string,
-        std::unordered_map<unsigned int, std::pair<Point<dim>, Point<dim>>>>
+      std::unordered_map<std::string,
+                         std::unordered_map<types::global_dof_index,
+                                            std::pair<Point<dim>, Point<dim>>>>
         all_cells_with_boundary_lines;
 
       // Iterating over the active cells in the triangulation
@@ -364,7 +364,7 @@ BoundaryCellsInformation<dim>::find_particle_point_and_line_contact_cells(
               if (cell->is_locally_owned())
                 {
                   std::string cell_id_string = cell->id().to_string();
-                  std::unordered_map<unsigned int,
+                  std::unordered_map<types::global_dof_index,
                                      std::pair<Point<dim>, Point<dim>>>
                     &cell_boundary_lines =
                       all_cells_with_boundary_lines[cell_id_string];

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -279,7 +279,7 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
-    unsigned int,
+    types::global_dof_index,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
                                         &boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -67,7 +67,7 @@ template <int dim>
 void
 ParticleWallBroadSearch<dim>::find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
-    unsigned int,
+    types::global_dof_index,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
                                         &boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,


### PR DESCRIPTION
# Description of the problem

- Compiling Lethe in 64bit didn't work

# Description of the solution

- Some types are now generalized in DEM functions

# How Has This Been Tested?

- Lethe can now be compiled in 64bit on Niagara by adding ` -DDEAL_II_WITH_64BIT_INDICES=ON` to the `cmake` command of deal.II