### PR TITLE
Compile with C++20

### DIFF
--- a/applications/lethe-fluid-particles/cfd_dem_coupling.cc
+++ b/applications/lethe-fluid-particles/cfd_dem_coupling.cc
@@ -22,7 +22,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, dealii::numbers::invalid_unsigned_int);
 
 
       if (argc != 2)

--- a/applications/lethe-fluid-sharp/gls_sharp_navier_stokes.cc
+++ b/applications/lethe-fluid-sharp/gls_sharp_navier_stokes.cc
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, dealii::numbers::invalid_unsigned_int);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-vans/gls_vans.cc
+++ b/applications/lethe-fluid-vans/gls_vans.cc
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, dealii::numbers::invalid_unsigned_int);
 
       if (argc != 2)
         {

--- a/applications/lethe-particles/dem.cc
+++ b/applications/lethe-particles/dem.cc
@@ -10,7 +10,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, dealii::numbers::invalid_unsigned_int);
 
 
       if (argc != 2)

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -349,9 +349,9 @@ public:
    * @param position The sphere center
    * @param orientation The sphere orientation
    */
-  Sphere<dim>(double              radius,
-              const Point<dim>   &position,
-              const Tensor<1, 3> &orientation)
+  Sphere(double              radius,
+         const Point<dim>   &position,
+         const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
   {
 #if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
@@ -435,11 +435,11 @@ public:
    * @param position The superquadric center
    * @param orientation The superquadric orientation
    */
-  Superquadric<dim>(const Tensor<1, dim> half_lengths,
-                    const Tensor<1, dim> exponents,
-                    const double         epsilon,
-                    const Point<dim>    &position,
-                    const Tensor<1, 3>  &orientation)
+  Superquadric(const Tensor<1, dim> half_lengths,
+               const Tensor<1, dim> exponents,
+               const double         epsilon,
+               const Point<dim>    &position,
+               const Tensor<1, 3>  &orientation)
     : Shape<dim>(half_lengths.norm(), position, orientation)
     , half_lengths(half_lengths)
     , exponents(exponents)
@@ -588,9 +588,9 @@ public:
    * @param position The hyper rectangle center
    * @param orientation The hyper rectangle orientation
    */
-  HyperRectangle<dim>(const Tensor<1, dim> &half_lengths,
-                      const Point<dim>     &position,
-                      const Tensor<1, 3>   &orientation)
+  HyperRectangle(const Tensor<1, dim> &half_lengths,
+                 const Point<dim>     &position,
+                 const Tensor<1, 3>   &orientation)
     : Shape<dim>(half_lengths.norm(), position, orientation)
     , half_lengths(half_lengths)
   {}
@@ -635,9 +635,9 @@ public:
    * @param position The ellipsoid center
    * @param orientation The ellipsoid orientation
    */
-  Ellipsoid<dim>(const Tensor<1, dim> &radii,
-                 const Point<dim>     &position,
-                 const Tensor<1, 3>   &orientation)
+  Ellipsoid(const Tensor<1, dim> &radii,
+            const Point<dim>     &position,
+            const Tensor<1, 3>   &orientation)
     : Shape<dim>(radii.norm(), position, orientation)
     , radii(radii)
   {}
@@ -684,10 +684,10 @@ public:
    * @param position The torus center
    * @param orientation The orientation of the axis at the center of the torus
    */
-  Torus<dim>(double              ring_radius,
-             double              ring_thickness,
-             const Point<dim>   &position,
-             const Tensor<1, 3> &orientation)
+  Torus(double              ring_radius,
+        double              ring_thickness,
+        const Point<dim>   &position,
+        const Tensor<1, 3> &orientation)
     : Shape<dim>(ring_thickness, position, orientation)
     , ring_radius(ring_radius)
     , ring_thickness(ring_thickness)
@@ -735,10 +735,10 @@ public:
    * @param position The position of the center of cone's base
    * @param orientation The orientation of the cone axis, from its base to its tip
    */
-  Cone<dim>(double              tan_base_angle,
-            double              height,
-            const Point<dim>   &position,
-            const Tensor<1, 3> &orientation)
+  Cone(double              tan_base_angle,
+       double              height,
+       const Point<dim>   &position,
+       const Tensor<1, 3> &orientation)
     : Shape<dim>(height, position, orientation)
     , tan_base_angle(tan_base_angle)
     , height(height)
@@ -793,11 +793,11 @@ public:
    * @param position The center of the sphere
    * @param orientation The orientation of the sphere, from it's center to the cut's center
    */
-  CutHollowSphere<dim>(double              radius,
-                       double              cut_depth,
-                       double              shell_thickness,
-                       const Point<dim>   &position,
-                       const Tensor<1, 3> &orientation)
+  CutHollowSphere(double              radius,
+                  double              cut_depth,
+                  double              shell_thickness,
+                  const Point<dim>   &position,
+                  const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
     , radius(radius)
     , cut_depth(cut_depth)
@@ -852,11 +852,11 @@ public:
    * @param position The main sphere's center
    * @param orientation The orientation from the main sphere's center to the removed sphere's center
    */
-  DeathStar<dim>(double              radius,
-                 double              hole_radius,
-                 double              spheres_distance,
-                 const Point<dim>   &position,
-                 const Tensor<1, 3> &orientation)
+  DeathStar(double              radius,
+            double              hole_radius,
+            double              spheres_distance,
+            const Point<dim>   &position,
+            const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
     , radius(radius)
     , hole_radius(hole_radius)
@@ -925,7 +925,7 @@ public:
    * @param constituents The shapes from which this composite shape will be composed
    * @param operations The list of operations to perform to construct the composite
    */
-  CompositeShape<dim>(
+  CompositeShape(
     std::map<unsigned int, std::shared_ptr<Shape<dim>>> constituents,
     std::map<unsigned int,
              std::tuple<BooleanOperation, unsigned int, unsigned int>>
@@ -951,10 +951,9 @@ public:
    * global levelset function defined as a union.
    * @param constituents_vector The shapes from which this composite sphere will be composed
    */
-  CompositeShape<dim>(
-    std::vector<std::shared_ptr<Shape<dim>>> constituents_vector,
-    const Point<dim>                        &position,
-    const Tensor<1, 3>                      &orientation)
+  CompositeShape(std::vector<std::shared_ptr<Shape<dim>>> constituents_vector,
+                 const Point<dim>                        &position,
+                 const Tensor<1, 3>                      &orientation)
     : Shape<dim>(0., position, orientation)
   {
     size_t number_of_constituents = constituents_vector.size();
@@ -1111,9 +1110,9 @@ public:
    * @param position The shape center
    * @param orientation The shape orientation
    */
-  OpenCascadeShape<dim>(const std::string   file_name,
-                        const Point<dim>   &position,
-                        const Tensor<1, 3> &orientation)
+  OpenCascadeShape(const std::string   file_name,
+                   const Point<dim>   &position,
+                   const Tensor<1, 3> &orientation)
     : Shape<dim>(0.1, position, orientation)
   {
     // First, we read the shape file name
@@ -1349,9 +1348,9 @@ public:
    * @param orientation the orientation of the shape with respect to each main
    * axis
    */
-  RBFShape<dim>(const std::string   shape_arguments_str,
-                const Point<dim>   &position,
-                const Tensor<1, 3> &orientation);
+  RBFShape(const std::string   shape_arguments_str,
+           const Point<dim>   &position,
+           const Tensor<1, 3> &orientation);
 
   /**
    * @brief Load RBF data from file. To be called at initialization, after repartitioning or when shape has moved.
@@ -1885,10 +1884,10 @@ public:
    * @param position position of the barycenter of the cylinder
    * @param orientation orientation of the cylinder
    */
-  Cylinder<dim>(double              radius,
-                double              half_length,
-                const Point<dim>   &position,
-                const Tensor<1, 3> &orientation)
+  Cylinder(double              radius,
+           double              half_length,
+           const Point<dim>   &position,
+           const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
     , radius(radius)
     , half_length(half_length)
@@ -1938,11 +1937,11 @@ public:
    * @param position position of the barycenter of the cylinder
    * @param orientation orientation of the cylinder
    */
-  CylindricalTube<dim>(double              radius_inside,
-                       double              radius_outside,
-                       double              half_length,
-                       const Point<dim>   &position,
-                       const Tensor<1, 3> &orientation)
+  CylindricalTube(double              radius_inside,
+                  double              radius_outside,
+                  double              half_length,
+                  const Point<dim>   &position,
+                  const Tensor<1, 3> &orientation)
     : Shape<dim>((radius_outside + radius_inside) / 2., position, orientation)
     , radius((radius_outside + radius_inside) / 2.)
     , height(half_length * 2.)
@@ -1996,12 +1995,12 @@ public:
    * @param position the position of the helix base
    * @param orientation the orientation of the helix axis compared to the z axis
    */
-  CylindricalHelix<dim>(double              radius_helix,
-                        double              radius_disk,
-                        double              height,
-                        double              pitch,
-                        const Point<dim>   &position,
-                        const Tensor<1, 3> &orientation)
+  CylindricalHelix(double              radius_helix,
+                   double              radius_disk,
+                   double              height,
+                   double              pitch,
+                   const Point<dim>   &position,
+                   const Tensor<1, 3> &orientation)
     : Shape<dim>(radius_disk, position, orientation)
     , radius(radius_helix)
     , height(height)

--- a/include/dem/disable_contacts.h
+++ b/include/dem/disable_contacts.h
@@ -86,7 +86,7 @@ template <int dim>
 class DisableContacts
 {
 public:
-  DisableContacts<dim>();
+  DisableContacts();
 
   /**
    * Mobility status flag used to identify the status at nodes and the status

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -53,7 +53,7 @@ template <int dim>
 class BoundaryCellsInformation
 {
 public:
-  BoundaryCellsInformation<dim>();
+  BoundaryCellsInformation();
 
   /**
    * @brief The build function builds all the boundary cell information

--- a/include/dem/find_cell_neighbors.h
+++ b/include/dem/find_cell_neighbors.h
@@ -46,7 +46,7 @@ template <int dim>
 class FindCellNeighbors
 {
 public:
-  FindCellNeighbors<dim>();
+  FindCellNeighbors();
 
   /**
    * @brief Finds the neighbor list (without repetition) of all the active

--- a/include/dem/integrator.h
+++ b/include/dem/integrator.h
@@ -43,7 +43,7 @@ public:
    * the index to the velocity property, the force property and the acceleration
    * property manually
    */
-  Integrator<dim>()
+  Integrator()
   {}
 
   virtual ~Integrator()

--- a/include/dem/lagrangian_post_processing.h
+++ b/include/dem/lagrangian_post_processing.h
@@ -50,7 +50,7 @@ template <int dim>
 class LagrangianPostProcessing
 {
 public:
-  LagrangianPostProcessing<dim>();
+  LagrangianPostProcessing();
 
   /**
    * Carries out writing the grid of the domain

--- a/include/dem/list_insertion.h
+++ b/include/dem/list_insertion.h
@@ -39,7 +39,7 @@ template <int dim>
 class ListInsertion : public Insertion<dim>
 {
 public:
-  ListInsertion<dim>(const DEMSolverParameters<dim> &dem_parameters);
+  ListInsertion(const DEMSolverParameters<dim> &dem_parameters);
 
   /**
    * @brief The ListInsertion class inserts particles using a list specific position.

--- a/include/dem/non_uniform_insertion.h
+++ b/include/dem/non_uniform_insertion.h
@@ -51,8 +51,8 @@ public:
    * @param maximum_particle_diameter Maximum particle diameter based on values
    * defined in the parameter handler
    */
-  NonUniformInsertion<dim>(const DEMSolverParameters<dim> &dem_parameters,
-                           const double maximum_particle_diameter);
+  NonUniformInsertion(const DEMSolverParameters<dim> &dem_parameters,
+                      const double maximum_particle_diameter);
 
   /**
    * Carries out the non-uniform insertion of particles.

--- a/include/dem/particle_particle_broad_search.h
+++ b/include/dem/particle_particle_broad_search.h
@@ -48,7 +48,7 @@ template <int dim>
 class ParticleParticleBroadSearch
 {
 public:
-  ParticleParticleBroadSearch<dim>();
+  ParticleParticleBroadSearch();
 
   /**
    * @brief Finds a vector of pairs (particle_particle_candidates) which shows the

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -141,8 +141,7 @@ class ParticleParticleContactForce
   : public ParticleParticleContactForceBase<dim>
 {
 public:
-  ParticleParticleContactForce<dim, force_model, rolling_friction_model>(
-    const DEMSolverParameters<dim> &dem_parameters);
+  ParticleParticleContactForce(const DEMSolverParameters<dim> &dem_parameters);
 
 
   virtual ~ParticleParticleContactForce()

--- a/include/dem/particle_particle_fine_search.h
+++ b/include/dem/particle_particle_fine_search.h
@@ -52,7 +52,7 @@ template <int dim>
 class ParticleParticleFineSearch
 {
 public:
-  ParticleParticleFineSearch<dim>();
+  ParticleParticleFineSearch();
 
   /**
    * Iterates over a vector of maps (pairs_in_contact) to see if the particles

--- a/include/dem/particle_point_line_broad_search.h
+++ b/include/dem/particle_point_line_broad_search.h
@@ -44,7 +44,7 @@ template <int dim>
 class ParticlePointLineBroadSearch
 {
 public:
-  ParticlePointLineBroadSearch<dim>();
+  ParticlePointLineBroadSearch();
 
   /**
    * Finds a map of pairs (pair of particle and the boundary vertex location)

--- a/include/dem/particle_point_line_contact_force.h
+++ b/include/dem/particle_point_line_contact_force.h
@@ -47,7 +47,7 @@ template <int dim>
 class ParticlePointLineForce
 {
 public:
-  ParticlePointLineForce<dim>();
+  ParticlePointLineForce();
 
   /**
    * Carries out the calculation of the particle-point contact force using

--- a/include/dem/particle_point_line_fine_search.h
+++ b/include/dem/particle_point_line_fine_search.h
@@ -47,7 +47,7 @@ template <int dim>
 class ParticlePointLineFineSearch
 {
 public:
-  ParticlePointLineFineSearch<dim>();
+  ParticlePointLineFineSearch();
 
   /**
    * Iterates over a map of pairs (particle_point_contact_candidates) to see if

--- a/include/dem/particle_wall_broad_search.h
+++ b/include/dem/particle_wall_broad_search.h
@@ -52,7 +52,7 @@ template <int dim>
 class ParticleWallBroadSearch
 {
 public:
-  ParticleWallBroadSearch<dim>();
+  ParticleWallBroadSearch();
 
   /**
    * Finds unordered map of tuples (tuple of particle located in

--- a/include/dem/particle_wall_fine_search.h
+++ b/include/dem/particle_wall_fine_search.h
@@ -50,7 +50,7 @@ template <int dim>
 class ParticleWallFineSearch
 {
 public:
-  ParticleWallFineSearch<dim>();
+  ParticleWallFineSearch();
 
   /**
    * Iterates over the contact candidates from particle-wall broad search

--- a/include/dem/particle_wall_jkr_force.h
+++ b/include/dem/particle_wall_jkr_force.h
@@ -51,7 +51,7 @@ class ParticleWallJKRForce : public ParticleWallContactForce<dim>
   FuncPtrType calculate_rolling_resistance_torque;
 
 public:
-  ParticleWallJKRForce<dim>(
+  ParticleWallJKRForce(
     const DEMSolverParameters<dim>       &dem_parameters,
     const std::vector<types::boundary_id> boundary_index = {});
 

--- a/include/dem/particle_wall_linear_force.h
+++ b/include/dem/particle_wall_linear_force.h
@@ -52,7 +52,7 @@ class ParticleWallLinearForce : public ParticleWallContactForce<dim>
   FuncPtrType calculate_rolling_resistance_torque;
 
 public:
-  ParticleWallLinearForce<dim>(
+  ParticleWallLinearForce(
     const DEMSolverParameters<dim>       &dem_parameters,
     const std::vector<types::boundary_id> boundary_index = {});
 

--- a/include/dem/particle_wall_nonlinear_force.h
+++ b/include/dem/particle_wall_nonlinear_force.h
@@ -52,7 +52,7 @@ class ParticleWallNonLinearForce : public ParticleWallContactForce<dim>
   FuncPtrType calculate_rolling_resistance_torque;
 
 public:
-  ParticleWallNonLinearForce<dim>(
+  ParticleWallNonLinearForce(
     const DEMSolverParameters<dim>       &dem_parameters,
     const std::vector<types::boundary_id> boundary_index = {});
 

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -49,7 +49,7 @@ template <int dim>
 class PeriodicBoundariesManipulator
 {
 public:
-  PeriodicBoundariesManipulator<dim>();
+  PeriodicBoundariesManipulator();
 
   /**
    * @brief Sets the periodic boundaries parameters

--- a/include/dem/plane_insertion.h
+++ b/include/dem/plane_insertion.h
@@ -54,7 +54,7 @@ public:
    * @param dem_parameters DEM parameters declared in the .prm file
    * @param triangulation Triangulation object used in the simulation.
    */
-  PlaneInsertion<dim>(
+  PlaneInsertion(
     const DEMSolverParameters<dim>                  &dem_parameters,
     const parallel::distributed::Triangulation<dim> &triangulation);
 

--- a/include/dem/uniform_insertion.h
+++ b/include/dem/uniform_insertion.h
@@ -41,8 +41,8 @@ template <int dim>
 class UniformInsertion : public Insertion<dim>
 {
 public:
-  UniformInsertion<dim>(const DEMSolverParameters<dim> &dem_parameters,
-                        const double maximum_particle_diameter);
+  UniformInsertion(const DEMSolverParameters<dim> &dem_parameters,
+                   const double                    maximum_particle_diameter);
 
   /**
    * Carries out the insertion of particles by discretizing and looping over the

--- a/include/dem/visualization.h
+++ b/include/dem/visualization.h
@@ -46,7 +46,7 @@ template <int dim>
 class Visualization : public dealii::DataOutInterface<0, dim>
 {
 public:
-  Visualization<dim>();
+  Visualization();
 
   /**
    * Carries out building the patches of properties of particles for

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -58,11 +58,11 @@ template <int dim>
 class CahnHilliard : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  CahnHilliard<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
-                    const SimulationParameters<dim> &p_simulation_parameters,
-                    std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
-                                                       p_triangulation,
-                    std::shared_ptr<SimulationControl> p_simulation_control)
+  CahnHilliard(MultiphysicsInterface<dim>      *multiphysics_interface,
+               const SimulationParameters<dim> &p_simulation_parameters,
+               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
+                                                  p_triangulation,
+               std::shared_ptr<SimulationControl> p_simulation_control)
     : AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>(
         p_simulation_parameters.non_linear_solver.at(PhysicsID::cahn_hilliard))
     , multiphysics(multiphysics_interface)

--- a/include/solvers/copy_data.h
+++ b/include/solvers/copy_data.h
@@ -156,8 +156,8 @@ public:
    *
    * @param n_q_points Number of quadrature points
    */
-  StabilizedMethodsTensorCopyData<dim>(const unsigned int n_dofs,
-                                       const unsigned int n_q_points)
+  StabilizedMethodsTensorCopyData(const unsigned int n_dofs,
+                                  const unsigned int n_q_points)
     : local_matrix(n_dofs, n_dofs)
     , local_rhs(n_dofs)
     , local_dof_indices(n_dofs)

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -54,11 +54,11 @@ template <int dim>
 class HeatTransfer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  HeatTransfer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
-                    const SimulationParameters<dim> &p_simulation_parameters,
-                    std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
-                                                       p_triangulation,
-                    std::shared_ptr<SimulationControl> p_simulation_control)
+  HeatTransfer(MultiphysicsInterface<dim>      *multiphysics_interface,
+               const SimulationParameters<dim> &p_simulation_parameters,
+               std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
+                                                  p_triangulation,
+               std::shared_ptr<SimulationControl> p_simulation_control)
     : AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>(
         p_simulation_parameters.non_linear_solver.at(PhysicsID::heat_transfer))
     , multiphysics(multiphysics_interface)

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -53,11 +53,11 @@ template <int dim>
 class Tracer : public AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>
 {
 public:
-  Tracer<dim>(MultiphysicsInterface<dim>      *multiphysics_interface,
-              const SimulationParameters<dim> &p_simulation_parameters,
-              std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
-                                                 p_triangulation,
-              std::shared_ptr<SimulationControl> p_simulation_control)
+  Tracer(MultiphysicsInterface<dim>      *multiphysics_interface,
+         const SimulationParameters<dim> &p_simulation_parameters,
+         std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
+                                            p_triangulation,
+         std::shared_ptr<SimulationControl> p_simulation_control)
     : AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>(
         p_simulation_parameters.non_linear_solver.at(PhysicsID::tracer))
     , multiphysics(multiphysics_interface)

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -60,12 +60,11 @@ public:
   /**
    * @brief VOF - Base constructor.
    */
-  VolumeOfFluid<dim>(
-    MultiphysicsInterface<dim>      *multiphysics_interface,
-    const SimulationParameters<dim> &p_simulation_parameters,
-    std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
-                                       p_triangulation,
-    std::shared_ptr<SimulationControl> p_simulation_control)
+  VolumeOfFluid(MultiphysicsInterface<dim>      *multiphysics_interface,
+                const SimulationParameters<dim> &p_simulation_parameters,
+                std::shared_ptr<parallel::DistributedTriangulationBase<dim>>
+                                                   p_triangulation,
+                std::shared_ptr<SimulationControl> p_simulation_control)
     : AuxiliaryPhysics<dim, TrilinosWrappers::MPI::Vector>(
         p_simulation_parameters.non_linear_solver.at(PhysicsID::VOF))
     , multiphysics(multiphysics_interface)

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -2051,7 +2051,7 @@ GLSSharpNavierStokesSolver<dim>::integrate_particles()
   // implicit Euler algorithm. To find the force at t+dt the function use the
   // fix point algorithm in parallel to the newton iteration used for the fluid
   // resolution.
-  using numbers::PI;
+  using dealii::numbers::PI;
   double dt    = this->simulation_control->get_time_steps_vector()[0];
   double time  = this->simulation_control->get_current_time();
   double alpha = this->simulation_parameters.particlesParameters->alpha;
@@ -2901,7 +2901,7 @@ GLSSharpNavierStokesSolver<dim>::sharp_edge()
   // on a solid of dim=2 or dim=3
 
   TimerOutput::Scope t(this->computing_timer, "assemble_sharp");
-  using numbers::PI;
+  using dealii::numbers::PI;
   Point<dim>                                                  center_immersed;
   Point<dim>                                                  pressure_bridge;
   std::vector<typename DoFHandler<dim>::active_cell_iterator> active_neighbors;
@@ -4305,7 +4305,7 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::load_particles_from_file()
 {
-  using numbers::PI;
+  using dealii::numbers::PI;
   TimerOutput::Scope t(this->computing_timer,
                        "Reset Sharp-Edge particle information");
   this->pcout << "Loading particles from a file" << std::endl;

--- a/source/fem-dem/ib_particles_dem.cc
+++ b/source/fem-dem/ib_particles_dem.cc
@@ -319,7 +319,7 @@ IBParticlesDEM<dim>::calculate_pp_lubrication_force(
   std::vector<Tensor<1, 3>> &lubrication_force,
   std::vector<Tensor<1, 3>> & /*lubrication_torque*/)
 {
-  using numbers::PI;
+  using dealii::numbers::PI;
   // loop over all particles to find pair of close partilces
   for (auto &particle_one : dem_particles)
     {
@@ -652,7 +652,7 @@ IBParticlesDEM<dim>::calculate_pw_lubrication_force(
   std::vector<Tensor<1, 3>> &lubrication_force,
   std::vector<Tensor<1, 3>> & /*lubrication_torque*/)
 {
-  using numbers::PI;
+  using dealii::numbers::PI;
 
   // Loop over the particles
   for (auto &particle : dem_particles)
@@ -773,7 +773,7 @@ IBParticlesDEM<dim>::integrate_particles_motion(const double dt,
                                                 const double mu)
 {
   // Initialize local containers and physical variables
-  using numbers::PI;
+  using dealii::numbers::PI;
   double dt_dem = dt / parameters->coupling_frequency;
 
   std::vector<Tensor<1, 3>> contact_force(dem_particles.size());


### PR DESCRIPTION
# Description of the problem

- Code does not compile with C++20.

# Description of the solution

- Fix some namespaces.
- Fix some constructors.
- ~Fix one implicit capturing of a lambda function.~

# How Has This Been Tested?

# Documentation

# Future changes

There are still some warning that need to be fixed:

```
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc: In instantiation of ‘void GLSSharpNavierStokesSolver<dim>::load_particles_from_file() [with int dim = 2]’:
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4643:16:   required from here
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4339:41: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4339 |           if (restart_data["type"][p_i] == Shape<dim>::ShapeType::sphere)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4345:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4345 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4354:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4354 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4414:41: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4414 |           if (restart_data["type"][p_i] == Shape<dim>::ShapeType::sphere)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4420:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4420 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4430:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4430 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4439:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4439 |           else if (restart_data["type"][p_i] == Shape<dim>::ShapeType::torus)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4446:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4446 |           else if (restart_data["type"][p_i] == Shape<dim>::ShapeType::cone)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4453:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4453 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4463:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4463 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4472:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<2>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4472 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc: In instantiation of ‘void GLSSharpNavierStokesSolver<dim>::load_particles_from_file() [with int dim = 3]’:
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4644:16:   required from here
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4339:41: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4339 |           if (restart_data["type"][p_i] == Shape<dim>::ShapeType::sphere)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4345:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4345 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4354:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4354 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4414:41: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4414 |           if (restart_data["type"][p_i] == Shape<dim>::ShapeType::sphere)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4420:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4420 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4430:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4430 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4439:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4439 |           else if (restart_data["type"][p_i] == Shape<dim>::ShapeType::torus)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4446:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4446 |           else if (restart_data["type"][p_i] == Shape<dim>::ShapeType::cone)
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4453:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4453 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4463:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4463 |           else if (restart_data["type"][p_i] ==
/home/munch/sw-p3/lethe/source/fem-dem/gls_sharp_navier_stokes.cc:4472:46: warning: comparison of floating-point type ‘__gnu_cxx::__alloc_traits<std::allocator<double>, double>::value_type’ {aka ‘double’} with enumeration type ‘Shape<3>::ShapeType’ is deprecated [-Wdeprecated-enum-float-conversion]
 4472 |           else if (restart_data["type"][p_i] ==

```

# Comments

