### PR TITLE
Dem fixing plane insertion distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the Lethe project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+## [Master] - 2023-11-23
+
+### Fixed
+
+- MINOR The plane insertion for the DEM was only supporting the uniform diameter distribution. Now it supports all types of distribution. 
+
 ## [Master] - 2023-11-16
   
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MAJOR The "number" parameter within "subsection lagrangian physical properties" and "particle type n" was changed to "number of particles" to prevent confusions with the "number" used for boundary conditions. The "number" for boundary conditions will be changed to "number of boundary conditions" in the near future.
 
+## [Master] - 2023-11-12
+  
+### Deprecated
+
+- MINOR The uniform insertion method had been removed. The non-uniform insertion method has been renamed to volume method to remain coherent with the plane method. If you want to use an insertion method equivalent to the uniform insertion method, use the volume method with a "insertion random number range " equal to zero. [#926](https://github.com/lethe-cfd/lethe/pull/926)
+
+
 ## [Master] - 2023-10-01
   
 ### Fixed
@@ -40,13 +47,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Master] - 2023-10-30
 
 - MINOR The rotational vector for the rotational boundary condition in the lethe-particles solver is now define with one line in the parameters file. [#920](https://github.com/lethe-cfd/lethe/pull/920)
-
-
-## [Master] - 2023-11-12
-  
-### Deprecated
-
-- MINOR The uniform insertion method had been removed. The non-uniform insertion method has been renamed to volume method to remain coherent with the plane method. If you want to use an insertion method equivalent to the uniform insertion method, use the volume method with a "insertion random number range " equal to zero. [#926](https://github.com/lethe-cfd/lethe/pull/926)
 
  
 

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -105,14 +105,12 @@ protected:
    * at each insertion step on each processor. This value can change in the last
    * insertion step to reach the desired number of particles
    * @param current_inserting_particle_type Type of inserting particles
-   * @param particle_properties Properties of all inserted particles at each insertion step
    */
   void
   assign_particle_properties(
-    const DEMSolverParameters<dim>   &dem_parameters,
-    const unsigned int               &inserted_this_step_this_proc,
-    const unsigned int               &current_inserting_particle_type,
-    std::vector<std::vector<double>> &particle_properties);
+    const DEMSolverParameters<dim> &dem_parameters,
+    const unsigned int             &inserted_this_step_this_proc,
+    const unsigned int             &current_inserting_particle_type);
 
   /**
    * @brief Carries out finding the maximum number of inserted particles based on the

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -105,12 +105,14 @@ protected:
    * at each insertion step on each processor. This value can change in the last
    * insertion step to reach the desired number of particles
    * @param current_inserting_particle_type Type of inserting particles
+   * @param particle_properties Properties of all inserted particles at each insertion step
    */
   void
   assign_particle_properties(
-    const DEMSolverParameters<dim> &dem_parameters,
-    const unsigned int             &inserted_this_step_this_proc,
-    const unsigned int             &current_inserting_particle_type);
+    const DEMSolverParameters<dim>   &dem_parameters,
+    const unsigned int               &inserted_this_step_this_proc,
+    const unsigned int               &current_inserting_particle_type,
+    std::vector<std::vector<double>> &particle_properties);
 
   /**
    * @brief Carries out finding the maximum number of inserted particles based on the
@@ -144,9 +146,6 @@ protected:
   // Inserted number of particles at this step on this processor
   unsigned int inserted_this_step_this_proc;
 
-  // A vector of vectors, which contains all the properties of all inserted
-  // particles at each insertion step
-  std::vector<std::vector<double>> particle_properties;
 
   // A distribution object that carries out the attribution of diameter to every
   // particle during an insertion time step

--- a/include/dem/plane_insertion.h
+++ b/include/dem/plane_insertion.h
@@ -100,7 +100,6 @@ private:
   int                                          particles_of_each_type_remaining;
   unsigned int                                 current_inserting_particle_type;
   std::unordered_map<unsigned int, Point<dim>> cells_centers;
-  std::unordered_map<unsigned int, double>     number_particles_to_insert;
   std::unordered_map<unsigned int, double>     type_of_particle_left_to_insert;
   bool                                         mark_for_update;
   boost::signals2::connection                  change_to_triangulation;

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -66,10 +66,9 @@ Insertion<dim>::print_insertion_info(const unsigned int &inserted_this_step,
 template <int dim>
 void
 Insertion<dim>::assign_particle_properties(
-  const DEMSolverParameters<dim>   &dem_parameters,
-  const unsigned int               &inserted_this_step_this_proc,
-  const unsigned int               &current_inserting_particle_type,
-  std::vector<std::vector<double>> &particle_properties)
+  const DEMSolverParameters<dim> &dem_parameters,
+  const unsigned int             &inserted_this_step_this_proc,
+  const unsigned int             &current_inserting_particle_type)
 {
   // Clearing and resizing particle_properties
   particle_properties.clear();

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -66,12 +66,12 @@ Insertion<dim>::print_insertion_info(const unsigned int &inserted_this_step,
 template <int dim>
 void
 Insertion<dim>::assign_particle_properties(
-  const DEMSolverParameters<dim> &dem_parameters,
-  const unsigned int             &inserted_this_step_this_proc,
-  const unsigned int             &current_inserting_particle_type)
+  const DEMSolverParameters<dim>   &dem_parameters,
+  const unsigned int               &inserted_this_step_this_proc,
+  const unsigned int               &current_inserting_particle_type,
+  std::vector<std::vector<double>> &particle_properties)
 {
   // Clearing and resizing particle_properties
-  particle_properties.clear();
   particle_properties.reserve(inserted_this_step_this_proc);
 
   // Getting properties as local parameters

--- a/source/dem/list_insertion.cc
+++ b/source/dem/list_insertion.cc
@@ -110,19 +110,22 @@ ListInsertion<dim>::insert(
       const auto global_bounding_boxes =
         Utilities::MPI::all_gather(communicator, my_bounding_box);
 
+      // A vector of vectors, which contains all the properties of all inserted
+      // particles at each insertion step
+      std::vector<std::vector<double>> particle_properties;
 
       // Assign inserted particles properties
       this->assign_particle_properties_for_list_insertion(
         dem_parameters,
         n_particles_to_insert_this_proc,
         current_inserting_particle_type,
-        this->particle_properties);
+        particle_properties);
 
       // Insert the particles using the points and assigned properties
       particle_handler.insert_global_particles(
         insertion_points_on_proc_this_step,
         global_bounding_boxes,
-        this->particle_properties);
+        particle_properties);
 
       // Update number of particles remaining to be inserted
       remaining_particles_of_each_type -= n_total_particles_to_insert;
@@ -146,7 +149,6 @@ ListInsertion<dim>::assign_particle_properties_for_list_insertion(
   std::vector<std::vector<double>> &particle_properties)
 {
   // Clearing and resizing particle_properties
-  particle_properties.clear();
   particle_properties.reserve(inserted_this_step_this_proc);
 
   // Getting properties as local parameters

--- a/source/dem/plane_insertion.cc
+++ b/source/dem/plane_insertion.cc
@@ -259,45 +259,13 @@ PlaneInsertion<dim>::insert(
           empty_cells_on_proc.erase(it); // Erase the first element
         }
 
-      // There's probably a better ways to define the properties of a particle,
-      // but for now it works...
-      double type     = this->current_inserting_particle_type;
-      double diameter = dem_parameters.lagrangian_physical_properties
-                          .particle_average_diameter.at(type);
-      double density =
-        dem_parameters.lagrangian_physical_properties.density_particle.at(type);
-      double vel_x        = dem_parameters.insertion_info.vel_x;
-      double vel_y        = dem_parameters.insertion_info.vel_y;
-      double vel_z        = dem_parameters.insertion_info.vel_z;
-      double omega_x      = dem_parameters.insertion_info.omega_x;
-      double omega_y      = dem_parameters.insertion_info.omega_y;
-      double omega_z      = dem_parameters.insertion_info.omega_z;
-      double fem_force_x  = 0.;
-      double fem_force_y  = 0.;
-      double fem_force_z  = 0.;
-      double fem_torque_x = 0.;
-      double fem_torque_y = 0.;
-      double fem_torque_z = 0.;
-      double mass         = density * 4. / 3. * M_PI *
-                    Utilities::fixed_power<3, double>(diameter * 0.5);
-      double volumetric_contribution = 0.;
+      this->assign_particle_properties(
+        dem_parameters,
+        number_of_particles_to_insert_on_this_core,
+        current_inserting_particle_type);
 
-      std::vector<double> properties_of_one_particle{type,
-                                                     diameter,
-                                                     vel_x,
-                                                     vel_y,
-                                                     vel_z,
-                                                     omega_x,
-                                                     omega_y,
-                                                     omega_z,
-                                                     fem_force_x,
-                                                     fem_force_y,
-                                                     fem_force_z,
-                                                     fem_torque_x,
-                                                     fem_torque_y,
-                                                     fem_torque_z,
-                                                     mass,
-                                                     volumetric_contribution};
+      // This is to iterate over the particle_properties vector
+      unsigned int i = 0;
 
       // Loop over the empty cells we have kept.
       for (const auto &cell : empty_cells_on_proc)
@@ -325,7 +293,7 @@ PlaneInsertion<dim>::insert(
                                            ref_point,
                                            starting_ID_on_proc++,
                                            cell,
-                                           properties_of_one_particle);
+                                           this->particle_properties.at(i++));
         }
     }
 }

--- a/source/dem/plane_insertion.cc
+++ b/source/dem/plane_insertion.cc
@@ -259,10 +259,15 @@ PlaneInsertion<dim>::insert(
           empty_cells_on_proc.erase(it); // Erase the first element
         }
 
+      // A vector of vectors, which contains all the properties of all inserted
+      // particles at each insertion step
+      std::vector<std::vector<double>> particle_properties;
+
       this->assign_particle_properties(
         dem_parameters,
         number_of_particles_to_insert_on_this_core,
-        current_inserting_particle_type);
+        current_inserting_particle_type,
+        particle_properties);
 
       // This is to iterate over the particle_properties vector
       unsigned int i = 0;
@@ -293,7 +298,7 @@ PlaneInsertion<dim>::insert(
                                            ref_point,
                                            starting_ID_on_proc++,
                                            cell,
-                                           this->particle_properties.at(i++));
+                                           particle_properties.at(i++));
         }
     }
 }

--- a/source/dem/volume_insertion.cc
+++ b/source/dem/volume_insertion.cc
@@ -121,8 +121,7 @@ VolumeInsertion<dim>::insert(
       // assign_particle_properties function
       this->assign_particle_properties(dem_parameters,
                                        this->inserted_this_step_this_proc,
-                                       current_inserting_particle_type,
-                                       this->particle_properties);
+                                       current_inserting_particle_type);
 
       // Insert the particles using the points and assigned properties
       particle_handler.insert_global_particles(insertion_points_on_proc,

--- a/source/dem/volume_insertion.cc
+++ b/source/dem/volume_insertion.cc
@@ -117,16 +117,19 @@ VolumeInsertion<dim>::insert(
           insertion_points_on_proc.push_back(insertion_location);
         }
 
+      std::vector<std::vector<double>> particle_properties;
+
       // Assigning inserted particles properties using
       // assign_particle_properties function
       this->assign_particle_properties(dem_parameters,
                                        this->inserted_this_step_this_proc,
-                                       current_inserting_particle_type);
+                                       current_inserting_particle_type,
+                                       particle_properties);
 
       // Insert the particles using the points and assigned properties
       particle_handler.insert_global_particles(insertion_points_on_proc,
                                                global_bounding_boxes,
-                                               this->particle_properties);
+                                               particle_properties);
 
       // Updating remaining particles
       particles_of_each_type_remaining -= this->inserted_this_step;

--- a/tests/dem/insertion_plane.cc
+++ b/tests/dem/insertion_plane.cc
@@ -61,6 +61,9 @@ test()
   dem_parameters.lagrangian_physical_properties.particle_type_number = 1;
   dem_parameters.lagrangian_physical_properties.particle_average_diameter[0] =
     0.2;
+  dem_parameters.lagrangian_physical_properties.size_distribution_type =
+    Parameters::Lagrangian::LagrangianPhysicalProperties::
+      size_distribution_type::uniform;
   dem_parameters.lagrangian_physical_properties.particle_size_std[0] = 0;
   dem_parameters.lagrangian_physical_properties.density_particle[0]  = 2500;
   dem_parameters.lagrangian_physical_properties.number[0]            = 16;


### PR DESCRIPTION
# Description of the problem

- The plane insertion method was only supporting the uniform diameter distribution. 

# Description of the solution

- assign_particle_properties is now used in the PlaneInsertion::insert function. 
- A few attribute got removed because they weren't being used. 
- The assign_particle_properties function last input got removed. 

# How Has This Been Tested?

- All the tests passed. 
- The uniform type had to me specified in the dem/insertion_plane.cc test. 

# Documentation

- N/A

# Future changes

- N/A

# Comments

- The CHANGELOG file got modified because of an error I made two week ago. (The order was wrong)
