### PR TITLE
Add evaporative heat and momentum fluxes

### DIFF
--- a/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.output
+++ b/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.output
@@ -1,0 +1,19 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       1024
+   Number of degrees of freedom: 6150
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 2050
+   Number of VOF degrees of freedom: 2050
+
+*****************************
+Steady iteration:        1/1
+*****************************
+L2 error velocity : 0
+L2 error temperature : 0.119054
+L2 error phase : 0.000325521
+cells error_velocity error_pressure 
+ 1024 0.000000e+00 - 0.000000e+00 - 
+cells error_temperature 
+ 1024 1.190539e-01    - 
+cells error_phase  
+ 1024 3.255208e-04 

--- a/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
@@ -1,0 +1,185 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = steady
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer  = true
+  set VOF            = true
+  set fluid dynamics = false
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order    = 1
+  set pressure order    = 1
+  set temperature order = 1
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+  subsection uvwp
+    set Function expression = 0; 0; 0
+  end
+
+  subsection temperature
+    set Function expression = 700
+  end
+
+  subsection VOF
+    set Function expression = if (y>0, 0, 1)
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions heat transfer
+  set number = 4
+  subsection bc 0
+    set id   = 2
+    set type = temperature
+    subsection value
+      set Function expression = 700
+    end
+  end
+  subsection bc 1
+    set id   = 0
+    set type = noflux
+  end
+  subsection bc 2
+    set id   = 1
+    set type = noflux
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noflux
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+
+  subsection fluid 0
+    set density              = 1
+    set kinematic viscosity  = 1
+    set thermal conductivity = 1
+    set specific heat        = 1
+  end
+
+  subsection fluid 1
+    set density              = 1
+    set kinematic viscosity  = 1
+    set thermal conductivity = 1
+    set specific heat        = 1
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 1, 1024: 0, -0.50 : 1, 0.50 : true
+  set initial refinement = 0
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable    = true
+  set verbosity = verbose
+  subsection uvwp
+    set Function expression = 0 ; 0 ; 0
+  end
+  subsection VOF
+    set Function expression = if (y>0, 0, 1)
+  end
+  subsection temperature
+    set Function expression = if (y>0, 200.0,  -1*1000*y+700.0-1.0*1000*0.5)
+  end
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set tolerance      = 1e-4
+    set max iterations = 100
+    set verbosity      = quiet
+  end
+  subsection VOF
+    set tolerance      = 1e-8
+    set max iterations = 100
+    set verbosity      = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end
+
+#---------------------------------------------------
+# Evaporation
+#---------------------------------------------------
+
+subsection evaporation
+  set evaporation mass flux model = constant
+  set enable evaporative cooling  = true
+  set evaporation latent heat     = 1000
+  set evaporation mass flux       = 1.0
+end

--- a/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
@@ -38,10 +38,6 @@ end
 
 subsection initial conditions
   set type = nodal
-  subsection uvwp
-    set Function expression = 0; 0; 0
-  end
-
   subsection temperature
     set Function expression = 700
   end
@@ -118,9 +114,6 @@ end
 subsection analytical solution
   set enable    = true
   set verbosity = verbose
-  subsection uvwp
-    set Function expression = 0 ; 0 ; 0
-  end
   subsection VOF
     set Function expression = if (y>0, 0, 1)
   end

--- a/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.output
+++ b/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.output
@@ -1,0 +1,19 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       1024
+   Number of degrees of freedom: 6150
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 2050
+   Number of VOF degrees of freedom: 2050
+
+*****************************
+Steady iteration:        1/1
+*****************************
+L2 error velocity : 0
+L2 error temperature : 0.0469432
+L2 error phase : 0.000325521
+cells error_velocity error_pressure 
+ 1024 0.000000e+00 - 0.000000e+00 - 
+cells error_temperature 
+ 1024 4.694317e-02    - 
+cells error_phase  
+ 1024 3.255208e-04 

--- a/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.prm
@@ -1,0 +1,183 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = steady
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer  = true
+  set VOF            = true
+  set fluid dynamics = false
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set temperature order = 1
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+
+  subsection temperature
+    set Function expression = 3300
+  end
+
+  subsection VOF
+    set Function expression = if (y>0, 0, 1)
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions heat transfer
+  set number = 4
+  subsection bc 0
+    set id   = 2
+    set type = temperature
+    subsection value
+      set Function expression = 3300
+    end
+  end
+  subsection bc 1
+    set id   = 0
+    set type = noflux
+  end
+  subsection bc 2
+    set id   = 1
+    set type = noflux
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noflux
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+
+  subsection fluid 0
+    set density              = 4000
+    set kinematic viscosity  = 1
+    set thermal conductivity = 1
+    set specific heat        = 1
+  end
+
+  subsection fluid 1
+    set density              = 4000
+    set kinematic viscosity  = 1
+    set thermal conductivity = 1
+    set specific heat        = 1
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 1, 1024: 0, -0.50 : 1, 0.50 : true
+  set initial refinement = 0
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable    = true
+  set verbosity = verbose
+  subsection VOF
+    set Function expression = if (y>0, 0, 1)
+  end
+  subsection temperature
+    set Function expression = if (y>0, 2766.29962639806,  -1067.40074720387*y+2766.29962639806)
+  end
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set tolerance      = 1e-4
+    set max iterations = 100
+    set verbosity      = quiet
+  end
+  subsection VOF
+    set tolerance      = 1e-8
+    set max iterations = 100
+    set verbosity      = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-8
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end
+
+#---------------------------------------------------
+# Evaporation
+#---------------------------------------------------
+
+subsection evaporation
+  set evaporation mass flux model = temperature_dependent
+  set enable evaporative cooling  = true
+  set evaporation latent heat     = 6e6
+  set molar mass                  = 4.46e-1
+  set boiling temperature         = 3133
+
+  set evaporation coefficient     = 0.82
+  set recoil pressure coefficient = 0.56
+  set ambient pressure            = 101325
+  set liquid density              = 4000.0
+end

--- a/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.output
+++ b/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.output
@@ -1,0 +1,16 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       16384
+   Number of degrees of freedom: 49923
+   Volume of triangulation:      25
+   Number of VOF degrees of freedom: 16641
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.005    Time step: 0.005    CFL: 0       
+*******************************************************************************
+
+**********************************************************************************
+Transient iteration: 2        Time: 0.01     Time step: 0.005    CFL: 0.000623696
+**********************************************************************************
+ time  error_velocity error_pressure 
+0.0050   2.695232e-03         0.4665 
+0.0100   2.843550e-03         0.7745 

--- a/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
@@ -1,0 +1,186 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = bdf1
+  set time end         = 0.01
+  set time step        = 0.005
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set VOF = true
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_rectangle
+  set grid arguments     = -2.5, -2.5 : 2.5, 2.5 : true
+  set initial refinement = 7
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+  subsection uvwp
+    set Function expression = 0; 0; 0
+  end
+  subsection VOF
+    set Function expression = if (x^2 + y^2 < 0.5^2 , 1, 0)
+    subsection projection step
+      set enable           = true
+      set diffusion factor = 1
+    end
+  end
+end
+
+#---------------------------------------------------
+# VOF
+#---------------------------------------------------
+
+subsection VOF
+  subsection surface tension force
+    set enable                                   = true
+    set phase fraction gradient diffusion factor = 4
+    set curvature diffusion factor               = 1
+    set output auxiliary fields                  = true
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 1
+    set density             = 10
+    set kinematic viscosity = 0.1
+  end
+  subsection fluid 0
+    set density             = 1
+    set kinematic viscosity = 0.1
+  end
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 1
+    end
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 4
+  subsection bc 0
+    set id   = 0
+    set type = noslip
+  end
+  subsection bc 1
+    set id   = 1
+    set type = noslip
+  end
+  subsection bc 2
+    set id   = 2
+    set type = noslip
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noslip
+  end
+end
+
+#---------------------------------------------------
+# Analytical solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable    = true
+  set verbosity = quiet
+  set filename  = L2Error
+  subsection uvwp
+    set Function expression = 0; 0; if (x^2 + y^2 < 0.5^2 , 2, 0)
+  end
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 1
+  set pressure order = 1
+  set VOF order      = 1
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection VOF
+    set tolerance      = 1e-9
+    set max iterations = 20
+    set verbosity      = quiet
+  end
+  subsection fluid dynamics
+    set tolerance      = 1e-9
+    set max iterations = 20
+    set verbosity      = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity         = quiet
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+    set preconditioner    = ilu
+  end
+  subsection VOF
+    set verbosity         = quiet
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+    set preconditioner    = ilu
+  end
+end
+
+#---------------------------------------------------
+# Evaporation
+#---------------------------------------------------
+
+subsection evaporation
+  set evaporation mass flux model = constant
+  set enable recoil pressure      = true
+  set evaporation mass flux       = 1.0
+end

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -99,7 +99,7 @@ public:
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the heat flux 
+   * @param field_vectors Values of the various fields on which the heat flux
    * evaluated at multiple points may depend.
    * @param heat_flux_vector Vector of heat flux values.
    */
@@ -110,7 +110,7 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field.
-   * @param field_vectors Values of the various fields on which the heat flux 
+   * @param field_vectors Values of the various fields on which the heat flux
    * evaluated at multiple points may depend.
    * @param heat_flux_vector Vector of heat flux values.
    */
@@ -125,7 +125,7 @@ public:
    * evaluated at multiple points may depend.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
-   * @param jacobian_vector Vector of the values of the derivative of the heat 
+   * @param jacobian_vector Vector of the values of the derivative of the heat
    * flux with respect to the field.
    */
   virtual void
@@ -146,7 +146,7 @@ public:
   /**
    * @brief vector_momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Values of the various fields on which the evaporation 
+   * @param field_vectors Values of the various fields on which the evaporation
    * momentum flux evaluated at multiple points may depend.
    * @param momentum_flux_vector Vector of momentum flux values.
    */
@@ -176,7 +176,7 @@ public:
    * pressure may depend.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
-   * @param jacobian_vector Vector of the value of the derivative of the momentum 
+   * @param jacobian_vector Vector of the value of the derivative of the momentum
    * flux with respect to the field.
    */
   virtual void
@@ -212,7 +212,7 @@ public:
 
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
-   * @param fields_value Values of the various fields on which the mass flux may 
+   * @param fields_value Values of the various fields on which the mass flux may
    * depend.
    * @return Value of the flux calculated with the fields_value.
    */
@@ -225,7 +225,7 @@ public:
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the mass flux 
+   * @param field_vectors Values of the various fields on which the mass flux
    * evaluated at multiple points may depend.
    * @param mass_flux_vector Vector of mass flux values.
    */
@@ -239,7 +239,7 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Values of the various fields on which the heat flux may 
+   * @param fields_value Values of the various fields on which the heat flux may
    * depend.
    * @return Value of the heat flux calculated with the fields_value.
    */
@@ -252,7 +252,7 @@ public:
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the heat flux may 
+   * @param field_vectors Values of the various fields on which the heat flux may
    * depend.
    * @param heat_flux_vector Vectors of the heat flux values.
    */
@@ -269,7 +269,7 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field.
-   * @param field_values Values of the various fields on which the heat flux 
+   * @param field_values Values of the various fields on which the heat flux
    * evaluated at a point may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
@@ -284,11 +284,11 @@ public:
   /**
    * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field.
-   * @param field_vectors Values of the fields on which the heat flux 
+   * @param field_vectors Values of the fields on which the heat flux
    * evaluated at multiple points may depend.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
-   * @param jacobian_vector Vector of the values of the derivative of the heat 
+   * @param jacobian_vector Vector of the values of the derivative of the heat
    * flux with respect to the field.
    */
   void
@@ -299,7 +299,7 @@ public:
   {
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
-  
+
   /**
    * @brief momentum_flux Calculates the value of the evaporation momentum flux.
    * @param fields_value Values of the various fields on which the momentum flux
@@ -406,7 +406,7 @@ public:
 
   /**
    * @brief saturation_pressure Calculates the value of the saturation pressure.
-   * @param fields_value Values of the various field on which the saturated vapor 
+   * @param fields_value Values of the various field on which the saturated vapor
    * pressure evaluated at a point may depend.
    * @return Value of the saturation pressure calculated with the fields_value.
    */
@@ -424,7 +424,7 @@ public:
   /**
    * @brief vector_mass_flux Calculates the values of the saturation pressure
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the saturated vapor 
+   * @param field_vectors Values of the various fields on which the saturated vapor
    * pressure evaluated at multiple points may depend.
    * @param saturation_pressure_vector Vector of the saturation pressure values.
    */
@@ -470,7 +470,7 @@ public:
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the evaporation mass flux 
+   * @param field_vectors Values of the various fields on which the evaporation mass flux
    * evaluated at multiple points may depend.
    * @param mass_flux_vector Vector of mass flux values.
    */
@@ -498,7 +498,7 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Values of the various fields on which the heat flux may 
+   * @param fields_value Values of the various fields on which the heat flux may
    * depend.
    * @return Value of the heat flux calculated with the fields_value.
    */
@@ -535,11 +535,11 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field.
-   * @param field_values Values of the various fields on which the heat flux 
+   * @param field_values Values of the various fields on which the heat flux
    * evaluated at a point may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
-   * @return Value of the partial derivative of the heat flux with respect to 
+   * @return Value of the partial derivative of the heat flux with respect to
    * the field.
    */
   double
@@ -567,7 +567,7 @@ public:
    * evaluated at a point may depend.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
-   * @param jacobian_vector Vector of the values of the derivative of the heat flux 
+   * @param jacobian_vector Vector of the values of the derivative of the heat flux
    * with respect to the field.
    */
   void
@@ -595,7 +595,7 @@ public:
     else
       std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
-  
+
   /**
    * @brief momentum_flux Calculates the value of the evaporation momentum flux.
    * @param fields_value Values of the various fields on which the momentum flux
@@ -628,7 +628,7 @@ public:
   /**
    * @brief vector_momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Values of the various fields on which the momentum flux 
+   * @param field_vectors Values of the various fields on which the momentum flux
    * may depend.
    * @param momentum_flux_vector Vectors of the momentum flux values.
    */

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -25,29 +25,29 @@ using namespace dealii;
  * @brief EvaporationModel. Abstract class that allows to calculate the
  * evaporation mass, heat and momentum fluxes. This model computes all the terms
  * required for the assembly of the governing equations, i.e., Navier-Stokes
- * momentum and energy, when evaporation is considered. The former terms are 
- * the momentum flux (i.e., pressure) acting on the evaporative front in the 
+ * momentum and energy, when evaporation is considered. The former terms are
+ * the momentum flux (i.e., pressure) acting on the evaporative front in the
  * normal direction, the heat flux, acting at the same location as a cooling
  * term, and the fluxes' jacobian, if required.
  *
  * The EvaporativeModel is the parent class, and its childs are specific
- * types of evaporative models, e.g., constant, temperature dependent. The 
- * selected model is instanciated in the assemblers' constructor 
- * (NavierStokesVOFAssemblerEvaporation and/or HeatTransferAssemblerVOFEvaporation), 
- * using the model_cast method according to the evaporation model parameters. 
+ * types of evaporative models, e.g., constant, temperature dependent. The
+ * selected model is instanciated in the assemblers' constructor
+ * (NavierStokesVOFAssemblerEvaporation and/or
+ * HeatTransferAssemblerVOFEvaporation), using the model_cast method according
+ * to the evaporation model parameters.
  *
  * The assemblers call the required method of the EvaporationModel for either
- * the assembly of the rhs or matrix terms. Hence, no matter the selected 
+ * the assembly of the rhs or matrix terms. Hence, no matter the selected
  * evaporation model, the same assembler is called, avoiding repetitions of
  * the assembler classes.
- *  
+ *
  */
 class EvaporationModel
 {
 public:
   EvaporationModel()
-  {
-  }
+  {}
 
   /**
    * @brief Instantiates and returns a pointer to a EvaporationModel
@@ -370,8 +370,8 @@ private:
 
 /**
  * @brief EvaporationModelTemperature. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a temperature dependent mass flux is
- * considered.
+ * evaporation heat and momentum fluxes when a temperature dependent mass flux
+ * is considered.
  *
  * @param p_evaporation evaporation model parameters.
  */
@@ -403,7 +403,8 @@ public:
   double
   saturation_pressure(const std::map<field, double> &fields_value)
   {
-    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
+    const double temperature_inv =
+      1.0 / (fields_value.at(field::temperature) + 1e-16);
 
     return ambient_pressure *
            std::exp(-L_vap_x_M_x_R_inv *
@@ -426,7 +427,7 @@ public:
 
     for (unsigned int i = 0; i < saturation_pressure_vector.size(); ++i)
       {
-        const double temperature_inv = 1.0 / (temperature[i]+1e-16);
+        const double temperature_inv = 1.0 / (temperature[i] + 1e-16);
 
         saturation_pressure_vector[i] =
           ambient_pressure *
@@ -445,7 +446,8 @@ public:
   mass_flux(const std::map<field, double> &fields_value) override
   {
     const double saturation_pressure_value = saturation_pressure(fields_value);
-    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
+    const double temperature_inv =
+      1.0 / (fields_value.at(field::temperature) + 1e-16);
 
     const double mass_flux_value =
       evaporation_coefficient * saturation_pressure_value *
@@ -474,7 +476,7 @@ public:
 
     for (unsigned int i = 0; i < mass_flux_vector.size(); ++i)
       {
-        const double temperature_inv = 1.0 / (temperature[i]+1e-16);
+        const double temperature_inv = 1.0 / (temperature[i] + 1e-16);
 
         mass_flux_vector[i] = evaporation_coefficient *
                               saturation_pressure_vector[i] *
@@ -528,7 +530,8 @@ public:
   heat_flux_jacobian(const std::map<field, double> &fields_value,
                      const field                    id) override
   {
-    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
+    const double temperature_inv =
+      1.0 / (fields_value.at(field::temperature) + 1e-16);
 
     if (id == field::temperature)
       return latent_heat_evaporation * ambient_pressure *
@@ -563,7 +566,7 @@ public:
           field_vectors.at(field::temperature);
         for (unsigned int i = 0; i < jacobian_vector.size(); ++i)
           {
-            const double temperature_inv = 1.0 / (temperature[i]+1e-16);
+            const double temperature_inv = 1.0 / (temperature[i] + 1e-16);
             jacobian_vector[i] =
               latent_heat_evaporation * ambient_pressure *
               evaporation_coefficient * temperature_inv *
@@ -587,18 +590,20 @@ public:
   {
     const double saturation_pressure_value = saturation_pressure(fields_value);
     const double mass_flux_value           = mass_flux(fields_value);
-    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
-    
-    const double vapor_saturation_density_value = molar_mass*
-      saturation_pressure_value * R_inv * temperature_inv;
+    const double temperature_inv =
+      1.0 / (fields_value.at(field::temperature) + 1e-16);
+
+    const double vapor_saturation_density_value =
+      molar_mass * saturation_pressure_value * R_inv * temperature_inv;
 
     // rho_vap = 0.31*rho_sat according to Anisimov and Khokhlov 1995
     const double vapor_density_inv =
       1.0 / (0.31 * vapor_saturation_density_value);
-      
-    const double pressure = -mass_flux_value * mass_flux_value *
-             (liquid_density_inv - vapor_density_inv) +
-           recoil_pressure_coefficient * saturation_pressure_value;
+
+    const double pressure =
+      -mass_flux_value * mass_flux_value *
+        (liquid_density_inv - vapor_density_inv) +
+      recoil_pressure_coefficient * saturation_pressure_value;
 
     return std::max(pressure - ambient_pressure, 0.0);
   }
@@ -626,10 +631,10 @@ public:
 
     for (unsigned int i = 0; i < momentum_flux_vector.size(); ++i)
       {
-        const double temperature_inv = 1.0 / (temperature[i]+1e-16);
+        const double temperature_inv = 1.0 / (temperature[i] + 1e-16);
 
-        const double vapor_saturation_density_value = molar_mass*
-          saturation_pressure_vector[i] * R_inv * temperature_inv;
+        const double vapor_saturation_density_value =
+          molar_mass * saturation_pressure_vector[i] * R_inv * temperature_inv;
 
         // rho_vap = 0.31*rho_sat according to Anisimov and Khokhlov 1995
         const double vapor_density_inv =

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -88,7 +88,7 @@ public:
    */
   virtual void
   mass_flux(const std::map<field, std::vector<double>> &field_vectors,
-                   std::vector<double> &mass_flux_vector) = 0;
+            std::vector<double>                        &mass_flux_vector) = 0;
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
@@ -109,7 +109,7 @@ public:
    */
   virtual void
   heat_flux(const std::map<field, std::vector<double>> &field_vectors,
-                   std::vector<double> &heat_flux_vector) = 0;
+            std::vector<double>                        &heat_flux_vector) = 0;
 
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
@@ -135,10 +135,9 @@ public:
    * flux with respect to the field.
    */
   virtual void
-  heat_flux_jacobian(
-    const std::map<field, std::vector<double>> &field_vectors,
-    const field                                 id,
-    std::vector<double>                        &jacobian_vector) = 0;
+  heat_flux_jacobian(const std::map<field, std::vector<double>> &field_vectors,
+                     const field                                 id,
+                     std::vector<double> &jacobian_vector) = 0;
 
   /**
    * @brief momentum_flux Calculates the value of the evaporation momentum flux.
@@ -158,9 +157,8 @@ public:
    * @param momentum_flux_vector Vector of momentum flux values.
    */
   virtual void
-  momentum_flux(
-    const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double>                        &momentum_flux_vector) = 0;
+  momentum_flux(const std::map<field, std::vector<double>> &field_vectors,
+                std::vector<double> &momentum_flux_vector) = 0;
 
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
@@ -239,9 +237,8 @@ public:
    * @param mass_flux_vector Vector of mass flux values.
    */
   void
-  mass_flux(
-    const std::map<field, std::vector<double>> & /*field_vectors*/,
-    std::vector<double> &mass_flux_vector) override
+  mass_flux(const std::map<field, std::vector<double>> & /*field_vectors*/,
+            std::vector<double> &mass_flux_vector) override
   {
     std::fill(mass_flux_vector.begin(), mass_flux_vector.end(), n_evaporation);
   }
@@ -267,9 +264,8 @@ public:
    * @param heat_flux_vector Vectors of the heat flux values.
    */
   void
-  heat_flux(
-    const std::map<field, std::vector<double>> & /*field_vectors*/,
-    std::vector<double> &heat_flux_vector) override
+  heat_flux(const std::map<field, std::vector<double>> & /*field_vectors*/,
+            std::vector<double> &heat_flux_vector) override
   {
     std::fill(heat_flux_vector.begin(),
               heat_flux_vector.end(),
@@ -333,9 +329,8 @@ public:
    * @param momentum_flux_vector Vector of momentum flux values.
    */
   void
-  momentum_flux(
-    const std::map<field, std::vector<double>> & /*field_vectors*/,
-    std::vector<double> &momentum_flux_vector) override
+  momentum_flux(const std::map<field, std::vector<double>> & /*field_vectors*/,
+                std::vector<double> &momentum_flux_vector) override
   {
     const double momentum_flux_value =
       -n_evaporation * n_evaporation *
@@ -444,9 +439,8 @@ public:
    * @param saturation_pressure_vector Vector of the saturation pressure values.
    */
   void
-  saturation_pressure(
-    const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double>                        &saturation_pressure_vector)
+  saturation_pressure(const std::map<field, std::vector<double>> &field_vectors,
+                      std::vector<double> &saturation_pressure_vector)
   {
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
@@ -500,7 +494,7 @@ public:
    */
   void
   mass_flux(const std::map<field, std::vector<double>> &field_vectors,
-                   std::vector<double> &mass_flux_vector) override
+            std::vector<double> &mass_flux_vector) override
   {
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
@@ -547,7 +541,7 @@ public:
    */
   void
   heat_flux(const std::map<field, std::vector<double>> &field_vectors,
-                   std::vector<double> &heat_flux_vector) override
+            std::vector<double> &heat_flux_vector) override
   {
     const unsigned int n_pts = heat_flux_vector.size();
 
@@ -605,10 +599,9 @@ public:
    * with respect to the field.
    */
   void
-  heat_flux_jacobian(
-    const std::map<field, std::vector<double>> &field_vectors,
-    const field                                 id,
-    std::vector<double>                        &jacobian_vector) override
+  heat_flux_jacobian(const std::map<field, std::vector<double>> &field_vectors,
+                     const field                                 id,
+                     std::vector<double> &jacobian_vector) override
   {
     const double R_inv = 1.0 / 8.3145;
     const double L_vap_x_M_x_R_inv =
@@ -675,9 +668,8 @@ public:
    * @param momentum_flux_vector Vectors of the momentum flux values.
    */
   void
-  momentum_flux(
-    const std::map<field, std::vector<double>> &field_vectors,
-    std::vector<double>                        &momentum_flux_vector) override
+  momentum_flux(const std::map<field, std::vector<double>> &field_vectors,
+                std::vector<double> &momentum_flux_vector) override
   {
     const unsigned int         n_pts = momentum_flux_vector.size();
     const std::vector<double> &temperature =

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -569,17 +569,19 @@ public:
     const double saturation_pressure_value = saturation_pressure(fields_value);
     const double mass_flux_value           = mass_flux(fields_value);
     const double temperature_inv = 1.0 / fields_value.at(field::temperature);
-
-    const double vapor_saturation_density_value =
+    
+    const double vapor_saturation_density_value = molar_mass*
       saturation_pressure_value * R_inv * temperature_inv;
 
     // rho_vap = 0.31*rho_sat according to Anisimov and Khokhlov 1995
     const double vapor_density_inv =
       1.0 / (0.31 * vapor_saturation_density_value);
-
-    return -mass_flux_value * mass_flux_value *
+      
+    const double pressure = -mass_flux_value * mass_flux_value *
              (liquid_density_inv - vapor_density_inv) +
            recoil_pressure_coefficient * saturation_pressure_value;
+
+    return std::max(pressure - ambient_pressure, 0.0);
   }
 
   /**
@@ -607,7 +609,7 @@ public:
       {
         const double temperature_inv = 1.0 / temperature[i];
 
-        const double vapor_saturation_density_value =
+        const double vapor_saturation_density_value = molar_mass*
           saturation_pressure_vector[i] * R_inv * temperature_inv;
 
         // rho_vap = 0.31*rho_sat according to Anisimov and Khokhlov 1995

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -168,8 +168,9 @@ protected:
 };
 
 /**
- * @brief EvaporationModel. Abstract class that allows to calculate the
- * evaporation mass, heat and momentum fluxes.
+ * @brief EvaporationModelConstant. Class that allows to calculate the
+ * evaporation heat and momentum fluxes when a constant mass flux is 
+ * considered.
  */
 class EvaporationModelConstant : public EvaporationModel
 {
@@ -198,7 +199,7 @@ public:
    * @param mass_flux_vector Vectors of the mass flux values
    */
   void
-  vector_mass_flux(const std::map<field, std::vector<double>> & /*fields_value*/,
+  vector_mass_flux(const std::map<field, std::vector<double>> & /*field_vectors*/,
                std::vector<double>                        &mass_flux_vector) override
   {
     std::fill(mass_flux_vector.begin(), mass_flux_vector.end(), n_evaporation);
@@ -327,6 +328,240 @@ private:
   const double latent_heat_evaporation;
   const double ambient_gas_density_inv;
   const double liquid_density_inv;
+};
+
+/**
+ * @brief EvaporationModelConstant. Class that allows to calculate the
+ * evaporation heat and momentum fluxes when a constant mass flux is 
+ * considered.
+ */
+class EvaporationModelTemperature : public EvaporationModel
+{
+public:
+  EvaporationModelTemperature(const Parameters::Evaporation &p_evaporation): evaporation_coefficient(p_evaporation.evaporation_coefficient), molar_mass(p_evaporation.molar_mass), boiling_temperature_inv(1.0/p_evaporation.boiling_temperature),  latent_heat_evaporation(p_evaporation.latent_heat_evaporation), ambient_pressure(p_evaporation.ambient_pressure), ambient_gas_density_inv(1.0/p_evaporation.ambient_gas_density), liquid_density_inv(1.0/p_evaporation.liquid_density)
+  {
+    model_depends_on[temperature] = true;
+    this->L_vap_x_M_x_R_inv = latent_heat_evaporation*molar_mass/8.3145;
+    this->M_x_2PI_inv_x_R_inv = molar_mass/(2.0*M_PI*8.3145);
+  }
+  
+  /**
+   * @brief mass_flux Calculates the value of the saturated vapor pressure.
+   * @param fields_value Value of the various field on which the saturated 
+   * vapor pressure may depend.
+   * @return value of the pressure calculated with the fields_value
+   */
+  double
+  saturation_pressure(const std::map<field, double> & fields_value)
+  {
+    const double temperature_inv = 1.0/fields_value.at(field::temperature);
+    
+    return ambient_pressure*std::exp(-L_vap_x_M_x_R_inv*(temperature_inv - boiling_temperature_inv));
+  }
+  
+  /**
+   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
+   * for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param mass_flux_vector Vectors of the mass flux values
+   */
+  void
+  vector_saturation_pressure(const std::map<field, std::vector<double>> & field_vectors,
+               std::vector<double>                        &saturation_pressure_vector) 
+  {
+    const std::vector<double> &temperature =
+      field_vectors.at(field::temperature);
+    
+    for (unsigned int i = 0; i < saturation_pressure_vector.size(); ++i)
+    {
+      const double temperature_inv = 1.0/temperature[i];
+      
+      saturation_pressure_vector[i] = ambient_pressure*std::exp(-L_vap_x_M_x_R_inv*(temperature_inv - boiling_temperature_inv));
+    }
+  }
+  
+  /**
+   * @brief saturation_pressure Calculates the value of the evaporation mass flux.
+   * @param fields_value Value of the various field on which the flux may depend.
+   * @return value of the flux calculated with the fields_value
+   */
+  double
+  mass_flux(const std::map<field, double> & fields_value) override
+  {
+    const double saturation_pressure_value = saturation_pressure(fields_value);
+    const double temperature_inv = 1.0/fields_value.at(field::temperature);
+
+    return evaporation_coefficient*saturation_pressure_value*std::sqrt(M_x_2PI_inv_x_R_inv*temperature_inv);
+  }
+  
+  /**
+   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
+   * for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param mass_flux_vector Vectors of the mass flux values
+   */
+  void
+  vector_mass_flux(const std::map<field, std::vector<double>> & field_vectors,
+               std::vector<double>                        &mass_flux_vector) override
+  {
+    const std::vector<double> &temperature =
+      field_vectors.at(field::temperature);
+      
+    const unsigned int n_pts = mass_flux_vector.size();
+    
+    std::vector<double> saturation_pressure_vector(n_pts);
+    vector_saturation_pressure(field_vectors, saturation_pressure_vector);
+      
+    for (unsigned int i = 0; i < mass_flux_vector.size(); ++i)
+    {
+      const double temperature_inv = 1.0/temperature[i];
+      
+      mass_flux_vector[i] = evaporation_coefficient*saturation_pressure_vector[i]*std::sqrt(M_x_2PI_inv_x_R_inv*temperature_inv);
+    }
+  }
+               
+  /**
+   * @brief heat_flux Calculates the value of the evaporation heat flux.
+   * @param fields_value Value of the various field on which the flux may depend.
+   * @return value of the heat flux calculated with the fields_value
+   */
+  double
+  heat_flux(const std::map<field, double> & fields_value) override
+  {
+    const double mass_flux_value = mass_flux(fields_value);
+    
+    return mass_flux_value*latent_heat_evaporation;
+  }
+  
+  /**
+   * @brief vector_heat_flux Calculates the values of the evaporation heat flux 
+   * for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param heat_flux_vector Vectors of the heat flux values
+   */
+  void
+  vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
+               std::vector<double>                        &heat_flux_vector) override
+  {
+    const unsigned int n_pts = heat_flux_vector.size();
+    
+    std::vector<double> mass_flux_vector(n_pts);
+    vector_mass_flux(field_vectors, mass_flux_vector);
+    
+    for (unsigned int i = 0; i < n_pts; ++i)
+    {
+      heat_flux_vector[i] = mass_flux_vector[i]*latent_heat_evaporation;
+    }
+  }
+
+  /**
+   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative) 
+   * of the evaporation heat flux with respect to a field
+   * @param field_values Value of the various fields on which the flux may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated
+   * @return value of the partial derivative of the heat flux with respect to the field.
+   */
+  double
+  heat_flux_jacobian(const std::map<field, double> & /*fields_value*/, const field /*id*/) override
+  {
+    return 0.0;
+  }
+
+  /**
+   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation 
+   * heat flux with respect to a field
+   * @param field_vectors Vector for the values of the fields used to evaluate 
+   * the flux
+   * @param id Identifier of the field with respect to which a derivative should
+   * be calculated
+   * @param jacobian Vector of the values of the derivative of the heat flux with
+   * respect to the field id
+   */
+  void
+  vector_heat_flux_jacobian(const std::map<field, std::vector<double>> &/*field_vectors*/,
+                  const field                                 /*id*/,
+                  std::vector<double> &jacobian_vector) override
+  {
+    std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+  }
+  /**
+   * @brief recoil_pressure Calculates the value of the evaporation recoil pressure.
+   * @param fields_value Value of the various field on which the recoil pressure 
+   * may depend.
+   * @return value of the recoil pressure calculated with the fields_value
+   */
+  double
+  recoil_pressure(const std::map<field, double> & /*fields_value*/) override
+  {
+    return 0.0;//-n_evaporation*n_evaporation*(liquid_density_inv - ambient_gas_density_inv);
+  }
+  
+  /**
+   * @brief vector_recoil_pressure Calculates the values of the evaporation recoil 
+   * pressure for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param recoil_pressure_vector Vectors of the recoil pressure values
+   */
+  void
+  vector_recoil_pressure(const std::map<field, std::vector<double>> &/*field_vectors*/,
+               std::vector<double>                        &recoil_pressure_vector) override
+  { 
+    
+    // const double recoil_pressure_value = -n_evaporation*n_evaporation*(liquid_density_inv - ambient_gas_density_inv);
+    
+    std::fill(recoil_pressure_vector.begin(), recoil_pressure_vector.end(), 0.0);
+  }
+
+  /**
+   * @brief recoil_pressure_jacobian Calculates the jacobian (the partial derivative) 
+   * of the evaporation recoil pressure with respect to a field
+   * @param field_values Value of the various fields on which the recoil pressure 
+   * may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated
+   * @return value of the partial derivative of the recoil pressure with respect 
+   * to the field.
+   */
+  double
+  recoil_pressure_jacobian(const std::map<field, double> &/*field_values*/, const field /*id*/) override
+  {
+    return 0.0;
+  }
+
+  /**
+   * @brief vector_recoil_pressure_jacobian Calculate the derivative of the  
+   * evaporation recoil pressure with respect to a field
+   * @param field_vectors Vector for the values of the fields on which the recoil 
+   * pressure may depend.
+   * @param id Identifier of the field with respect to which a derivative should 
+   * be calculated
+   * @param jacobian Vector of the value of the derivative of the recoil pressure
+   * with respect to the field id
+   */
+  void
+  vector_recoil_pressure_jacobian(const std::map<field, std::vector<double>> & /*field_vectors*/,
+                  const field                                 /*id*/,
+                  std::vector<double> &jacobian_vector) override
+  {
+    std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+  }
+
+private:
+  
+  const double evaporation_coefficient;
+  const double molar_mass;
+  const double boiling_temperature_inv;
+  const double latent_heat_evaporation;
+  const double ambient_pressure;
+  const double ambient_gas_density_inv;
+  const double liquid_density_inv;
+  
+  // L_vap*M/R
+  double L_vap_x_M_x_R_inv;
+  
+  // M/(2*PI*R)
+  double M_x_2PI_inv_x_R_inv;
 };
 
 #endif

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -17,21 +17,36 @@
 #define lethe_evaporation_model_h
 
 #include <core/parameters.h>
-// only for the field definition
 #include <core/physical_property_model.h>
 
 using namespace dealii;
 
 /**
  * @brief EvaporationModel. Abstract class that allows to calculate the
- * evaporation mass, heat and momentum fluxes.
+ * evaporation mass, heat and momentum fluxes. This model computes all the terms
+ * required for the assembly of the governing equations, i.e., Navier-Stokes
+ * momentum and energy, when evaporation is considered. The former terms are 
+ * the momentum flux (i.e., pressure) acting on the evaporative front in the 
+ * normal direction, the heat flux, acting at the same location as a cooling
+ * term, and the fluxes' jacobian, if required.
+ *
+ * The EvaporativeModel is the parent class, and its childs are specific
+ * types of evaporative models, e.g., constant, temperature dependent. The 
+ * selected model is instanciated in the assemblers' constructor 
+ * (NavierStokesVOFAssemblerEvaporation and/or HeatTransferAssemblerVOFEvaporation), 
+ * using the model_cast method according to the evaporation model parameters. 
+ *
+ * The assemblers call the required method of the EvaporationModel for either
+ * the assembly of the rhs or matrix terms. Hence, no matter the selected 
+ * evaporation model, the same assembler is called, avoiding repetitions of
+ * the assembler classes.
+ *  
  */
 class EvaporationModel
 {
 public:
   EvaporationModel()
   {
-    model_depends_on[temperature] = false;
   }
 
   /**
@@ -176,6 +191,8 @@ protected:
  * @brief EvaporationModelConstant. Class that allows to calculate the
  * evaporation heat and momentum fluxes when a constant mass flux is
  * considered.
+ *
+ * @param p_evaporation evaporation model parameters.
  */
 class EvaporationModelConstant : public EvaporationModel
 {
@@ -352,9 +369,11 @@ private:
 };
 
 /**
- * @brief EvaporationModelConstant. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a constant mass flux is
+ * @brief EvaporationModelTemperature. Class that allows to calculate the
+ * evaporation heat and momentum fluxes when a temperature dependent mass flux is
  * considered.
+ *
+ * @param p_evaporation evaporation model parameters.
  */
 class EvaporationModelTemperature : public EvaporationModel
 {
@@ -384,7 +403,7 @@ public:
   double
   saturation_pressure(const std::map<field, double> &fields_value)
   {
-    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
 
     return ambient_pressure *
            std::exp(-L_vap_x_M_x_R_inv *
@@ -407,7 +426,7 @@ public:
 
     for (unsigned int i = 0; i < saturation_pressure_vector.size(); ++i)
       {
-        const double temperature_inv = 1.0 / temperature[i];
+        const double temperature_inv = 1.0 / (temperature[i]+1e-16);
 
         saturation_pressure_vector[i] =
           ambient_pressure *
@@ -426,7 +445,7 @@ public:
   mass_flux(const std::map<field, double> &fields_value) override
   {
     const double saturation_pressure_value = saturation_pressure(fields_value);
-    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
 
     const double mass_flux_value =
       evaporation_coefficient * saturation_pressure_value *
@@ -455,7 +474,7 @@ public:
 
     for (unsigned int i = 0; i < mass_flux_vector.size(); ++i)
       {
-        const double temperature_inv = 1.0 / temperature[i];
+        const double temperature_inv = 1.0 / (temperature[i]+1e-16);
 
         mass_flux_vector[i] = evaporation_coefficient *
                               saturation_pressure_vector[i] *
@@ -509,7 +528,7 @@ public:
   heat_flux_jacobian(const std::map<field, double> &fields_value,
                      const field                    id) override
   {
-    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
 
     if (id == field::temperature)
       return latent_heat_evaporation * ambient_pressure *
@@ -544,7 +563,7 @@ public:
           field_vectors.at(field::temperature);
         for (unsigned int i = 0; i < jacobian_vector.size(); ++i)
           {
-            const double temperature_inv = 1.0 / temperature[i];
+            const double temperature_inv = 1.0 / (temperature[i]+1e-16);
             jacobian_vector[i] =
               latent_heat_evaporation * ambient_pressure *
               evaporation_coefficient * temperature_inv *
@@ -568,7 +587,7 @@ public:
   {
     const double saturation_pressure_value = saturation_pressure(fields_value);
     const double mass_flux_value           = mass_flux(fields_value);
-    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+    const double temperature_inv = 1.0 / (fields_value.at(field::temperature)+1e-16);
     
     const double vapor_saturation_density_value = molar_mass*
       saturation_pressure_value * R_inv * temperature_inv;
@@ -607,7 +626,7 @@ public:
 
     for (unsigned int i = 0; i < momentum_flux_vector.size(); ++i)
       {
-        const double temperature_inv = 1.0 / temperature[i];
+        const double temperature_inv = 1.0 / (temperature[i]+1e-16);
 
         const double vapor_saturation_density_value = molar_mass*
           saturation_pressure_vector[i] * R_inv * temperature_inv;

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -79,7 +79,7 @@ public:
   mass_flux(const std::map<field, double> &field_values) = 0;
 
   /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux
+   * @brief mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the mass flux may depend. Each vector contains the field values at
@@ -87,7 +87,7 @@ public:
    * @param mass_flux_vector Vector of mass flux values.
    */
   virtual void
-  vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
+  mass_flux(const std::map<field, std::vector<double>> &field_vectors,
                    std::vector<double> &mass_flux_vector) = 0;
 
   /**
@@ -100,7 +100,7 @@ public:
   heat_flux(const std::map<field, double> &field_values) = 0;
 
   /**
-   * @brief vector_heat_flux Calculates the values of the evaporation heat flux
+   * @brief heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the heat flux may depend. Each vector contains the field values at
@@ -108,7 +108,7 @@ public:
    * @param heat_flux_vector Vector of heat flux values.
    */
   virtual void
-  vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
+  heat_flux(const std::map<field, std::vector<double>> &field_vectors,
                    std::vector<double> &heat_flux_vector) = 0;
 
   /**
@@ -124,7 +124,7 @@ public:
                      const field                    id) = 0;
 
   /**
-   * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
+   * @brief heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the heat flux may depend. Each vector contains the field values at
@@ -135,7 +135,7 @@ public:
    * flux with respect to the field.
    */
   virtual void
-  vector_heat_flux_jacobian(
+  heat_flux_jacobian(
     const std::map<field, std::vector<double>> &field_vectors,
     const field                                 id,
     std::vector<double>                        &jacobian_vector) = 0;
@@ -150,7 +150,7 @@ public:
   momentum_flux(const std::map<field, double> &field_values) = 0;
 
   /**
-   * @brief vector_momentum_flux Calculates the values of the evaporation momentum
+   * @brief momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the evaporation momentum flux may depend. Each vector contains the
@@ -158,7 +158,7 @@ public:
    * @param momentum_flux_vector Vector of momentum flux values.
    */
   virtual void
-  vector_momentum_flux(
+  momentum_flux(
     const std::map<field, std::vector<double>> &field_vectors,
     std::vector<double>                        &momentum_flux_vector) = 0;
 
@@ -177,7 +177,7 @@ public:
                          const field                    id) = 0;
 
   /**
-   * @brief vector_momentum_flux_jacobian Calculates the derivative of the
+   * @brief momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the momentum flux may depend. Each vector contains the field
@@ -188,7 +188,7 @@ public:
    * flux with respect to the field.
    */
   virtual void
-  vector_momentum_flux_jacobian(
+  momentum_flux_jacobian(
     const std::map<field, std::vector<double>> &field_vectors,
     const field                                 id,
     std::vector<double>                        &jacobian_vector) = 0;
@@ -231,7 +231,7 @@ public:
   }
 
   /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux
+   * @brief mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the mass flux may depend. Each vector contains the field values at
@@ -239,7 +239,7 @@ public:
    * @param mass_flux_vector Vector of mass flux values.
    */
   void
-  vector_mass_flux(
+  mass_flux(
     const std::map<field, std::vector<double>> & /*field_vectors*/,
     std::vector<double> &mass_flux_vector) override
   {
@@ -259,7 +259,7 @@ public:
   }
 
   /**
-   * @brief vector_heat_flux Calculates the values of the evaporation heat flux
+   * @brief heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the heat flux may depend. Each vector contains the field values at
@@ -267,7 +267,7 @@ public:
    * @param heat_flux_vector Vectors of the heat flux values.
    */
   void
-  vector_heat_flux(
+  heat_flux(
     const std::map<field, std::vector<double>> & /*field_vectors*/,
     std::vector<double> &heat_flux_vector) override
   {
@@ -292,7 +292,7 @@ public:
   }
 
   /**
-   * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
+   * @brief heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field.
    * @param field_vectors Vector for the values of the fields on which the heat
    * flux may depend. Each vector contains the field values at the points of
@@ -303,7 +303,7 @@ public:
    * flux with respect to the field.
    */
   void
-  vector_heat_flux_jacobian(
+  heat_flux_jacobian(
     const std::map<field, std::vector<double>> & /*field_vectors*/,
     const field /*id*/,
     std::vector<double> &jacobian_vector) override
@@ -325,7 +325,7 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux Calculates the values of the evaporation momentum
+   * @brief momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the momentum flux may depend. Each vector contains the field
@@ -333,7 +333,7 @@ public:
    * @param momentum_flux_vector Vector of momentum flux values.
    */
   void
-  vector_momentum_flux(
+  momentum_flux(
     const std::map<field, std::vector<double>> & /*field_vectors*/,
     std::vector<double> &momentum_flux_vector) override
   {
@@ -364,7 +364,7 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux_jacobian Calculates the derivative of the
+   * @brief momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the momentum flux may depend. Each vector contains the field
@@ -375,7 +375,7 @@ public:
    * flux with respect to the field.
    */
   void
-  vector_momentum_flux_jacobian(
+  momentum_flux_jacobian(
     const std::map<field, std::vector<double>> & /*field_vectors*/,
     const field /*id*/,
     std::vector<double> &jacobian_vector) override
@@ -436,7 +436,7 @@ public:
   }
 
   /**
-   * @brief vector_mass_flux Calculates the values of the saturation pressure
+   * @brief mass_flux Calculates the values of the saturation pressure
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the saturated vapor pressure may depend. Each vector contains the
@@ -444,7 +444,7 @@ public:
    * @param saturation_pressure_vector Vector of the saturation pressure values.
    */
   void
-  vector_saturation_pressure(
+  saturation_pressure(
     const std::map<field, std::vector<double>> &field_vectors,
     std::vector<double>                        &saturation_pressure_vector)
   {
@@ -491,7 +491,7 @@ public:
   }
 
   /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux
+   * @brief mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the evaporation mass flux may depend. Each vector contains the
@@ -499,7 +499,7 @@ public:
    * @param mass_flux_vector Vector of mass flux values.
    */
   void
-  vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
+  mass_flux(const std::map<field, std::vector<double>> &field_vectors,
                    std::vector<double> &mass_flux_vector) override
   {
     const std::vector<double> &temperature =
@@ -511,7 +511,7 @@ public:
     const unsigned int n_pts = mass_flux_vector.size();
 
     std::vector<double> saturation_pressure_vector(n_pts);
-    vector_saturation_pressure(field_vectors, saturation_pressure_vector);
+    saturation_pressure(field_vectors, saturation_pressure_vector);
 
     for (unsigned int i = 0; i < n_pts; ++i)
       {
@@ -538,7 +538,7 @@ public:
   }
 
   /**
-   * @brief vector_heat_flux Calculates the values of the evaporation heat flux
+   * @brief heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the heat flux may depend. Each vector contains the field values at
@@ -546,13 +546,13 @@ public:
    * @param heat_flux_vector Vector of heat flux values.
    */
   void
-  vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
+  heat_flux(const std::map<field, std::vector<double>> &field_vectors,
                    std::vector<double> &heat_flux_vector) override
   {
     const unsigned int n_pts = heat_flux_vector.size();
 
     std::vector<double> mass_flux_vector(n_pts);
-    vector_mass_flux(field_vectors, mass_flux_vector);
+    mass_flux(field_vectors, mass_flux_vector);
 
     for (unsigned int i = 0; i < n_pts; ++i)
       {
@@ -594,7 +594,7 @@ public:
   }
 
   /**
-   * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
+   * @brief heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which heat flux evaluated at a point may depend. Each vector contains
@@ -605,7 +605,7 @@ public:
    * with respect to the field.
    */
   void
-  vector_heat_flux_jacobian(
+  heat_flux_jacobian(
     const std::map<field, std::vector<double>> &field_vectors,
     const field                                 id,
     std::vector<double>                        &jacobian_vector) override
@@ -667,7 +667,7 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux Calculates the values of the evaporation momentum
+   * @brief momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
    * @param field_vectors Map storing the vectors of the values for each fields
    * on which the momentum flux may depend. Each vector contains the field
@@ -675,7 +675,7 @@ public:
    * @param momentum_flux_vector Vectors of the momentum flux values.
    */
   void
-  vector_momentum_flux(
+  momentum_flux(
     const std::map<field, std::vector<double>> &field_vectors,
     std::vector<double>                        &momentum_flux_vector) override
   {
@@ -686,10 +686,10 @@ public:
     const double R_inv = 1.0 / 8.3145;
 
     std::vector<double> saturation_pressure_vector(n_pts);
-    vector_saturation_pressure(field_vectors, saturation_pressure_vector);
+    saturation_pressure(field_vectors, saturation_pressure_vector);
 
     std::vector<double> mass_flux_vector(n_pts);
-    vector_mass_flux(field_vectors, mass_flux_vector);
+    mass_flux(field_vectors, mass_flux_vector);
 
     for (unsigned int i = 0; i < n_pts; ++i)
       {
@@ -727,7 +727,7 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux_jacobian Calculates the derivative of the
+   * @brief momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field.
    * @param field_vectors Map storing the vectors of the values for each fields
    * flux may depend. Each vector contains the field values at the points of
@@ -738,7 +738,7 @@ public:
    * flux with respect to the field.
    */
   void
-  vector_momentum_flux_jacobian(
+  momentum_flux_jacobian(
     const std::map<field, std::vector<double>> & /*field_vectors*/,
     const field /*id*/,
     std::vector<double> &jacobian_vector) override

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -30,9 +30,9 @@ using namespace dealii;
  * normal direction, the heat flux, acting at the same location as a cooling
  * term, and the fluxes' jacobian, if required.
  *
- * The EvaporativeModel is the parent class, and its childs are specific
+ * The EvaporativeModel is the parent class, and its children are specific
  * types of evaporative models, e.g., constant, temperature dependent. The
- * selected model is instanciated in the assemblers' constructor
+ * selected model is instantiated in the assemblers' constructor
  * (NavierStokesVOFAssemblerEvaporation and/or
  * HeatTransferAssemblerVOFEvaporation), using the model_cast method according
  * to the evaporation model parameters.
@@ -50,10 +50,10 @@ public:
   {}
 
   /**
-   * @brief Instantiates and returns a pointer to a EvaporationModel
-   * object by casting it to the proper child class
+   * @brief Instantiates and returns a pointer to an EvaporationModel
+   * object by casting it to the proper child class.
    *
-   * @param evaporation_parameters Evaporation model parameters
+   * @param evaporation_parameters Evaporation model parameters.
    */
   static std::shared_ptr<EvaporationModel>
   model_cast(const Parameters::Evaporation &evaporation_parameters);
@@ -61,6 +61,7 @@ public:
 
   /**
    * @brief Returns true if the EvaporationModel depends on a field, false if not.
+   * @param id Identifier of the field for which the function is called.
    */
   inline bool
   depends_on(const field &id)
@@ -70,17 +71,18 @@ public:
 
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
-   * @param fields_value Value of the various field on which the flux may depend.
-   * @return value of the flux calculated with the fields_value
+   * @param fields_value Values of the various fields on which the mass flux may depend.
+   * @return Value of the flux calculated with the fields_value.
    */
   virtual double
   mass_flux(const std::map<field, double> &fields_value) = 0;
 
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param mass_flux_vector Vectors of the mass flux values
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the mass flux
+   * evaluated at multiple points may depend.
+   * @param mass_flux_vector Vector of mass flux values.
    */
   virtual void
   vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
@@ -88,17 +90,18 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Value of the various field on which the flux may depend.
-   * @return value of the heat flux calculated with the fields_value
+   * @param fields_value Values of the various fields on which the heat flux may depend.
+   * @return Value of the heat flux calculated with the fields_value
    */
   virtual double
   heat_flux(const std::map<field, double> &fields_value) = 0;
 
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param heat_flux_vector Vectors of the heat flux values
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the heat flux 
+   * evaluated at multiple points may depend.
+   * @param heat_flux_vector Vector of heat flux values.
    */
   virtual void
   vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
@@ -106,25 +109,24 @@ public:
 
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
-   * of the evaporation heat flux with respect to a field
-   * @param field_values Value of the various fields on which the flux may depend.
-   * @param id Indicator of the field with respect to which the jacobian
-   * should be calculated
-   * @return value of the partial derivative of the heat flux with respect to the field.
+   * of the evaporation heat flux with respect to a field.
+   * @param field_vectors Values of the various fields on which the heat flux 
+   * evaluated at multiple points may depend.
+   * @param heat_flux_vector Vector of heat flux values.
    */
   virtual double
   heat_flux_jacobian(const std::map<field, double> &field_values,
                      const field                    id) = 0;
 
   /**
-   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation
-   * heat flux with respect to a field
-   * @param field_vectors Vector for the values of the fields used to evaluate
-   * the flux
+   * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
+   * heat flux with respect to a field.
+   *  @param field_vectors Values of the various fields on which the heat flux
+   * evaluated at multiple points may depend.
    * @param id Identifier of the field with respect to which a derivative should
-   * be calculated
-   * @param jacobian Vector of the values of the derivative of the heat flux with
-   * respect to the field id
+   * be calculated.
+   * @param jacobian_vector Vector of the values of the derivative of the heat 
+   * flux with respect to the field.
    */
   virtual void
   vector_heat_flux_jacobian(
@@ -133,19 +135,20 @@ public:
     std::vector<double>                        &jacobian_vector) = 0;
 
   /**
-   * @brief momentum_flux Calculates the value of the evaporation recoil pressure.
-   * @param fields_value Value of the various field on which the recoil pressure
+   * @brief momentum_flux Calculates the value of the evaporation momentum flux.
+   * @param fields_value Value of the various field on which the momentum flux
    * may depend.
-   * @return value of the recoil pressure calculated with the fields_value
+   * @return Value of the momentum flux calculated with the fields_value.
    */
   virtual double
   momentum_flux(const std::map<field, double> &fields_value) = 0;
 
   /**
-   * @brief vector_momentum_flux Calculates the values of the evaporation recoil
-   * pressure for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param momentum_flux_vector Vectors of the recoil pressure values
+   * @brief vector_momentum_flux Calculates the values of the evaporation momentum
+   * flux for multiple points.
+   * @param field_vectors Values of the various fields on which the evaporation 
+   * momentum flux evaluated at multiple points may depend.
+   * @param momentum_flux_vector Vector of momentum flux values.
    */
   virtual void
   vector_momentum_flux(
@@ -154,12 +157,12 @@ public:
 
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
-   * of the evaporation recoil pressure with respect to a field
-   * @param field_values Value of the various fields on which the recoil pressure
+   * of the evaporation momentum flux with respect to a field.
+   * @param field_values Values of the various fields on which the momentum flux
    * may depend.
-   * @param id Indicator of the field with respect to which the jacobian
-   * should be calculated
-   * @return value of the partial derivative of the recoil pressure with respect
+   * @param id Identifier of the field with respect to which the jacobian
+   * should be calculated.
+   * @return Value of the partial derivative of the momentum flux with respect
    * to the field.
    */
   virtual double
@@ -167,14 +170,14 @@ public:
                          const field                    id) = 0;
 
   /**
-   * @brief vector_momentum_flux_jacobian Calculate the derivative of the
-   * evaporation recoil pressure with respect to a field
+   * @brief vector_momentum_flux_jacobian Calculates the derivative of the
+   * evaporation momentum flux with respect to a field.
    * @param field_vectors Vector for the values of the fields on which the recoil
    * pressure may depend.
    * @param id Identifier of the field with respect to which a derivative should
-   * be calculated
-   * @param jacobian Vector of the value of the derivative of the recoil pressure
-   * with respect to the field id
+   * be calculated.
+   * @param jacobian_vector Vector of the value of the derivative of the momentum 
+   * flux with respect to the field.
    */
   virtual void
   vector_momentum_flux_jacobian(
@@ -183,7 +186,7 @@ public:
     std::vector<double>                        &jacobian_vector) = 0;
 
 protected:
-  // Map to indicate on which variables the model depends on
+  // Map that indicates on which fields the model depends on
   std::map<field, bool> model_depends_on;
 };
 
@@ -198,7 +201,7 @@ class EvaporationModelConstant : public EvaporationModel
 {
 public:
   EvaporationModelConstant(const Parameters::Evaporation &p_evaporation)
-    : n_evaporation(p_evaporation.n_evaporation)
+    : n_evaporation(p_evaporation.evaporation_mass_flux)
     , latent_heat_evaporation(p_evaporation.latent_heat_evaporation)
     , ambient_gas_density_inv(1.0 / p_evaporation.ambient_gas_density)
     , liquid_density_inv(1.0 / p_evaporation.liquid_density)
@@ -209,8 +212,9 @@ public:
 
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
-   * @param fields_value Value of the various field on which the flux may depend.
-   * @return value of the flux calculated with the fields_value
+   * @param fields_value Values of the various fields on which the mass flux may 
+   * depend.
+   * @return Value of the flux calculated with the fields_value.
    */
   double
   mass_flux(const std::map<field, double> & /*fields_value*/) override
@@ -220,9 +224,10 @@ public:
 
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param mass_flux_vector Vectors of the mass flux values
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the mass flux 
+   * evaluated at multiple points may depend.
+   * @param mass_flux_vector Vector of mass flux values.
    */
   void
   vector_mass_flux(
@@ -234,8 +239,9 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Value of the various field on which the flux may depend.
-   * @return value of the heat flux calculated with the fields_value
+   * @param fields_value Values of the various fields on which the heat flux may 
+   * depend.
+   * @return Value of the heat flux calculated with the fields_value.
    */
   double
   heat_flux(const std::map<field, double> & /*fields_value*/) override
@@ -245,9 +251,10 @@ public:
 
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param heat_flux_vector Vectors of the heat flux values
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the heat flux may 
+   * depend.
+   * @param heat_flux_vector Vectors of the heat flux values.
    */
   void
   vector_heat_flux(
@@ -261,11 +268,11 @@ public:
 
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
-   * of the evaporation heat flux with respect to a field
-   * @param field_values Value of the various fields on which the flux may depend.
-   * @param id Indicator of the field with respect to which the jacobian
-   * should be calculated
-   * @return value of the partial derivative of the heat flux with respect to the field.
+   * of the evaporation heat flux with respect to a field.
+   * @param field_values Values of the various fields on which the heat flux 
+   * evaluated at a point may depend.
+   * @param id Identifier of the field with respect to which the jacobian
+   * should be calculated.
    */
   double
   heat_flux_jacobian(const std::map<field, double> & /*fields_value*/,
@@ -275,14 +282,14 @@ public:
   }
 
   /**
-   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation
-   * heat flux with respect to a field
-   * @param field_vectors Vector for the values of the fields used to evaluate
-   * the flux
+   * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
+   * heat flux with respect to a field.
+   * @param field_vectors Values of the fields on which the heat flux 
+   * evaluated at multiple points may depend.
    * @param id Identifier of the field with respect to which a derivative should
-   * be calculated
-   * @param jacobian Vector of the values of the derivative of the heat flux with
-   * respect to the field id
+   * be calculated.
+   * @param jacobian_vector Vector of the values of the derivative of the heat 
+   * flux with respect to the field.
    */
   void
   vector_heat_flux_jacobian(
@@ -292,11 +299,12 @@ public:
   {
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
+  
   /**
-   * @brief momentum_flux Calculates the value of the evaporation recoil pressure.
-   * @param fields_value Value of the various field on which the recoil pressure
+   * @brief momentum_flux Calculates the value of the evaporation momentum flux.
+   * @param fields_value Values of the various fields on which the momentum flux
    * may depend.
-   * @return value of the recoil pressure calculated with the fields_value
+   * @return Value of the momentum flux calculated with the fields_value
    */
   double
   momentum_flux(const std::map<field, double> & /*fields_value*/) override
@@ -306,10 +314,11 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux Calculates the values of the evaporation recoil
-   * pressure for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param momentum_flux_vector Vectors of the recoil pressure values
+   * @brief vector_momentum_flux Calculates the values of the evaporation momentum
+   * flux for multiple points.
+   * @param field_vectors Values of the various fields on which the momentum flux
+   * evaluated at multiple points may depend.
+   * @param momentum_flux_vector Vector of momentum flux values.
    */
   void
   vector_momentum_flux(
@@ -327,12 +336,12 @@ public:
 
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
-   * of the evaporation recoil pressure with respect to a field
-   * @param field_values Value of the various fields on which the recoil pressure
+   * of the evaporation momentum flux with respect to a field.
+   * @param field_values Values of the various fields on which the momentum flux
    * may depend.
-   * @param id Indicator of the field with respect to which the jacobian
+   * @param id Identifier of the field with respect to which the jacobian
    * should be calculated
-   * @return value of the partial derivative of the recoil pressure with respect
+   * @return Value of the partial derivative of the momentum flux with respect
    * to the field.
    */
   double
@@ -343,14 +352,14 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux_jacobian Calculate the derivative of the
-   * evaporation recoil pressure with respect to a field
-   * @param field_vectors Vector for the values of the fields on which the recoil
-   * pressure may depend.
+   * @brief vector_momentum_flux_jacobian Calculates the derivative of the
+   * evaporation momentum flux with respect to a field
+   * @param field_vectors Vector for the values of the fields on which the momentum
+   * flux evaluated at multiple points may depend.
    * @param id Identifier of the field with respect to which a derivative should
-   * be calculated
-   * @param jacobian Vector of the value of the derivative of the recoil pressure
-   * with respect to the field id
+   * be calculated.
+   * @param jacobian_vector Vector of the values of the derivative of the momentum flux
+   * with respect to the field.
    */
   void
   vector_momentum_flux_jacobian(
@@ -370,7 +379,7 @@ private:
 
 /**
  * @brief EvaporationModelTemperature. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a temperature dependent mass flux
+ * evaporation heat and momentum fluxes when a temperature-dependent mass flux
  * is considered.
  *
  * @param p_evaporation evaporation model parameters.
@@ -396,9 +405,10 @@ public:
   }
 
   /**
-   * @brief saturation_pressure Calculates the value of the staturation pressure.
-   * @param fields_value Value of the various field on which the flux may depend.
-   * @return value of the flux calculated with the fields_value
+   * @brief saturation_pressure Calculates the value of the saturation pressure.
+   * @param fields_value Values of the various field on which the saturated vapor 
+   * pressure evaluated at a point may depend.
+   * @return Value of the saturation pressure calculated with the fields_value.
    */
   double
   saturation_pressure(const std::map<field, double> &fields_value)
@@ -412,10 +422,11 @@ public:
   }
 
   /**
-   * @brief vector_mass_flux Calculates the values of the staturation pressure
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param mass_flux_vector Vectors of the mass flux values
+   * @brief vector_mass_flux Calculates the values of the saturation pressure
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the saturated vapor 
+   * pressure evaluated at multiple points may depend.
+   * @param saturation_pressure_vector Vector of the saturation pressure values.
    */
   void
   vector_saturation_pressure(
@@ -437,10 +448,10 @@ public:
   }
 
   /**
-   * @brief mass_flux Calculates the value of the saturated vapor pressure.
-   * @param fields_value Value of the various field on which the saturated
-   * vapor pressure may depend.
-   * @return value of the pressure calculated with the fields_value
+   * @brief mass_flux Calculates the value of the evaporation mass flux.
+   * @param fields_value Values of the various fields on which the evaporation
+   * mass flux may depend.
+   * @return Value of the evaporation mass flux calculated with the fields_value.
    */
   double
   mass_flux(const std::map<field, double> &fields_value) override
@@ -458,9 +469,10 @@ public:
 
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param mass_flux_vector Vectors of the mass flux values
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the evaporation mass flux 
+   * evaluated at multiple points may depend.
+   * @param mass_flux_vector Vector of mass flux values.
    */
   void
   vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
@@ -474,7 +486,7 @@ public:
     std::vector<double> saturation_pressure_vector(n_pts);
     vector_saturation_pressure(field_vectors, saturation_pressure_vector);
 
-    for (unsigned int i = 0; i < mass_flux_vector.size(); ++i)
+    for (unsigned int i = 0; i < n_pts; ++i)
       {
         const double temperature_inv = 1.0 / (temperature[i] + 1e-16);
 
@@ -486,8 +498,9 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Value of the various field on which the flux may depend.
-   * @return value of the heat flux calculated with the fields_value
+   * @param fields_value Values of the various fields on which the heat flux may 
+   * depend.
+   * @return Value of the heat flux calculated with the fields_value.
    */
   double
   heat_flux(const std::map<field, double> &fields_value) override
@@ -499,9 +512,10 @@ public:
 
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param heat_flux_vector Vectors of the heat flux values
+   * for multiple points.
+   * @param field_vectors Values of the various fields on which the heat flux
+   * evaluated at multiple points may depend.
+   * @param heat_flux_vector Vector of heat flux values.
    */
   void
   vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
@@ -520,11 +534,13 @@ public:
 
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
-   * of the evaporation heat flux with respect to a field
-   * @param field_values Value of the various fields on which the flux may depend.
-   * @param id Indicator of the field with respect to which the jacobian
-   * should be calculated
-   * @return value of the partial derivative of the heat flux with respect to the field.
+   * of the evaporation heat flux with respect to a field.
+   * @param field_values Values of the various fields on which the heat flux 
+   * evaluated at a point may depend.
+   * @param id Identifier of the field with respect to which the jacobian
+   * should be calculated.
+   * @return Value of the partial derivative of the heat flux with respect to 
+   * the field.
    */
   double
   heat_flux_jacobian(const std::map<field, double> &fields_value,
@@ -545,14 +561,14 @@ public:
   }
 
   /**
-   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation
-   * heat flux with respect to a field
-   * @param field_vectors Vector for the values of the fields used to evaluate
-   * the flux
+   * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
+   * heat flux with respect to a field.
+   * @param field_vectors Vector for the values of the fields on which the heat flux
+   * evaluated at a point may depend.
    * @param id Identifier of the field with respect to which a derivative should
-   * be calculated
-   * @param jacobian Vector of the values of the derivative of the heat flux with
-   * respect to the field id
+   * be calculated.
+   * @param jacobian_vector Vector of the values of the derivative of the heat flux 
+   * with respect to the field.
    */
   void
   vector_heat_flux_jacobian(
@@ -579,11 +595,12 @@ public:
     else
       std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
+  
   /**
-   * @brief momentum_flux Calculates the value of the evaporation recoil pressure.
-   * @param fields_value Value of the various field on which the recoil pressure
+   * @brief momentum_flux Calculates the value of the evaporation momentum flux.
+   * @param fields_value Values of the various fields on which the momentum flux
    * may depend.
-   * @return value of the recoil pressure calculated with the fields_value
+   * @return Value of the momentum flux calculated with the fields_value
    */
   double
   momentum_flux(const std::map<field, double> &fields_value) override
@@ -609,10 +626,11 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux Calculates the values of the evaporation recoil
-   * pressure for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param momentum_flux_vector Vectors of the recoil pressure values
+   * @brief vector_momentum_flux Calculates the values of the evaporation momentum
+   * flux for multiple points.
+   * @param field_vectors Values of the various fields on which the momentum flux 
+   * may depend.
+   * @param momentum_flux_vector Vectors of the momentum flux values.
    */
   void
   vector_momentum_flux(
@@ -629,7 +647,7 @@ public:
     std::vector<double> mass_flux_vector(n_pts);
     vector_mass_flux(field_vectors, mass_flux_vector);
 
-    for (unsigned int i = 0; i < momentum_flux_vector.size(); ++i)
+    for (unsigned int i = 0; i < n_pts; ++i)
       {
         const double temperature_inv = 1.0 / (temperature[i] + 1e-16);
 
@@ -649,12 +667,12 @@ public:
 
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
-   * of the evaporation recoil pressure with respect to a field
-   * @param field_values Value of the various fields on which the recoil pressure
+   * of the evaporation momentum flux with respect to a field.
+   * @param field_values Values of the various fields on which the momentum flux
    * may depend.
-   * @param id Indicator of the field with respect to which the jacobian
+   * @param id Identifier of the field with respect to which the jacobian
    * should be calculated
-   * @return value of the partial derivative of the recoil pressure with respect
+   * @return Value of the partial derivative of the momentum flux with respect
    * to the field.
    */
   double
@@ -665,14 +683,14 @@ public:
   }
 
   /**
-   * @brief vector_momentum_flux_jacobian Calculate the derivative of the
-   * evaporation recoil pressure with respect to a field
-   * @param field_vectors Vector for the values of the fields on which the recoil
-   * pressure may depend.
+   * @brief vector_momentum_flux_jacobian Calculates the derivative of the
+   * evaporation momentum flux with respect to a field.
+   * @param field_vectors Vector for the values of the fields on which the momentum
+   * flux evaluated at multiple points may depend.
    * @param id Identifier of the field with respect to which a derivative should
-   * be calculated
-   * @param jacobian Vector of the value of the derivative of the recoil pressure
-   * with respect to the field id
+   * be calculated.
+   * @param jacobian_vector Vector of the values of the derivative of the momentum flux
+   * with respect to the field.
    */
   void
   vector_momentum_flux_jacobian(

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -33,7 +33,7 @@ public:
   {
     model_depends_on[temperature] = false;
   }
-  
+
   /**
    * @brief Instantiates and returns a pointer to a EvaporationModel
    * object by casting it to the proper child class
@@ -52,7 +52,7 @@ public:
   {
     return model_depends_on[id];
   }
-  
+
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
    * @param fields_value Value of the various field on which the flux may depend.
@@ -60,17 +60,17 @@ public:
    */
   virtual double
   mass_flux(const std::map<field, double> &fields_value) = 0;
-  
+
   /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
+   * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points
    * @param field_vectors Value of the various fields on which the flux may depend.
    * @param mass_flux_vector Vectors of the mass flux values
    */
   virtual void
   vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
-               std::vector<double>                        &mass_flux_vector) = 0;
-               
+                   std::vector<double> &mass_flux_vector) = 0;
+
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
    * @param fields_value Value of the various field on which the flux may depend.
@@ -78,19 +78,19 @@ public:
    */
   virtual double
   heat_flux(const std::map<field, double> &fields_value) = 0;
-  
+
   /**
-   * @brief vector_heat_flux Calculates the values of the evaporation heat flux 
+   * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points
    * @param field_vectors Value of the various fields on which the flux may depend.
    * @param heat_flux_vector Vectors of the heat flux values
    */
   virtual void
   vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
-               std::vector<double>                        &heat_flux_vector) = 0;
+                   std::vector<double> &heat_flux_vector) = 0;
 
   /**
-   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative) 
+   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field
    * @param field_values Value of the various fields on which the flux may depend.
    * @param id Indicator of the field with respect to which the jacobian
@@ -98,12 +98,13 @@ public:
    * @return value of the partial derivative of the heat flux with respect to the field.
    */
   virtual double
-  heat_flux_jacobian(const std::map<field, double> &field_values, const field id) = 0;
+  heat_flux_jacobian(const std::map<field, double> &field_values,
+                     const field                    id) = 0;
 
   /**
-   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation 
+   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation
    * heat flux with respect to a field
-   * @param field_vectors Vector for the values of the fields used to evaluate 
+   * @param field_vectors Vector for the values of the fields used to evaluate
    * the flux
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated
@@ -111,56 +112,60 @@ public:
    * respect to the field id
    */
   virtual void
-  vector_heat_flux_jacobian(const std::map<field, std::vector<double>> &field_vectors,
-                  const field                                 id,
-                  std::vector<double> &jacobian_vector) = 0;
+  vector_heat_flux_jacobian(
+    const std::map<field, std::vector<double>> &field_vectors,
+    const field                                 id,
+    std::vector<double>                        &jacobian_vector) = 0;
 
   /**
-   * @brief recoil_pressure Calculates the value of the evaporation recoil pressure.
-   * @param fields_value Value of the various field on which the recoil pressure 
+   * @brief momentum_flux Calculates the value of the evaporation recoil pressure.
+   * @param fields_value Value of the various field on which the recoil pressure
    * may depend.
    * @return value of the recoil pressure calculated with the fields_value
    */
   virtual double
-  recoil_pressure(const std::map<field, double> &fields_value) = 0;
-  
-  /**
-   * @brief vector_recoil_pressure Calculates the values of the evaporation recoil 
-   * pressure for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param recoil_pressure_vector Vectors of the recoil pressure values
-   */
-  virtual void
-  vector_recoil_pressure(const std::map<field, std::vector<double>> &field_vectors,
-               std::vector<double>                        &recoil_pressure_vector) = 0;
+  momentum_flux(const std::map<field, double> &fields_value) = 0;
 
   /**
-   * @brief recoil_pressure_jacobian Calculates the jacobian (the partial derivative) 
+   * @brief vector_momentum_flux Calculates the values of the evaporation recoil
+   * pressure for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param momentum_flux_vector Vectors of the recoil pressure values
+   */
+  virtual void
+  vector_momentum_flux(
+    const std::map<field, std::vector<double>> &field_vectors,
+    std::vector<double>                        &momentum_flux_vector) = 0;
+
+  /**
+   * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation recoil pressure with respect to a field
-   * @param field_values Value of the various fields on which the recoil pressure 
+   * @param field_values Value of the various fields on which the recoil pressure
    * may depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated
-   * @return value of the partial derivative of the recoil pressure with respect 
+   * @return value of the partial derivative of the recoil pressure with respect
    * to the field.
    */
   virtual double
-  recoil_pressure_jacobian(const std::map<field, double> &field_values, const field id) = 0;
+  momentum_flux_jacobian(const std::map<field, double> &field_values,
+                         const field                    id) = 0;
 
   /**
-   * @brief vector_recoil_pressure_jacobian Calculate the derivative of the  
+   * @brief vector_momentum_flux_jacobian Calculate the derivative of the
    * evaporation recoil pressure with respect to a field
-   * @param field_vectors Vector for the values of the fields on which the recoil 
+   * @param field_vectors Vector for the values of the fields on which the recoil
    * pressure may depend.
-   * @param id Identifier of the field with respect to which a derivative should 
+   * @param id Identifier of the field with respect to which a derivative should
    * be calculated
    * @param jacobian Vector of the value of the derivative of the recoil pressure
    * with respect to the field id
    */
   virtual void
-  vector_recoil_pressure_jacobian(const std::map<field, std::vector<double>> &field_vectors,
-                  const field                                 id,
-                  std::vector<double> &jacobian_vector) = 0;
+  vector_momentum_flux_jacobian(
+    const std::map<field, std::vector<double>> &field_vectors,
+    const field                                 id,
+    std::vector<double>                        &jacobian_vector) = 0;
 
 protected:
   // Map to indicate on which variables the model depends on
@@ -169,18 +174,22 @@ protected:
 
 /**
  * @brief EvaporationModelConstant. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a constant mass flux is 
+ * evaporation heat and momentum fluxes when a constant mass flux is
  * considered.
  */
 class EvaporationModelConstant : public EvaporationModel
 {
 public:
-  EvaporationModelConstant(const Parameters::Evaporation &p_evaporation): n_evaporation(p_evaporation.n_evaporation), latent_heat_evaporation(p_evaporation.latent_heat_evaporation), ambient_gas_density_inv(1.0/p_evaporation.ambient_gas_density), liquid_density_inv(1.0/p_evaporation.liquid_density)
+  EvaporationModelConstant(const Parameters::Evaporation &p_evaporation)
+    : n_evaporation(p_evaporation.n_evaporation)
+    , latent_heat_evaporation(p_evaporation.latent_heat_evaporation)
+    , ambient_gas_density_inv(1.0 / p_evaporation.ambient_gas_density)
+    , liquid_density_inv(1.0 / p_evaporation.liquid_density)
   {
     model_depends_on[temperature] = false;
   }
-  
-  
+
+
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
    * @param fields_value Value of the various field on which the flux may depend.
@@ -191,20 +200,21 @@ public:
   {
     return n_evaporation;
   }
-  
+
   /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
+   * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points
    * @param field_vectors Value of the various fields on which the flux may depend.
    * @param mass_flux_vector Vectors of the mass flux values
    */
   void
-  vector_mass_flux(const std::map<field, std::vector<double>> & /*field_vectors*/,
-               std::vector<double>                        &mass_flux_vector) override
+  vector_mass_flux(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    std::vector<double> &mass_flux_vector) override
   {
     std::fill(mass_flux_vector.begin(), mass_flux_vector.end(), n_evaporation);
   }
-               
+
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
    * @param fields_value Value of the various field on which the flux may depend.
@@ -213,24 +223,27 @@ public:
   double
   heat_flux(const std::map<field, double> & /*fields_value*/) override
   {
-    return n_evaporation*latent_heat_evaporation;
+    return n_evaporation * latent_heat_evaporation;
   }
-  
+
   /**
-   * @brief vector_heat_flux Calculates the values of the evaporation heat flux 
+   * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points
    * @param field_vectors Value of the various fields on which the flux may depend.
    * @param heat_flux_vector Vectors of the heat flux values
    */
   void
-  vector_heat_flux(const std::map<field, std::vector<double>> &/*field_vectors*/,
-               std::vector<double>                        &heat_flux_vector) override
+  vector_heat_flux(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    std::vector<double> &heat_flux_vector) override
   {
-    std::fill(heat_flux_vector.begin(), heat_flux_vector.end(),  n_evaporation*latent_heat_evaporation);
+    std::fill(heat_flux_vector.begin(),
+              heat_flux_vector.end(),
+              n_evaporation * latent_heat_evaporation);
   }
 
   /**
-   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative) 
+   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field
    * @param field_values Value of the various fields on which the flux may depend.
    * @param id Indicator of the field with respect to which the jacobian
@@ -238,15 +251,16 @@ public:
    * @return value of the partial derivative of the heat flux with respect to the field.
    */
   double
-  heat_flux_jacobian(const std::map<field, double> & /*fields_value*/, const field /*id*/) override
+  heat_flux_jacobian(const std::map<field, double> & /*fields_value*/,
+                     const field /*id*/) override
   {
     return 0.0;
   }
 
   /**
-   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation 
+   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation
    * heat flux with respect to a field
-   * @param field_vectors Vector for the values of the fields used to evaluate 
+   * @param field_vectors Vector for the values of the fields used to evaluate
    * the flux
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated
@@ -254,76 +268,83 @@ public:
    * respect to the field id
    */
   void
-  vector_heat_flux_jacobian(const std::map<field, std::vector<double>> &/*field_vectors*/,
-                  const field                                 /*id*/,
-                  std::vector<double> &jacobian_vector) override
+  vector_heat_flux_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field /*id*/,
+    std::vector<double> &jacobian_vector) override
   {
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
   /**
-   * @brief recoil_pressure Calculates the value of the evaporation recoil pressure.
-   * @param fields_value Value of the various field on which the recoil pressure 
+   * @brief momentum_flux Calculates the value of the evaporation recoil pressure.
+   * @param fields_value Value of the various field on which the recoil pressure
    * may depend.
    * @return value of the recoil pressure calculated with the fields_value
    */
   double
-  recoil_pressure(const std::map<field, double> & /*fields_value*/) override
+  momentum_flux(const std::map<field, double> & /*fields_value*/) override
   {
-    return -n_evaporation*n_evaporation*(liquid_density_inv - ambient_gas_density_inv);
-  }
-  
-  /**
-   * @brief vector_recoil_pressure Calculates the values of the evaporation recoil 
-   * pressure for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param recoil_pressure_vector Vectors of the recoil pressure values
-   */
-  void
-  vector_recoil_pressure(const std::map<field, std::vector<double>> &/*field_vectors*/,
-               std::vector<double>                        &recoil_pressure_vector) override
-  { 
-    
-    const double recoil_pressure_value = -n_evaporation*n_evaporation*(liquid_density_inv - ambient_gas_density_inv);
-    
-    std::fill(recoil_pressure_vector.begin(), recoil_pressure_vector.end(), recoil_pressure_value);
+    return -n_evaporation * n_evaporation *
+           (liquid_density_inv - ambient_gas_density_inv);
   }
 
   /**
-   * @brief recoil_pressure_jacobian Calculates the jacobian (the partial derivative) 
+   * @brief vector_momentum_flux Calculates the values of the evaporation recoil
+   * pressure for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param momentum_flux_vector Vectors of the recoil pressure values
+   */
+  void
+  vector_momentum_flux(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    std::vector<double> &momentum_flux_vector) override
+  {
+    const double momentum_flux_value =
+      -n_evaporation * n_evaporation *
+      (liquid_density_inv - ambient_gas_density_inv);
+
+    std::fill(momentum_flux_vector.begin(),
+              momentum_flux_vector.end(),
+              momentum_flux_value);
+  }
+
+  /**
+   * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation recoil pressure with respect to a field
-   * @param field_values Value of the various fields on which the recoil pressure 
+   * @param field_values Value of the various fields on which the recoil pressure
    * may depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated
-   * @return value of the partial derivative of the recoil pressure with respect 
+   * @return value of the partial derivative of the recoil pressure with respect
    * to the field.
    */
   double
-  recoil_pressure_jacobian(const std::map<field, double> &/*field_values*/, const field /*id*/) override
+  momentum_flux_jacobian(const std::map<field, double> & /*field_values*/,
+                         const field /*id*/) override
   {
     return 0.0;
   }
 
   /**
-   * @brief vector_recoil_pressure_jacobian Calculate the derivative of the  
+   * @brief vector_momentum_flux_jacobian Calculate the derivative of the
    * evaporation recoil pressure with respect to a field
-   * @param field_vectors Vector for the values of the fields on which the recoil 
+   * @param field_vectors Vector for the values of the fields on which the recoil
    * pressure may depend.
-   * @param id Identifier of the field with respect to which a derivative should 
+   * @param id Identifier of the field with respect to which a derivative should
    * be calculated
    * @param jacobian Vector of the value of the derivative of the recoil pressure
    * with respect to the field id
    */
   void
-  vector_recoil_pressure_jacobian(const std::map<field, std::vector<double>> & /*field_vectors*/,
-                  const field                                 /*id*/,
-                  std::vector<double> &jacobian_vector) override
+  vector_momentum_flux_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field /*id*/,
+    std::vector<double> &jacobian_vector) override
   {
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
 
 private:
-  
   const double n_evaporation;
   const double latent_heat_evaporation;
   const double ambient_gas_density_inv;
@@ -332,130 +353,152 @@ private:
 
 /**
  * @brief EvaporationModelConstant. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a constant mass flux is 
+ * evaporation heat and momentum fluxes when a constant mass flux is
  * considered.
  */
 class EvaporationModelTemperature : public EvaporationModel
 {
 public:
-  EvaporationModelTemperature(const Parameters::Evaporation &p_evaporation): evaporation_coefficient(p_evaporation.evaporation_coefficient), molar_mass(p_evaporation.molar_mass), boiling_temperature_inv(1.0/p_evaporation.boiling_temperature),  latent_heat_evaporation(p_evaporation.latent_heat_evaporation), ambient_pressure(p_evaporation.ambient_pressure), ambient_gas_density_inv(1.0/p_evaporation.ambient_gas_density), liquid_density_inv(1.0/p_evaporation.liquid_density)
+  EvaporationModelTemperature(const Parameters::Evaporation &p_evaporation)
+    : evaporation_coefficient(p_evaporation.evaporation_coefficient)
+    , recoil_pressure_coefficient(p_evaporation.recoil_pressure_coefficient)
+    , molar_mass(p_evaporation.molar_mass)
+    , boiling_temperature_inv(1.0 / p_evaporation.boiling_temperature)
+    , latent_heat_evaporation(p_evaporation.latent_heat_evaporation)
+    , ambient_pressure(p_evaporation.ambient_pressure)
+    , ambient_gas_density_inv(1.0 / p_evaporation.ambient_gas_density)
+    , liquid_density_inv(1.0 / p_evaporation.liquid_density)
   {
     model_depends_on[temperature] = true;
-    this->L_vap_x_M_x_R_inv = latent_heat_evaporation*molar_mass/8.3145;
-    this->M_x_2PI_inv_x_R_inv = molar_mass/(2.0*M_PI*8.3145);
+    this->R_inv                   = 1.0 / 8.3145;
+    this->L_vap_x_M_x_R_inv =
+      latent_heat_evaporation * molar_mass * this->R_inv;
+    this->M_x_2PI_inv_x_R_inv = molar_mass / (2.0 * M_PI) * this->R_inv;
   }
-  
+
   /**
-   * @brief mass_flux Calculates the value of the saturated vapor pressure.
-   * @param fields_value Value of the various field on which the saturated 
-   * vapor pressure may depend.
-   * @return value of the pressure calculated with the fields_value
-   */
-  double
-  saturation_pressure(const std::map<field, double> & fields_value)
-  {
-    const double temperature_inv = 1.0/fields_value.at(field::temperature);
-    
-    return ambient_pressure*std::exp(-L_vap_x_M_x_R_inv*(temperature_inv - boiling_temperature_inv));
-  }
-  
-  /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
-   * for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param mass_flux_vector Vectors of the mass flux values
-   */
-  void
-  vector_saturation_pressure(const std::map<field, std::vector<double>> & field_vectors,
-               std::vector<double>                        &saturation_pressure_vector) 
-  {
-    const std::vector<double> &temperature =
-      field_vectors.at(field::temperature);
-    
-    for (unsigned int i = 0; i < saturation_pressure_vector.size(); ++i)
-    {
-      const double temperature_inv = 1.0/temperature[i];
-      
-      saturation_pressure_vector[i] = ambient_pressure*std::exp(-L_vap_x_M_x_R_inv*(temperature_inv - boiling_temperature_inv));
-    }
-  }
-  
-  /**
-   * @brief saturation_pressure Calculates the value of the evaporation mass flux.
+   * @brief saturation_pressure Calculates the value of the staturation pressure.
    * @param fields_value Value of the various field on which the flux may depend.
    * @return value of the flux calculated with the fields_value
    */
   double
-  mass_flux(const std::map<field, double> & fields_value) override
+  saturation_pressure(const std::map<field, double> &fields_value)
   {
-    const double saturation_pressure_value = saturation_pressure(fields_value);
-    const double temperature_inv = 1.0/fields_value.at(field::temperature);
+    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
 
-    return evaporation_coefficient*saturation_pressure_value*std::sqrt(M_x_2PI_inv_x_R_inv*temperature_inv);
+    return ambient_pressure *
+           std::exp(-L_vap_x_M_x_R_inv *
+                    (temperature_inv - boiling_temperature_inv));
   }
-  
+
   /**
-   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
+   * @brief vector_mass_flux Calculates the values of the staturation pressure
    * for multiple points
    * @param field_vectors Value of the various fields on which the flux may depend.
    * @param mass_flux_vector Vectors of the mass flux values
    */
   void
-  vector_mass_flux(const std::map<field, std::vector<double>> & field_vectors,
-               std::vector<double>                        &mass_flux_vector) override
+  vector_saturation_pressure(
+    const std::map<field, std::vector<double>> &field_vectors,
+    std::vector<double>                        &saturation_pressure_vector)
   {
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
-      
+
+    for (unsigned int i = 0; i < saturation_pressure_vector.size(); ++i)
+      {
+        const double temperature_inv = 1.0 / temperature[i];
+
+        saturation_pressure_vector[i] =
+          ambient_pressure *
+          std::exp(-L_vap_x_M_x_R_inv *
+                   (temperature_inv - boiling_temperature_inv));
+      }
+  }
+
+  /**
+   * @brief mass_flux Calculates the value of the saturated vapor pressure.
+   * @param fields_value Value of the various field on which the saturated
+   * vapor pressure may depend.
+   * @return value of the pressure calculated with the fields_value
+   */
+  double
+  mass_flux(const std::map<field, double> &fields_value) override
+  {
+    const double saturation_pressure_value = saturation_pressure(fields_value);
+    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+
+    const double mass_flux_value =
+      evaporation_coefficient * saturation_pressure_value *
+      std::sqrt(M_x_2PI_inv_x_R_inv * temperature_inv);
+
+    return mass_flux_value;
+  }
+
+  /**
+   * @brief vector_mass_flux Calculates the values of the evaporation mass flux
+   * for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param mass_flux_vector Vectors of the mass flux values
+   */
+  void
+  vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
+                   std::vector<double> &mass_flux_vector) override
+  {
+    const std::vector<double> &temperature =
+      field_vectors.at(field::temperature);
+
     const unsigned int n_pts = mass_flux_vector.size();
-    
+
     std::vector<double> saturation_pressure_vector(n_pts);
     vector_saturation_pressure(field_vectors, saturation_pressure_vector);
-      
+
     for (unsigned int i = 0; i < mass_flux_vector.size(); ++i)
-    {
-      const double temperature_inv = 1.0/temperature[i];
-      
-      mass_flux_vector[i] = evaporation_coefficient*saturation_pressure_vector[i]*std::sqrt(M_x_2PI_inv_x_R_inv*temperature_inv);
-    }
+      {
+        const double temperature_inv = 1.0 / temperature[i];
+
+        mass_flux_vector[i] = evaporation_coefficient *
+                              saturation_pressure_vector[i] *
+                              std::sqrt(M_x_2PI_inv_x_R_inv * temperature_inv);
+      }
   }
-               
+
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
    * @param fields_value Value of the various field on which the flux may depend.
    * @return value of the heat flux calculated with the fields_value
    */
   double
-  heat_flux(const std::map<field, double> & fields_value) override
+  heat_flux(const std::map<field, double> &fields_value) override
   {
     const double mass_flux_value = mass_flux(fields_value);
-    
-    return mass_flux_value*latent_heat_evaporation;
+
+    return mass_flux_value * latent_heat_evaporation;
   }
-  
+
   /**
-   * @brief vector_heat_flux Calculates the values of the evaporation heat flux 
+   * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points
    * @param field_vectors Value of the various fields on which the flux may depend.
    * @param heat_flux_vector Vectors of the heat flux values
    */
   void
   vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
-               std::vector<double>                        &heat_flux_vector) override
+                   std::vector<double> &heat_flux_vector) override
   {
     const unsigned int n_pts = heat_flux_vector.size();
-    
+
     std::vector<double> mass_flux_vector(n_pts);
     vector_mass_flux(field_vectors, mass_flux_vector);
-    
+
     for (unsigned int i = 0; i < n_pts; ++i)
-    {
-      heat_flux_vector[i] = mass_flux_vector[i]*latent_heat_evaporation;
-    }
+      {
+        heat_flux_vector[i] = mass_flux_vector[i] * latent_heat_evaporation;
+      }
   }
 
   /**
-   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative) 
+   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field
    * @param field_values Value of the various fields on which the flux may depend.
    * @param id Indicator of the field with respect to which the jacobian
@@ -463,15 +506,26 @@ public:
    * @return value of the partial derivative of the heat flux with respect to the field.
    */
   double
-  heat_flux_jacobian(const std::map<field, double> & /*fields_value*/, const field /*id*/) override
+  heat_flux_jacobian(const std::map<field, double> &fields_value,
+                     const field                    id) override
   {
-    return 0.0;
+    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+
+    if (id == field::temperature)
+      return latent_heat_evaporation * ambient_pressure *
+             evaporation_coefficient * temperature_inv *
+             std::sqrt(M_x_2PI_inv_x_R_inv * temperature_inv) *
+             std::exp(-L_vap_x_M_x_R_inv *
+                      (temperature_inv - boiling_temperature_inv)) *
+             (L_vap_x_M_x_R_inv * temperature_inv - 0.5);
+    else
+      return 0.0;
   }
 
   /**
-   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation 
+   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation
    * heat flux with respect to a field
-   * @param field_vectors Vector for the values of the fields used to evaluate 
+   * @param field_vectors Vector for the values of the fields used to evaluate
    * the flux
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated
@@ -479,87 +533,147 @@ public:
    * respect to the field id
    */
   void
-  vector_heat_flux_jacobian(const std::map<field, std::vector<double>> &/*field_vectors*/,
-                  const field                                 /*id*/,
-                  std::vector<double> &jacobian_vector) override
+  vector_heat_flux_jacobian(
+    const std::map<field, std::vector<double>> &field_vectors,
+    const field                                 id,
+    std::vector<double>                        &jacobian_vector) override
   {
-    std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
+    if (id == field::temperature)
+      {
+        const std::vector<double> &temperature =
+          field_vectors.at(field::temperature);
+        for (unsigned int i = 0; i < jacobian_vector.size(); ++i)
+          {
+            const double temperature_inv = 1.0 / temperature[i];
+            jacobian_vector[i] =
+              latent_heat_evaporation * ambient_pressure *
+              evaporation_coefficient * temperature_inv *
+              std::sqrt(M_x_2PI_inv_x_R_inv * temperature_inv) *
+              std::exp(-L_vap_x_M_x_R_inv *
+                       (temperature_inv - boiling_temperature_inv)) *
+              (L_vap_x_M_x_R_inv * temperature_inv - 0.5);
+          }
+      }
+    else
+      std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
   /**
-   * @brief recoil_pressure Calculates the value of the evaporation recoil pressure.
-   * @param fields_value Value of the various field on which the recoil pressure 
+   * @brief momentum_flux Calculates the value of the evaporation recoil pressure.
+   * @param fields_value Value of the various field on which the recoil pressure
    * may depend.
    * @return value of the recoil pressure calculated with the fields_value
    */
   double
-  recoil_pressure(const std::map<field, double> & /*fields_value*/) override
+  momentum_flux(const std::map<field, double> &fields_value) override
   {
-    return 0.0;//-n_evaporation*n_evaporation*(liquid_density_inv - ambient_gas_density_inv);
-  }
-  
-  /**
-   * @brief vector_recoil_pressure Calculates the values of the evaporation recoil 
-   * pressure for multiple points
-   * @param field_vectors Value of the various fields on which the flux may depend.
-   * @param recoil_pressure_vector Vectors of the recoil pressure values
-   */
-  void
-  vector_recoil_pressure(const std::map<field, std::vector<double>> &/*field_vectors*/,
-               std::vector<double>                        &recoil_pressure_vector) override
-  { 
-    
-    // const double recoil_pressure_value = -n_evaporation*n_evaporation*(liquid_density_inv - ambient_gas_density_inv);
-    
-    std::fill(recoil_pressure_vector.begin(), recoil_pressure_vector.end(), 0.0);
+    const double saturation_pressure_value = saturation_pressure(fields_value);
+    const double mass_flux_value           = mass_flux(fields_value);
+    const double temperature_inv = 1.0 / fields_value.at(field::temperature);
+
+    const double vapor_saturation_density_value =
+      saturation_pressure_value * R_inv * temperature_inv;
+
+    // rho_vap = 0.31*rho_sat according to Anisimov and Khokhlov 1995
+    const double vapor_density_inv =
+      1.0 / (0.31 * vapor_saturation_density_value);
+
+    return -mass_flux_value * mass_flux_value *
+             (liquid_density_inv - vapor_density_inv) +
+           recoil_pressure_coefficient * saturation_pressure_value;
   }
 
   /**
-   * @brief recoil_pressure_jacobian Calculates the jacobian (the partial derivative) 
+   * @brief vector_momentum_flux Calculates the values of the evaporation recoil
+   * pressure for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param momentum_flux_vector Vectors of the recoil pressure values
+   */
+  void
+  vector_momentum_flux(
+    const std::map<field, std::vector<double>> &field_vectors,
+    std::vector<double>                        &momentum_flux_vector) override
+  {
+    const unsigned int         n_pts = momentum_flux_vector.size();
+    const std::vector<double> &temperature =
+      field_vectors.at(field::temperature);
+
+    std::vector<double> saturation_pressure_vector(n_pts);
+    vector_saturation_pressure(field_vectors, saturation_pressure_vector);
+
+    std::vector<double> mass_flux_vector(n_pts);
+    vector_mass_flux(field_vectors, mass_flux_vector);
+
+    for (unsigned int i = 0; i < momentum_flux_vector.size(); ++i)
+      {
+        const double temperature_inv = 1.0 / temperature[i];
+
+        const double vapor_saturation_density_value =
+          saturation_pressure_vector[i] * R_inv * temperature_inv;
+
+        // rho_vap = 0.31*rho_sat according to Anisimov and Khokhlov 1995
+        const double vapor_density_inv =
+          1.0 / (0.31 * vapor_saturation_density_value);
+
+        momentum_flux_vector[i] =
+          -mass_flux_vector[i] * mass_flux_vector[i] *
+            (liquid_density_inv - vapor_density_inv) +
+          recoil_pressure_coefficient * saturation_pressure_vector[i];
+      }
+  }
+
+  /**
+   * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation recoil pressure with respect to a field
-   * @param field_values Value of the various fields on which the recoil pressure 
+   * @param field_values Value of the various fields on which the recoil pressure
    * may depend.
    * @param id Indicator of the field with respect to which the jacobian
    * should be calculated
-   * @return value of the partial derivative of the recoil pressure with respect 
+   * @return value of the partial derivative of the recoil pressure with respect
    * to the field.
    */
   double
-  recoil_pressure_jacobian(const std::map<field, double> &/*field_values*/, const field /*id*/) override
+  momentum_flux_jacobian(const std::map<field, double> & /*field_values*/,
+                         const field /*id*/) override
   {
     return 0.0;
   }
 
   /**
-   * @brief vector_recoil_pressure_jacobian Calculate the derivative of the  
+   * @brief vector_momentum_flux_jacobian Calculate the derivative of the
    * evaporation recoil pressure with respect to a field
-   * @param field_vectors Vector for the values of the fields on which the recoil 
+   * @param field_vectors Vector for the values of the fields on which the recoil
    * pressure may depend.
-   * @param id Identifier of the field with respect to which a derivative should 
+   * @param id Identifier of the field with respect to which a derivative should
    * be calculated
    * @param jacobian Vector of the value of the derivative of the recoil pressure
    * with respect to the field id
    */
   void
-  vector_recoil_pressure_jacobian(const std::map<field, std::vector<double>> & /*field_vectors*/,
-                  const field                                 /*id*/,
-                  std::vector<double> &jacobian_vector) override
+  vector_momentum_flux_jacobian(
+    const std::map<field, std::vector<double>> & /*field_vectors*/,
+    const field /*id*/,
+    std::vector<double> &jacobian_vector) override
   {
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
   }
 
 private:
-  
   const double evaporation_coefficient;
+  const double recoil_pressure_coefficient;
+
   const double molar_mass;
   const double boiling_temperature_inv;
   const double latent_heat_evaporation;
   const double ambient_pressure;
   const double ambient_gas_density_inv;
   const double liquid_density_inv;
-  
+
+  // 1/R
+  double R_inv;
+
   // L_vap*M/R
   double L_vap_x_M_x_R_inv;
-  
+
   // M/(2*PI*R)
   double M_x_2PI_inv_x_R_inv;
 };

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -71,17 +71,19 @@ public:
 
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
-   * @param fields_value Values of the various fields on which the mass flux may depend.
-   * @return Value of the flux calculated with the fields_value.
+   * @param field_values Map storing the values of the various fields on which the
+   * mass flux may depend.
+   * @return Value of the flux calculated with the field_values.
    */
   virtual double
-  mass_flux(const std::map<field, double> &fields_value) = 0;
+  mass_flux(const std::map<field, double> &field_values) = 0;
 
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the mass flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the mass flux may depend. Each vector contains the field values at
+   * the points of interest.
    * @param mass_flux_vector Vector of mass flux values.
    */
   virtual void
@@ -90,17 +92,19 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Values of the various fields on which the heat flux may depend.
-   * @return Value of the heat flux calculated with the fields_value
+   * @param field_values Map storing the values of the various fields on which
+   * the heat flux may depend.
+   * @return Value of the heat flux calculated with the field_values
    */
   virtual double
-  heat_flux(const std::map<field, double> &fields_value) = 0;
+  heat_flux(const std::map<field, double> &field_values) = 0;
 
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the heat flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the heat flux may depend. Each vector contains the field values at
+   * the points of interest.
    * @param heat_flux_vector Vector of heat flux values.
    */
   virtual void
@@ -110,9 +114,10 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field.
-   * @param field_vectors Values of the various fields on which the heat flux
-   * evaluated at multiple points may depend.
-   * @param heat_flux_vector Vector of heat flux values.
+   * @param field_values Map storing the values of the various fields on which the
+   * heat flux evaluated at a point may depend.
+   * @param id Identifier of the field with respect to which the jacobian
+   * should be calculated.
    */
   virtual double
   heat_flux_jacobian(const std::map<field, double> &field_values,
@@ -120,9 +125,10 @@ public:
 
   /**
    * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
-   * heat flux with respect to a field.
-   *  @param field_vectors Values of the various fields on which the heat flux
-   * evaluated at multiple points may depend.
+   * heat flux with respect to a field for multiple points.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the heat flux may depend. Each vector contains the field values at
+   * the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
    * @param jacobian_vector Vector of the values of the derivative of the heat
@@ -136,18 +142,19 @@ public:
 
   /**
    * @brief momentum_flux Calculates the value of the evaporation momentum flux.
-   * @param fields_value Value of the various field on which the momentum flux
-   * may depend.
-   * @return Value of the momentum flux calculated with the fields_value.
+   * @param field_values Map storing the values of the various fields on which the
+   * momentum flux may depend.
+   * @return Value of the momentum flux calculated with the field_values.
    */
   virtual double
-  momentum_flux(const std::map<field, double> &fields_value) = 0;
+  momentum_flux(const std::map<field, double> &field_values) = 0;
 
   /**
    * @brief vector_momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Values of the various fields on which the evaporation
-   * momentum flux evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the evaporation momentum flux may depend. Each vector contains the
+   * field values at the points of interest.
    * @param momentum_flux_vector Vector of momentum flux values.
    */
   virtual void
@@ -158,8 +165,8 @@ public:
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation momentum flux with respect to a field.
-   * @param field_values Values of the various fields on which the momentum flux
-   * may depend.
+   * @param field_values Map storing the values of the various fields on which the
+   * momentum flux may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
    * @return Value of the partial derivative of the momentum flux with respect
@@ -171,9 +178,10 @@ public:
 
   /**
    * @brief vector_momentum_flux_jacobian Calculates the derivative of the
-   * evaporation momentum flux with respect to a field.
-   * @param field_vectors Vector for the values of the fields on which the recoil
-   * pressure may depend.
+   * evaporation momentum flux with respect to a field for multiple points.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the momentum flux may depend. Each vector contains the field
+   * values at the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
    * @param jacobian_vector Vector of the value of the derivative of the momentum
@@ -192,7 +200,7 @@ protected:
 
 /**
  * @brief EvaporationModelConstant. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a constant mass flux is
+ * evaporation mass, heat, and momentum fluxes when a constant mass flux is
  * considered.
  *
  * @param p_evaporation evaporation model parameters.
@@ -212,12 +220,12 @@ public:
 
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
-   * @param fields_value Values of the various fields on which the mass flux may
-   * depend.
-   * @return Value of the flux calculated with the fields_value.
+   * @param field_values Map storing the values of the various fields on which the
+   * mass flux may depend.
+   * @return Value of the flux calculated with the field_values.
    */
   double
-  mass_flux(const std::map<field, double> & /*fields_value*/) override
+  mass_flux(const std::map<field, double> & /*field_values*/) override
   {
     return n_evaporation;
   }
@@ -225,8 +233,9 @@ public:
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the mass flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the mass flux may depend. Each vector contains the field values at
+   * the points of interest.
    * @param mass_flux_vector Vector of mass flux values.
    */
   void
@@ -239,12 +248,12 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Values of the various fields on which the heat flux may
-   * depend.
-   * @return Value of the heat flux calculated with the fields_value.
+   * @param field_values Map storing the values of the various fields on which the
+   * heat flux may depend.
+   * @return Value of the heat flux calculated with the field_values.
    */
   double
-  heat_flux(const std::map<field, double> & /*fields_value*/) override
+  heat_flux(const std::map<field, double> & /*field_values*/) override
   {
     return n_evaporation * latent_heat_evaporation;
   }
@@ -252,8 +261,9 @@ public:
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the heat flux may
-   * depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the heat flux may depend. Each vector contains the field values at
+   * the points of interest.
    * @param heat_flux_vector Vectors of the heat flux values.
    */
   void
@@ -269,13 +279,13 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field.
-   * @param field_values Values of the various fields on which the heat flux
-   * evaluated at a point may depend.
+   * @param field_values Map storing the values of the various fields on which the
+   * heat flux evaluated at a point may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
    */
   double
-  heat_flux_jacobian(const std::map<field, double> & /*fields_value*/,
+  heat_flux_jacobian(const std::map<field, double> & /*field_values*/,
                      const field /*id*/) override
   {
     return 0.0;
@@ -284,8 +294,9 @@ public:
   /**
    * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field.
-   * @param field_vectors Values of the fields on which the heat flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Vector for the values of the fields on which the heat
+   * flux may depend. Each vector contains the field values at the points of
+   * interest.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
    * @param jacobian_vector Vector of the values of the derivative of the heat
@@ -302,12 +313,12 @@ public:
 
   /**
    * @brief momentum_flux Calculates the value of the evaporation momentum flux.
-   * @param fields_value Values of the various fields on which the momentum flux
-   * may depend.
-   * @return Value of the momentum flux calculated with the fields_value
+   * @param field_values Map storing the values of the various fields on which the
+   * momentum flux may depend.
+   * @return Value of the momentum flux calculated with the field_values
    */
   double
-  momentum_flux(const std::map<field, double> & /*fields_value*/) override
+  momentum_flux(const std::map<field, double> & /*field_values*/) override
   {
     return -n_evaporation * n_evaporation *
            (liquid_density_inv - ambient_gas_density_inv);
@@ -316,8 +327,9 @@ public:
   /**
    * @brief vector_momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Values of the various fields on which the momentum flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the momentum flux may depend. Each vector contains the field
+   * values at the points of interest.
    * @param momentum_flux_vector Vector of momentum flux values.
    */
   void
@@ -337,8 +349,8 @@ public:
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation momentum flux with respect to a field.
-   * @param field_values Values of the various fields on which the momentum flux
-   * may depend.
+   * @param field_values Map storing the values of the various fields on which the
+   * momentum flux may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated
    * @return Value of the partial derivative of the momentum flux with respect
@@ -354,12 +366,13 @@ public:
   /**
    * @brief vector_momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field
-   * @param field_vectors Vector for the values of the fields on which the momentum
-   * flux evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the momentum flux may depend. Each vector contains the field
+   * values at the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
-   * @param jacobian_vector Vector of the values of the derivative of the momentum flux
-   * with respect to the field.
+   * @param jacobian_vector Vector of the values of the derivative of the momentum
+   * flux with respect to the field.
    */
   void
   vector_momentum_flux_jacobian(
@@ -379,8 +392,8 @@ private:
 
 /**
  * @brief EvaporationModelTemperature. Class that allows to calculate the
- * evaporation heat and momentum fluxes when a temperature-dependent mass flux
- * is considered.
+ * evaporation mass, heat, and momentum fluxes  when a temperature-dependent
+ * mass flux is considered.
  *
  * @param p_evaporation evaporation model parameters.
  */
@@ -398,23 +411,24 @@ public:
     , liquid_density_inv(1.0 / p_evaporation.liquid_density)
   {
     model_depends_on[temperature] = true;
-    this->R_inv                   = 1.0 / 8.3145;
-    this->L_vap_x_M_x_R_inv =
-      latent_heat_evaporation * molar_mass * this->R_inv;
-    this->M_x_2PI_inv_x_R_inv = molar_mass / (2.0 * M_PI) * this->R_inv;
   }
 
   /**
    * @brief saturation_pressure Calculates the value of the saturation pressure.
-   * @param fields_value Values of the various field on which the saturated vapor
-   * pressure evaluated at a point may depend.
-   * @return Value of the saturation pressure calculated with the fields_value.
+   * @param field_values Map storing the values of the various field on which the
+   * saturated vapor pressure evaluated at a point may depend.
+   * @return Value of the saturation pressure calculated with the field_values.
    */
   double
-  saturation_pressure(const std::map<field, double> &fields_value)
+  saturation_pressure(const std::map<field, double> &field_values)
   {
     const double temperature_inv =
-      1.0 / (fields_value.at(field::temperature) + 1e-16);
+      1.0 / (field_values.at(field::temperature) + 1e-16);
+
+    const double R_inv = 1.0 / 8.3145;
+
+    const double L_vap_x_M_x_R_inv =
+      latent_heat_evaporation * molar_mass * R_inv;
 
     return ambient_pressure *
            std::exp(-L_vap_x_M_x_R_inv *
@@ -424,8 +438,9 @@ public:
   /**
    * @brief vector_mass_flux Calculates the values of the saturation pressure
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the saturated vapor
-   * pressure evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the saturated vapor pressure may depend. Each vector contains the
+   * field values at the points of interest.
    * @param saturation_pressure_vector Vector of the saturation pressure values.
    */
   void
@@ -435,6 +450,11 @@ public:
   {
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
+
+    const double R_inv = 1.0 / 8.3145;
+
+    const double L_vap_x_M_x_R_inv =
+      latent_heat_evaporation * molar_mass * R_inv;
 
     for (unsigned int i = 0; i < saturation_pressure_vector.size(); ++i)
       {
@@ -449,16 +469,19 @@ public:
 
   /**
    * @brief mass_flux Calculates the value of the evaporation mass flux.
-   * @param fields_value Values of the various fields on which the evaporation
-   * mass flux may depend.
-   * @return Value of the evaporation mass flux calculated with the fields_value.
+   * @param field_values Map storing the values of the various fields on which the
+   * evaporation mass flux may depend.
+   * @return Value of the evaporation mass flux calculated with the field_values.
    */
   double
-  mass_flux(const std::map<field, double> &fields_value) override
+  mass_flux(const std::map<field, double> &field_values) override
   {
-    const double saturation_pressure_value = saturation_pressure(fields_value);
+    const double saturation_pressure_value = saturation_pressure(field_values);
     const double temperature_inv =
-      1.0 / (fields_value.at(field::temperature) + 1e-16);
+      1.0 / (field_values.at(field::temperature) + 1e-16);
+
+    const double R_inv               = 1.0 / 8.3145;
+    const double M_x_2PI_inv_x_R_inv = molar_mass / (2.0 * M_PI) * R_inv;
 
     const double mass_flux_value =
       evaporation_coefficient * saturation_pressure_value *
@@ -470,8 +493,9 @@ public:
   /**
    * @brief vector_mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the evaporation mass flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the evaporation mass flux may depend. Each vector contains the
+   * field values at the points of interest.
    * @param mass_flux_vector Vector of mass flux values.
    */
   void
@@ -480,6 +504,9 @@ public:
   {
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
+
+    const double R_inv               = 1.0 / 8.3145;
+    const double M_x_2PI_inv_x_R_inv = molar_mass / (2.0 * M_PI) * R_inv;
 
     const unsigned int n_pts = mass_flux_vector.size();
 
@@ -498,14 +525,14 @@ public:
 
   /**
    * @brief heat_flux Calculates the value of the evaporation heat flux.
-   * @param fields_value Values of the various fields on which the heat flux may
-   * depend.
-   * @return Value of the heat flux calculated with the fields_value.
+   * @param field_values Map storing the values of the various fields on which the
+   * heat flux may depend.
+   * @return Value of the heat flux calculated with the field_values.
    */
   double
-  heat_flux(const std::map<field, double> &fields_value) override
+  heat_flux(const std::map<field, double> &field_values) override
   {
-    const double mass_flux_value = mass_flux(fields_value);
+    const double mass_flux_value = mass_flux(field_values);
 
     return mass_flux_value * latent_heat_evaporation;
   }
@@ -513,8 +540,9 @@ public:
   /**
    * @brief vector_heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Values of the various fields on which the heat flux
-   * evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the heat flux may depend. Each vector contains the field values at
+   * the points of interest.
    * @param heat_flux_vector Vector of heat flux values.
    */
   void
@@ -535,19 +563,24 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation heat flux with respect to a field.
-   * @param field_values Values of the various fields on which the heat flux
-   * evaluated at a point may depend.
+   * @param field_values Map storing the values of the various fields on which the
+   * heat flux evaluated at a point may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
    * @return Value of the partial derivative of the heat flux with respect to
    * the field.
    */
   double
-  heat_flux_jacobian(const std::map<field, double> &fields_value,
+  heat_flux_jacobian(const std::map<field, double> &field_values,
                      const field                    id) override
   {
     const double temperature_inv =
-      1.0 / (fields_value.at(field::temperature) + 1e-16);
+      1.0 / (field_values.at(field::temperature) + 1e-16);
+
+    const double R_inv = 1.0 / 8.3145;
+    const double L_vap_x_M_x_R_inv =
+      latent_heat_evaporation * molar_mass * R_inv;
+    const double M_x_2PI_inv_x_R_inv = molar_mass / (2.0 * M_PI) * R_inv;
 
     if (id == field::temperature)
       return latent_heat_evaporation * ambient_pressure *
@@ -563,8 +596,9 @@ public:
   /**
    * @brief vector_heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field.
-   * @param field_vectors Vector for the values of the fields on which the heat flux
-   * evaluated at a point may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which heat flux evaluated at a point may depend. Each vector contains
+   * the field values at the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
    * @param jacobian_vector Vector of the values of the derivative of the heat flux
@@ -576,6 +610,11 @@ public:
     const field                                 id,
     std::vector<double>                        &jacobian_vector) override
   {
+    const double R_inv = 1.0 / 8.3145;
+    const double L_vap_x_M_x_R_inv =
+      latent_heat_evaporation * molar_mass * R_inv;
+    const double M_x_2PI_inv_x_R_inv = molar_mass / (2.0 * M_PI) * R_inv;
+
     if (id == field::temperature)
       {
         const std::vector<double> &temperature =
@@ -598,17 +637,19 @@ public:
 
   /**
    * @brief momentum_flux Calculates the value of the evaporation momentum flux.
-   * @param fields_value Values of the various fields on which the momentum flux
-   * may depend.
-   * @return Value of the momentum flux calculated with the fields_value
+   * @param field_values Map storing the values of the various fields on which the
+   * momentum flux may depend.
+   * @return Value of the momentum flux calculated with the field_values
    */
   double
-  momentum_flux(const std::map<field, double> &fields_value) override
+  momentum_flux(const std::map<field, double> &field_values) override
   {
-    const double saturation_pressure_value = saturation_pressure(fields_value);
-    const double mass_flux_value           = mass_flux(fields_value);
+    const double saturation_pressure_value = saturation_pressure(field_values);
+    const double mass_flux_value           = mass_flux(field_values);
     const double temperature_inv =
-      1.0 / (fields_value.at(field::temperature) + 1e-16);
+      1.0 / (field_values.at(field::temperature) + 1e-16);
+
+    const double R_inv = 1.0 / 8.3145;
 
     const double vapor_saturation_density_value =
       molar_mass * saturation_pressure_value * R_inv * temperature_inv;
@@ -628,8 +669,9 @@ public:
   /**
    * @brief vector_momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Values of the various fields on which the momentum flux
-   * may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * on which the momentum flux may depend. Each vector contains the field
+   * values at the points of interest.
    * @param momentum_flux_vector Vectors of the momentum flux values.
    */
   void
@@ -640,6 +682,8 @@ public:
     const unsigned int         n_pts = momentum_flux_vector.size();
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
+
+    const double R_inv = 1.0 / 8.3145;
 
     std::vector<double> saturation_pressure_vector(n_pts);
     vector_saturation_pressure(field_vectors, saturation_pressure_vector);
@@ -668,8 +712,8 @@ public:
   /**
    * @brief momentum_flux_jacobian Calculates the jacobian (the partial derivative)
    * of the evaporation momentum flux with respect to a field.
-   * @param field_values Values of the various fields on which the momentum flux
-   * may depend.
+   * @param field_values Map storing the values of the various fields on which the
+   * momentum flux may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated
    * @return Value of the partial derivative of the momentum flux with respect
@@ -685,12 +729,13 @@ public:
   /**
    * @brief vector_momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field.
-   * @param field_vectors Vector for the values of the fields on which the momentum
-   * flux evaluated at multiple points may depend.
+   * @param field_vectors Map storing the vectors of the values for each fields
+   * flux may depend. Each vector contains the field values at the points of
+   * interest.
    * @param id Identifier of the field with respect to which a derivative should
    * be calculated.
-   * @param jacobian_vector Vector of the values of the derivative of the momentum flux
-   * with respect to the field.
+   * @param jacobian_vector Vector of the values of the derivative of the momentum
+   * flux with respect to the field.
    */
   void
   vector_momentum_flux_jacobian(
@@ -711,15 +756,6 @@ private:
   const double ambient_pressure;
   const double ambient_gas_density_inv;
   const double liquid_density_inv;
-
-  // 1/R
-  double R_inv;
-
-  // L_vap*M/R
-  double L_vap_x_M_x_R_inv;
-
-  // M/(2*PI*R)
-  double M_x_2PI_inv_x_R_inv;
 };
 
 #endif

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -54,6 +54,7 @@ public:
    * object by casting it to the proper child class.
    *
    * @param evaporation_parameters Evaporation model parameters.
+   * @return Pointer to the instantiated EvaporationModel.
    */
   static std::shared_ptr<EvaporationModel>
   model_cast(const Parameters::Evaporation &evaporation_parameters);
@@ -61,6 +62,7 @@ public:
   /**
    * @brief Returns true if the EvaporationModel depends on a field, false if not.
    * @param id Identifier of the field for which the function is called.
+   * @return Boolean stating if the EvaporationModel depends on the field.
    */
   inline bool
   depends_on(const field &id)
@@ -80,7 +82,7 @@ public:
   /**
    * @brief mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the mass flux may depend. Each vector contains the field values at
    * the points of interest.
    * @param mass_flux_vector Vector of mass flux values.
@@ -101,7 +103,7 @@ public:
   /**
    * @brief heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the heat flux may depend. Each vector contains the field values at
    * the points of interest.
    * @param heat_flux_vector Vector of heat flux values.
@@ -117,6 +119,8 @@ public:
    * heat flux evaluated at a point may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
+   * @return Value of the partial derivative of the heat flux with respect to
+   * the field.
    */
   virtual double
   heat_flux_jacobian(const std::map<field, double> &field_values,
@@ -125,7 +129,7 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the heat flux may depend. Each vector contains the field values at
    * the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
@@ -150,7 +154,7 @@ public:
   /**
    * @brief momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the evaporation momentum flux may depend. Each vector contains the
    * field values at the points of interest.
    * @param momentum_flux_vector Vector of momentum flux values.
@@ -176,7 +180,7 @@ public:
   /**
    * @brief momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the momentum flux may depend. Each vector contains the field
    * values at the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
@@ -200,7 +204,7 @@ protected:
  * evaporation mass, heat, and momentum fluxes when a constant mass flux is
  * considered.
  *
- * @param p_evaporation evaporation model parameters.
+ * @param p_evaporation Evaporation model parameters.
  */
 class EvaporationModelConstant : public EvaporationModel
 {
@@ -230,7 +234,7 @@ public:
   /**
    * @brief mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the mass flux may depend. Each vector contains the field values at
    * the points of interest.
    * @param mass_flux_vector Vector of mass flux values.
@@ -259,7 +263,7 @@ public:
   /**
    * @brief heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the heat flux may depend. Each vector contains the field values at
    * the points of interest.
    * @param heat_flux_vector Vectors of the heat flux values.
@@ -280,6 +284,8 @@ public:
    * heat flux evaluated at a point may depend.
    * @param id Identifier of the field with respect to which the jacobian
    * should be calculated.
+   * @return Value of the partial derivative of the heat flux with respect to
+   * the field.
    */
   double
   heat_flux_jacobian(const std::map<field, double> & /*field_values*/,
@@ -324,7 +330,7 @@ public:
   /**
    * @brief momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the momentum flux may depend. Each vector contains the field
    * values at the points of interest.
    * @param momentum_flux_vector Vector of momentum flux values.
@@ -362,7 +368,7 @@ public:
   /**
    * @brief momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the momentum flux may depend. Each vector contains the field
    * values at the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
@@ -391,7 +397,7 @@ private:
  * evaporation mass, heat, and momentum fluxes  when a temperature-dependent
  * mass flux is considered.
  *
- * @param p_evaporation evaporation model parameters.
+ * @param p_evaporation Evaporation model parameters.
  */
 class EvaporationModelTemperature : public EvaporationModel
 {
@@ -434,7 +440,7 @@ public:
   /**
    * @brief mass_flux Calculates the values of the saturation pressure
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the saturated vapor pressure may depend. Each vector contains the
    * field values at the points of interest.
    * @param saturation_pressure_vector Vector of the saturation pressure values.
@@ -490,7 +496,7 @@ public:
   /**
    * @brief mass_flux Calculates the values of the evaporation mass flux
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the evaporation mass flux may depend. Each vector contains the
    * field values at the points of interest.
    * @param mass_flux_vector Vector of mass flux values.
@@ -537,7 +543,7 @@ public:
   /**
    * @brief heat_flux Calculates the values of the evaporation heat flux
    * for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the heat flux may depend. Each vector contains the field values at
    * the points of interest.
    * @param heat_flux_vector Vector of heat flux values.
@@ -593,7 +599,7 @@ public:
   /**
    * @brief heat_flux_jacobian Calculates the derivative of the evaporation
    * heat flux with respect to a field.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which heat flux evaluated at a point may depend. Each vector contains
    * the field values at the points of interest.
    * @param id Identifier of the field with respect to which a derivative should
@@ -668,7 +674,7 @@ public:
   /**
    * @brief momentum_flux Calculates the values of the evaporation momentum
    * flux for multiple points.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * on which the momentum flux may depend. Each vector contains the field
    * values at the points of interest.
    * @param momentum_flux_vector Vectors of the momentum flux values.
@@ -727,7 +733,7 @@ public:
   /**
    * @brief momentum_flux_jacobian Calculates the derivative of the
    * evaporation momentum flux with respect to a field.
-   * @param field_vectors Map storing the vectors of the values for each fields
+   * @param field_vectors Map storing the vectors of the values for each field
    * flux may depend. Each vector contains the field values at the points of
    * interest.
    * @param id Identifier of the field with respect to which a derivative should

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -1,0 +1,170 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+#ifndef lethe_evaporation_model_h
+#define lethe_evaporation_model_h
+
+#include <core/parameters.h>
+// only for the field definition
+#include <core/physical_property_model.h>
+
+using namespace dealii;
+
+/**
+ * @brief SurfaceTensionModel. Abstract class that allows to calculate the
+ * evaporation mass, heat and momentum fluxes.
+ */
+class EvaporationModel
+{
+public:
+  EvaporationModel()
+  {
+    model_depends_on[temperature] = false;
+  }
+  
+  /**
+   * @brief Instantiates and returns a pointer to a EvaporationModel
+   * object by casting it to the proper child class
+   *
+   * @param evaporation_parameters Evaporation model parameters
+   */
+  static std::shared_ptr<EvaporationModel>
+  model_cast(const Parameters::Evaporation &evaporation_parameters);
+
+
+  /**
+   * @brief Returns true if the EvaporationModel depends on a field, false if not.
+   */
+  inline bool
+  depends_on(const field &id)
+  {
+    return model_depends_on[id];
+  }
+  
+  /**
+   * @brief mass_flux Calculates the value of the evaporation mass flux.
+   * @param fields_value Value of the various field on which the flux may depend.
+   * @return value of the flux calculated with the fields_value
+   */
+  virtual double
+  mass_flux(const std::map<field, double> &fields_value) = 0;
+  
+  /**
+   * @brief vector_mass_flux Calculates the values of the evaporation mass flux 
+   * for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param mass_flux_vector Vectors of the mass flux values
+   */
+  virtual void
+  vector_mass_flux(const std::map<field, std::vector<double>> &field_vectors,
+               std::vector<double>                        &mass_flux_vector) = 0;
+               
+  /**
+   * @brief heat_flux Calculates the value of the evaporation heat flux.
+   * @param fields_value Value of the various field on which the flux may depend.
+   * @return value of the heat flux calculated with the fields_value
+   */
+  virtual double
+  heat_flux(const std::map<field, double> &fields_value) = 0;
+  
+  /**
+   * @brief vector_heat_flux Calculates the values of the evaporation heat flux 
+   * for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param heat_flux_vector Vectors of the heat flux values
+   */
+  virtual void
+  vector_heat_flux(const std::map<field, std::vector<double>> &field_vectors,
+               std::vector<double>                        &heat_flux_vector) = 0;
+
+  /**
+   * @brief heat_flux_jacobian Calculates the jacobian (the partial derivative) 
+   * of the evaporation heat flux with respect to a field
+   * @param field_values Value of the various fields on which the flux may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated
+   * @return value of the partial derivative of the heat flux with respect to the field.
+   */
+  virtual double
+  heat_flux_jacobian(const std::map<field, double> &field_values, const field id) = 0;
+
+  /**
+   * @brief vector_heat_flux_jacobian Calculate the derivative of the evaporation 
+   * heat flux with respect to a field
+   * @param field_vectors Vector for the values of the fields used to evaluate 
+   * the flux
+   * @param id Identifier of the field with respect to which a derivative should
+   * be calculated
+   * @param jacobian Vector of the values of the derivative of the heat flux with
+   * respect to the field id
+   */
+  virtual void
+  vector_heat_flux_jacobian(const std::map<field, std::vector<double>> &field_vectors,
+                  const field                                 id,
+                  std::vector<double> &jacobian_vector) = 0;
+
+  /**
+   * @brief recoil_pressure Calculates the value of the evaporation recoil pressure.
+   * @param fields_value Value of the various field on which the recoil pressure 
+   * may depend.
+   * @return value of the recoil pressure calculated with the fields_value
+   */
+  virtual double
+  recoil_pressure(const std::map<field, double> &fields_value) = 0;
+  
+  /**
+   * @brief vector_recoil_pressure Calculates the values of the evaporation recoil 
+   * pressure for multiple points
+   * @param field_vectors Value of the various fields on which the flux may depend.
+   * @param recoil_pressure_vector Vectors of the recoil pressure values
+   */
+  virtual void
+  vector_recoil_pressure(const std::map<field, std::vector<double>> &field_vectors,
+               std::vector<double>                        &recoil_pressure_vector) = 0;
+
+  /**
+   * @brief recoil_pressure_jacobian Calculates the jacobian (the partial derivative) 
+   * of the evaporation recoil pressure with respect to a field
+   * @param field_values Value of the various fields on which the recoil pressure 
+   * may depend.
+   * @param id Indicator of the field with respect to which the jacobian
+   * should be calculated
+   * @return value of the partial derivative of the recoil pressure with respect 
+   * to the field.
+   */
+  virtual double
+  recoil_pressure_jacobian(const std::map<field, double> &field_values, const field id) = 0;
+
+  /**
+   * @brief vector_recoil_pressure_jacobian Calculate the derivative of the  
+   * evaporation recoil pressure with respect to a field
+   * @param field_vectors Vector for the values of the fields on which the recoil 
+   * pressure may depend.
+   * @param id Identifier of the field with respect to which a derivative should 
+   * be calculated
+   * @param jacobian Vector of the value of the derivative of the recoil pressure
+   * with respect to the field id
+   */
+  virtual void
+  vector_recoil_pressure_jacobian(const std::map<field, std::vector<double>> &field_vectors,
+                  const field                                 id,
+                  std::vector<double> &jacobian_vector) = 0;
+
+protected:
+  // Map to indicate on which variables the model depends on
+  std::map<field, bool> model_depends_on;
+};
+
+#endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1366,7 +1366,8 @@ namespace Parameters
   {
     enum class EvaporativeMassFluxModelType
     {
-      constant
+      constant,
+      temperature_dependent
     } evaporative_mass_flux_model_type;
     
     bool enable_evaporation_cooling;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1356,6 +1356,37 @@ namespace Parameters
     void
     parse_parameters(ParameterHandler &prm);
   };
+  
+  /**
+   * @brief Evaporation - Defines the subparameters for
+   * the evaporation cooling and recoil pressure at the free surface 
+   * (air/metal interface).
+   */
+  struct Evaporation
+  {
+    enum class EvaporativeMassFluxModelType
+    {
+      constant
+    } evaporative_mass_flux_model_type;
+    
+    bool enable_evaporation_cooling;
+    bool enable_recoil_pressure;
+    
+    // Parameters for the evaporation terms at the melt pool free surface
+    double evaporation_coefficient;
+    double molar_mass;
+    double boiling_temperature;
+    double latent_heat_evaporation;
+    double ambient_pressure;
+    
+    
+    
+    static void
+    declare_parameters(ParameterHandler &prm);
+    void
+    parse_parameters(ParameterHandler &prm);
+  };
+  
 
   /**
    * @brief Return the tensor of entry @p entry_string. If the entry is specified in the .prm file,

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1356,10 +1356,10 @@ namespace Parameters
     void
     parse_parameters(ParameterHandler &prm);
   };
-  
+
   /**
    * @brief Evaporation - Defines the subparameters for
-   * the evaporation cooling and recoil pressure at the free surface 
+   * the evaporation cooling and recoil pressure at the free surface
    * (air/metal interface).
    */
   struct Evaporation
@@ -1369,13 +1369,14 @@ namespace Parameters
       constant,
       temperature_dependent
     } evaporative_mass_flux_model_type;
-    
+
     bool enable_evaporation_cooling;
     bool enable_recoil_pressure;
-    
+
     // Parameters for the evaporation terms at the melt pool free surface
     double n_evaporation;
     double evaporation_coefficient;
+    double recoil_pressure_coefficient;
     double molar_mass;
     double boiling_temperature;
     double latent_heat_evaporation;
@@ -1388,7 +1389,7 @@ namespace Parameters
     void
     parse_parameters(ParameterHandler &prm);
   };
-  
+
 
   /**
    * @brief Return the tensor of entry @p entry_string. If the entry is specified in the .prm file,

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1374,7 +1374,7 @@ namespace Parameters
     bool enable_recoil_pressure;
 
     // Parameters for the evaporation terms at the melt pool free surface
-    double n_evaporation;
+    double evaporation_mass_flux;
     double evaporation_coefficient;
     double recoil_pressure_coefficient;
     double molar_mass;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1373,14 +1373,15 @@ namespace Parameters
     bool enable_recoil_pressure;
     
     // Parameters for the evaporation terms at the melt pool free surface
+    double n_evaporation;
     double evaporation_coefficient;
     double molar_mass;
     double boiling_temperature;
     double latent_heat_evaporation;
     double ambient_pressure;
-    
-    
-    
+    double ambient_gas_density;
+    double liquid_density;
+
     static void
     declare_parameters(ParameterHandler &prm);
     void

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -503,7 +503,8 @@ protected:
 
 /**
  * @brief Class that assembles the evaporation sink for the heat
- * transfer solver at the free surface (air/metal interface) when VOF is enabled.
+ * transfer solver at the free surface (air/metal interface) when VOF is
+ * enabled.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions.
  *

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -503,11 +503,15 @@ protected:
 
 /**
  * @brief Class that assembles the evaporation sink for the heat
- * transfer solver at the free surface (air/metal interface) when VOF.
+ * transfer solver at the free surface (air/metal interface) when VOF is enabled.
  *
- * @tparam dim An integer that denotes the number of spatial dimensions
+ * @tparam dim An integer that denotes the number of spatial dimensions.
  *
- * @ingroup assemblers
+ * @param simulation_control Shared pointer of the SimulationControl object
+ * controlling the current simulation.
+ * @param p_evaporation Struct that holds all evaporation model
+ * parameters.
+ * @ingroup assemblers.
  */
 template <int dim>
 class HeatTransferAssemblerVOFEvaporation

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -515,8 +515,8 @@ class HeatTransferAssemblerVOFEvaporation
 {
 public:
   HeatTransferAssemblerVOFEvaporation(
-    std::shared_ptr<SimulationControl>      simulation_control,
-    const Parameters::Evaporation &p_evaporation)
+    std::shared_ptr<SimulationControl> simulation_control,
+    const Parameters::Evaporation     &p_evaporation)
     : HeatTransferAssemblerBase<dim>(simulation_control)
   {
     this->evaporation_model = EvaporationModel::model_cast(p_evaporation);
@@ -543,7 +543,6 @@ public:
 private:
   // Evaporation model
   std::shared_ptr<EvaporationModel> evaporation_model;
-  
 };
 
 #endif

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -26,6 +26,7 @@
 #define lethe_heat_transfer_assemblers_h
 
 #include <core/ale.h>
+#include <core/evaporation_model.h>
 #include <core/simulation_control.h>
 
 #include <solvers/copy_data.h>
@@ -498,6 +499,51 @@ public:
 
 protected:
   std::shared_ptr<Parameters::Laser<dim>> laser_parameters;
+};
+
+/**
+ * @brief Class that assembles the evaporation sink for the heat
+ * transfer solver at the free surface (air/metal interface) when VOF.
+ *
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+template <int dim>
+class HeatTransferAssemblerVOFEvaporation
+  : public HeatTransferAssemblerBase<dim>
+{
+public:
+  HeatTransferAssemblerVOFEvaporation(
+    std::shared_ptr<SimulationControl>      simulation_control,
+    const Parameters::Evaporation &p_evaporation)
+    : HeatTransferAssemblerBase<dim>(simulation_control)
+  {
+    this->evaporation_model = EvaporationModel::model_cast(p_evaporation);
+  }
+
+  /**
+   * @brief assemble_matrix Assembles the matrix
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_matrix(HeatTransferScratchData<dim> &scratch_data,
+                  StabilizedMethodsCopyData    &copy_data) override;
+
+  /**
+   * @brief assemble_rhs Assembles the rhs
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_rhs(HeatTransferScratchData<dim> &scratch_data,
+               StabilizedMethodsCopyData    &copy_data) override;
+
+private:
+  // Evaporation model
+  std::shared_ptr<EvaporationModel> evaporation_model;
+  
 };
 
 #endif

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -223,8 +223,8 @@ class NavierStokesVOFAssemblerEvaporation
 {
 public:
   NavierStokesVOFAssemblerEvaporation(
-    std::shared_ptr<SimulationControl>  p_simulation_control,
-    const Parameters::Evaporation &p_evaporation)
+    std::shared_ptr<SimulationControl> p_simulation_control,
+    const Parameters::Evaporation     &p_evaporation)
     : simulation_control(p_simulation_control)
   {
     this->evaporation_model = EvaporationModel::model_cast(p_evaporation);
@@ -249,7 +249,7 @@ public:
                StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   std::shared_ptr<SimulationControl> simulation_control;
-  
+
 private:
   // Evaporation model
   std::shared_ptr<EvaporationModel> evaporation_model;

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -16,10 +16,10 @@
 #include <core/evaporation_model.h>
 #include <core/simulation_control.h>
 
-#include <solvers/auxiliary_physics.h>
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
+#include <solvers/simulation_parameters.h>
 
 #ifndef lethe_navier_stokes_vof_assemblers_h
 #  define lethe_navier_stokes_vof_assemblers_h

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -215,6 +215,11 @@ public:
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
+ * @param simulation_control Shared pointer of the SimulationControl object
+ * controlling the current simulation
+ * @param p_evaporation A  struct that holds all evaporation model
+ * parameters
+ *
  * @ingroup assemblers
  */
 template <int dim>

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -217,7 +217,7 @@ public:
  *
  * @param simulation_control Shared pointer of the SimulationControl object
  * controlling the current simulation
- * @param p_evaporation A  struct that holds all evaporation model
+ * @param p_evaporation Struct that holds all evaporation model
  * parameters
  *
  * @ingroup assemblers

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -13,7 +13,7 @@
  *
  * ---------------------------------------------------------------------*/
 
-
+#include <core/evaporation_model.h>
 #include <core/simulation_control.h>
 
 #include <solvers/auxiliary_physics.h>
@@ -207,6 +207,51 @@ public:
 
   // Surface tension force (STF)
   const Parameters::VOF_SurfaceTensionForce STF_properties;
+};
+
+/**
+ * @brief Class that assembles the momentum source due to evaporation for the
+ * Navier-Stokes equations.
+ *
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+template <int dim>
+class NavierStokesVOFAssemblerEvaporation
+  : public NavierStokesAssemblerBase<dim>
+{
+public:
+  NavierStokesVOFAssemblerEvaporation(
+    std::shared_ptr<SimulationControl>  p_simulation_control,
+    const Parameters::Evaporation &p_evaporation)
+    : simulation_control(p_simulation_control)
+  {
+    this->evaporation_model = EvaporationModel::model_cast(p_evaporation);
+  }
+
+  /**
+   * @brief assemble_matrix Assembles the matrix
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+                  StabilizedMethodsTensorCopyData<dim> &copy_data) override;
+
+  /**
+   * @brief assemble_rhs Assembles the rhs
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+               StabilizedMethodsTensorCopyData<dim> &copy_data) override;
+
+  std::shared_ptr<SimulationControl> simulation_control;
+  
+  // Evaporation model
+  std::shared_ptr<EvaporationModel> evaporation_model;
 };
 
 /**

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -250,6 +250,7 @@ public:
 
   std::shared_ptr<SimulationControl> simulation_control;
   
+private:
   // Evaporation model
   std::shared_ptr<EvaporationModel> evaporation_model;
 };

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -135,7 +135,7 @@ public:
 
     ale.declare_parameters(prm);
     
-    evaporation.declare_parameters(prm);
+    Parameters::Evaporation::declare_parameters(prm);
 
     multiphysics.declare_parameters(prm);
   }

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -68,6 +68,7 @@ public:
   Parameters::Multiphysics                      multiphysics;
   Parameters::Stabilization                     stabilization;
   Parameters::ALE<dim>                          ale;
+  Parameters::Evaporation                       evaporation;
 
 
 
@@ -133,13 +134,16 @@ public:
     Parameters::Stabilization::declare_parameters(prm);
 
     ale.declare_parameters(prm);
+    
+    evaporation.declare_parameters(prm);
 
     multiphysics.declare_parameters(prm);
   }
 
   void
   parse(ParameterHandler &prm)
-  {
+  {    
+
     dimensionality.parse_parameters(prm);
     test.parse_parameters(prm);
 
@@ -178,7 +182,8 @@ public:
     multiphysics.parse_parameters(prm);
     stabilization.parse_parameters(prm);
     ale.parse_parameters(prm);
-
+    evaporation.parse_parameters(prm);
+    
     physical_properties_manager.initialize(physical_properties);
 
 

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -134,7 +134,7 @@ public:
     Parameters::Stabilization::declare_parameters(prm);
 
     ale.declare_parameters(prm);
-    
+
     Parameters::Evaporation::declare_parameters(prm);
 
     multiphysics.declare_parameters(prm);
@@ -142,8 +142,7 @@ public:
 
   void
   parse(ParameterHandler &prm)
-  {    
-
+  {
     dimensionality.parse_parameters(prm);
     test.parse_parameters(prm);
 
@@ -183,7 +182,7 @@ public:
     stabilization.parse_parameters(prm);
     ale.parse_parameters(prm);
     evaporation.parse_parameters(prm);
-    
+
     physical_properties_manager.initialize(physical_properties);
 
 

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(lethe-core
   dem_properties.cc
   density_model.cc
   dimensionality.cc
+  evaporation_model.cc
   grids.cc
   ib_particle.cc
   ib_stencil.cc

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(lethe-core
   ../../include/core/dem_properties.h
   ../../include/core/density_model.h
   ../../include/core/dimensionality.h
+  ../../include/core/evaporation_model.h
   ../../include/core/exceptions.h
   ../../include/core/grids.h
   ../../include/core/ib_particle.h

--- a/source/core/evaporation_model.cc
+++ b/source/core/evaporation_model.cc
@@ -1,0 +1,24 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#include <core/evaporation_model.h>
+
+std::shared_ptr<EvaporationModel>
+EvaporationModel::model_cast(
+  const Parameters::Evaporation &evaporation_parameters)
+{
+    return std::make_shared<EvaporationModel>();
+}

--- a/source/core/evaporation_model.cc
+++ b/source/core/evaporation_model.cc
@@ -20,5 +20,8 @@ std::shared_ptr<EvaporationModel>
 EvaporationModel::model_cast(
   const Parameters::Evaporation &evaporation_parameters)
 {
+  if (evaporation_parameters.evaporative_mass_flux_model_type == Parameters::Evaporation::EvaporativeMassFluxModelType::constant)
+    return std::make_shared<EvaporationModelConstant>(evaporation_parameters);
+  else 
     return std::make_shared<EvaporationModelConstant>(evaporation_parameters);
 }

--- a/source/core/evaporation_model.cc
+++ b/source/core/evaporation_model.cc
@@ -20,8 +20,11 @@ std::shared_ptr<EvaporationModel>
 EvaporationModel::model_cast(
   const Parameters::Evaporation &evaporation_parameters)
 {
-  if (evaporation_parameters.evaporative_mass_flux_model_type == Parameters::Evaporation::EvaporativeMassFluxModelType::temperature_dependent)
-    return std::make_shared<EvaporationModelTemperature>(evaporation_parameters);
-  else 
+  if (evaporation_parameters.evaporative_mass_flux_model_type ==
+      Parameters::Evaporation::EvaporativeMassFluxModelType::
+        temperature_dependent)
+    return std::make_shared<EvaporationModelTemperature>(
+      evaporation_parameters);
+  else
     return std::make_shared<EvaporationModelConstant>(evaporation_parameters);
 }

--- a/source/core/evaporation_model.cc
+++ b/source/core/evaporation_model.cc
@@ -20,5 +20,5 @@ std::shared_ptr<EvaporationModel>
 EvaporationModel::model_cast(
   const Parameters::Evaporation &evaporation_parameters)
 {
-    return std::make_shared<EvaporationModel>();
+    return std::make_shared<EvaporationModelConstant>(evaporation_parameters);
 }

--- a/source/core/evaporation_model.cc
+++ b/source/core/evaporation_model.cc
@@ -20,8 +20,8 @@ std::shared_ptr<EvaporationModel>
 EvaporationModel::model_cast(
   const Parameters::Evaporation &evaporation_parameters)
 {
-  if (evaporation_parameters.evaporative_mass_flux_model_type == Parameters::Evaporation::EvaporativeMassFluxModelType::constant)
-    return std::make_shared<EvaporationModelConstant>(evaporation_parameters);
+  if (evaporation_parameters.evaporative_mass_flux_model_type == Parameters::Evaporation::EvaporativeMassFluxModelType::temperature_dependent)
+    return std::make_shared<EvaporationModelTemperature>(evaporation_parameters);
   else 
     return std::make_shared<EvaporationModelConstant>(evaporation_parameters);
 }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3237,7 +3237,7 @@ namespace Parameters
 
     prm.leave_subsection();
   }
-  
+
   void
   Evaporation::declare_parameters(dealii::ParameterHandler &prm)
   {
@@ -3270,35 +3270,34 @@ namespace Parameters
         Patterns::Double(),
         "Evaporation coefficient corresponding to the ratio between the net mass flux (evaporation-condensation) and the mass flux of evaporation");
       prm.declare_entry(
-        "molar mass",
-        "1.0",
+        "recoil pressure coefficient",
+        "0.56",
         Patterns::Double(),
-        "Molar mass of the material in kg/mol");
-      prm.declare_entry(
-        "boiling temperature",
-        "1.0",
-        Patterns::Double(),
-        "Boiling temperature in K");
-      prm.declare_entry(
-        "evaporation latent heat",
-        "0.0",
-        Patterns::Double(),
-        "Latent heat of evaporation in J/kg");
-      prm.declare_entry(
-        "ambient pressure",
-        "101.325",
-        Patterns::Double(),
-        "Ambient pressure in kPa");
-      prm.declare_entry(
-        "ambient gas density",
-        "1.0",
-        Patterns::Double(),
-        "Ambient gas density in kg/m3");
-      prm.declare_entry(
-        "liquid density",
-        "10.0",
-        Patterns::Double(),
-        "Liquid density in kg/m3");
+        "Recoil pressure coefficient corresponding to the factor applied to the staturation pressure to compute the recoil pressure in an out of equilibrium evaportation");
+      prm.declare_entry("molar mass",
+                        "1.0",
+                        Patterns::Double(),
+                        "Molar mass of the material in kg/mol");
+      prm.declare_entry("boiling temperature",
+                        "1.0",
+                        Patterns::Double(),
+                        "Boiling temperature in K");
+      prm.declare_entry("evaporation latent heat",
+                        "0.0",
+                        Patterns::Double(),
+                        "Latent heat of evaporation in J/kg");
+      prm.declare_entry("ambient pressure",
+                        "101.325",
+                        Patterns::Double(),
+                        "Ambient pressure in kPa");
+      prm.declare_entry("ambient gas density",
+                        "1.0",
+                        Patterns::Double(),
+                        "Ambient gas density in kg/m3");
+      prm.declare_entry("liquid density",
+                        "10.0",
+                        Patterns::Double(),
+                        "Liquid density in kg/m3");
     }
     prm.leave_subsection();
   }
@@ -3312,28 +3311,31 @@ namespace Parameters
       op = prm.get("evaporation mass flux model");
       if (op == "constant")
         {
-          evaporative_mass_flux_model_type = EvaporativeMassFluxModelType::constant;
+          evaporative_mass_flux_model_type =
+            EvaporativeMassFluxModelType::constant;
         }
       else if (op == "temperature dependent")
         {
-          evaporative_mass_flux_model_type = EvaporativeMassFluxModelType::temperature_dependent;
+          evaporative_mass_flux_model_type =
+            EvaporativeMassFluxModelType::temperature_dependent;
         }
       else
         throw(std::runtime_error(
           "Invalid evaporative mass flux model. The choices are <constant>."));
 
       enable_evaporation_cooling = prm.get_bool("enable evaporative cooling");
-      enable_recoil_pressure = prm.get_bool("enable recoil pressure");
-      
-      n_evaporation =  prm.get_double("evaporation mass flux");
-      evaporation_coefficient =  prm.get_double("evaporation coefficient");
-      molar_mass = prm.get_double("molar mass");
-      boiling_temperature = prm.get_double("boiling temperature");
+      enable_recoil_pressure     = prm.get_bool("enable recoil pressure");
+
+      n_evaporation           = prm.get_double("evaporation mass flux");
+      evaporation_coefficient = prm.get_double("evaporation coefficient");
+      recoil_pressure_coefficient =
+        prm.get_double("recoil pressure coefficient");
+      molar_mass              = prm.get_double("molar mass");
+      boiling_temperature     = prm.get_double("boiling temperature");
       latent_heat_evaporation = prm.get_double("evaporation latent heat");
-      ambient_pressure = prm.get_double("ambient pressure");
-      ambient_gas_density = prm.get_double("ambient gas density");
-      liquid_density = prm.get_double("liquid density");
-      
+      ambient_pressure        = prm.get_double("ambient pressure");
+      ambient_gas_density     = prm.get_double("ambient gas density");
+      liquid_density          = prm.get_double("liquid density");
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3246,7 +3246,7 @@ namespace Parameters
       prm.declare_entry(
         "evaporation mass flux model",
         "constant",
-        Patterns::Selection("constant|temperature dependent"),
+        Patterns::Selection("constant|temperature_dependent"),
         "Model used for the calculation of the evaporative mass flux"
         "Choices are <constant|temperature dependent>.");
       prm.declare_entry(
@@ -3314,7 +3314,7 @@ namespace Parameters
           evaporative_mass_flux_model_type =
             EvaporativeMassFluxModelType::constant;
         }
-      else if (op == "temperature dependent")
+      else if (op == "temperature_dependent")
         {
           evaporative_mass_flux_model_type =
             EvaporativeMassFluxModelType::temperature_dependent;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3248,7 +3248,7 @@ namespace Parameters
         "constant",
         Patterns::Selection("constant|temperature_dependent"),
         "Model used for the calculation of the evaporative mass flux"
-        "Choices are <constant|temperature dependent>.");
+        "Choices are <constant|temperature_dependent>.");
       prm.declare_entry(
         "enable evaporative cooling",
         "false",
@@ -3273,7 +3273,7 @@ namespace Parameters
         "recoil pressure coefficient",
         "0.56",
         Patterns::Double(),
-        "Recoil pressure coefficient corresponding to the factor applied to the staturation pressure to compute the recoil pressure in an out of equilibrium evaportation");
+        "Recoil pressure coefficient corresponding to the factor applied to the saturation pressure to compute the recoil pressure in an out of equilibrium evaportation");
       prm.declare_entry("molar mass",
                         "1.0",
                         Patterns::Double(),
@@ -3289,15 +3289,15 @@ namespace Parameters
       prm.declare_entry("ambient pressure",
                         "101325",
                         Patterns::Double(),
-                        "Ambient pressure in Pa");
+                        "Pressure of the ambient gas in Pa");
       prm.declare_entry("ambient gas density",
                         "1.0",
                         Patterns::Double(),
-                        "Ambient gas density in kg/m3");
+                        "Ambient gas density in kg/m^3");
       prm.declare_entry("liquid density",
                         "10.0",
                         Patterns::Double(),
-                        "Liquid density in kg/m3");
+                        "Liquid density in kg/m^3");
     }
     prm.leave_subsection();
   }
@@ -3321,12 +3321,12 @@ namespace Parameters
         }
       else
         throw(std::runtime_error(
-          "Invalid evaporative mass flux model. The choices are <constant>."));
+          "Invalid evaporative mass flux model. The choices are <constant|temperature_dependent>."));
 
       enable_evaporation_cooling = prm.get_bool("enable evaporative cooling");
       enable_recoil_pressure     = prm.get_bool("enable recoil pressure");
 
-      n_evaporation           = prm.get_double("evaporation mass flux");
+      evaporation_mass_flux   = prm.get_double("evaporation mass flux");
       evaporation_coefficient = prm.get_double("evaporation coefficient");
       recoil_pressure_coefficient =
         prm.get_double("recoil pressure coefficient");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3260,6 +3260,11 @@ namespace Parameters
         Patterns::Bool(),
         "Enable the recoil pressure due to evaporation at the free surface (air/metal interface) in the momentum equation <true|false>");
       prm.declare_entry(
+        "evaporation mass flux",
+        "0.1",
+        Patterns::Double(),
+        "Evaporation mass flux used if the constant evaporation model is selected");
+      prm.declare_entry(
         "evaporation coefficient",
         "0.82",
         Patterns::Double(),
@@ -3284,7 +3289,18 @@ namespace Parameters
         "101.325",
         Patterns::Double(),
         "Ambient pressure in kPa");
+      prm.declare_entry(
+        "ambient gas density",
+        "1.0",
+        Patterns::Double(),
+        "Ambient gas density in kg/m3");
+      prm.declare_entry(
+        "liquid density",
+        "10.0",
+        Patterns::Double(),
+        "Liquid density in kg/m3");
     }
+    prm.leave_subsection();
   }
 
   void
@@ -3305,12 +3321,17 @@ namespace Parameters
       enable_evaporation_cooling = prm.get_bool("enable evaporative cooling");
       enable_recoil_pressure = prm.get_bool("enable recoil pressure");
       
+      n_evaporation =  prm.get_double("evaporation mass flux");
       evaporation_coefficient =  prm.get_double("evaporation coefficient");
       molar_mass = prm.get_double("molar mass");
       boiling_temperature = prm.get_double("boiling temperature");
       latent_heat_evaporation = prm.get_double("latent heat of evaporation");
       ambient_pressure = prm.get_double("ambient pressure");
+      ambient_gas_density = prm.get_double("ambient gas density");
+      liquid_density = prm.get_double("liquid density");
+      
     }
+    prm.leave_subsection();
   }
 
   Tensor<1, 3>

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3253,12 +3253,12 @@ namespace Parameters
         "enable evaporative cooling",
         "false",
         Patterns::Bool(),
-        "Enable the evaporative cooling at the free surface (air/metal interface) in the energy equation <true|false>");
+        "Enable the evaporative cooling at the free surface (gas/liquid interface) in the energy equation <true|false>");
       prm.declare_entry(
         "enable recoil pressure",
         "false",
         Patterns::Bool(),
-        "Enable the recoil pressure due to evaporation at the free surface (air/metal interface) in the momentum equation <true|false>");
+        "Enable the recoil pressure due to evaporation at the free surface (gas/liquid interface) in the momentum equation <true|false>");
       prm.declare_entry(
         "evaporation mass flux",
         "0.0",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3246,9 +3246,9 @@ namespace Parameters
       prm.declare_entry(
         "evaporation mass flux model",
         "constant",
-        Patterns::Selection("constant"),
+        Patterns::Selection("constant|temperature dependent"),
         "Model used for the calculation of the evaporative mass flux"
-        "Choices are <constant|pure material>.");
+        "Choices are <constant|temperature dependent>.");
       prm.declare_entry(
         "enable evaporative cooling",
         "false",
@@ -3261,7 +3261,7 @@ namespace Parameters
         "Enable the recoil pressure due to evaporation at the free surface (air/metal interface) in the momentum equation <true|false>");
       prm.declare_entry(
         "evaporation mass flux",
-        "0.1",
+        "0.0",
         Patterns::Double(),
         "Evaporation mass flux used if the constant evaporation model is selected");
       prm.declare_entry(
@@ -3271,12 +3271,12 @@ namespace Parameters
         "Evaporation coefficient corresponding to the ratio between the net mass flux (evaporation-condensation) and the mass flux of evaporation");
       prm.declare_entry(
         "molar mass",
-        "0.0",
+        "1.0",
         Patterns::Double(),
         "Molar mass of the material in kg/mol");
       prm.declare_entry(
         "boiling temperature",
-        "0.0",
+        "1.0",
         Patterns::Double(),
         "Boiling temperature in K");
       prm.declare_entry(
@@ -3313,6 +3313,10 @@ namespace Parameters
       if (op == "constant")
         {
           evaporative_mass_flux_model_type = EvaporativeMassFluxModelType::constant;
+        }
+      else if (op == "temperature dependent")
+        {
+          evaporative_mass_flux_model_type = EvaporativeMassFluxModelType::temperature_dependent;
         }
       else
         throw(std::runtime_error(

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3287,9 +3287,9 @@ namespace Parameters
                         Patterns::Double(),
                         "Latent heat of evaporation in J/kg");
       prm.declare_entry("ambient pressure",
-                        "101.325",
+                        "101325",
                         Patterns::Double(),
-                        "Ambient pressure in kPa");
+                        "Ambient pressure in Pa");
       prm.declare_entry("ambient gas density",
                         "1.0",
                         Patterns::Double(),

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3237,6 +3237,81 @@ namespace Parameters
 
     prm.leave_subsection();
   }
+  
+  void
+  Evaporation::declare_parameters(dealii::ParameterHandler &prm)
+  {
+    prm.enter_subsection("evaporation");
+    {
+      prm.declare_entry(
+        "evaporative mass flux model",
+        "constant",
+        Patterns::Selection("constant"),
+        "Model used for the calculation of the evaporative mass flux"
+        "Choices are <constant|pure material>.");
+      prm.declare_entry(
+        "enable evaporative cooling",
+        "false",
+        Patterns::Bool(),
+        "Enable the evaporative cooling at the free surface (air/metal interface) in the energy equation <true|false>");
+      prm.declare_entry(
+        "enable recoil pressure",
+        "false",
+        Patterns::Bool(),
+        "Enable the recoil pressure due to evaporation at the free surface (air/metal interface) in the momentum equation <true|false>");
+      prm.declare_entry(
+        "evaporation coefficient",
+        "0.82",
+        Patterns::Double(),
+        "Evaporation coefficient corresponding to the ratio between the net mass flux (evaporation-condensation) and the mass flux of evaporation");
+      prm.declare_entry(
+        "molar mass",
+        "0.0",
+        Patterns::Double(),
+        "Molar mass of the material in kg/mol");
+      prm.declare_entry(
+        "boiling temperature",
+        "0.0",
+        Patterns::Double(),
+        "Boiling temperature in K");
+      prm.declare_entry(
+        "latent heat of evaporation",
+        "0.0",
+        Patterns::Double(),
+        "Latent heat of evaporation in J/kg");
+      prm.declare_entry(
+        "ambient pressure",
+        "101.325",
+        Patterns::Double(),
+        "Ambient pressure in kPa");
+    }
+  }
+
+  void
+  Evaporation::parse_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection("evaporation");
+    {
+      std::string op;
+      op = prm.get("evaporative mass flux model");
+      if (op == "constant")
+        {
+          evaporative_mass_flux_model_type = EvaporativeMassFluxModelType::constant;
+        }
+      else
+        throw(std::runtime_error(
+          "Invalid evaporative mass flux model. The choices are <constant>."));
+
+      enable_evaporation_cooling = prm.get_bool("enable evaporative cooling");
+      enable_recoil_pressure = prm.get_bool("enable recoil pressure");
+      
+      evaporation_coefficient =  prm.get_double("evaporation coefficient");
+      molar_mass = prm.get_double("molar mass");
+      boiling_temperature = prm.get_double("boiling temperature");
+      latent_heat_evaporation = prm.get_double("latent heat of evaporation");
+      ambient_pressure = prm.get_double("ambient pressure");
+    }
+  }
 
   Tensor<1, 3>
   entry_string_to_tensor3(ParameterHandler  &prm,

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3244,7 +3244,7 @@ namespace Parameters
     prm.enter_subsection("evaporation");
     {
       prm.declare_entry(
-        "evaporative mass flux model",
+        "evaporation mass flux model",
         "constant",
         Patterns::Selection("constant"),
         "Model used for the calculation of the evaporative mass flux"
@@ -3280,7 +3280,7 @@ namespace Parameters
         Patterns::Double(),
         "Boiling temperature in K");
       prm.declare_entry(
-        "latent heat of evaporation",
+        "evaporation latent heat",
         "0.0",
         Patterns::Double(),
         "Latent heat of evaporation in J/kg");
@@ -3309,7 +3309,7 @@ namespace Parameters
     prm.enter_subsection("evaporation");
     {
       std::string op;
-      op = prm.get("evaporative mass flux model");
+      op = prm.get("evaporation mass flux model");
       if (op == "constant")
         {
           evaporative_mass_flux_model_type = EvaporativeMassFluxModelType::constant;
@@ -3325,7 +3325,7 @@ namespace Parameters
       evaporation_coefficient =  prm.get_double("evaporation coefficient");
       molar_mass = prm.get_double("molar mass");
       boiling_temperature = prm.get_double("boiling temperature");
-      latent_heat_evaporation = prm.get_double("latent heat of evaporation");
+      latent_heat_evaporation = prm.get_double("evaporation latent heat");
       ambient_pressure = prm.get_double("ambient pressure");
       ambient_gas_density = prm.get_double("ambient gas density");
       liquid_density = prm.get_double("liquid density");

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -486,15 +486,15 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
                   this->simulation_control, this->simulation_parameters));
             }
         }
-        
-      // Recoil pressure 
+
+      // Recoil pressure
       if (this->simulation_parameters.evaporation.enable_recoil_pressure)
-      {
-        this->assemblers.push_back(
-              std::make_shared<NavierStokesVOFAssemblerEvaporation<dim>>(
-                this->simulation_control,
-                this->simulation_parameters.evaporation));
-      }
+        {
+          this->assemblers.push_back(
+            std::make_shared<NavierStokesVOFAssemblerEvaporation<dim>>(
+              this->simulation_control,
+              this->simulation_parameters.evaporation));
+        }
 
       if (this->simulation_parameters.physical_properties_manager
             .is_non_newtonian())

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -486,6 +486,15 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
                   this->simulation_control, this->simulation_parameters));
             }
         }
+        
+      // Recoil pressure 
+      if (this->simulation_parameters.evaporation.enable_recoil_pressure)
+      {
+        this->assemblers.push_back(
+              std::make_shared<NavierStokesVOFAssemblerEvaporation<dim>>(
+                this->simulation_control,
+                this->simulation_parameters.evaporation));
+      }
 
       if (this->simulation_parameters.physical_properties_manager
             .is_non_newtonian())

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -315,7 +315,18 @@ HeatTransfer<dim>::setup_assemblers()
               this->simulation_parameters.laser_parameters));
         }
     }
-
+  
+  // Evaporation cooling 
+  if (this->simulation_parameters.multiphysics.VOF)
+    {
+      if (this->simulation_parameters.evaporation.enable_evaporation_cooling)
+        {
+          this->assemblers.push_back(
+                std::make_shared<HeatTransferAssemblerVOFEvaporation<dim>>(
+                  this->simulation_control,
+                  this->simulation_parameters.evaporation));
+        }
+    }
   // Robin boundary condition
   this->assemblers.push_back(
     std::make_shared<HeatTransferAssemblerRobinBC<dim>>(

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -315,16 +315,16 @@ HeatTransfer<dim>::setup_assemblers()
               this->simulation_parameters.laser_parameters));
         }
     }
-  
-  // Evaporation cooling 
+
+  // Evaporation cooling
   if (this->simulation_parameters.multiphysics.VOF)
     {
       if (this->simulation_parameters.evaporation.enable_evaporation_cooling)
         {
           this->assemblers.push_back(
-                std::make_shared<HeatTransferAssemblerVOFEvaporation<dim>>(
-                  this->simulation_control,
-                  this->simulation_parameters.evaporation));
+            std::make_shared<HeatTransferAssemblerVOFEvaporation<dim>>(
+              this->simulation_control,
+              this->simulation_parameters.evaporation));
         }
     }
   // Robin boundary condition

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -327,6 +327,7 @@ HeatTransfer<dim>::setup_assemblers()
               this->simulation_parameters.evaporation));
         }
     }
+    
   // Robin boundary condition
   this->assemblers.push_back(
     std::make_shared<HeatTransferAssemblerRobinBC<dim>>(

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -327,7 +327,7 @@ HeatTransfer<dim>::setup_assemblers()
               this->simulation_parameters.evaporation));
         }
     }
-    
+
   // Robin boundary condition
   this->assemblers.push_back(
     std::make_shared<HeatTransferAssemblerRobinBC<dim>>(

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -1160,8 +1160,7 @@ HeatTransferAssemblerFreeSurfaceRadiationVOF<dim>::assemble_rhs(
           // surface, T is the current temperature and T_inf is the reference
           // (environment) temperature.
           local_rhs(i) -=
-            filtered_phase_gradient_q.norm() * Stefan_Boltzmann_constant *
-            emissivity *
+            filtered_phase_gradient_q.norm() * Stefan_Boltzmann_constant * emissivity *
             (temperature * temperature * temperature * temperature -
              T_inf * T_inf * T_inf * T_inf) *
             phi_T_i * JxW;
@@ -1198,7 +1197,7 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_matrix(
         this->evaporation_model->heat_flux_jacobian(field_value,
                                                     field::temperature);
 
-      const Tensor<1, dim> phase_gradient_q =
+      const Tensor<1, dim> filtered_phase_gradient_q =
         scratch_data.filtered_phase_gradient_values[q];
 
       // Store JxW in local variable for faster access
@@ -1212,7 +1211,7 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_matrix(
             {
               const auto phi_T_j = scratch_data.phi_T[q][j];
 
-              local_matrix(i, j) += phase_gradient_q.norm() *
+              local_matrix(i, j) += filtered_phase_gradient_q.norm() *
                                     evaporative_heat_flux_jacobian * phi_T_i *
                                     phi_T_j * JxW;
             }
@@ -1244,7 +1243,7 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
       const double evaporative_heat_flux =
         this->evaporation_model->heat_flux(field_value);
 
-      const Tensor<1, dim> phase_gradient_q =
+      const Tensor<1, dim> filtered_phase_gradient_q =
         scratch_data.filtered_phase_gradient_values[q];
       // Store JxW in local variable for faster access
       const double JxW = scratch_data.fe_values_T.JxW(q);
@@ -1254,7 +1253,7 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
           const auto phi_T_i = scratch_data.phi_T[q][i];
 
           local_rhs(i) -=
-            phase_gradient_q.norm() * evaporative_heat_flux * phi_T_i * JxW;
+            filtered_phase_gradient_q.norm() * evaporative_heat_flux * phi_T_i * JxW;
         }
 
     } // end loop on quadrature points

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -1172,3 +1172,99 @@ HeatTransferAssemblerFreeSurfaceRadiationVOF<dim>::assemble_rhs(
 
 template class HeatTransferAssemblerFreeSurfaceRadiationVOF<2>;
 template class HeatTransferAssemblerFreeSurfaceRadiationVOF<3>;
+
+template <int dim>
+void
+HeatTransferAssemblerVOFEvaporation<dim>::assemble_matrix(
+  HeatTransferScratchData<dim> &scratch_data,
+  StabilizedMethodsCopyData    &copy_data)
+{
+  // Loop and quadrature informations
+  const unsigned int n_q_points = scratch_data.n_q_points;
+  const unsigned int n_dofs     = scratch_data.n_dofs;
+
+  // Copy data elements
+  auto &local_matrix = copy_data.local_matrix;
+
+  // assembling local matrix and right hand side
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      const double temperature = scratch_data.present_temperature_values[q];
+      
+      std::map<field, double> field_value;
+      field_value[field::temperature] = temperature;
+      
+      const double evaporative_heat_flux_jacobian = this->evaporation_model->heat_flux_jacobian(field_value, field::temperature);
+
+      const Tensor<1, dim> phase_gradient_q =
+        scratch_data.filtered_phase_gradient_values[q];
+        
+      // Store JxW in local variable for faster access
+      const double JxW = scratch_data.fe_values_T.JxW(q);
+
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto phi_T_i = scratch_data.phi_T[q][i];
+
+          for (unsigned int j = 0; j < n_dofs; ++j)
+            {
+              const auto phi_T_j = scratch_data.phi_T[q][j];
+              
+              local_matrix(i, j) +=
+                phase_gradient_q.norm() *
+                evaporative_heat_flux_jacobian *
+                phi_T_i * phi_T_j * JxW;
+            }
+        }
+    } // end loop on quadrature points
+}
+
+template <int dim>
+void
+HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
+  HeatTransferScratchData<dim> &scratch_data,
+  StabilizedMethodsCopyData    &copy_data)
+{
+  // Loop and quadrature informations
+  const unsigned int n_q_points = scratch_data.n_q_points;
+  const unsigned int n_dofs     = scratch_data.n_dofs;
+
+  // Copy data elements
+  auto &local_rhs = copy_data.local_rhs;
+
+  // assembling local matrix and right hand side
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      const double temperature = scratch_data.present_temperature_values[q];
+      
+      std::map<field, double> field_value;
+      field_value[field::temperature] = temperature;
+      
+      const double evaporative_heat_flux = this->evaporation_model->heat_flux(field_value);
+      
+      const Tensor<1, dim> phase_gradient_q =
+        scratch_data.filtered_phase_gradient_values[q];
+      // Store JxW in local variable for faster access
+      const double JxW = scratch_data.fe_values_T.JxW(q);
+
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto phi_T_i = scratch_data.phi_T[q][i];
+
+          // Rhs for the linearised radiation sink term at the meltpool free
+          // surface: |grad alpha|* sigma * epsilon * (T^3 - T_inf^3),
+          // where |grad alpha| is the phase gradient norm (which indicates an
+          // interface between the metal and air if non-null), sigma is the
+          // Stefan Boltzmann constant, epsilon is the emissivity of the free
+          // surface, T is the current temperature and T_inf is the reference
+          // (environment) temperature.
+          local_rhs(i) -=
+            phase_gradient_q.norm() * evaporative_heat_flux *
+            phi_T_i * JxW;
+        }
+
+    } // end loop on quadrature points
+}
+
+template class HeatTransferAssemblerVOFEvaporation<2>;
+template class HeatTransferAssemblerVOFEvaporation<3>;

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -1160,7 +1160,8 @@ HeatTransferAssemblerFreeSurfaceRadiationVOF<dim>::assemble_rhs(
           // surface, T is the current temperature and T_inf is the reference
           // (environment) temperature.
           local_rhs(i) -=
-            filtered_phase_gradient_q.norm() * Stefan_Boltzmann_constant * emissivity *
+            filtered_phase_gradient_q.norm() * Stefan_Boltzmann_constant *
+            emissivity *
             (temperature * temperature * temperature * temperature -
              T_inf * T_inf * T_inf * T_inf) *
             phi_T_i * JxW;
@@ -1252,8 +1253,8 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
         {
           const auto phi_T_i = scratch_data.phi_T[q][i];
 
-          local_rhs(i) -=
-            filtered_phase_gradient_q.norm() * evaporative_heat_flux * phi_T_i * JxW;
+          local_rhs(i) -= filtered_phase_gradient_q.norm() *
+                          evaporative_heat_flux * phi_T_i * JxW;
         }
 
     } // end loop on quadrature points

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -1256,7 +1256,6 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
           local_rhs(i) -= filtered_phase_gradient_q.norm() *
                           evaporative_heat_flux * phi_T_i * JxW;
         }
-
     } // end loop on quadrature points
 }
 

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -1190,15 +1190,17 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_matrix(
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       const double temperature = scratch_data.present_temperature_values[q];
-      
+
       std::map<field, double> field_value;
       field_value[field::temperature] = temperature;
-      
-      const double evaporative_heat_flux_jacobian = this->evaporation_model->heat_flux_jacobian(field_value, field::temperature);
+
+      const double evaporative_heat_flux_jacobian =
+        this->evaporation_model->heat_flux_jacobian(field_value,
+                                                    field::temperature);
 
       const Tensor<1, dim> phase_gradient_q =
         scratch_data.filtered_phase_gradient_values[q];
-        
+
       // Store JxW in local variable for faster access
       const double JxW = scratch_data.fe_values_T.JxW(q);
 
@@ -1209,11 +1211,10 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_matrix(
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
               const auto phi_T_j = scratch_data.phi_T[q][j];
-              
-              local_matrix(i, j) +=
-                phase_gradient_q.norm() *
-                evaporative_heat_flux_jacobian *
-                phi_T_i * phi_T_j * JxW;
+
+              local_matrix(i, j) += phase_gradient_q.norm() *
+                                    evaporative_heat_flux_jacobian * phi_T_i *
+                                    phi_T_j * JxW;
             }
         }
     } // end loop on quadrature points
@@ -1236,12 +1237,13 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       const double temperature = scratch_data.present_temperature_values[q];
-      
+
       std::map<field, double> field_value;
       field_value[field::temperature] = temperature;
-      
-      const double evaporative_heat_flux = this->evaporation_model->heat_flux(field_value);
-      
+
+      const double evaporative_heat_flux =
+        this->evaporation_model->heat_flux(field_value);
+
       const Tensor<1, dim> phase_gradient_q =
         scratch_data.filtered_phase_gradient_values[q];
       // Store JxW in local variable for faster access
@@ -1251,16 +1253,8 @@ HeatTransferAssemblerVOFEvaporation<dim>::assemble_rhs(
         {
           const auto phi_T_i = scratch_data.phi_T[q][i];
 
-          // Rhs for the linearised radiation sink term at the meltpool free
-          // surface: |grad alpha|* sigma * epsilon * (T^3 - T_inf^3),
-          // where |grad alpha| is the phase gradient norm (which indicates an
-          // interface between the metal and air if non-null), sigma is the
-          // Stefan Boltzmann constant, epsilon is the emissivity of the free
-          // surface, T is the current temperature and T_inf is the reference
-          // (environment) temperature.
           local_rhs(i) -=
-            phase_gradient_q.norm() * evaporative_heat_flux *
-            phi_T_i * JxW;
+            phase_gradient_q.norm() * evaporative_heat_flux * phi_T_i * JxW;
         }
 
     } // end loop on quadrature points

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -598,7 +598,10 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
       // Only temporary, should change if the evaporation also depends on the 
       // species concentration
       std::map<field, double> field_value;
-      field_value[field::temperature] = scratch_data.temperature_values[q];
+      if (this->evaporation_model->depends_on(field::temperature))
+      {
+        field_value[field::temperature] = scratch_data.temperature_values[q];
+      }
       
       // Recoil pressure
       const double recoil_pressure = this->evaporation_model->recoil_pressure(field_value);

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -622,7 +622,7 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
           const auto phi_u_i     = scratch_data.phi_u[q][i];
           double     local_rhs_i = 0;
 
-          local_rhs_i -= recoil_pressure_force * phi_u_i;
+          local_rhs_i += recoil_pressure_force * phi_u_i;
           local_rhs(i) += local_rhs_i * JxW_value;
         }
     }

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -465,12 +465,12 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
 
       // Gather pfg and curvature values
       const double         &curvature_value = scratch_data.curvature_values[q];
-      const Tensor<1, dim> &phase_gradient_value =
+      const Tensor<1, dim> &filtered_phase_gradient_value_q =
         scratch_data.filtered_phase_gradient_values[q];
       const double JxW_value = JxW[q];
 
       const Tensor<1, dim> surface_tension_force =
-        -surface_tension_coef * curvature_value * phase_gradient_value;
+        -surface_tension_coef * curvature_value * filtered_phase_gradient_value_q;
 
       strong_residual[q] += surface_tension_force;
 
@@ -528,13 +528,13 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
       const double &curvature_value = scratch_data.curvature_values[q];
 
       // Gather phase fraction gradient
-      const Tensor<1, dim> &phase_gradient_value =
+      const Tensor<1, dim> &filtered_phase_gradient_value_q =
         scratch_data.filtered_phase_gradient_values[q];
 
-      const double phase_gradient_norm = phase_gradient_value.norm();
+      const double filtered_phase_gradient_norm = filtered_phase_gradient_value_q.norm();
 
       const Tensor<1, dim> normalized_phase_fraction_gradient =
-        phase_gradient_value / (phase_gradient_norm + DBL_MIN);
+        filtered_phase_gradient_value_q / (filtered_phase_gradient_norm + DBL_MIN);
 
       // Gather temperature gradient
       const Tensor<1, dim> temperature_gradient =
@@ -544,14 +544,14 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
 
 
       const Tensor<1, dim> surface_tension_force =
-        -surface_tension * curvature_value * phase_gradient_value;
+        -surface_tension * curvature_value * filtered_phase_gradient_value_q;
 
       const Tensor<1, dim> marangoni_effect =
         -surface_tension_gradient *
         (temperature_gradient -
          normalized_phase_fraction_gradient *
            (normalized_phase_fraction_gradient * temperature_gradient)) *
-        phase_gradient_norm;
+        filtered_phase_gradient_norm;
 
       strong_residual[q] += marangoni_effect + surface_tension_force;
 
@@ -607,13 +607,13 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
         this->evaporation_model->momentum_flux(field_value);
 
       // Gather phase fraction gradient
-      const Tensor<1, dim> &phase_gradient_value =
+      const Tensor<1, dim> &filtered_phase_gradient_value_q =
         scratch_data.filtered_phase_gradient_values[q];
 
       const double JxW_value = JxW[q];
 
       const Tensor<1, dim> recoil_pressure_force =
-        recoil_pressure * phase_gradient_value;
+        recoil_pressure * filtered_phase_gradient_value_q;
 
       strong_residual[q] += recoil_pressure_force;
 

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -582,7 +582,6 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
-
   // Loop and quadrature information
   const auto        &JxW        = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
@@ -595,16 +594,17 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      // Only temporary, should change if the evaporation also depends on the 
+      // Only temporary, should change if the evaporation also depends on the
       // species concentration
       std::map<field, double> field_value;
       if (this->evaporation_model->depends_on(field::temperature))
-      {
-        field_value[field::temperature] = scratch_data.temperature_values[q];
-      }
-      
+        {
+          field_value[field::temperature] = scratch_data.temperature_values[q];
+        }
+
       // Recoil pressure
-      const double recoil_pressure = this->evaporation_model->recoil_pressure(field_value);
+      const double recoil_pressure =
+        this->evaporation_model->momentum_flux(field_value);
 
       // Gather phase fraction gradient
       const Tensor<1, dim> &phase_gradient_value =

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -470,7 +470,8 @@ GLSNavierStokesVOFAssemblerSTF<dim>::assemble_rhs(
       const double JxW_value = JxW[q];
 
       const Tensor<1, dim> surface_tension_force =
-        -surface_tension_coef * curvature_value * filtered_phase_gradient_value_q;
+        -surface_tension_coef * curvature_value *
+        filtered_phase_gradient_value_q;
 
       strong_residual[q] += surface_tension_force;
 
@@ -531,10 +532,12 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
       const Tensor<1, dim> &filtered_phase_gradient_value_q =
         scratch_data.filtered_phase_gradient_values[q];
 
-      const double filtered_phase_gradient_norm = filtered_phase_gradient_value_q.norm();
+      const double filtered_phase_gradient_norm =
+        filtered_phase_gradient_value_q.norm();
 
       const Tensor<1, dim> normalized_phase_fraction_gradient =
-        filtered_phase_gradient_value_q / (filtered_phase_gradient_norm + DBL_MIN);
+        filtered_phase_gradient_value_q /
+        (filtered_phase_gradient_norm + DBL_MIN);
 
       // Gather temperature gradient
       const Tensor<1, dim> temperature_gradient =

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -569,6 +569,71 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
 template class GLSNavierStokesVOFAssemblerMarangoni<2>;
 template class GLSNavierStokesVOFAssemblerMarangoni<3>;
 
+template <int dim>
+void
+NavierStokesVOFAssemblerEvaporation<dim>::assemble_matrix(
+  NavierStokesScratchData<dim> & /*scratch_data*/,
+  StabilizedMethodsTensorCopyData<dim> & /*copy_data*/)
+{}
+
+template <int dim>
+void
+NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
+  NavierStokesScratchData<dim>         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &copy_data)
+{
+
+  // Loop and quadrature information
+  const auto        &JxW        = scratch_data.JxW;
+  const unsigned int n_q_points = scratch_data.n_q_points;
+  const unsigned int n_dofs     = scratch_data.n_dofs;
+
+  // Copy data elements
+  auto &strong_residual = copy_data.strong_residual;
+  auto &local_rhs       = copy_data.local_rhs;
+
+  // Loop over the quadrature points
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      // Only temporary, should change if the evaporation also depends on the 
+      // species concentration
+      std::map<field, double> field_value;
+      field_value[field::temperature] = scratch_data.temperature_values[q];
+      
+      // Recoil pressure
+      const double recoil_pressure = this->evaporation_model->recoil_pressure(field_value);
+
+      // Gather phase fraction gradient
+      const Tensor<1, dim> &phase_gradient_value =
+        scratch_data.filtered_phase_gradient_values[q];
+
+      const double phase_gradient_norm = phase_gradient_value.norm();
+
+      const Tensor<1, dim> normalized_phase_fraction_gradient =
+        phase_gradient_value / (phase_gradient_norm + DBL_MIN);
+
+
+      const double JxW_value = JxW[q];
+
+
+      const Tensor<1, dim> recoil_pressure_force =
+        recoil_pressure * phase_gradient_value;
+
+      strong_residual[q] += recoil_pressure_force;
+
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto phi_u_i     = scratch_data.phi_u[q][i];
+          double     local_rhs_i = 0;
+
+          local_rhs_i -= recoil_pressure_force * phi_u_i;
+          local_rhs(i) += local_rhs_i * JxW_value;
+        }
+    }
+}
+
+template class NavierStokesVOFAssemblerEvaporation<2>;
+template class NavierStokesVOFAssemblerEvaporation<3>;
 
 template <int dim>
 void

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -607,14 +607,7 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
       const Tensor<1, dim> &phase_gradient_value =
         scratch_data.filtered_phase_gradient_values[q];
 
-      const double phase_gradient_norm = phase_gradient_value.norm();
-
-      const Tensor<1, dim> normalized_phase_fraction_gradient =
-        phase_gradient_value / (phase_gradient_norm + DBL_MIN);
-
-
       const double JxW_value = JxW[q];
-
 
       const Tensor<1, dim> recoil_pressure_force =
         recoil_pressure * phase_gradient_value;


### PR DESCRIPTION
# Description of the problem

The evaporative heat and momentum fluxes were missing to complete the LPBF model.

# Description of the solution

- Both terms were added.
- Two model are now avaible: a constant one and a tempereture dependent one. The latter is based on Anisimov and Khokhlov 1995.

# How Has This Been Tested?

The following tests were added.

- [x] static_bubble_evaporation.prm for the constant momentum flux
- [x] constant_evaporation_plane.prm for the constant heat flux
- [x] temperature_dependent_evaporation_plane.prm for the temperature dependent heat flux

Temperature dependent momentum flux will be tested in an upcoming 2D lpbf simulation.

# Documentation

- it will be added in a future PR

# Future changes

- Documenation and a complete LPBF 2D example will be added in an upcoming PR.


