### PR TITLE
Update installation with apt

### DIFF
--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -34,9 +34,9 @@ Regular Installation on Linux
 Installing deal.II using apt (Step #1)
 -----------------------------------------
 
-This is done following `this procedure<https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
+This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
 
-In case you are using Ubuntu, you will need to `update the backports<https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
+In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
 
 .. code-block:: text
   :class: copy-button
@@ -62,7 +62,7 @@ This should output several information about the installed version. Everything w
 
 .. note::
 
-  If the installed version is other than ``deal.ii-9.5.1``, follow the procedure `here<https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
+  If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 Installing deal.II using Candi (Step #1)
 -----------------------------------------
@@ -258,6 +258,17 @@ where $numprocs can be the number of physical cores on your machine.
 
 Updating deal.II
 -------------------
+
+Through apt
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As all other ``apt`` packages, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt update
+  sudo apt upgrade -y
 
 Through the Git Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -6,29 +6,63 @@ Regular Installation on Linux
    :height: 100px
 
 .. important::
-	Distributions compatibility: Ubuntu 18.04 LTS, Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro
+  Distributions compatibility: Ubuntu 18.04 LTS, Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro
 
 * Dependencies: deal.II library (`deal.II website <https://www.dealii.org/>`_) and its dependencies (MPI, numdiff, p4est, trilinos and METIS)
-	* Lethe requires a modern version of the deal.II library. At the time of this writing, ``deal.II 9.4`` and ``deal.II 10.0pre`` (the ``master`` branch version) are supported. 
-	* The compatibility with these two branches is ensured by Continuous Integration (CI) using Github Actions. 
-	* A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. We work hard to ensure compatibility with the latest deal.II version and we do not modify the library except through pull requests on the official deal.II repository.
+  * Lethe requires a modern version of the deal.II library. At the time of this writing, ``deal.II 9.4`` and ``deal.II 10.0pre`` (the ``master`` branch version) are supported.
+  * The compatibility with these two branches is ensured by Continuous Integration (CI) using Github Actions.
+  * A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. We work hard to ensure compatibility with the latest deal.II version and we do not modify the library except through pull requests on the official deal.II repository.
 
 .. warning:: 
-	Lethe cannot be installed if deal.II has not been configured with p4est, trilinos and METIS. Although Lethe can be run in serial and parallel mode (through MPI), it uses p4est, METIS and trilinos for mesh decomposition and the linear solvers respectively. 
+  Lethe cannot be installed if deal.II has not been configured with p4est, trilinos and METIS. Although Lethe can be run in serial and parallel mode (through MPI), it uses p4est, METIS and trilinos for mesh decomposition and the linear solvers respectively.
 
 * Lethe installation steps:
-	1. Installation of deal.II dependencies (MPI, numdiff, p4est, trilinos and METIS)
-	2. Installation of the deal.II library
-	3. Installation of Lethe
+  1. Installation of deal.II dependencies (MPI, numdiff, p4est, trilinos and METIS)
+  2. Installation of the deal.II library
+  3. Installation of Lethe
 
 * Methods to install deal.II and its dependencies:
-	1. through candi shell script (`candi github page <https://github.com/dealii/candi>`_): **this is by far the easiest way to proceed**, since it requires much less manual intervention. Even if you do not want to use candi to install deal.II, you can use it for the dependencies.	
-	
-	2. manually 
+  1. Through Advanced Packaging Tool (apt): **this is by far the easiest way to proceed**, since it requires much less manual intervention.
+
+  2. through candi shell script (`candi github page <https://github.com/dealii/candi>`_). Even if you do not want to use candi to install deal.II, you can use it for the dependencies.
+
+  3. manually
 
 .. warning::
-	On a single core computer with 8GB of RAM, count up to 8 hours for a first installation, and 3 hours for a deal.II update. On a machine with 16 cores and 32GB of RAM, this process will take less than an hour or so. The installation of deal.II and its dependencies (especially trilinos), can be extremely RAM consuming. Installation on a machine with less than 8GB of RAM is difficult at best, impossible at worst.
+  On a single core computer with 8GB of RAM, count up to 8 hours for a first installation, and 3 hours for a deal.II update. On a machine with 16 cores and 32GB of RAM, this process will take less than an hour or so. The installation of deal.II and its dependencies (especially trilinos), can be extremely RAM consuming. Installation on a machine with less than 8GB of RAM is difficult at best, impossible at worst.
 
+Installing deal.II using apt (Step #1)
+-----------------------------------------
+
+This is done following `this procedure<https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
+
+In case you are using Ubuntu, you will need to `update the backports<https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
+  sudo apt update
+
+To install deal.II, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libdeal.ii-dev
+
+To verify if the correct version of deal.II is installed, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  apt show libdeal.ii-dev
+
+This should output several information about the installed version. Everything worked as expected if ``deal.ii-9.5.1`` is output
+
+.. note::
+
+  If the installed version is other than ``deal.ii-9.5.1``, follow the procedure `here<https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 Installing deal.II using Candi (Step #1)
 -----------------------------------------

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -9,7 +9,7 @@ Regular Installation on Linux
   Distributions compatibility: Ubuntu 18.04 LTS, Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro
 
 * Dependencies: deal.II library (`deal.II website <https://www.dealii.org/>`_) and its dependencies (MPI, numdiff, p4est, trilinos and METIS)
-  * Lethe requires a modern version of the deal.II library. At the time of this writing, ``deal.II 9.4`` and ``deal.II 10.0pre`` (the ``master`` branch version) are supported.
+  * Lethe requires a modern version of the deal.II library. At the time of this writing, ``deal.II 9.5`` and ``deal.II 9.6pre`` (the ``master`` branch version) are supported.
   * The compatibility with these two branches is ensured by Continuous Integration (CI) using Github Actions.
   * A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. We work hard to ensure compatibility with the latest deal.II version and we do not modify the library except through pull requests on the official deal.II repository.
 

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -55,11 +55,13 @@ Installing WSL and Ubuntu (Step #0)
 When prompted "do you want to continue?", proceed by typing ``y`` and hitting ``Enter``.
 
 3. |win_shell| (optional) To activate copy/paste in the Linux sub-terminal (`tutorial with screenshots <https://defragged.org/2020/10/29/how-to-copy-paste-in-windows-subsystem-for-linux-wsl/>`_):
+
   * right-click on the Ubuntu Window pane header
   * in ``Properties``, select ``Use Ctrl+Shift+C/V as Copy/Paste``
   * you can then use ``Ctrl+Shift+V`` to paste text or commands in the Linux sub-terminal
 
 4. |win_shell| (optional) For better ease in the Linux terminal (better coloring, multiple tabs), change the default terminal:
+
   * in the microsoft store, download ``Windows Terminal``
   * in the ``parameters`` of ``Windows Terminal``, select on the left pannel "start": change default profile with ``Ubuntu-22.04``
   * from now on, you can use this application instead to launch Ubuntu terminal
@@ -84,9 +86,9 @@ The following step is to install deal.II. This can be done through
 Installing deal.II using apt (Step #1)
 -----------------------------------------
 
-This is done following `this procedure<https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
+This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
 
-In case you are using Ubuntu, you will need to `update the backports<https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
+In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
 
 .. code-block:: text
   :class: copy-button
@@ -112,7 +114,7 @@ This should output several information about the installed version. Everything w
 
 .. note::
 
-  If the installed version is other than ``deal.ii-9.5.1``, follow the procedure `here<https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
+  If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 
 Installing deal.II using Candi (Step #1)
@@ -172,6 +174,7 @@ Note the use of ``;`` which enable to serialize operations on a single execution
 Do not forget the ``.`` at the end of the command, which means "here".
 
 5. |win_shell| Modify installation parameters (deal.II version and trilinos version):
+
   * open Windows file manager, and on the left panel (along with ``Files``, ``Computer`` etc.) click on the ``Ubuntu`` mount.
 
   .. tip::
@@ -251,6 +254,7 @@ Where ``$numprocs`` corresponds to the number of processors used for the compila
   You can exit the installation at any time hitting ``Ctrl+C`` 2-3 times.
 
 7. |win_shell| At the end of the installation, check that you have deal.II and its dependencies installed:
+
   * on Windows file manager, go to the Ubuntu mount
   * in ``home/<user_name>`` you should have a folder ``deal.ii-candi``, or ``dealii-candi``
   * inside this folder, you should have folders for the dependencies, namely: p4est, petsc, parmetis, trilinos
@@ -316,6 +320,7 @@ Where ``$numprocs`` corresponds to the number of processors used for the compila
   * if you have 16Gb of RAM and above, ``$numprocs`` can be the number of physical cores minus 1. For instance, for a computer with 6 physical cores: ``make -j5``
 
 5. |linux_shell| (optional) Finally, it is recommended to test your installation:
+
   * If you are running these tests for the first time, install ``numdiff``:
 
   .. code-block:: text
@@ -418,6 +423,7 @@ Modify Candi Installation Parameters with Nano
 2. Modify the text in the file, using only the keyboard. 
 
 3. Save the file: 
+
   * hit ``Ctrl + X``
   * a prompt will appear at the bottom of the terminal asking ``Save modified buffer?``
   * confirm by hitting ``y``

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -6,7 +6,7 @@ Windows with WSL
    :height: 100px
 
 .. important::
-	Distributions compatibility: Windows 10 and Windows 11
+  Distributions compatibility: Windows 10 and Windows 11
  
 .. |linux_shell| image:: ./images/linux.png
    :height: 15px
@@ -16,14 +16,14 @@ Windows with WSL
 
 .. seealso::
 
-	This tutorial is aimed at Windows users who have no prior knowledge of Linux. To keep it simple, all dependencies are installed using candi. Installation options given in this tutorial are well suited for lethe users. If you are a developer or need more options, see :doc:`regular_installation`.
+  This tutorial is aimed at Windows users who have no prior knowledge of Linux. To keep it simple, all dependencies are installed using candi. Installation options given in this tutorial are well suited for lethe users. If you are a developer or need more options, see :doc:`regular_installation`.
 
 Throughout this tutorial:
-	* |win_shell| indicates operations performed in the Windows session, and 
-	* |linux_shell| indicates operations performed in the Linux subsystem.
+  * |win_shell| indicates operations performed in the Windows session, and
+  * |linux_shell| indicates operations performed in the Linux subsystem.
 
 .. tip::
-	To execute a command on a shell (Ubuntu or Windows command prompt), type or copy/paste the given command and hit ``Enter``. Multiple commands are given in multiple lines, or separated by ``;``: when copying/pasting, they will be executed one after the other.
+  To execute a command on a shell (Ubuntu or Windows command prompt), type or copy/paste the given command and hit ``Enter``. Multiple commands are given in multiple lines, or separated by ``;``: when copying/pasting, they will be executed one after the other.
 
 Installing WSL and Ubuntu (Step #0)
 ------------------------------------
@@ -32,14 +32,14 @@ Installing WSL and Ubuntu (Step #0)
 
 .. admonition:: Verify the installed version of WSL
 
-	In the windows command prompt (Start menu > ``cmd``):
+  In the windows command prompt (Start menu > ``cmd``):
 
-	.. code-block:: text
-  	  :class: copy-button
+  .. code-block:: text
+      :class: copy-button
 
-  	  wsl -l -v
+      wsl -l -v
 
-	should indicate ``version 2``. If not, follow this to update WSL: https://docs.microsoft.com/fr-fr/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2
+  should indicate ``version 2``. If not, follow this to update WSL: https://docs.microsoft.com/fr-fr/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2
 
 2. |win_shell| Launch Ubuntu (from the start menu) and |linux_shell| update Ubuntu: 
 
@@ -50,36 +50,76 @@ Installing WSL and Ubuntu (Step #0)
   sudo apt upgrade
 
 .. tip::
-	The ``sudo`` command will ask you to type your user password, as defined during Ubuntu installation. Note that Linux does not show any symbol while typing a password, contrary to Windows with ``*``: simply type your password and press ``Enter``.
+  The ``sudo`` command will ask you to type your user password, as defined during Ubuntu installation. Note that Linux does not show any symbol while typing a password, contrary to Windows with ``*``: simply type your password and press ``Enter``.
 
 When prompted "do you want to continue?", proceed by typing ``y`` and hitting ``Enter``.
 
 3. |win_shell| (optional) To activate copy/paste in the Linux sub-terminal (`tutorial with screenshots <https://defragged.org/2020/10/29/how-to-copy-paste-in-windows-subsystem-for-linux-wsl/>`_):
-	* right-click on the Ubuntu Window pane header 
-	* in ``Properties``, select ``Use Ctrl+Shift+C/V as Copy/Paste``
-	* you can then use ``Ctrl+Shift+V`` to paste text or commands in the Linux sub-terminal
+  * right-click on the Ubuntu Window pane header
+  * in ``Properties``, select ``Use Ctrl+Shift+C/V as Copy/Paste``
+  * you can then use ``Ctrl+Shift+V`` to paste text or commands in the Linux sub-terminal
 
 4. |win_shell| (optional) For better ease in the Linux terminal (better coloring, multiple tabs), change the default terminal:
-	* in the microsoft store, download ``Windows Terminal``
-	* in the ``parameters`` of ``Windows Terminal``, select on the left pannel "start": change default profile with ``Ubuntu-22.04``
-	* from now on, you can use this application instead to launch Ubuntu terminal
+  * in the microsoft store, download ``Windows Terminal``
+  * in the ``parameters`` of ``Windows Terminal``, select on the left pannel "start": change default profile with ``Ubuntu-22.04``
+  * from now on, you can use this application instead to launch Ubuntu terminal
 
 .. tip::
-	A (very) few Linux commands useful for navigation:
-		* ``mkdir $dir``: (make directory) create a directory with the name specified as ``$dir``
-		* ``cd $dir``: (change directory) move to the directory ``$dir``
-		* ``cd ..``: move up to the parent directory
-		* ``pwd``: (print working directory) return the directory you are in
-		* ``cd $HOME``: move to your home directory (``/home/<user_name>/``)
+  A (very) few Linux commands useful for navigation:
+    * ``mkdir $dir``: (make directory) create a directory with the name specified as ``$dir``
+    * ``cd $dir``: (change directory) move to the directory ``$dir``
+    * ``cd ..``: move up to the parent directory
+    * ``pwd``: (print working directory) return the directory you are in
+    * ``cd $HOME``: move to your home directory (``/home/<user_name>/``)
 
-	You can find `here <https://linuxconfig.org/linux-commands>`_ a thorough guide for the most basic Linux commands.
+  You can find `here <https://linuxconfig.org/linux-commands>`_ a thorough guide for the most basic Linux commands.
+
+
+The following step is to install deal.II. This can be done through
+
+  1. Advanced Packaging Tool (apt): **this is by far the easiest way to proceed**
+
+  2. Candi shell script (`candi github page <https://github.com/dealii/candi>`_).
+
+Installing deal.II using apt (Step #1)
+-----------------------------------------
+
+This is done following `this procedure<https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
+
+In case you are using Ubuntu, you will need to `update the backports<https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
+  sudo apt update
+
+To install deal.II, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libdeal.ii-dev
+
+To verify if the correct version of deal.II is installed, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  apt show libdeal.ii-dev
+
+This should output several information about the installed version. Everything worked as expected if ``deal.ii-9.5.1`` is output
+
+.. note::
+
+  If the installed version is other than ``deal.ii-9.5.1``, follow the procedure `here<https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 
 Installing deal.II using Candi (Step #1)
 -----------------------------------------
 
 .. important::
-	This step is by far the most troublesome in all Lethe installation. Read and follow each step carefully.
+  This step is by far the most troublesome in all Lethe installation. Read and follow each step carefully.
 
 1. |linux_shell| Install candi required packages:
 
@@ -93,7 +133,7 @@ Installing deal.II using Candi (Step #1)
   liblapack3 liblapack-dev libsuitesparse-dev
 
 .. tip::
-	The symbols ``\`` indicate that this a single command written on multiple lines.
+  The symbols ``\`` indicate that this a single command written on multiple lines.
 
 2. |linux_shell| Install compilers:
 
@@ -104,21 +144,21 @@ Installing deal.II using Candi (Step #1)
 
 .. admonition:: Check the default version of the compilers
 
-	In the Ubuntu terminal:
+  In the Ubuntu terminal:
 
-	.. code-block:: text
+  .. code-block:: text
 
-		gcc --version
+    gcc --version
 
-	should return ``gcc (Ubuntu 10.X.X...) 10.X.X``. If not, go to :ref:`change compiler default version`.
+  should return ``gcc (Ubuntu 10.X.X...) 10.X.X``. If not, go to :ref:`change compiler default version`.
 
 3. |linux_shell| Create folders (suggested structure):
 
 .. code-block:: text
   :class: copy-button
 
-	mkdir Software; cd Software
-	mkdir candi; cd candi
+  mkdir Software; cd Software
+  mkdir candi; cd candi
 
 Note the use of ``;`` which enable to serialize operations on a single execution line.
 
@@ -132,64 +172,64 @@ Note the use of ``;`` which enable to serialize operations on a single execution
 Do not forget the ``.`` at the end of the command, which means "here".
 
 5. |win_shell| Modify installation parameters (deal.II version and trilinos version):
-	* open Windows file manager, and on the left panel (along with ``Files``, ``Computer`` etc.) click on the ``Ubuntu`` mount.
+  * open Windows file manager, and on the left panel (along with ``Files``, ``Computer`` etc.) click on the ``Ubuntu`` mount.
 
-	.. tip::
-		If you do not see any ``Ubuntu`` mount, use this alternative method: :ref:`modify candi installation parameters with nano`.
+  .. tip::
+    If you do not see any ``Ubuntu`` mount, use this alternative method: :ref:`modify candi installation parameters with nano`.
 
-	* navigate to reach the candi folder, in: ``/home/<user_name>/Software/candi``
-	* open the ``candi.cfg`` file with notepad (or other text editor) and change the following lines:
+  * navigate to reach the candi folder, in: ``/home/<user_name>/Software/candi``
+  * open the ``candi.cfg`` file with notepad (or other text editor) and change the following lines:
 
-	+--------+------------------------------------------+----------------------------------------+
-	| line # | initial parameter                        | changed parameter                      |
-	+========+==========================================+========================================+
-	|      7 | ``CLEAN_BUILD=OFF``                      | ``CLEAN_BUILD=ON``                     |
-	+--------+------------------------------------------+----------------------------------------+
-	|     86 | ``# PACKAGES="${PACKAGES} once:netcdf"`` | ``PACKAGES="${PACKAGES} once:netcdf"`` |
-	+--------+------------------------------------------+----------------------------------------+
-	|     97 | ``DEAL_II_VERSION=v9.5.0``               | ``DEAL_II_VERSION=master``             |
-	+--------+------------------------------------------+----------------------------------------+
+  +--------+------------------------------------------+----------------------------------------+
+  | line # | initial parameter                        | changed parameter                      |
+  +========+==========================================+========================================+
+  |      7 | ``CLEAN_BUILD=OFF``                      | ``CLEAN_BUILD=ON``                     |
+  +--------+------------------------------------------+----------------------------------------+
+  |     86 | ``# PACKAGES="${PACKAGES} once:netcdf"`` | ``PACKAGES="${PACKAGES} once:netcdf"`` |
+  +--------+------------------------------------------+----------------------------------------+
+  |     97 | ``DEAL_II_VERSION=v9.5.0``               | ``DEAL_II_VERSION=master``             |
+  +--------+------------------------------------------+----------------------------------------+
 
-	* save and close 
-	* navigate to reach the following subfolder: ``deal.II-toolchain/packages/``
-	* open the ``trilinos.package`` file with notepad and change the following lines:
+  * save and close
+  * navigate to reach the following subfolder: ``deal.II-toolchain/packages/``
+  * open the ``trilinos.package`` file with notepad and change the following lines:
 
-	.. tip::
-		The prefix ``#`` is used to comment a line. Here we are simply commenting lines 44 and 45, and uncommenting lines 50 and 51, to change the trilinos version.
+  .. tip::
+    The prefix ``#`` is used to comment a line. Here we are simply commenting lines 44 and 45, and uncommenting lines 50 and 51, to change the trilinos version.
 
-	+--------+------------------------------------------------+-----------------------------------------------+
-	| line # | initial parameter                              | changed parameter                             |
-	+========+================================================+===============================================+
-	|     44 | ``VERSION=12-18-1``                            | ``#VERSION=12-18-1``                          |
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     45 | ``CHECKSUM=9c1d151169949bca6cf203831e4d6aee``  | ``#CHECKSUM=9c1d151169949bca6cf203831e4d6aee``|
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     50 | ``#VERSION=12-12-1``                           | ``VERSION=12-12-1``                           |
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     51 | ``#CHECKSUM=ecd4606fa332212433c98bf950a69cc7`` | ``CHECKSUM=ecd4606fa332212433c98bf950a69cc7`` |
-	+--------+------------------------------------------------+-----------------------------------------------+
+  +--------+------------------------------------------------+-----------------------------------------------+
+  | line # | initial parameter                              | changed parameter                             |
+  +========+================================================+===============================================+
+  |     44 | ``VERSION=12-18-1``                            | ``#VERSION=12-18-1``                          |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     45 | ``CHECKSUM=9c1d151169949bca6cf203831e4d6aee``  | ``#CHECKSUM=9c1d151169949bca6cf203831e4d6aee``|
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     50 | ``#VERSION=12-12-1``                           | ``VERSION=12-12-1``                           |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     51 | ``#CHECKSUM=ecd4606fa332212433c98bf950a69cc7`` | ``CHECKSUM=ecd4606fa332212433c98bf950a69cc7`` |
+  +--------+------------------------------------------------+-----------------------------------------------+
 
-	* save and close 
-	* still in the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with notepad and change the following lines:
+  * save and close
+  * still in the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with notepad and change the following lines:
 
-	.. tip::
-		The prefix ``#`` is used to comment a line. Here we are simply uncommenting line 7, and commenting lines 9 to 12, to change the p4est version.
+  .. tip::
+    The prefix ``#`` is used to comment a line. Here we are simply uncommenting line 7, and commenting lines 9 to 12, to change the p4est version.
 
-	+--------+------------------------------------------------+-----------------------------------------------+
-	| line # | initial parameter                              | changed parameter                             |
-	+========+================================================+===============================================+
-	|     7  | ``#VERSION=2.2;CHECKSUM=6943949a...``          | ``VERSION=2.2;CHECKSUM=6943949a...``          |
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     9  | ``VERSION=2.3.2``                              | ``#VERSION=2.3.2``                            |
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     10 | ``CHECKSUM=076df9e...``                        | ``#CHECKSUM=076df9e...``                      |
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     11 | ``CHECKSUM="${CHECKSUM} b41c8ef29ca...``       | ``#CHECKSUM="${CHECKSUM} b41c8ef29ca...``     |
-	+--------+------------------------------------------------+-----------------------------------------------+
-	|     12 | ``CHECKSUM="${CHECKSUM} 0ea6e4806b6...``       | ``#CHECKSUM="${CHECKSUM} 0ea6e4806b6...``     |
-	+--------+------------------------------------------------+-----------------------------------------------+
+  +--------+------------------------------------------------+-----------------------------------------------+
+  | line # | initial parameter                              | changed parameter                             |
+  +========+================================================+===============================================+
+  |     7  | ``#VERSION=2.2;CHECKSUM=6943949a...``          | ``VERSION=2.2;CHECKSUM=6943949a...``          |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     9  | ``VERSION=2.3.2``                              | ``#VERSION=2.3.2``                            |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     10 | ``CHECKSUM=076df9e...``                        | ``#CHECKSUM=076df9e...``                      |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     11 | ``CHECKSUM="${CHECKSUM} b41c8ef29ca...``       | ``#CHECKSUM="${CHECKSUM} b41c8ef29ca...``     |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     12 | ``CHECKSUM="${CHECKSUM} 0ea6e4806b6...``       | ``#CHECKSUM="${CHECKSUM} 0ea6e4806b6...``     |
+  +--------+------------------------------------------------+-----------------------------------------------+
 
-	* save and close 
+  * save and close
 
 6. |linux_shell| Still in the candi subfolder, run candi installation script:
 
@@ -199,22 +239,22 @@ Do not forget the ``.`` at the end of the command, which means "here".
   ./candi.sh -j$numprocs
 
 Where ``$numprocs`` corresponds to the number of processors used for the compilation:
-	* if you have less than 8Gb of RAM, use 1 to 2 procs: ``./candi.sh -j1`` or ``./candi.sh -j2``
-	* if you have 16Gb of RAM and above, ``$numprocs`` can be the number of physical cores minus 1. For instance, for a computer with 6 physical cores: ``./candi.sh -j5``
+  * if you have less than 8Gb of RAM, use 1 to 2 procs: ``./candi.sh -j1`` or ``./candi.sh -j2``
+  * if you have 16Gb of RAM and above, ``$numprocs`` can be the number of physical cores minus 1. For instance, for a computer with 6 physical cores: ``./candi.sh -j5``
 
 .. tip::
 
-	Candi will print messages asking you if you installed the dependency. Hit ``Enter`` two times to validate and the installation will launch. If new lines are written in the console, this means the installation is going on correctly. The installation will take from 1 to 3 hours depending on your hardware.
+  Candi will print messages asking you if you installed the dependency. Hit ``Enter`` two times to validate and the installation will launch. If new lines are written in the console, this means the installation is going on correctly. The installation will take from 1 to 3 hours depending on your hardware.
 
-	If the installation is stuck (no change on the console for a few minutes), hitting ``Enter`` can unstuck it.
+  If the installation is stuck (no change on the console for a few minutes), hitting ``Enter`` can unstuck it.
 
-	You can exit the installation at any time hitting ``Ctrl+C`` 2-3 times.
+  You can exit the installation at any time hitting ``Ctrl+C`` 2-3 times.
 
 7. |win_shell| At the end of the installation, check that you have deal.II and its dependencies installed:
-	* on Windows file manager, go to the Ubuntu mount
-	* in ``home/<user_name>`` you should have a folder ``deal.ii-candi``, or ``dealii-candi``
-	* inside this folder, you should have folders for the dependencies, namely: p4est, petsc, parmetis, trilinos
-	* you should also see this folder: ``deal.II-master``
+  * on Windows file manager, go to the Ubuntu mount
+  * in ``home/<user_name>`` you should have a folder ``deal.ii-candi``, or ``dealii-candi``
+  * inside this folder, you should have folders for the dependencies, namely: p4est, petsc, parmetis, trilinos
+  * you should also see this folder: ``deal.II-master``
 
 8. |linux_shell| Add a deal.II environment variable in Ubuntu through the following command:
 
@@ -225,11 +265,11 @@ Where ``$numprocs`` corresponds to the number of processors used for the compila
 
 .. note::
 
-	Even if we use a ``echo`` command, nothing will be outputted in the terminal: the text is written directly at the end the ``.bashrc`` file.
+  Even if we use a ``echo`` command, nothing will be outputted in the terminal: the text is written directly at the end the ``.bashrc`` file.
 
 .. warning::
 
-	For this change to be effective, you may need to restart your Ubuntu terminal.
+  For this change to be effective, you may need to restart your Ubuntu terminal.
 
 
 Installing Lethe (Step #2)
@@ -261,8 +301,8 @@ After installation is complete, the folder structure will be:
 .. code-block:: text
   :class: copy-button
 
-	cd build
-	cmake ../git -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst/
+  cd build
+  cmake ../git -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst/
 
 4. |linux_shell| Compile lethe:
 
@@ -272,29 +312,29 @@ After installation is complete, the folder structure will be:
   make -j$numprocs
 
 Where ``$numprocs`` corresponds to the number of processors used for the compilation:
-	* if you have less than 8Gb of RAM, use 1 to 2 procs: ``make -j1`` or ``make -j2``
-	* if you have 16Gb of RAM and above, ``$numprocs`` can be the number of physical cores minus 1. For instance, for a computer with 6 physical cores: ``make -j5``
+  * if you have less than 8Gb of RAM, use 1 to 2 procs: ``make -j1`` or ``make -j2``
+  * if you have 16Gb of RAM and above, ``$numprocs`` can be the number of physical cores minus 1. For instance, for a computer with 6 physical cores: ``make -j5``
 
 5. |linux_shell| (optional) Finally, it is recommended to test your installation:
-	* If you are running these tests for the first time, install ``numdiff``:
+  * If you are running these tests for the first time, install ``numdiff``:
 
-	.. code-block:: text
-	  :class: copy-button
+  .. code-block:: text
+    :class: copy-button
     
-		apt-get numdiff
+    apt-get numdiff
 
-	* Run the tests in the build folder:
+  * Run the tests in the build folder:
 
 .. code-block:: text
   :class: copy-button
 
   ctest -j$numprocs
 
-	This will take from a few minutes to an hour, depending on your hardware. At the end, you should have this message on the console:
+  This will take from a few minutes to an hour, depending on your hardware. At the end, you should have this message on the console:
 
-	.. code-block:: text
+  .. code-block:: text
 
-		100% tests passed
+    100% tests passed
 
 Congratulations, you are now ready to use lethe! For instance, proceed to :doc:`../first_simulation`.
 
@@ -308,20 +348,20 @@ If you have already installed deal.II and lethe, you can update them without doi
 .. code-block:: text
   :class: copy-button
 
-	cd Software/candi
-	./candi.sh -j$numprocs
+  cd Software/candi
+  ./candi.sh -j$numprocs
 
 2. |linux_shell| Then, update lethe:
 
 .. code-block:: text
   :class: copy-button
 
-	cd ../lethe/git
-	git pull
-	cd ../build
-	cmake ../git -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst/
-	make -j$numprocs
-	
+  cd ../lethe/git
+  git pull
+  cd ../build
+  cmake ../git -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst/
+  make -j$numprocs
+
 
 Troubleshooting
 -------------------------------------
@@ -335,18 +375,18 @@ Change Compiler Default Version
 
 .. code-block:: text
 
-	sudo update-alternatives --remove-all gcc
-	sudo update-alternatives --remove-all g++
-	sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-	sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
-	sudo update-alternatives --set cc /usr/bin/gcc
-	sudo update-alternatives --set c++ /usr/bin/g++
+  sudo update-alternatives --remove-all gcc
+  sudo update-alternatives --remove-all g++
+  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+  sudo update-alternatives --set cc /usr/bin/gcc
+  sudo update-alternatives --set c++ /usr/bin/g++
 
 Then, check again the version used:
 
 .. code-block:: text
 
-	gcc --version
+  gcc --version
 
 Should return ``gcc (Ubuntu 10.X.X...) 10.X.X``.
 
@@ -359,30 +399,30 @@ Modify Candi Installation Parameters with Nano
 |linux_shell| If you do not see the Ubuntu mount in the Windows file manager, you can modify the candi parameter files in the Ubuntu terminal directly. 
 
 .. note::
-	You cannot click, so use the keyboard arrows to move inside the text.
+  You cannot click, so use the keyboard arrows to move inside the text.
 
 1. Open the desired file in the terminal with ``nano`` (built-in text editor):
 
 .. code-block:: text
 
-	cd <folder_name>
-	nano <file_name>
+  cd <folder_name>
+  nano <file_name>
 
 .. admonition:: Example for the candi.cfg
 
-	.. code-block:: text
+  .. code-block:: text
 
-		cd /home/<user_name>/Software/candi
-		nano candi.cfg
+    cd /home/<user_name>/Software/candi
+    nano candi.cfg
 
 2. Modify the text in the file, using only the keyboard. 
 
 3. Save the file: 
-	* hit ``Ctrl + X``
-	* a prompt will appear at the bottom of the terminal asking ``Save modified buffer?``
-	* confirm by hitting ``y`` 
-	* a prompt will appear at the bottom of the terminal to recall the file name
-	* hit ``Enter`` to confirm
-	* the file will be closed automatically and you will be back on the Ubuntu terminal
+  * hit ``Ctrl + X``
+  * a prompt will appear at the bottom of the terminal asking ``Save modified buffer?``
+  * confirm by hitting ``y``
+  * a prompt will appear at the bottom of the terminal to recall the file name
+  * hit ``Enter`` to confirm
+  * the file will be closed automatically and you will be back on the Ubuntu terminal
 
 


### PR DESCRIPTION
# Description of the problem

- Deal.II installation procedure did not include the ``apt install`` option

# Description of the solution

- Add it

# How Has This Been Tested?

- Test for Ubuntu 20.04 LTS.

- [x] Installation
- [x] Application tests
- [x] Example flow around cylinder

# Documentation

- [x] Installation WSL
- [x] Regular installation

# Comments

- This PR also fixes some indentation problems.

- This PR addresses the Issue #872
