### PR TITLE
Add synchronization after header line

### DIFF
--- a/source/dem/visualization.cc
+++ b/source/dem/visualization.cc
@@ -88,6 +88,8 @@ Visualization<dim>::print_xyz(
 {
   pcout << "id, type, dp, x, y, z " << std::endl;
   usleep(100);
+  MPI_Barrier(mpi_communicator);
+
 
   std::map<int, Particles::ParticleIterator<dim>> global_particles;
   unsigned int current_id, current_id_max = 0;


### PR DESCRIPTION
# Description of the problem

- There was an issue with parallel tests where the header was not being printed at the right time. It's a weird edge case. 

# Description of the solution

- Fixed the issue with the test by forcing an additional layer of synchronization within the output of the test.
