### PR TITLE
Enable eigenvalue estimation in multigrid preconditioners

### DIFF
--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -105,10 +105,13 @@ In this subsection, the control options of the linear solvers are specified. The
 .. tip::
 	Consider using ``set max krylov vectors = 200`` for complex simulations with convergence issues. 
 
-* ``preconditioner`` sets the type of preconditioning used for the linear solver. It can be either ``ilu`` for an Incomplete LU decomposition, ``amg`` for an Algebraic Multigrid, ``lsmg`` for a Local Smoothing Multigrid, or ``gcmg`` for a Global Coarsening Multigrid. The latter two are only available for the ``lethe-fluid-matrix-free`` application.
+* ``preconditioner`` sets the type of preconditioning used for the linear solver. It can be either ``ilu`` for an Incomplete LU decomposition, ``amg`` for an Algebraic Multigrid, ``lsmg`` for a Local Smoothing Multigrid, or ``gcmg`` for a Global Coarsening Multigrid.
 
 .. warning::
     Currently, the ``lethe-fluid-sharp`` solver makes it almost impossible to reach convergence with the ``amg`` preconditioner. Therefore, it is recommended to use ``ilu`` instead, even for fine meshes. In addition, the ``VOF``, ``heat transfer``, ``cahn hilliard`` and ``tracer`` physics only support ``ilu``.
+
+.. warning::
+    Currently, the ``lsmg`` and ``gcmg`` preconditioners can only be used within the ``lethe-fluid-matrix-free`` application.
 
 .. caution:: 
 		Be aware that the setup of the ``amg`` preconditioner is very expensive and does not scale linearly with the size of the matrix. As such, it is generally preferable to minimize the number of assembly of such preconditioner. This can be achieved by using the ``inexact newton`` for the nonlinear solver (see :doc:`non-linear_solver_control`).
@@ -180,7 +183,7 @@ AMG preconditioner
 LSMG and GCMG preconditioners
 ------------------------------
 
-Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother, the coarse-grid solver or the coarse-grid solver preconditioner. For the latter, one can choose between ``amg`` or ``ilu``.
+Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother, the coarse-grid solver or the coarse-grid solver preconditioner. For the latter, one can choose between ``amg`` and ``ilu``.
 
 .. code-block:: text
 
@@ -190,8 +193,15 @@ Different parameters for the main components of the two geometric multigrid algo
     set mg level min cells = -1
 
     # Relaxation smoother parameters
-    set mg smoother iterations = 10
-    set mg smoother relaxation = 0.5
+    set mg smoother iterations     = 10
+    set mg smoother relaxation     = 0.5
+    set mg smoother eig estimation = false #if set to true, previous parameter is not used
+
+    # Eigenvalue estimation parameters
+    set eig estimation degree          = 3
+    set eig estimation smoothing range = 10
+    set eig estimation cg n iterations = 10
+    set eig estimation verbosity       = quiet
 
     # Coarse-grid solver parameters
     set mg coarse grid max iterations     = 2000
@@ -220,6 +230,3 @@ Different parameters for the main components of the two geometric multigrid algo
 
 .. tip::
   The default algorithms build and use ALL the multigrid levels. There are two ways to change the number of levels, either by setting the ``mg min level`` parameter OR the ``mg level min cells`` parameter. For ``lsmg`` the coarsest mesh should cover the whole domain, i.e., no hanging nodes are allowed. 
-
-.. warning::
-    Currently, these preconditioners can only be used within the ``lethe-fluid-matrix-free`` application.

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -1125,18 +1125,20 @@ NavierStokesFunctionDefined<dim>::value(const Point<dim>  &p,
                                         const unsigned int component) const
 {
   Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components)) if (component == 0)
-  {
-    return u->value(p);
-  }
+         ExcIndexRange(component, 0, this->n_components));
+
+  if (component == 0)
+    {
+      return u->value(p);
+    }
   else if (component == 1)
-  {
-    return v->value(p);
-  }
+    {
+      return v->value(p);
+    }
   else if (component == 2)
-  {
-    return w->value(p);
-  }
+    {
+      return w->value(p);
+    }
   return 0.;
 }
 
@@ -1214,14 +1216,16 @@ CahnHilliardFunctionDefined<dim>::value(const Point<dim>  &p,
                                         const unsigned int component) const
 {
   Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components)) if (component == 0)
-  {
-    return phi->value(p);
-  }
+         ExcIndexRange(component, 0, this->n_components));
+
+  if (component == 0)
+    {
+      return phi->value(p);
+    }
   else if (component == 1)
-  {
-    return 0.;
-  }
+    {
+      return 0.;
+    }
   return 0.;
 }
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -982,28 +982,43 @@ namespace Parameters
     // MG minimum number of cells per level
     int mg_level_min_cells;
 
-    // LSMG or GCMG smoother number of iterations
+    // MG smoother number of iterations
     int mg_smoother_iterations;
 
-    // LSMG or GCMG smoother relaxation parameter
+    // MG smoother relaxation parameter
     double mg_smoother_relaxation;
 
-    // LSMG or GCMG coarse-grid solver maximum number of iterations
+    // MG eigenvalue estimation for smoother relaxation parameter
+    bool mg_smoother_eig_estimation;
+
+    // MG degree of Chebyshev polynomial used for eigenvalue estimation
+    int eig_estimation_degree;
+
+    // MG smoothing range to set range between eigenvalues
+    int eig_estimation_smoothing_range;
+
+    // MG number of cg iterations to find eigenvalue
+    int eig_estimation_cg_n_iterations;
+
+    // MG print max, min, eigenvalues
+    Verbosity eig_estimation_verbose;
+
+    // MG coarse-grid solver maximum number of iterations
     int mg_coarse_grid_max_iterations;
 
-    // LSMG or GCMG coarse-grid solver tolerance
+    // MG coarse-grid solver tolerance
     double mg_coarse_grid_tolerance;
 
-    // LSMG or GCMG coarse-grid solver reduce
+    // MG coarse-grid solver reduce
     double mg_coarse_grid_reduce;
 
-    // LSMG or GCMG coarse-grid solver maximum number of krylov vectors
+    // MG coarse-grid solver maximum number of krylov vectors
     int mg_coarse_grid_max_krylov_vectors;
 
-    // LSMG or GCMG coarse-grid solver preconditioner
+    // MG coarse-grid solver preconditioner
     PreconditionerType mg_coarse_grid_preconditioner;
 
-    // LSMG or GCMG information about levels
+    // MG information about levels
     Verbosity mg_verbosity;
 
     static void

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2127,6 +2127,32 @@ namespace Parameters
                           Patterns::Double(),
                           "mg smoother relaxation for lsmg or gcmg");
 
+        prm.declare_entry("mg smoother eig estimation",
+                          "false",
+                          Patterns::Bool(),
+                          "estimate eigenvalues for relaxation parameter");
+
+        prm.declare_entry("eig estimation degree",
+                          "3",
+                          Patterns::Integer(),
+                          "degree used for the Chebyshev polynomial");
+
+        prm.declare_entry("eig estimation smoothing range",
+                          "10",
+                          Patterns::Integer(),
+                          "sets range between largest and smallest eig");
+
+        prm.declare_entry("eig estimation cg n iterations",
+                          "10",
+                          Patterns::Integer(),
+                          "cg iterations performed to find eigenvalue");
+
+        prm.declare_entry("eig estimation verbosity",
+                          "verbose",
+                          Patterns::Selection("quiet|verbose"),
+                          "State whether MG should print max and min eigenvalue"
+                          "Choices are <quiet|verbose>.");
+
         prm.declare_entry("mg coarse grid max iterations",
                           "2000",
                           Patterns::Integer(),
@@ -2218,6 +2244,7 @@ namespace Parameters
         ilu_precond_rtol =
           prm.get_double("ilu preconditioner relative tolerance");
         amg_precond_ilu_fill = prm.get_double("amg preconditioner ilu fill");
+
         amg_precond_ilu_atol =
           prm.get_double("amg preconditioner ilu absolute tolerance");
         amg_precond_ilu_rtol =
@@ -2227,12 +2254,32 @@ namespace Parameters
         amg_w_cycles              = prm.get_bool("amg w cycles");
         amg_smoother_sweeps       = prm.get_integer("amg smoother sweeps");
         amg_smoother_overlap      = prm.get_integer("amg smoother overlap");
+
         force_linear_solver_continuation =
           prm.get_bool("force linear solver continuation");
-        mg_min_level           = prm.get_integer("mg min level");
-        mg_level_min_cells     = prm.get_integer("mg level min cells");
-        mg_smoother_iterations = prm.get_integer("mg smoother iterations");
-        mg_smoother_relaxation = prm.get_double("mg smoother relaxation");
+
+        mg_min_level       = prm.get_integer("mg min level");
+        mg_level_min_cells = prm.get_integer("mg level min cells");
+
+        mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
+        mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");
+        mg_smoother_eig_estimation = prm.get_bool("mg smoother eig estimation");
+        eig_estimation_degree      = prm.get_integer("eig estimation degree");
+        eig_estimation_smoothing_range =
+          prm.get_integer("eig estimation smoothing range");
+        eig_estimation_cg_n_iterations =
+          prm.get_integer("eig estimation cg n iterations");
+
+        const std::string eig_estimation_v =
+          prm.get("eig estimation verbosity");
+        if (eig_estimation_v == "verbose")
+          eig_estimation_verbose = Parameters::Verbosity::verbose;
+        else if (eig_estimation_v == "quiet")
+          eig_estimation_verbose = Parameters::Verbosity::quiet;
+        else
+          throw(std::runtime_error(
+            "Unknown verbosity mode for the eigenvalue estimation"));
+
         mg_coarse_grid_max_iterations =
           prm.get_integer("mg coarse grid max iterations");
         mg_coarse_grid_tolerance = prm.get_double("mg coarse grid tolerance");

--- a/source/rpt/rpt.cc
+++ b/source/rpt/rpt.cc
@@ -43,10 +43,10 @@ RPT<dim>::setup_and_calculate()
         ExcMessage(
           "Prior tuning parameters, the number of particle positions provided"
           " has to be the same number of counts of experimental data. "
-          "Note : The experimental counts also have to be at the same positions which can not be verified."))
+          "Note : The experimental counts also have to be at the same positions which can not be verified."));
 
-        double cost_function =
-          calculate_cost_function(measured_counts, calculated_counts);
+      double cost_function =
+        calculate_cost_function(measured_counts, calculated_counts);
       std::cout << cost_function << std::endl;
     }
 }

--- a/source/rpt/rpt_cell_reconstruction.cc
+++ b/source/rpt/rpt_cell_reconstruction.cc
@@ -44,7 +44,7 @@ RPTCellReconstruction<dim>::execute_cell_reconstruction()
       AssertThrow(
         known_positions.size() == reconstruction_counts.size(),
         ExcMessage(
-          "Reconstruction counts and known positions files do not have data for the same number of positions."))
+          "Reconstruction counts and known positions files do not have data for the same number of positions."));
     }
 
   // Create a grid for the reactor vessel


### PR DESCRIPTION
# Description of the problem

The mechanism for estimating eigenvalues and using them as relaxation parameter in the smoother of the multigrid preconditioners was there but was not being used.

# Description of the solution

This PR adds the appropriate parameters to be able to enable and tune the eigenvalue estimation when using both of the multigrid preconditioners in the matrix-free application. 

# Documentation

- The new parameters were added to the linear solver documentation: 
- [X] `doc/source/parameters/cfd/linear_solver_control.rst`

# Comments

- The following files were missing a semicolon which was preventing me from compiling Lethe using deal.II master so they have been fixed in this PR as well:
- [X] `include/core/boundary_conditions.h`
- [X] `source/rpt/rpt.cc`
- [X] `source/rpt/rpt_cell_reconstruction.cc`
