### PR TITLE
Add ILU preconditioner for MG coarse grid solvers

### DIFF
--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
@@ -128,6 +128,7 @@ subsection linear solver
     set mg coarse grid tolerance          = 1e-14
     set mg coarse grid reduce             = 1e-4
     set mg coarse grid max krylov vectors = 30
+    set mg coarse grid preconditioner     = amg
 
     #coarse-grid AMG preconditioner
     set amg aggregation threshold                 = 1e-14

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
@@ -128,6 +128,7 @@ subsection linear solver
     set mg coarse grid tolerance          = 1e-14
     set mg coarse grid reduce             = 1e-4
     set mg coarse grid max krylov vectors = 30
+    set mg coarse grid preconditioner     = amg
 
     #coarse-grid AMG preconditioner
     set amg aggregation threshold                 = 1e-14

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -180,7 +180,7 @@ AMG preconditioner
 LSMG and GCMG preconditioners
 ------------------------------
 
-Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother, the coarse-grid solver or the coarse-grid solver preconditioner.
+Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother, the coarse-grid solver or the coarse-grid solver preconditioner. For the latter, one can choose between ``amg`` or ``ilu``.
 
 .. code-block:: text
 
@@ -198,6 +198,7 @@ Different parameters for the main components of the two geometric multigrid algo
     set mg coarse grid tolerance          = 1e-14
     set mg coarse grid reduce             = 1e-4
     set mg coarse grid max krylov vectors = 30
+    set mg coarse grid preconditioner     = amg
     
     # Coarse-grid AMG preconditioner parameters
     set amg preconditioner ilu fill               = 0
@@ -212,8 +213,13 @@ Different parameters for the main components of the two geometric multigrid algo
     set amg preconditioner ilu absolute tolerance = 1e-12
     set amg preconditioner ilu relative tolerance = 1.00
 
+    # Coarse-grid ILU preconditioner parameters
+    set ilu preconditioner fill               = 1
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1
+
 .. tip::
-  The default algorithms build and use ALL the multigrid levels. There are two ways to change the number of levels, either by setting the ``mg min level`` parameter OR the ``mg level min cells`` parameter. For LSMG the coarsest mesh should cover the whole domain, i.e., no hanging nodes are allowed. 
+  The default algorithms build and use ALL the multigrid levels. There are two ways to change the number of levels, either by setting the ``mg min level`` parameter OR the ``mg level min cells`` parameter. For ``lsmg`` the coarsest mesh should cover the whole domain, i.e., no hanging nodes are allowed. 
 
 .. warning::
     Currently, these preconditioners can only be used within the ``lethe-fluid-matrix-free`` application.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1000,6 +1000,9 @@ namespace Parameters
     // LSMG or GCMG coarse-grid solver maximum number of krylov vectors
     int mg_coarse_grid_max_krylov_vectors;
 
+    // LSMG or GCMG coarse-grid solver preconditioner
+    PreconditionerType mg_coarse_grid_preconditioner;
+
     // LSMG or GCMG information about levels
     Verbosity mg_verbosity;
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2147,6 +2147,12 @@ namespace Parameters
                           Patterns::Integer(),
                           "mg coarse grid max krylov vectors for lsmg or gcmg");
 
+        prm.declare_entry("mg coarse grid preconditioner",
+                          "amg",
+                          Patterns::Selection("amg|ilu"),
+                          "The preconditioner for the mg coarse grid solver"
+                          "Choices are <amg|ilu>.");
+
         prm.declare_entry(
           "mg verbosity",
           "verbose",
@@ -2204,7 +2210,7 @@ namespace Parameters
           preconditioner = PreconditionerType::gcmg;
         else
           throw std::logic_error(
-            "Error, invalid preconditioner type. Choices are amg or ilu");
+            "Error, invalid preconditioner type. Choices are amg, ilu, lsmg or gcmg.");
 
         ilu_precond_fill = prm.get_double("ilu preconditioner fill");
         ilu_precond_atol =
@@ -2233,6 +2239,16 @@ namespace Parameters
         mg_coarse_grid_reduce    = prm.get_double("mg coarse grid reduce");
         mg_coarse_grid_max_krylov_vectors =
           prm.get_integer("mg coarse grid max krylov vectors");
+
+        const std::string cg_precond = prm.get("mg coarse grid preconditioner");
+        if (cg_precond == "amg")
+          mg_coarse_grid_preconditioner = PreconditionerType::amg;
+        else if (cg_precond == "ilu")
+          mg_coarse_grid_preconditioner = PreconditionerType::ilu;
+        else
+          throw std::logic_error(
+            "Error, invalid preconditioner type for mg coarse grid solver. Choices are amg or ilu.");
+
         const std::string mg_op = prm.get("mg verbosity");
         if (mg_op == "verbose")
           mg_verbosity = Parameters::Verbosity::verbose;


### PR DESCRIPTION
# Description of the problem

The coarse grid solver of the multigrid preconditioners used in the matrix free application only supported AMG as preconditioner. 

# Description of the solution

An ILU preconditioner was added as well. For this, a new parameter was created, where one can choose between AMG and ILU for the coarse-grid solver.

# How Has This Been Tested?

- No application test was added for this future. It was tested using the mms3d problem and it yield the same results.

# Documentation

- The parameter to choose the coarse grid solver preconditioner and the parameters specific to ILU were added in the MG section of the linear solver documentation:
- [X] `doc/source/parameters/cfd/linear_solver_control.rst`
