### PR TITLE
Use compute element size function in MF operators

### DIFF
--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -124,7 +124,7 @@ NavierStokesOperatorBase<dim, number>::reinit(
 
   this->simulation_control = simulation_control;
 
-  // this->compute_element_size();
+  this->compute_element_size();
 
   constrained_indices.clear();
   for (auto i : this->matrix_free.get_constrained_dofs())
@@ -589,7 +589,7 @@ NavierStokesSUPGPSPGOperator<dim, number>::do_cell_integral_local(
 
   const unsigned int cell = integrator.get_current_cell_index();
 
-  // auto h = integrator.read_cell_data(this->get_element_size());
+  const auto h = integrator.read_cell_data(this->get_element_size());
 
   for (unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
@@ -619,42 +619,14 @@ NavierStokesSUPGPSPGOperator<dim, number>::do_cell_integral_local(
         this->nonlinear_previous_hessian_diagonal(cell, q);
 
       // Calculate tau
-      VectorizedArray<number> u_mag = VectorizedArray<number>(1e-12);
-      VectorizedArray<number> tau   = VectorizedArray<number>(0.0);
-
-      std::array<number, VectorizedArray<number>::size()> h_k;
-      std::array<number, VectorizedArray<number>::size()> h;
-
-      for (auto lane = 0u;
-           lane < this->matrix_free.n_active_entries_per_cell_batch(cell);
-           lane++)
-        {
-          h_k[lane] =
-            this->matrix_free.get_cell_iterator(cell, lane)->measure();
-        }
-
-      for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-        {
-          if (dim == 2)
-            {
-              h[v] = std::sqrt(4. * h_k[v] / M_PI) / this->fe_degree;
-            }
-          else if (dim == 3)
-            {
-              h[v] = std::pow(6 * h_k[v] / M_PI, 1. / 3.) / this->fe_degree;
-            }
-        }
-
+      VectorizedArray<number> u_mag = 1e-12;
       for (unsigned int k = 0; k < dim; ++k)
         u_mag += Utilities::fixed_power<2>(previous_values[k]);
 
-      for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-        {
-          tau[v] = 1. / std::sqrt(
-                          4. * u_mag[v] / h[v] / h[v] +
-                          9 * Utilities::fixed_power<2>(
-                                4 * this->kinematic_viscosity / (h[v] * h[v])));
-        }
+      const auto tau =
+        1. / std::sqrt(4. * u_mag / h / h +
+                       9. * Utilities::fixed_power<2>(
+                              4. * this->kinematic_viscosity / (h * h)));
 
       // Weak form Jacobian
       for (unsigned int i = 0; i < dim; ++i)
@@ -757,7 +729,7 @@ NavierStokesSUPGPSPGOperator<dim, number>::local_evaluate_residual(
       integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
                           EvaluationFlags::hessians);
 
-      // auto h = integrator.read_cell_data(this->get_element_size());
+      const auto h = integrator.read_cell_data(this->get_element_size());
 
       for (unsigned int q = 0; q < integrator.n_q_points; ++q)
         {
@@ -777,42 +749,15 @@ NavierStokesSUPGPSPGOperator<dim, number>::local_evaluate_residual(
             integrator.get_hessian_diagonal(q);
 
           // Calculate tau
-          VectorizedArray<number> u_mag = VectorizedArray<number>(1e-12);
-          VectorizedArray<number> tau   = VectorizedArray<number>(0.0);
-
-          std::array<number, VectorizedArray<number>::size()> h_k;
-          std::array<number, VectorizedArray<number>::size()> h;
-
-          for (auto lane = 0u;
-               lane < matrix_free.n_active_entries_per_cell_batch(cell);
-               lane++)
-            {
-              h_k[lane] = matrix_free.get_cell_iterator(cell, lane)->measure();
-            }
-
-          for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-            {
-              if (dim == 2)
-                {
-                  h[v] = std::sqrt(4. * h_k[v] / M_PI) / this->fe_degree;
-                }
-              else if (dim == 3)
-                {
-                  h[v] = std::pow(6 * h_k[v] / M_PI, 1. / 3.) / this->fe_degree;
-                }
-            }
-
+          VectorizedArray<number> u_mag = 1e-12;
           for (unsigned int k = 0; k < dim; ++k)
             u_mag += Utilities::fixed_power<2>(value[k]);
 
-          for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-            {
-              tau[v] =
-                1. /
-                std::sqrt(4. * u_mag[v] / h[v] / h[v] +
-                          9 * Utilities::fixed_power<2>(
-                                4 * this->kinematic_viscosity / (h[v] * h[v])));
-            }
+          const auto tau =
+            1. / std::sqrt(4. * u_mag / h / h +
+                           9. * Utilities::fixed_power<2>(
+                                  4. * this->kinematic_viscosity / (h * h)));
+
           // Result value/gradient we will use
           typename FECellIntegrator::value_type    value_result;
           typename FECellIntegrator::gradient_type gradient_result;
@@ -909,11 +854,11 @@ NavierStokesTransientSUPGPSPGOperator<dim, number>::do_cell_integral_local(
 
   const unsigned int cell = integrator.get_current_cell_index();
 
-  // auto h = integrator.read_cell_data(this->get_element_size());
+  const auto h = integrator.read_cell_data(this->get_element_size());
 
   // Time stepping information
-  const auto          method = this->simulation_control->get_assembly_method();
-  std::vector<double> time_steps_vector =
+  const auto method = this->simulation_control->get_assembly_method();
+  const auto time_steps_vector =
     this->simulation_control->get_time_steps_vector();
   const double   dt        = time_steps_vector[0];
   const double   sdt       = 1. / dt;
@@ -946,49 +891,19 @@ NavierStokesTransientSUPGPSPGOperator<dim, number>::do_cell_integral_local(
       auto previous_hessian_diagonal =
         this->nonlinear_previous_hessian_diagonal(cell, q);
 
-
       // Time derivatives of previous solutions
       auto previous_time_derivatives =
         this->time_derivatives_previous_solutions(cell, q);
 
       // Calculate tau
-      VectorizedArray<number> u_mag = VectorizedArray<number>(1e-12);
-      VectorizedArray<number> tau   = VectorizedArray<number>(0.0);
-
-      std::array<number, VectorizedArray<number>::size()> h_k;
-      std::array<number, VectorizedArray<number>::size()> h;
-
-      for (auto lane = 0u;
-           lane < this->matrix_free.n_active_entries_per_cell_batch(cell);
-           lane++)
-        {
-          h_k[lane] =
-            this->matrix_free.get_cell_iterator(cell, lane)->measure();
-        }
-
-      for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-        {
-          if (dim == 2)
-            {
-              h[v] = std::sqrt(4. * h_k[v] / M_PI) / this->fe_degree;
-            }
-          else if (dim == 3)
-            {
-              h[v] = std::pow(6 * h_k[v] / M_PI, 1. / 3.) / this->fe_degree;
-            }
-        }
-
+      VectorizedArray<number> u_mag = 1e-12;
       for (unsigned int k = 0; k < dim; ++k)
         u_mag += Utilities::fixed_power<2>(previous_values[k]);
 
-      for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-        {
-          tau[v] = 1. / std::sqrt(
-                          Utilities::fixed_power<2>(sdt) +
-                          4. * u_mag[v] / h[v] / h[v] +
-                          9 * Utilities::fixed_power<2>(
-                                4 * this->kinematic_viscosity / (h[v] * h[v])));
-        }
+      const auto tau =
+        1. / std::sqrt(Utilities::fixed_power<2>(sdt) + 4. * u_mag / h / h +
+                       9. * Utilities::fixed_power<2>(
+                              4. * this->kinematic_viscosity / (h * h)));
 
       // Weak form Jacobian
       for (unsigned int i = 0; i < dim; ++i)
@@ -1098,11 +1013,11 @@ NavierStokesTransientSUPGPSPGOperator<dim, number>::local_evaluate_residual(
       integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
                           EvaluationFlags::hessians);
 
-      // auto h = integrator.read_cell_data(this->get_element_size());
+      const auto h = integrator.read_cell_data(this->get_element_size());
 
       // Time stepping information
       const auto method = this->simulation_control->get_assembly_method();
-      std::vector<double> time_steps_vector =
+      const auto time_steps_vector =
         this->simulation_control->get_time_steps_vector();
       const double   dt        = time_steps_vector[0];
       const double   sdt       = 1. / dt;
@@ -1130,43 +1045,15 @@ NavierStokesTransientSUPGPSPGOperator<dim, number>::local_evaluate_residual(
             this->time_derivatives_previous_solutions(cell, q);
 
           // Calculate tau
-          VectorizedArray<number> u_mag = VectorizedArray<number>(1e-12);
-          VectorizedArray<number> tau   = VectorizedArray<number>(0.0);
-
-          std::array<number, VectorizedArray<number>::size()> h_k;
-          std::array<number, VectorizedArray<number>::size()> h;
-
-          for (auto lane = 0u;
-               lane < matrix_free.n_active_entries_per_cell_batch(cell);
-               lane++)
-            {
-              h_k[lane] = matrix_free.get_cell_iterator(cell, lane)->measure();
-            }
-
-          for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-            {
-              if (dim == 2)
-                {
-                  h[v] = std::sqrt(4. * h_k[v] / M_PI) / this->fe_degree;
-                }
-              else if (dim == 3)
-                {
-                  h[v] = std::pow(6 * h_k[v] / M_PI, 1. / 3.) / this->fe_degree;
-                }
-            }
-
+          VectorizedArray<number> u_mag = 1e-12;
           for (unsigned int k = 0; k < dim; ++k)
             u_mag += Utilities::fixed_power<2>(value[k]);
 
-          for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
-            {
-              tau[v] =
-                1. /
-                std::sqrt(Utilities::fixed_power<2>(sdt) +
-                          4. * u_mag[v] / h[v] / h[v] +
-                          9 * Utilities::fixed_power<2>(
-                                4 * this->kinematic_viscosity / (h[v] * h[v])));
-            }
+          const auto tau =
+            1. / std::sqrt(Utilities::fixed_power<2>(sdt) + 4. * u_mag / h / h +
+                           9. * Utilities::fixed_power<2>(
+                                  4. * this->kinematic_viscosity / (h * h)));
+
           // Result value/gradient we will use
           typename FECellIntegrator::value_type    value_result;
           typename FECellIntegrator::gradient_type gradient_result;


### PR DESCRIPTION
# Description of the problem

The compute element size function was not being used due to some bug that we had in the past.

# Description of the solution

The bug is no longer present, so the compute element size function is no longer commented and it is used in both the Jacobian and right hand side of the steady and transient operators. This function pre calculates the element size reducing the work needed to calculate the stabilization parameter. 

# How Has This Been Tested?

All the tests are passing. In addition, I tested this on my machine with the case that was failing before and now it works without any issue. 