### PR TITLE
Remove avg dia + fix documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master] - 2023-11-27
 
+### Removed
+
+- MINOR The average diameter of the uniform size distribution with the DEM module was specified with a "average diameter" paramter. It is now specified directly from the diameter parameter. This is correctly documented. [#940](https://github.com/lethe-cfd/lethe/pull/940).
+
+## [Master] - 2023-11-27
+
 ### Fixed
 
 - MINOR The DEM time step verification was outputting the the most permissive time step (the biggest) and not the most restrive (the smallest). This bugfix doesn`t affect the uniform particle size simulation. [#939](https://github.com/lethe-cfd/lethe/pull/939).

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -27,6 +27,9 @@ In this subsection, gravitational acceleration, and the physical properties of t
       # Particle diameter
       set diameter                          = 0.005
 
+      # Standard deviation
+      set standard deviation                = 0.0
+
       # Number of particles in type 0
       set number of particles               = 132300
 
@@ -85,9 +88,9 @@ In this subsection, gravitational acceleration, and the physical properties of t
 .. note::
     For each particle type, two ``size distribution type``s can be defined: ``uniform`` and ``normal``. In ``uniform`` size distribution, the diameter of the particles is constant, while in ``normal`` size distribution, the particle diameters are sampled from a normal distribution with an average of ``average diameter`` and standard deviation of ``standard deviation``.
 
-* The ``diameter`` parameter defines the diameter of the particles in a ``uniform`` distribution.
+* The ``diameter`` parameter defines the diameter of the particles in a ``uniform`` distribution. In the case of a ``normal`` distribution, this parameter indicates the average diameter.
 
-* For a ``normal`` distribution, we need to define ``average diameter`` and ``standard deviation`` parameters.
+* For a ``normal`` distribution, the ``standard deviation`` parameter should be defined to indicate the standard deviation on the particle size distribution.
 
 * The ``number of particles`` parameter defines the number of particles for each type.
 

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -18,10 +18,6 @@ namespace Parameters
                         "0.001",
                         Patterns::Double(),
                         "Particle diameter");
-      prm.declare_entry("average diameter",
-                        "0.001",
-                        Patterns::Double(),
-                        "Average particle diameter");
       prm.declare_entry("standard deviation",
                         "0",
                         Patterns::Double(),
@@ -67,6 +63,7 @@ namespace Parameters
     {
       const std::string size_distribution_type_str =
         prm.get("size distribution type");
+
       if (size_distribution_type_str == "uniform")
         {
           size_distribution_type = size_distribution_type::uniform;
@@ -77,7 +74,7 @@ namespace Parameters
         {
           size_distribution_type = size_distribution_type::normal;
           particle_average_diameter.at(particle_type) =
-            prm.get_double("average diameter");
+            prm.get_double("diameter");
           particle_size_std.at(particle_type) =
             prm.get_double("standard deviation");
         }


### PR DESCRIPTION


# Description of the problem

- The standard deviation parameter was not clearly defined in the documentation
-  We had an average diameter and diameter parameter. This is confusing for no reason.

# Description of the solution

- Clear our the documentation and remove the average diameter parameter. It does not impact anything on the data structures anyway so yay!

# How Has This Been Tested?

-  All unit tests passed on my machine.

# Documentation

-  Changed documentation on the particle type themselves.
