### PR TITLE
Add viscous and ramp initial conditions for MF

### DIFF
--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -30,6 +30,7 @@
 
 using namespace dealii;
 
+
 /**
  * @brief A solver class for the Navier-Stokes equation that uses the matrix
  * free approach.

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -251,10 +251,9 @@ public:
   evaluate_residual(VectorType &dst, const VectorType &src);
 
   /**
-   * @brief Evaluate right hand side using the matrix-free operator
+   * @brief Sets the kinematic viscosity in the operator
    *
-   * @param dst Destination vector holding the result
-   * @param src Input vector for which the residual is evaluated
+   * @param p_kinematic_viscosity New value of the kinematic viscosity
    */
   void
   set_kinematic_viscosity(const double p_kinematic_viscosity)

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -250,6 +250,18 @@ public:
   void
   evaluate_residual(VectorType &dst, const VectorType &src);
 
+  /**
+   * @brief Evaluate right hand side using the matrix-free operator
+   *
+   * @param dst Destination vector holding the result
+   * @param src Input vector for which the residual is evaluated
+   */
+  void
+  set_kinematic_viscosity(const double p_kinematic_viscosity)
+  {
+    kinematic_viscosity = p_kinematic_viscosity;
+  }
+
 protected:
   /**
    * @brief Interface to function that performs a cell integral in a cell batch

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -221,13 +221,13 @@ public:
   double
   get_kinematic_viscosity_scale() const
   {
-    return kinematic_viscosity_scale;
+    return rheology[0]->get_kinematic_viscosity_scale();
   }
 
   double
   get_density_scale() const
   {
-    return density_scale;
+    return density[0]->get_density_ref();
   }
 
   void
@@ -335,11 +335,6 @@ private:
   bool non_newtonian_flow;
   bool constant_density;
   bool constant_surface_tension;
-
-  // Temporary scaling variable are overly used right now. They will eventually
-  // be deprecated for the majority of places they are used.
-  double kinematic_viscosity_scale;
-  double density_scale;
 
   unsigned int number_of_fluids;
   unsigned int number_of_solids;

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -55,9 +55,6 @@ PhysicalPropertiesManager::initialize(
   fluid_solid_interactions_with_material_interaction_ids =
     physical_properties.fluid_solid_interactions_with_material_interaction_ids;
 
-  kinematic_viscosity_scale = physical_properties.fluids[0].kinematic_viscosity;
-  density_scale             = physical_properties.fluids[0].density;
-
   non_newtonian_flow       = false;
   constant_density         = true;
   constant_surface_tension = true;


### PR DESCRIPTION
# Description of the problem

- The matrix free implementation did not allow for viscous or ramp initial conditions

# Description of the solution

- Added them.

# How Has This Been Tested?

- Tested it on a case and it works just fine. Not sure if it needs a dedicated application_test though. @lpsaavedra what's your take on this?
