### PR TITLE
Update residual to stop steady bdf in lethe-fluid-matrix-free

### DIFF
--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -413,7 +413,8 @@ MFNavierStokesSolver<dim>::assemble_system_rhs()
 
   this->system_rhs *= -1.0;
 
-  // Provide residual to simulation control for stopping criterion when using steady bdf
+  // Provide residual to simulation control for stopping criterion when using
+  // steady bdf
   if (this->simulation_control->is_first_assembly())
     this->simulation_control->provide_residual(this->system_rhs.l2_norm());
 }

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -412,6 +412,10 @@ MFNavierStokesSolver<dim>::assemble_system_rhs()
                                            this->evaluation_point);
 
   this->system_rhs *= -1.0;
+
+  // Provide residual to simulation control for stopping criterion when using steady bdf
+  if (this->simulation_control->is_first_assembly())
+    this->simulation_control->provide_residual(this->system_rhs.l2_norm());
 }
 
 template <int dim>


### PR DESCRIPTION
# Description of the problem

When using `lethe-fluid-matrix-free`, the residual variable in the simulation control was not being updated, therefore, the stopping criterion for a steady bdf simulation was not working. 

# Description of the solution

The residual of the right hand side is now being provided to the simulation control after assembling it, which allows the solver to stop once the stop tolerance has being reached.
