### PR TITLE
Layer thickening

### DIFF
--- a/doc/source/parameters/sharp-immersed-boundary/sharp-immersed-boundary.rst
+++ b/doc/source/parameters/sharp-immersed-boundary/sharp-immersed-boundary.rst
@@ -64,6 +64,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
         set integrate motion           = false
         set pressure location          = 0; 0; 0
         set mesh-based precalculations = true
+        set layer thickening           = 0
         
         subsection position
           set Function expression = 0; 0; 0
@@ -254,6 +255,8 @@ The following parameter and subsection are all inside the subsection ``particle 
 * The ``integrate motion`` parameter controls if the dynamics equations of the particles are calculated. If this parameter is set to false, the particles position, velocity, and angular velocity are defined directly by the functions. If ``integrate motion=true`` the position and the velocity will be defined by the integration of the particle dynamic.
 
 * The ``mesh-based precalculations`` parameter controls if the mesh-based precalculations are applied. These precalculations are critical for good performance in medium to high detailed RBFs (and its composites), but can introduce deformations. These deformations appear when some RBF nodes are located outside of the background mesh.
+
+* The ``layer thickening`` is used to artificially inflate (positive value) or deflate (negative value) a particle. It can be used, for example, to evaluate the impact of uniform coating on a particle.
 
 * The ``pressure location`` parameter is used to define the X, Y, and Z coordinate offsets of the pressure reference point relative to the center of the particle. These parameters are used when the ``assemble Navier-Stokes inside particles`` parameter is set to ``true`` to define the pressure reference point.
 

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -226,7 +226,7 @@ public:
    * shape
    *
    * @param layer_thickening Thickness to be artificially added to the particle.
-   * A negative value will decrease the particle's thickness by subtracting a 
+   * A negative value will decrease the particle's thickness by subtracting a
    * layer of specified width.
    */
   void

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -225,7 +225,9 @@ public:
    * Sets the layer thickening value (positive or negative) of the particle's
    * shape
    *
-   * @param layer_thickening Thickness to be artificially added to the particle
+   * @param layer_thickening Thickness to be artificially added to the particle.
+   * A negative value will decrease the particle's thickness by subtracting a 
+   * layer of specified width.
    */
   void
   set_layer_thickening(const double layer_thickening)

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -221,6 +221,19 @@ public:
   set_orientation(const Tensor<1, 3> orientation);
 
   /**
+   * @brief
+   * Sets the layer thickening value (positive or negative) of the particle's
+   * shape
+   *
+   * @param layer_thickening Thickness to be artificially added to the particle
+   */
+  void
+  set_layer_thickening(const double layer_thickening)
+  {
+    shape->set_layer_thickening(layer_thickening);
+  }
+
+  /**
    * @brief Sets the proper dof handler, then computes/updates the map of cells
    * and their likely non-null nodes
    * @param updated_dof_handler the reference to the new dof_handler

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -301,7 +301,9 @@ public:
    * Sets the layer thickening value (positive or negative) of the particle's
    * shape
    *
-   * @param layer_thickening Thickness to be artificially added to the particle
+   * @param layer_thickening Thickness to be artificially added to the particle.
+   * A negative value will decrease the particle's thickness by subtracting a 
+   * layer of specified width.
    */
   virtual void
   set_layer_thickening(const double layer_thickening)

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -295,8 +295,24 @@ public:
     this->part_of_a_composite = part_of_a_composite;
   }
 
+  /**
+   * @brief
+   * Sets the layer thickening value (positive or negative) of the particle's
+   * shape
+   *
+   * @param layer_thickening Thickness to be artificially added to the particle
+   */
+  virtual void
+  set_layer_thickening(const double layer_thickening)
+  {
+    this->layer_thickening = layer_thickening;
+  }
+
   // Effective radius used for crown refinement
   double effective_radius;
+
+  // Layer thickening: used to artificially inflate/deflate the shape
+  double layer_thickening;
 
   // The string contains additional information on the shape. This may refer to
   // the file type used to define the shape or any other information relative to
@@ -1060,6 +1076,13 @@ public:
    */
   virtual void
   clear_cache() override;
+
+  /**
+   * @brief
+   * See base
+   */
+  void
+  set_layer_thickening(const double layer_thickening) override;
 
 private:
   // The members of this class are all the constituent and operations that are

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -302,7 +302,7 @@ public:
    * shape
    *
    * @param layer_thickening Thickness to be artificially added to the particle.
-   * A negative value will decrease the particle's thickness by subtracting a 
+   * A negative value will decrease the particle's thickness by subtracting a
    * layer of specified width.
    */
   virtual void

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -103,6 +103,7 @@ public:
     , position(position)
     , orientation(orientation)
     , part_of_a_composite(false)
+    , layer_thickening(0.)
   {}
 
   /**
@@ -311,9 +312,6 @@ public:
   // Effective radius used for crown refinement
   double effective_radius;
 
-  // Layer thickening: used to artificially inflate/deflate the shape
-  double layer_thickening;
-
   // The string contains additional information on the shape. This may refer to
   // the file type used to define the shape or any other information relative to
   // how the shape was defined.
@@ -333,6 +331,9 @@ protected:
   std::unordered_map<std::string, Tensor<1, dim>> gradient_cache;
   std::unordered_map<std::string, Point<dim>>     closest_point_cache;
   bool                                            part_of_a_composite;
+
+  // Layer thickening: used to artificially inflate/deflate the shape
+  double layer_thickening;
 };
 
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2600,7 +2600,8 @@ namespace Parameters
       "layer thickening",
       "0",
       Patterns::Double(),
-      "Thickness (positive or negative) of uniform additional layer of solid on particle");
+      "Thickness (positive or negative) of uniform additional layer of solid on particle."
+      "A negative value will decrease the particle's thickness by subtracting a layer of specified width.");
 
     prm.declare_entry(
       "pressure location",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2597,6 +2597,12 @@ namespace Parameters
                       "Arguments defining the geometry");
 
     prm.declare_entry(
+      "layer thickening",
+      "0",
+      Patterns::Double(),
+      "Thickness (positive or negative) of uniform additional layer of solid on particle");
+
+    prm.declare_entry(
       "pressure location",
       "0; 0; 0",
       Patterns::Anything(),
@@ -2996,6 +3002,8 @@ namespace Parameters
           std::string shape_type          = prm.get("type");
           std::string shape_arguments_str = prm.get("shape arguments");
           particles[i].initialize_shape(shape_type, shape_arguments_str);
+
+          particles[i].set_layer_thickening(prm.get_double("layer thickening"));
 
           particles[i].radius = particles[i].shape->effective_radius;
           prm.enter_subsection("physical properties");

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1463,6 +1463,15 @@ CompositeShape<dim>::clear_cache()
 }
 
 template <int dim>
+void
+CompositeShape<dim>::set_layer_thickening(const double layer_thickening)
+{
+  this->Shape<dim>::set_layer_thickening(layer_thickening);
+  for (auto const &constituent : constituents | boost::adaptors::map_values)
+    constituent->set_layer_thickening(layer_thickening);
+}
+
+template <int dim>
 RBFShape<dim>::RBFShape(const std::string   shape_arguments_str,
                         const Point<dim>   &position,
                         const Tensor<1, 3> &orientation)
@@ -1579,7 +1588,7 @@ RBFShape<dim>::value(const Point<dim> &evaluation_point,
           value += basis * weights[node_id];
         }
     }
-  return value;
+  return value - this->layer_thickening;
 }
 
 template <int dim>

--- a/tests/core/shape_thickening.cc
+++ b/tests/core/shape_thickening.cc
@@ -1,0 +1,96 @@
+/**
+ * @brief Tests the shape thickening feature.
+ */
+
+// Lethe
+#include <core/shape.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beginning" << std::endl;
+
+  // Solid parameters
+  double                    radius          = 0.5;
+  double                    layer_thickness = 0.1;
+  Point<3>                  position({0., 0., 0.});
+  Tensor<1, 3>              orientation({0., 0., 0.});
+  std::shared_ptr<Shape<3>> sphere =
+    std::make_shared<Sphere<3>>(radius, position, orientation);
+
+  deallog << "Testing value" << std::endl;
+  // Testing value of all shape, to confirm proper implementation
+  Point<3> p({1., 0.8, 0.75});
+  deallog << " Sphere , SD = " << sphere->value(p) << std::endl;
+  sphere->set_layer_thickening(layer_thickness);
+  deallog << " Sphere , SD = " << sphere->value(p) << std::endl;
+  sphere->set_layer_thickening(-layer_thickness);
+  deallog << " Sphere , SD = " << sphere->value(p) << std::endl;
+
+  deallog << "OK" << std::endl;
+
+  deallog << "Testing gradient" << std::endl;
+  sphere->set_layer_thickening(0);
+  Tensor<1, 3> gradient_sphere = sphere->gradient(p);
+  deallog << " Gradient for sphere at p[0] = " << gradient_sphere[0]
+          << std::endl;
+  deallog << " Gradient for sphere at p[1] = " << gradient_sphere[1]
+          << std::endl;
+  deallog << " Gradient for sphere at p[2] = " << gradient_sphere[2]
+          << std::endl;
+  sphere->set_layer_thickening(layer_thickness);
+  gradient_sphere = sphere->gradient(p);
+  deallog << " Gradient for sphere at p[0] = " << gradient_sphere[0]
+          << std::endl;
+  deallog << " Gradient for sphere at p[1] = " << gradient_sphere[1]
+          << std::endl;
+  deallog << " Gradient for sphere at p[2] = " << gradient_sphere[2]
+          << std::endl;
+  sphere->set_layer_thickening(-layer_thickness);
+  gradient_sphere = sphere->gradient(p);
+  deallog << " Gradient for sphere at p[0] = " << gradient_sphere[0]
+          << std::endl;
+  deallog << " Gradient for sphere at p[1] = " << gradient_sphere[1]
+          << std::endl;
+  deallog << " Gradient for sphere at p[2] = " << gradient_sphere[2]
+          << std::endl;
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/shape_thickening.output
+++ b/tests/core/shape_thickening.output
@@ -1,0 +1,18 @@
+
+DEAL::Beginning
+DEAL::Testing value
+DEAL:: Sphere , SD = 0.984082
+DEAL:: Sphere , SD = 0.884082
+DEAL:: Sphere , SD = 1.08408
+DEAL::OK
+DEAL::Testing gradient
+DEAL:: Gradient for sphere at p[0] = 0.673817
+DEAL:: Gradient for sphere at p[1] = 0.539054
+DEAL:: Gradient for sphere at p[2] = 0.505363
+DEAL:: Gradient for sphere at p[0] = 0.673817
+DEAL:: Gradient for sphere at p[1] = 0.539054
+DEAL:: Gradient for sphere at p[2] = 0.505363
+DEAL:: Gradient for sphere at p[0] = 0.673817
+DEAL:: Gradient for sphere at p[1] = 0.539054
+DEAL:: Gradient for sphere at p[2] = 0.505363
+DEAL::OK


### PR DESCRIPTION
# Description of the problem

- For some simulations, especially in porous media, in can be useful to artificially inflate or deflate a solid.
- This option is added in this PR, for all shapes.

# Description of the solution

- A member double is added to the Shape class, and not the IBParticle class: this is done so that the output, which calls Shape as a Function, can show the inflation/deflation.
- No change is made to the gradient (only value), because the inflation/deflation happens in the normal direction.

# How Has This Been Tested?

- [core/shape_thickening] Unit test that shows that value changes with thickening, but not the gradient.

# Documentation

- The parameter is added to the Sharp Immersed Boundary parameters page.