### PR TITLE
Improve output of multigrid information

### DIFF
--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -229,4 +229,7 @@ Different parameters for the main components of the two geometric multigrid algo
     set ilu preconditioner relative tolerance = 1
 
 .. tip::
-  The default algorithms build and use ALL the multigrid levels. There are two ways to change the number of levels, either by setting the ``mg min level`` parameter OR the ``mg level min cells`` parameter. For ``lsmg`` the coarsest mesh should cover the whole domain, i.e., no hanging nodes are allowed. 
+  The default algorithms build and use ALL the multigrid levels. There are two ways to change the number of levels, either by setting the ``mg min level`` parameter OR the ``mg level min cells`` parameter. For ``lsmg`` the coarsest mesh should cover the whole domain, i.e., no hanging nodes are allowed.
+
+.. tip::
+  If ``mg verbosity`` is set to ``verbose``, the information about the levels (cells and degrees of freedom) and the number of iterations of the coarse grid solver are displayed. If this parameter is set to ``extra verbose``, apart from all the previous information, an additional table with the time it took to set up the different components of the multigrid preconditioners is also displayed. 

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -197,11 +197,15 @@ private:
    *  MG smoother
    *
    * @param operator Operator for which the estimation needs to be done
+   *
+   * @param level Corresponding MG level
+   *
    * @return double Omega relaxation parameter
    */
   double
   estimate_omega(
-    std::shared_ptr<NavierStokesOperatorBase<dim, double>> &mg_operator);
+    std::shared_ptr<NavierStokesOperatorBase<dim, double>> &mg_operator,
+    const unsigned int                                     &level);
 
 protected:
   // Matrix-free operator
@@ -215,7 +219,7 @@ protected:
   // Vector to store the time derivative of the previous solutions at the end
   // of each time step
   VectorType time_derivative_previous_solutions;
-  // Time within MG preconditioners
+  // Setup timings for all MG components
   TimerOutput mg_computing_timer;
 };
 

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -200,12 +200,15 @@ private:
    *
    * @param level Corresponding MG level
    *
+   * @param diagonal Pre-computed diagonal of level operator
+   *
    * @return double Omega relaxation parameter
    */
   double
   estimate_omega(
     std::shared_ptr<NavierStokesOperatorBase<dim, double>> &mg_operator,
-    const unsigned int                                     &level);
+    const unsigned int                                     &level,
+    const VectorType                                       &diagonal);
 
 protected:
   // Matrix-free operator

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -215,6 +215,8 @@ protected:
   // Vector to store the time derivative of the previous solutions at the end
   // of each time step
   VectorType time_derivative_previous_solutions;
+  // Time within MG preconditioners
+  TimerOutput mg_computing_timer;
 };
 
 #endif

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2182,9 +2182,9 @@ namespace Parameters
         prm.declare_entry(
           "mg verbosity",
           "verbose",
-          Patterns::Selection("quiet|verbose"),
+          Patterns::Selection("quiet|verbose|extra verbose"),
           "State whether LSMG or GCMG should print information about levels "
-          "Choices are <quiet|verbose>.");
+          "Choices are <quiet|verbose|extra verbose>.");
       }
       prm.leave_subsection();
     }
@@ -2299,6 +2299,8 @@ namespace Parameters
         const std::string mg_op = prm.get("mg verbosity");
         if (mg_op == "verbose")
           mg_verbosity = Parameters::Verbosity::verbose;
+        else if (mg_op == "extra verbose")
+          mg_verbosity = Parameters::Verbosity::extra_verbose;
         else if (mg_op == "quiet")
           mg_verbosity = Parameters::Verbosity::quiet;
         else

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -48,6 +48,10 @@ template <int dim>
 MFNavierStokesSolver<dim>::MFNavierStokesSolver(
   SimulationParameters<dim> &nsparam)
   : NavierStokesBase<dim, VectorType, IndexSet>(nsparam)
+  , mg_computing_timer(this->mpi_communicator,
+                       this->pcout,
+                       TimerOutput::summary,
+                       TimerOutput::wall_times)
 {
   AssertThrow(
     nsparam.fem_parameters.velocity_order ==
@@ -134,6 +138,14 @@ MFNavierStokesSolver<dim>::solve()
 
       this->postprocess(false);
       this->finish_time_step();
+      if (this->simulation_parameters.linear_solver
+            .at(PhysicsID::fluid_dynamics)
+            .mg_verbosity == Parameters::Verbosity::extra_verbose)
+        {
+          announce_string(this->pcout, "Multigrid setup timings:");
+          this->mg_computing_timer.print_summary();
+        }
+      this->mg_computing_timer.reset();
     }
 
   this->finish_simulation();
@@ -158,7 +170,10 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
 
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .preconditioner == Parameters::LinearSolver::PreconditionerType::lsmg)
-    this->dof_handler.distribute_mg_dofs();
+    {
+      TimerOutput::Scope t(this->mg_computing_timer, "Distribute MG DoFs");
+      this->dof_handler.distribute_mg_dofs();
+    }
 
   this->locally_owned_dofs = this->dof_handler.locally_owned_dofs();
   DoFTools::extract_locally_relevant_dofs(this->dof_handler,
@@ -529,6 +544,8 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
   ls_mg_operators.resize(0, n_h_levels - 1);
 
   // Fill the constraints
+  this->mg_computing_timer.enter_subsection("Set boundary conditions");
+
   mg_constrained_dofs.initialize(this->dof_handler);
 
   FEValuesExtractors::Vector velocities(0);
@@ -600,6 +617,8 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
         }
     }
 
+  this->mg_computing_timer.leave_subsection("Set boundary conditions");
+
   // Create mg operators for each level and additional operators needed only for
   // local smoothing
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
@@ -623,6 +642,8 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
 #endif
 
       level_constraints[level].close();
+
+      this->mg_computing_timer.enter_subsection("Set up operators");
 
       if ((this->simulation_parameters.stabilization
              .use_default_stabilization == true) ||
@@ -657,9 +678,14 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
       ls_mg_interface_out[level].initialize(*mg_operators[level]);
 
       partitioners[level] = mg_operators[level]->get_vector_partitioner();
+
+      this->mg_computing_timer.leave_subsection("Set up operators");
     }
 
   // Create transfer operator and transfer solution to mg levels
+  this->mg_computing_timer.enter_subsection(
+    "Create transfer operator and execute relevant transfers");
+
   mg_transfer.initialize_constraints(mg_constrained_dofs);
   mg_transfer.build(this->dof_handler, partitioners);
   mg_transfer.interpolate_to_mg(this->dof_handler,
@@ -685,9 +711,14 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
         }
     }
 
+  this->mg_computing_timer.leave_subsection(
+    "Create transfer operator and execute relevant transfers");
+
   mg::Matrix<VectorType> mg_matrix(ls_mg_operators);
 
   // Create smoother, fill parameters for each level and intialize it
+  this->mg_computing_timer.enter_subsection("Set up and initialize smoother");
+
   MGSmootherPrecondition<OperatorType, SmootherType, VectorType> mg_smoother;
   MGLevelObject<typename SmootherType::AdditionalData> smoother_data(minlevel,
                                                                      maxlevel);
@@ -713,6 +744,9 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
     }
 
   mg_smoother.initialize(mg_operators, smoother_data);
+
+  this->mg_computing_timer.leave_subsection("Set up and initialize smoother");
+
 
   // If multigrid number of levels or minimum number of cells in level are
   // specified, change the min level for the coarse-grid solver and the
@@ -765,6 +799,8 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
                   << " cells" << std::endl;
 
   // Create coarse-grid GMRES solver and AMG preconditioner
+  this->mg_computing_timer.enter_subsection("Create coarse-grid solver");
+
   const int max_iterations =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .mg_coarse_grid_max_iterations;
@@ -883,6 +919,7 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
                                     decltype(precondition_ilu)>>(
         coarse_grid_solver, *mg_operators[minlevel], precondition_ilu);
     }
+  this->mg_computing_timer.leave_subsection("Create coarse-grid solver");
 
   // Create interface matrices needed for local smoothing in case of local
   // refinement
@@ -911,6 +948,12 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
                *ls_multigrid_preconditioner);
 
   this->computing_timer.leave_subsection("Solve linear system");
+
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_verbosity == Parameters::Verbosity::extra_verbose)
+    this->pcout << "    Coarse grid solver took : "
+                << coarse_grid_solver_control.last_step() << " steps "
+                << std::endl;
 }
 
 template <int dim>
@@ -938,9 +981,13 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
   std::vector<std::shared_ptr<const Triangulation<dim>>>
     coarse_grid_triangulations;
 
+  this->mg_computing_timer.enter_subsection("Create level triangulations");
+
   coarse_grid_triangulations =
     MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
       this->dof_handler.get_triangulation());
+
+  this->mg_computing_timer.leave_subsection("Create level triangulations");
 
   // Modify the triangulations if multigrid number of levels or minimum number
   // of cells in level are specified
@@ -1011,17 +1058,23 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
   constraints.resize(minlevel, maxlevel);
 
   // Distribute DoFs for each level
+  this->mg_computing_timer.enter_subsection(
+    "Create DoFHandlers and distribute DoFs");
   for (unsigned int l = minlevel; l <= maxlevel; ++l)
     {
       dof_handlers[l].reinit(*coarse_grid_triangulations[l]);
       dof_handlers[l].distribute_dofs(this->dof_handler.get_fe());
     }
+  this->mg_computing_timer.leave_subsection(
+    "Create DoFHandlers and distribute DoFs");
 
   // Apply constraints and create mg operators for each level
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
       const auto &level_dof_handler = dof_handlers[level];
       auto       &level_constraint  = constraints[level];
+
+      this->mg_computing_timer.enter_subsection("Set boundary conditions");
 
       level_constraint.clear();
       const IndexSet locally_relevant_dofs =
@@ -1097,6 +1150,10 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
 
       level_constraint.close();
 
+      this->mg_computing_timer.leave_subsection("Set boundary conditions");
+
+      this->mg_computing_timer.enter_subsection("Set up operators");
+
       if ((this->simulation_parameters.stabilization
              .use_default_stabilization == true) ||
           this->simulation_parameters.stabilization.stabilization ==
@@ -1120,9 +1177,14 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
           .get_kinematic_viscosity_scale(),
         numbers::invalid_unsigned_int,
         this->simulation_control);
+
+      this->mg_computing_timer.leave_subsection("Set up operators");
     }
 
   // Create transfer operators and transfer solution to mg levels
+  this->mg_computing_timer.enter_subsection(
+    "Create transfer operator and execute relevant transfers");
+
   for (unsigned int level = minlevel; level < maxlevel; ++level)
     transfers[level + 1].reinit(dof_handlers[level + 1],
                                 dof_handlers[level],
@@ -1157,6 +1219,9 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
         }
     }
 
+  this->mg_computing_timer.leave_subsection(
+    "Create transfer operator and execute relevant transfers");
+
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .mg_verbosity != Parameters::Verbosity::quiet)
     for (unsigned int level = minlevel; level <= maxlevel; ++level)
@@ -1168,6 +1233,8 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
   mg::Matrix<VectorType> mg_matrix(mg_operators);
 
   // Create smoother, fill parameters for each level and intialize it
+  this->mg_computing_timer.enter_subsection("Set up and initialize smoother");
+
   MGSmootherPrecondition<OperatorType, SmootherType, VectorType> mg_smoother;
   MGLevelObject<typename SmootherType::AdditionalData> smoother_data(minlevel,
                                                                      maxlevel);
@@ -1194,7 +1261,11 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
 
   mg_smoother.initialize(mg_operators, smoother_data);
 
+  this->mg_computing_timer.leave_subsection("Set up and initialize smoother");
+
   // Create coarse-grid GMRES solver and AMG preconditioner
+  this->mg_computing_timer.enter_subsection("Create coarse-grid solver");
+
   const int max_iterations =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .mg_coarse_grid_max_iterations;
@@ -1205,7 +1276,7 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .mg_coarse_grid_reduce;
   ReductionControl coarse_grid_solver_control(
-    max_iterations, tolerance, reduce, false, false);
+    max_iterations, tolerance, reduce, true, true);
   SolverGMRES<VectorType>::AdditionalData solver_parameters;
   solver_parameters.max_n_tmp_vectors =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
@@ -1314,6 +1385,8 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
         coarse_grid_solver, *mg_operators[minlevel], precondition_ilu);
     }
 
+  this->mg_computing_timer.leave_subsection("Create coarse-grid solver");
+
   // Create main MG object
   Multigrid<VectorType> mg(
     mg_matrix, *mg_coarse, mg_transfer, mg_smoother, mg_smoother);
@@ -1333,6 +1406,12 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
                *gc_multigrid_preconditioner);
 
   this->computing_timer.leave_subsection("Solve linear system");
+
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_verbosity == Parameters::Verbosity::extra_verbose)
+    this->pcout << "    Coarse grid solver took : "
+                << coarse_grid_solver_control.last_step() << " steps "
+                << std::endl;
 }
 
 template <int dim>

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -50,7 +50,7 @@ MFNavierStokesSolver<dim>::MFNavierStokesSolver(
   : NavierStokesBase<dim, VectorType, IndexSet>(nsparam)
   , mg_computing_timer(this->mpi_communicator,
                        this->pcout,
-                       TimerOutput::summary,
+                       TimerOutput::never,
                        TimerOutput::wall_times)
 {
   AssertThrow(
@@ -1297,7 +1297,7 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .mg_coarse_grid_reduce;
   ReductionControl coarse_grid_solver_control(
-    max_iterations, tolerance, reduce, true, true);
+    max_iterations, tolerance, reduce, false, false);
   SolverGMRES<VectorType>::AdditionalData solver_parameters;
   solver_parameters.max_n_tmp_vectors =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)


### PR DESCRIPTION
# Description of the problem

Until now, the only information being printed when the verbosity parameter of the multigrid preconditioners was enabled was the information of the levels. However, it is useful to have more information for debugging or analysis purposes.

# Description of the solution

The number of iterations needed by the coarse-grid solver was also added to this output. In addition, one can set the mg verbosity parameter to extra verbose to output a table with the timings required to set up the different components of the multigrid preconditioners. Also, the output of the eigenvalue estimation was fixed and now it reports the corresponding level. 

# How Has This Been Tested?

The output was tested with different problems on my machine, seems to work as expected.

# Documentation

An additional tip was added to the linear solver parameters doc page explaining the difference between verbose and extra verbose for the multigrid preconditioners.