### PR TITLE
Fix workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ![Lethe](logo/logo_black.png?raw=true)
 
 [![CI-Debug](https://github.com/lethe-cfd/lethe/actions/workflows/main_debug.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_debug.yml)
-
 [![CI-Release](https://github.com/lethe-cfd/lethe/actions/workflows/main_release.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_release.yml)
-
 [![CI-Warnings](https://github.com/lethe-cfd/lethe/actions/workflows/main_warnings.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_warnings.yml)
+[![Docker Image Build & Push](https://github.com/lethe-cfd/lethe/actions/workflows/docker.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/docker.yml)
+[![Publish doc to GitHub Pages](https://github.com/lethe-cfd/lethe/actions/workflows/doc-github-pages.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/doc-github-pages.yml)
 
 Lethe (pronounced /ˈliːθiː/) is open-source computational fluid dynamics
 (CFD), discrete element method (DEM) and coupled CFD-DEM

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![CI-Debug](https://github.com/lethe-cfd/lethe/actions/workflows/main_debug.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_debug.yml)
 [![CI-Release](https://github.com/lethe-cfd/lethe/actions/workflows/main_release.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_release.yml)
 [![CI-Warnings](https://github.com/lethe-cfd/lethe/actions/workflows/main_warnings.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_warnings.yml)
-[![Docker Image Build & Push](https://github.com/lethe-cfd/lethe/actions/workflows/docker.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/docker.yml)
-[![Publish doc to GitHub Pages](https://github.com/lethe-cfd/lethe/actions/workflows/doc-github-pages.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/doc-github-pages.yml)
+[![Docker Image](https://github.com/lethe-cfd/lethe/actions/workflows/docker.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/docker.yml)
+[![Documentation](https://github.com/lethe-cfd/lethe/actions/workflows/doc-github-pages.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/doc-github-pages.yml)
 
 Lethe (pronounced /ˈliːθiː/) is open-source computational fluid dynamics
 (CFD), discrete element method (DEM) and coupled CFD-DEM

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ![Lethe](logo/logo_black.png?raw=true)
 
-[![Build Status](https://github.com/lethe-cfd/lethe/workflows/CI/badge.svg)](https://github.com/lethe-cfd/lethe/workflows/CI/badge.svg)
+[![CI-Debug](https://github.com/lethe-cfd/lethe/actions/workflows/main_debug.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_debug.yml)
+
+[![CI-Release](https://github.com/lethe-cfd/lethe/actions/workflows/main_release.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_release.yml)
+
+[![CI-Warnings](https://github.com/lethe-cfd/lethe/actions/workflows/main_warnings.yml/badge.svg)](https://github.com/lethe-cfd/lethe/actions/workflows/main_warnings.yml)
 
 Lethe (pronounced /ˈliːθiː/) is open-source computational fluid dynamics
 (CFD), discrete element method (DEM) and coupled CFD-DEM


### PR DESCRIPTION
# Description of the problem

The workflow status badge in the `README.md` file (github banner) was not working correctly.

# Description of the solution

The badge was not working because it was pointing to an old workflow that is not used anymore. This was fixed and several badges for the different workflows were added. 

# Comments

We might need to clean the workflows as there are several old ones that are not being used anymore but still appear in the Actions tab: CI, an old CI-Debug, an old CI-Release and Pull requests.