### PR TITLE
Fix compilation of prototypes

### DIFF
--- a/prototypes/chorin_navier_stokes/chorin_navier_stokes.cc
+++ b/prototypes/chorin_navier_stokes/chorin_navier_stokes.cc
@@ -110,7 +110,7 @@ public:
   MMSSineForcingFunction()
     : Function<dim>(2){};
   virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const;
+  vector_value(const Point<dim> &p, Vector<double> &values) const override;
 };
 template <int dim>
 void
@@ -143,7 +143,7 @@ public:
   NoForce()
     : Function<dim>(2){};
   virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const;
+  vector_value(const Point<dim> &p, Vector<double> &values) const override;
 };
 template <int dim>
 void
@@ -163,7 +163,7 @@ public:
     : Function<dim>(2)
   {}
   virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const;
+  vector_value(const Point<dim> &p, Vector<double> &values) const override;
 };
 template <int dim>
 void

--- a/prototypes/direct_gls_navier_stokes/boundaryconditions.h
+++ b/prototypes/direct_gls_navier_stokes/boundaryconditions.h
@@ -8,7 +8,7 @@ public:
   RotatingWall () : Function<dim>(dim+1) {}
 
   virtual double value (const Point<dim>   &p,
-                        const unsigned int  component ) const;
+                        const unsigned int  component ) const override;
 };
 
 
@@ -17,7 +17,7 @@ double RotatingWall<dim>::value (const Point<dim> &p,
                                    const unsigned int component) const
 {
     Assert (component < this->n_components,
-            ExcIndexRange (component, 0, this->n_components))
+            ExcIndexRange (component, 0, this->n_components));
 
     if (component==0)
         return -p[1];

--- a/prototypes/direct_gls_navier_stokes/exactsolutions.h
+++ b/prototypes/direct_gls_navier_stokes/exactsolutions.h
@@ -10,7 +10,7 @@ class ExactSolutionMMS : public Function<dim>
 public:
     ExactSolutionMMS() : Function<dim>(3) {}
     virtual void vector_value(const Point<dim> &p,
-                              Vector<double> &values) const;
+                              Vector<double> &values) const override;
 };
 template<int dim>
 void ExactSolutionMMS<dim>::vector_value(const Point<dim> &p,

--- a/prototypes/direct_gls_navier_stokes/forcingfunctions.h
+++ b/prototypes/direct_gls_navier_stokes/forcingfunctions.h
@@ -9,7 +9,7 @@ class MMSSineForcingFunction : public Function<dim>
 public:
     MMSSineForcingFunction() : Function<dim>(3) {};
     virtual void vector_value(const Point<dim> &p,
-                              Vector<double> &values) const;
+                              Vector<double> &values) const override;
 };
 template<int dim>
 void MMSSineForcingFunction<dim>::vector_value(const Point<dim> &p,

--- a/prototypes/direct_steady_navier_stokes/boundaryconditions.h
+++ b/prototypes/direct_steady_navier_stokes/boundaryconditions.h
@@ -10,7 +10,7 @@ public:
   {}
 
   virtual double
-  value(const Point<dim> &p, const unsigned int component) const;
+  value(const Point<dim> &p, const unsigned int component) const override;
 };
 
 
@@ -20,10 +20,12 @@ RotatingWall<dim>::value(const Point<dim> & p,
                          const unsigned int component) const
 {
   Assert(component < this->n_components,
-         ExcIndexRange(component, 0, this->n_components))
+         ExcIndexRange(component, 0, this->n_components));
 
-    if (component == 0) return -p[1];
-  else if (component == 1) return p[0];
+  if (component == 0) 
+      return -p[1];
+  else if (component == 1) 
+      return p[0];
   return 0.;
 }
 

--- a/prototypes/direct_steady_navier_stokes/exactsolutions.h
+++ b/prototypes/direct_steady_navier_stokes/exactsolutions.h
@@ -13,7 +13,7 @@ public:
     : Function<dim>(3)
   {}
   virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const;
+  vector_value(const Point<dim> &p, Vector<double> &values) const override;
 };
 template <int dim>
 void

--- a/prototypes/direct_steady_navier_stokes/forcingfunctions.h
+++ b/prototypes/direct_steady_navier_stokes/forcingfunctions.h
@@ -10,7 +10,7 @@ public:
   MMSSineForcingFunction()
     : Function<dim>(3){};
   virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const;
+  vector_value(const Point<dim> &p, Vector<double> &values) const override;
 };
 template <int dim>
 void
@@ -43,7 +43,7 @@ public:
   NoForce()
     : Function<dim>(3){};
   virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const;
+  vector_value(const Point<dim> &p, Vector<double> &values) const override;
 };
 template <int dim>
 void


### PR DESCRIPTION
# Description of the problem

- The prototypes were not compiling due to a semicolon missing for two assert calls. In addition, there were several compilation warnings.

# Description of the solution

- Added the missing semicolons and fixed the warnings.