### PR TITLE
Bugfix, dem fixing critical rayleigh time step

### DIFF
--- a/applications_tests/lethe-particles/two_types_packing_in_circle.output
+++ b/applications_tests/lethe-particles/two_types_packing_in_circle.output
@@ -2,7 +2,7 @@
 *********************
 Running on 1 rank(s)
 *********************
-DEM time-step is 1.3343% of Rayleigh time step
+DEM time-step is 3.27105% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation

--- a/source/dem/input_parameter_inspection.cc
+++ b/source/dem/input_parameter_inspection.cc
@@ -19,7 +19,7 @@ input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
       double shear_modulus =
         physical_properties.youngs_modulus_particle[i] /
         (2.0 * (1.0 + physical_properties.poisson_ratio_particle[i]));
-      rayleigh_time_step = std::max(
+      rayleigh_time_step = std::min(
         M_PI_2 * physical_properties.particle_average_diameter[i] *
           sqrt(physical_properties.density_particle[i] / shear_modulus) /
           (0.1631 * physical_properties.poisson_ratio_particle[i] + 0.8766),

--- a/source/dem/input_parameter_inspection.cc
+++ b/source/dem/input_parameter_inspection.cc
@@ -12,7 +12,7 @@ input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
   // Getting the input parameters as local variable
   auto   parameters          = dem_parameters;
   auto   physical_properties = dem_parameters.lagrangian_physical_properties;
-  double rayleigh_time_step  = 0;
+  double rayleigh_time_step  = 1. / DBL_MIN;
 
   for (unsigned int i = 0; i < physical_properties.particle_type_number; ++i)
     {


### PR DESCRIPTION
# Description of the problem

- The inspection of the DEM time step was wrong. It should be searching for the more restrictive rayleigh time, that is the minimum rayleigh time, not the maximum. 

# Description of the solution

- The rayleigh time step is initialize to infinity. 
- We use std::min instead of std::max. 

# How Has This Been Tested?

- One test has been updated. 
- All the other test are still succeeding 
- 
# Documentation

- N/A
