### PR TITLE
Fixed executable name in ribbon example

### DIFF
--- a/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/template/launch-mixer.sh
+++ b/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/template/launch-mixer.sh
@@ -7,4 +7,4 @@
 #SBATCH --output=%x-%j.out
 
 source $HOME/.dealii
-srun  gls_navier_stokes_3d ribbon-gls.prm
+srun  lethe-fluid ribbon-gls.prm


### PR DESCRIPTION
# Description of the problem

- The ribbon example used the wrong executable name in the .sh file.

# Description of the solution

- Fixed it.


