### PR TITLE
Fixing a stability problem with the JKR model

### DIFF
--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -1063,10 +1063,10 @@ protected:
     const double root1 =
       0.25 * Utilities::fixed_power<2>(Q) + Utilities::fixed_power<3>(P) / 27.;
     const double U      = std::cbrt(-0.5 * Q + std::sqrt(root1));
-    double       s      = -c2 * (5. / 6.) + U - P / (3. * U);
-    const double w      = std::sqrt(c2 + 2. * s);
+    const double s      = -c2 * (5. / 6.) + U - P / (3. * U);
+    const double w      = std::sqrt(std::max(1e-16, c2 + 2. * s));
     const double lambda = 0.5 * c1 / w;
-    const double root2  = w * w - 4. * (c2 + s + lambda);
+    const double root2  = std::max(1e-16, w * w - 4. * (c2 + s + lambda));
     const double a      = 0.5 * (w + std::sqrt(root2));
 
     // Calculation of the normal damping constant.

--- a/source/dem/particle_wall_jkr_force.cc
+++ b/source/dem/particle_wall_jkr_force.cc
@@ -432,11 +432,11 @@ ParticleWallJKRForce<dim>::calculate_jkr_contact_force_and_torque(
   const double root1  = std::max(0.,
                                 (0.25 * Utilities::fixed_power<2>(Q)) +
                                   (Utilities::fixed_power<3>(P) / 27.));
-  const double U      = std::cbrt(-0.5 * Q + std::sqrt(root1)) + DBL_MIN;
-  double       s      = -c2 * (5. / 6.) + U - P / (3. * U);
-  const double w      = std::sqrt(c2 + 2. * s);
+  const double U      = std::cbrt(-0.5 * Q + std::sqrt(root1));
+  const double s      = -c2 * (5. / 6.) + U - P / (3. * U);
+  const double w      = std::sqrt(std::max(1e-16, c2 + 2. * s));
   const double lambda = 0.5 * c1 / w;
-  const double root2  = std::max(0., w * w - 4. * (c2 + s + lambda));
+  const double root2  = std::max(1e-16, w * w - 4. * (c2 + s + lambda));
   const double a      = 0.5 * (w + std::sqrt(root2));
 
   // Calculation of normal damping and tangential spring and dashpot constants


### PR DESCRIPTION
# Description of the problem

- When the particle surface energy was equal or close to zero, particles can disappear. The cause of the problem was a division by zero or the square-root of a negative number resulting in a NaN/NULL .  

# Description of the solution

- std::max(1e-16, ...) are now used in the code. 
- No problem was detected with the particle-wall contact force calculation, but to keep the consistency between the particle-particle and particle-wall code, the same procedure is used force for the particle-wall  calculation. 

# How Has This Been Tested?

- Every test still passes.

# Documentation

- N/A


