### PR TITLE
Documentation clean up for doxygen

### DIFF
--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -1236,7 +1236,7 @@ NavierStokesPressureFunctionDefined<dim>::value(
 }
 
 /**
- * @brief This class implements a boundary conditions for the Cahn-Hilliard equation
+ * @brief Class that implements a boundary conditions for the Cahn-Hilliard equation
  * where the phase and chemical potential are defined using individual functions
  */
 template <int dim>

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -20,7 +20,7 @@
 #include <core/physical_property_model.h>
 
 /**
- * @brief DensityModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * density.
  */
 class DensityModel : public PhysicalPropertyModel

--- a/include/core/dimensionality.h
+++ b/include/core/dimensionality.h
@@ -21,18 +21,18 @@
 
 using namespace dealii;
 
-/**
- * @brief Dimensionality - This is used to rescale physical properties for cases where the main dimensions
- * of the problems (Length, Mass, Time and Temperature) are not expressed in SI,
- * but are expressed in another set of units. For example, this can be used to
- * carry out a simulation where the mesh is expressed in millimeters instead of
- * meters. This class is currently only used to rescale the
- * physical properties in the FEM-based physics (e.g. all of those that are
- * solvers). Support for DEM, CFD-DEM and rescaling of boundary conditions is
- * planned in the mid-term.
- */
 namespace Parameters
 {
+  /**
+   * @brief Class used to rescale physical properties for cases where the main dimensions
+   * of the problems (Length, Mass, Time and Temperature) are not expressed in
+   * SI, but are expressed in another set of units. For example, this can be
+   * used to carry out a simulation where the mesh is expressed in millimeters
+   * instead of meters. This class is currently only used to rescale the
+   * physical properties in the FEM-based physics (e.g. all of those that are
+   * solvers). Support for DEM, CFD-DEM and rescaling of boundary conditions is
+   * planned in the mid-term.
+   */
   class Dimensionality
   {
   public:

--- a/include/core/interface_property_model.h
+++ b/include/core/interface_property_model.h
@@ -23,7 +23,7 @@
 using namespace dealii;
 
 /**
- * @brief InterfacePropertyModel. Abstract class that defines the interface for a interface property model
+ * @brief Abstract class that defines the interface for a interface property model.
  * Interface property model provides an abstract interface to calculate the
  * value of an interface property or a vector of interface property value for
  * given field value. By default, the interface does not require that all (or

--- a/include/core/mobility_cahn_hilliard_model.h
+++ b/include/core/mobility_cahn_hilliard_model.h
@@ -26,7 +26,7 @@ enum MobilityModel
 };
 
 /**
- * @brief MobilityCahnHilliardModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * mobility for the Cahn-Hilliard-Navier-Stokes equations.
  */
 class MobilityCahnHilliardModel : public InterfacePropertyModel

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -23,7 +23,7 @@
 #include <core/non_linear_solver.h>
 
 /**
- * @brief NewtonNonlinearSolver. Non-linear solver for non-linear systems of equations which uses a Newton
+ * @brief Non-linear solver for non-linear systems of equations which uses a Newton
  * method with \alpha relaxation to ensure that the residual is monotonically
  * decreasing.
  */

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -33,8 +33,7 @@
 using namespace dealii;
 
 /**
- * @brief PeriodicHillsGrid. The PeriodicHillsGrid class creates an
- * hyper_rectangle and transforms it to obtain the hill geometry with
+ * @brief Class that creates a hyper_rectangle and transforms it to obtain the hill geometry with
  * the hill_geometry function. It also attaches a manifold to the geometry.
  */
 

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -52,7 +52,7 @@ set_field_vector(const field                          &id,
 }
 
 /**
- * @brief PhysicalPropertyModel. Abstract class that defines the interface for a physical property model
+ * @brief Abstract class that defines the interface for a physical property model
  * Physical property model provides an abstract interface to calculate the
  * value of a physical property or a vector of physical property value for
  * given field value. By default, the interface does not require that all (or

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -23,7 +23,7 @@
 using namespace dealii;
 
 /**
- * @brief RheologicalModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * non-newtonian viscosity on each quadrature point and the shear rate
  * magnitude.
  */

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -417,10 +417,10 @@ private:
 };
 
 /**
- * @class This class defines superquadric shapes. Their signed distance function
+ * @brief Class that defines superquadric shapes. Their signed distance function
  * is:
- * \left|\frac{x}{a}\right|^r + \left|\frac{y}{b}\right|^s +
- * \left|\frac{z}{c}\right|^t - 1 = 0
+ * \f$ \left|\frac{x}{a}\right|^r + \left|\frac{y}{b}\right|^s +
+ * \left|\frac{z}{c}\right|^t - 1 = 0 \f$
  * @tparam dim Dimension of the shape
  */
 template <int dim>
@@ -904,7 +904,7 @@ private:
 };
 
 /**
- * @class This class was designed so that specific composite shapes could be
+ * @brief This class was designed so that specific composite shapes could be
  * defined through the parameter file. Boolean operations such as union,
  * difference, and intersection are allowed.
  * @tparam dim Dimension of the shape
@@ -1303,7 +1303,7 @@ private:
 
 /**
  * @tparam dim Dimension of the shape
- * @class RBF Shapes express the signed distance function as a linear
+ * @brief RBF Shapes express the signed distance function as a linear
  * combination of Radial Basis Functions (RBF), which have a defined support
  * radius and basis function. A collection of nodes and weights compose the
  * object. Outside of the domain covered by the nodes, the distance is computed

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -24,7 +24,7 @@
 using namespace dealii;
 
 /**
- * @brief SpecificHeatModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * specific heat on each quadrature point using the temperature of the fluid.
  * magnitude. SpecficiHeat::get_specific_heat() is a pure virtual method,
  * since it can only be calculated knowing the model for the specific
@@ -116,7 +116,7 @@ private:
 
 
 /**
- * @brief PhaseChangeSpecificHeat. This models takes into account the phase change of a material
+ * @brief This model takes into account the phase change of a material
  * by considering the latent heat into the specific heat over a phase change
  * interval determined by [T_solidus,T_liquidus].
  */

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -21,7 +21,7 @@
 #include <core/phase_change.h>
 
 /**
- * @brief SurfaceTensionModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * surface tension coefficient.
  */
 class SurfaceTensionModel : public InterfacePropertyModel

--- a/include/core/thermal_conductivity_model.h
+++ b/include/core/thermal_conductivity_model.h
@@ -22,7 +22,7 @@
 #include <core/physical_property_model.h>
 
 /**
- * @brief ThermalConductivityModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * thermal conductivity on each quadrature point using the temperature of the
  * fluid.
  */
@@ -113,7 +113,7 @@ private:
 
 
 /**
- * @brief ThermalConductivityLinear Implements a linear temperature-dependant thermal conductivity of the form k = A + BT
+ * @brief Implements a linear temperature-dependant thermal conductivity of the form k = A + BT
  */
 class ThermalConductivityLinear : public ThermalConductivityModel
 {
@@ -190,7 +190,7 @@ private:
 };
 
 /**
- * @brief ThermalConductivityPhaseChange Implements a phase-dependant thermal conductivity
+ * @brief Implements a phase-dependant thermal conductivity
  */
 class ThermalConductivityPhaseChange : public ThermalConductivityModel
 {

--- a/include/core/thermal_expansion_model.h
+++ b/include/core/thermal_expansion_model.h
@@ -21,7 +21,7 @@
 #include <core/physical_property_model.h>
 
 /**
- * @brief ThermalExpansionModel. Abstract class that allows to calculate the
+ * @brief Abstract class that allows to calculate the
  * thermal expansion coefficient (with unit of inverse temperature)
  */
 class ThermalExpansionModel : public PhysicalPropertyModel
@@ -112,7 +112,7 @@ private:
 };
 
 /**
- * @brief ThermalExpansionPhaseChange Implements a phase-dependant thermal expansion coefficient
+ * @brief Implements a phase-dependant thermal expansion coefficient
  */
 class ThermalExpansionPhaseChange : public ThermalExpansionModel
 {

--- a/include/core/tracer_diffusivity_model.h
+++ b/include/core/tracer_diffusivity_model.h
@@ -20,8 +20,8 @@
 #include <core/physical_property_model.h>
 
 /**
- * @brief DensityModel. Abstract class that allows to calculate the
- * density.
+ * @brief Abstract class that allows to calculates the
+ * tracer diffusivity.
  */
 class TracerDiffusivityModel : public PhysicalPropertyModel
 {

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -143,7 +143,7 @@ public:
  * integration for the Navier-Stokes equation with
  * free surface using VOF modeling.. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}{\Delta t}
+ * \f$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}}{\Delta t}\f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/cahn_hilliard_assemblers.h
+++ b/include/solvers/cahn_hilliard_assemblers.h
@@ -74,8 +74,8 @@ protected:
 
 
 /**
- * @brief Class that assembles the core of the Cahn-Hilliard equation.
- * This class assembles the weak form of:
+ * @brief Class that assembles the core of the Cahn-Hilliard equation
+ * with the following weak form:
  * dPhi/dt +  u * gradPhi =  div(M(Phi)*grad eta)
  * eta - f(Phi) + epsilon^2 * div(grad Phi) = 0
  *
@@ -219,7 +219,7 @@ public:
  * @brief Class that assembles the transient time arising from BDF time
  * integration for the Cahn-Hilliard equations. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{\mathbf{T}^{t+\Delta t}-\mathbf{T}^{t}{\Delta t}
+ * \f$\frac{\mathbf{T}^{t+\Delta t}-\mathbf{T}^{t}}{\Delta t}\f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/cahn_hilliard_scratch_data.h
+++ b/include/solvers/cahn_hilliard_scratch_data.h
@@ -40,8 +40,7 @@ using namespace dealii;
 
 
 /**
- * @brief CahnHilliardScratchData class
- * stores the information required by the assembly procedure
+ * @brief Class that stores the information required by the assembly procedure
  * for the Cahn-Hilliard equations. Consequently, this class
  * calculates the phase field parameter Phi (values, gradients, laplacians),
  * the chemical potential eta (values, gradients, laplacians) and the shape

--- a/include/solvers/copy_data.h
+++ b/include/solvers/copy_data.h
@@ -28,9 +28,8 @@
 using namespace dealii;
 
 /**
- * @brief CopyData class is responsible for
- * storing the information calculated using the assembly of regular (meaning
- * non-stablized) equations. This class is used to
+ * @brief Class responsible for storing the information calculated using the assembly of regular (meaning
+ * non-stabilized) equations. It is also used to
  * initialize, zero (reset) and store the cell_matrix, the cell_rhs and the
  * dof indices associated with the dofs of the cell.
  **/
@@ -70,8 +69,7 @@ public:
 
 
 /**
- * @brief The StabilizedMethodsCopyData class is responsible for
- * storing the information calculated using the assembly of stabilized
+ * @brief Class responsible for storing the information calculated using the assembly of stabilized
  * scalar equations. Like the CopyData class, this class is used to initialize,
  * zero (reset) and store the cell_matrix and the cell_rhs.
  * Contrary to the regular CopyData class, this class
@@ -131,8 +129,7 @@ public:
 };
 
 /**
- * @brief The StabilizedMethodsTensorCopyData class is responsible for
- * storing the information calculated using the assembly of stabilized
+ * @brief Class responsible for storing the information calculated using the assembly of stabilized
  * Tensor<1,dim> equations. Like the CopyData class, this class is used to
  * initialize, zero (reset) and store the cell_matrix and the cell_rhs. Contrary
  * to the regular CopyData class, this class also stores the strong_residual and

--- a/include/solvers/flow_control.h
+++ b/include/solvers/flow_control.h
@@ -35,8 +35,7 @@
 using namespace dealii;
 
 /**
- * @brief FlowControl. The FlowControl class allows to dynamically
- * control the flow with a beta coefficient calculated at each step time.
+ * @brief Class allows to dynamically control the flow with a beta coefficient calculated at each step time.
  */
 
 template <int dim>

--- a/include/solvers/heat_transfer_assemblers.h
+++ b/include/solvers/heat_transfer_assemblers.h
@@ -86,8 +86,8 @@ protected:
 /**
  * @brief Class that assembles the core of the heat transfer equation.
  * This class assembles the weak form of:
- * $$ - k * \nabla^2 T + \rho * cp * \mathbf{u} * \nabla T - f - \tau :
- * \nabla \mathbf{u} =0 $$
+ * \f$ - k * \nabla^2 T + \rho * cp * \mathbf{u} * \nabla T - f - \tau :
+ * \nabla \mathbf{u} =0 \f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -49,8 +49,7 @@ using namespace dealii;
 
 
 /**
- * @brief HeatTransferScratchData class
- * stores the information required by the assembly procedure
+ * @brief Class that stores the information required by the assembly procedure
  * for a heat transfer advection-diffusion equation. Consequently, this class
  * calculates the heat transfer (values, gradients, laplacians) and the shape
  * function (values, gradients, laplacians) at all the gauss points for all

--- a/include/solvers/isothermal_compressible_navier_stokes_assembler.h
+++ b/include/solvers/isothermal_compressible_navier_stokes_assembler.h
@@ -27,9 +27,9 @@
 
 /**
  * @brief Class that assembles the core of the isothermal compressible Navier-Stokes equations.
- * This class assembles the weak form of:
- * $$\nabla \cdot (\rho \mathbf{u}) + \rho \mathbf{u} \cdot \nabla \mathbf{u} -
- * \nabla p - \mu \nabla^2 \mathbf{u} = 0 $$ with a full GLS stabilization
+ *  According to the following weak form:
+ * \f$\nabla \cdot (\rho \mathbf{u}) + \rho \mathbf{u} \cdot \nabla \mathbf{u} -
+ * \nabla p - \mu \nabla^2 \mathbf{u} = 0\f$ with a full GLS stabilization
  * including the laplacian of the test function.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -72,8 +72,8 @@ public:
  * @brief Class that assembles the transient time arising from BDF time
  * integration for the isothermal compressible Navier Stokes equations. For
  * example, if a BDF1 scheme is chosen, the following is assembled
- * $$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}{\Delta t} +
- * \frac{(\psi \mathbf{p})^{t+\Delta t}-(\psi \mathbf{p})^{t}{\Delta t} $$
+ * \f$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}}{\Delta t} +
+ * \frac{(\psi \mathbf{p})^{t+\Delta t}-(\psi \mathbf{p})^{t}}{\Delta t} \f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
+++ b/include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
@@ -28,10 +28,10 @@
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation with
  * free surface using VOF modeling.
- * This class assembles the weak form of:
- * $$\nabla \cdot (\rho \mathbf{u}) + \rho \mathbf{u} \cdot \nabla
+ * According to the following weak form:
+ * \f$\nabla \cdot (\rho \mathbf{u}) + \rho \mathbf{u} \cdot \nabla
  * \mathbf{u} - \nabla p - \mu \nabla\cdot (\nabla \mathbf{u} +
- * (\nabla \mathbf{u})^T) = 0 $$ with a full GLS stabilization
+ * (\nabla \mathbf{u})^T) = 0 \f$ with a full GLS stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -67,9 +67,9 @@ public:
 
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation.
- * This class assembles the weak form of:
- * $$\mathbf{u} \cdot \nabla \mathbf{u} - \nabla p - \nu \nabla^2 \mathbf{u}
- * =0 $$ with an SUPG and PSPG stabilization
+ * According to the following weak form:
+ * \f$\mathbf{u} \cdot \nabla \mathbf{u} - \nabla p - \nu \nabla^2 \mathbf{u}
+ * =0 \f$ with an SUPG and PSPG stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -110,9 +110,9 @@ public:
 
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation.
- * This class assembles the weak form of:
- * $$\mathbf{u} \cdot \nabla \mathbf{u} - \nabla p - \nu \nabla^2 \mathbf{u}
- * =0 $$ with a full GLS stabilization including the laplacian of the test
+ * According to the following weak form:
+ * \f$\mathbf{u} \cdot \nabla \mathbf{u} - \nabla p - \nu \nabla^2 \mathbf{u}
+ * =0 \f$ with a full GLS stabilization including the laplacian of the test
  * function.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -155,14 +155,14 @@ public:
 
 /**
  * @brief Class that assembles the coriolis and the centrifugal
- * if a simulation is carried out in a rotating frame of reference.
- * This class assembles the following term:
- * $$2\mathbf{\omega} \times \mathbf{u} + \mathbf{\omega}\times (\mathbf{\omega}
- * \times \mathbf{r})$$ Where $\mathbf{\omega}$ is the rotation vector of the
- * frame of reference and $\mathbf{r}$ is the position vector (e.g. a vector
- * between a point on the rotation axis and the gauss point) By default, it is
- * assumed that the rotation vector passes through the point (0,0) in 2D or
- * (0,0,0) in 3D
+ * if a simulation is carried out in a rotating frame of reference
+ * according to the following term:
+ * \f$2\mathbf{\omega} \times \mathbf{u} + \mathbf{\omega}\times
+ * (\mathbf{\omega} \times \mathbf{r})\f$ Where $\mathbf{\omega}$ is the
+ * rotation vector of the frame of reference and $\mathbf{r}$ is the position
+ * vector (e.g. a vector between a point on the rotation axis and the gauss
+ * point) By default, it is assumed that the rotation vector passes through the
+ * point (0,0) in 2D or (0,0,0) in 3D
  *
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -202,7 +202,7 @@ public:
 
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation
- * using a Rheological model to predict non Newtonian behaviors
+ * using a Rheological model to predict non-Newtonian behaviors
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -305,7 +305,7 @@ public:
  * @brief Class that assembles the transient time arising from BDF time
  * integration for the Navier Stokes equations. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{\mathbf{u}^{t+\Delta t}-\mathbf{u}^{t}{\Delta t}
+ * \f$\frac{\mathbf{u}^{t+\Delta t}-\mathbf{u}^{t}{\Delta t}
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -345,9 +345,9 @@ public:
 
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation.
- * This class assembles the weak form of:
- * $$\mathbf{u} \cdot \nabla \mathbf{u} - \nabla p - \nu \nabla^2 \mathbf{u}
- * =0 $$ with a grad-div stabilization
+ * According to the following weak form:
+ * \f$\mathbf{u} \cdot \nabla \mathbf{u} - \nabla p - \nu \nabla^2 \mathbf{u}
+ * =0 \f$ with a grad-div stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -429,7 +429,7 @@ public:
 
 /**
  * @brief Class that assembles a Poisson problem for all velocity components and pressure variables.
- * This class assembles the weak form of: d^2 U/dx^2=0 and  d^2 P/dx^2=0
+ * According to the following weak form: d^2 U/dx^2=0 and  d^2 P/dx^2=0
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -469,7 +469,7 @@ public:
 
 /**
  * @brief Class that assembles a Neumann boundary condition.
- * This class assembles the weak form of: (p-mu*grad_u)*n at the boundary
+ * According to the following weak form: (p-mu*grad_u)*n at the boundary
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  * @param pressure_boundary_condition The boundary condition objects use to store the function.
@@ -515,7 +515,7 @@ public:
 
 /**
  * @brief Class that assembles the weak formulation of a Dirichlet boundary condition using the Nitsche method.
- * This class assembles the weak form of: (u_ib-u)-(u,grad v)
+ * According to the following weak form: (u_ib-u)-(u,grad v)
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  * @param boundary_condition The boundary condition objects us to store the function.
@@ -560,7 +560,7 @@ public:
 
 /**
  * @brief Class that assembles the special case of partial slip condition using the weak formulation of a Dirichlet boundary condition using the Nitsche method.
- * This class assembles the weak form of: beta n(nu-nv) +
+ * According to the following weak form: beta n(nu-nv) +
  * mu/boundary_layer_thickness t(tu-tv)
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -606,9 +606,9 @@ public:
 };
 
 /**
- * @brief Class that assembles the weak formulation of an outlet boundary condition.
- * This class assembles the weak form of (nu grad(u) * grad(v) + pI - (beta *
- * u)_ * n See the paper by Arndt, Braack and Lube
+ * @brief Class that assembles the weak formulation of an outlet boundary condition
+ * according to the following equation: (nu grad(u) * grad(v) + pI - (beta *
+ * u)_ * n. See the paper by Arndt, Braack and Lube
  * https://www.mathsim.eu/~darndt/files/ENUMATH_2015.pdf
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -682,7 +682,7 @@ public:
 
 
   /**
-   * @brief assemble_rhs Assembles the weak form of: $$-\mathbf{g} \times \alpha \times (T - T_0)$$
+   * @brief assemble_rhs Assembles the weak form of: \f$-\mathbf{g} \times \alpha \times (T - T_0)\f$
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */

--- a/include/solvers/navier_stokes_cahn_hilliard_assemblers.h
+++ b/include/solvers/navier_stokes_cahn_hilliard_assemblers.h
@@ -28,10 +28,10 @@
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation with
  * free surface using Cahn-Hilliard modeling.
- * This class assembles the weak form of:
- * $$ \nabla \cdot \mathbf{u} + \rho \mathbf{u} \cdot \nabla
+ * According to the following weak form:
+ * \f$ \nabla \cdot \mathbf{u} + \rho \mathbf{u} \cdot \nabla
  * \mathbf{u} + \nabla p - \mu \nabla\cdot (\nabla \mathbf{u} +
- * (\nabla \mathbf{u})^T)=0 $$ with an SUPG and PSPG stabilization
+ * (\nabla \mathbf{u})^T)=0 \f$ with an SUPG and PSPG stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -77,7 +77,7 @@ public:
  * integration for the Navier-Stokes equation with
  * free surface using Cahn-Hilliard modeling. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}{\Delta t}
+ * \f$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}}{\Delta t} \f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -46,8 +46,7 @@ using namespace dealii;
 
 
 /**
- * @brief NavierStokesScratchData class
- * stores the information required by the assembly procedure
+ * @brief Class that stores the information required by the assembly procedure
  * for a Navier-Stokes equation. Consequently, this class calculates
  * the velocity (values, gradients, laplacians) and the shape function
  * (values, gradients, laplacians) at all the gauss points for all degrees

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -28,10 +28,10 @@
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation with
  * free surface using VOF modeling.
- * This class assembles the weak form of:
- * $$ \nabla \cdot \mathbf{u} + \rho \mathbf{u} \cdot \nabla
+ * According to the following weak form:
+ * \f$ \nabla \cdot \mathbf{u} + \rho \mathbf{u} \cdot \nabla
  * \mathbf{u} + \nabla p - \mu \nabla\cdot (\nabla \mathbf{u} +
- * (\nabla \mathbf{u})^T) = 0 $$ with an SUPG and PSPG stabilization
+ * (\nabla \mathbf{u})^T) = 0 \f$ with an SUPG and PSPG stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -77,7 +77,7 @@ public:
  * integration for the Navier-Stokes equation with
  * free surface using VOF modeling. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}{\Delta t}
+ * \f$\frac{(\rho \mathbf{u})^{t+\Delta t}-(\rho \mathbf{u})^{t}}{\Delta t} \f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -116,9 +116,9 @@ public:
 
 /**
  * @brief Class that assembles the Surface Tension Force (STF) for the
- * Navier-Stokes equations. The following equation is assembled
+ * Navier-Stokes equations according to the following equation:
  *
- * $$\mathbf{F_{CSV}}=\sigma k \nabla \phi \frac{2 \rho}{\rho_0 + \rho_1}
+ * \f$\mathbf{F_{CSV}}=\sigma k \nabla \phi \frac{2 \rho}{\rho_0 + \rho_1} \f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -162,12 +162,12 @@ public:
 
 /**
  * @brief Class that assembles the marangoni effect for the
- * Navier-Stokes equations. The following equation is assembled
+ * Navier-Stokes equations according to the following equation:
  *
- * $$\mathbf{F_{Ma}}= \frac{\partial \sigma}{\partial T} \left[ \nabla T
+ * \f$\mathbf{F_{Ma}}= \frac{\partial \sigma}{\partial T} \left[ \nabla T
  * - \frac{\nabla \phi}{| \nabla \phi |} \left( \frac{ \nabla \phi }
  * {| \nabla \phi |} \cdot \nabla T \right) \right] | \nabla \phi |
- * \frac{2 \rho}{\rho_0 + \rho_1}
+ * \frac{2 \rho}{\rho_0 + \rho_1} \f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -211,7 +211,7 @@ public:
 
 /**
  * @brief Class that assembles the core of the Navier-Stokes equation
- * using a Rheological model to predict non Newtonian behaviors
+ * using a Rheological model to predict non-Newtonian behaviors
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -56,7 +56,7 @@ enum material_interactions_type
 };
 
 
-/** @class The PhysicalPropertiesManager class manages the physical properties
+/** @brief Class that manages the physical properties
  * model which are required to calculate the various physical properties
  * This centralizes the place where the models are created.
  * The class can be constructed empty and initialized from parameters

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -38,10 +38,12 @@
 using namespace dealii;
 
 /**
- * @brief AverageVelocities. The AverageVelocities class calculates the
- * time-averaged velocities and pressure (<u>, <v>, <w>, <p>) and the
- * independent components of the Reynolds stresses tensor (<u'u'>, <v'v'>,
- * <w'w'>, <u'v'>, <v'w'>, <w'u'>). The generated vectors are displayable of
+ * @brief Class that calculates the
+ * time-averaged velocities and pressure \f$(\langle u \rangle, \langle v
+ * \rangle, \langle w \rangle, \langle p \rangle)\f$ and the independent
+ * components of the Reynolds stresses tensor \f$(\langle u'u' \rangle, \langle
+ * v'v' \rangle, \langle w'w' \rangle, \langle u'v' \rangle, \langle v'w'
+ * \rangle, \langle w'u' \rangle)\f$. The generated vectors are displayable of
  * visualization software.
  */
 template <int dim, typename VectorType, typename DofsType>

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -65,8 +65,8 @@ public:
 /**
  * @brief Class that assembles the core of the Tracer equation.
  * This class assembles the weak form of:
- * $$\mathbf{u} \cdot \nabla T - D \nabla^2 =0 $$ with an SUPG
- * stabilziation
+ * \f$\mathbf{u} \cdot \nabla T - D \nabla^2 =0 \f$ with an SUPG
+ * stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -110,7 +110,7 @@ public:
  * @brief Class that assembles the transient time arising from BDF time
  * integration for the Tracer equations. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{\mathbf{T}^{t+\Delta t}-\mathbf{T}^{t}{\Delta t}
+ * \f$\frac{\mathbf{T}^{t+\Delta t}-\mathbf{T}^{t}}{\Delta t}\f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -40,8 +40,7 @@ using namespace dealii;
 
 
 /**
- * @brief TracerScratchData class
- * stores the information required by the assembly procedure
+ * @brief Class that stores the information required by the assembly procedure
  * for a Tracer advection-diffusion equation. Consequently, this class
  *calculates the tracer (values, gradients, laplacians) and the shape function
  * (values, gradients, laplacians) at all the gauss points for all degrees

--- a/include/solvers/vof_assemblers.h
+++ b/include/solvers/vof_assemblers.h
@@ -65,8 +65,8 @@ public:
 
 /**
  * @brief Class that assembles the core of the VOF solver.
- * This class assembles the weak form of:
- * $$\mathbf{u} \cdot T \cdot \nabla T =0 $$ with an SUPG
+ * According to the following weak form:
+ * \f$\mathbf{u} \cdot T \cdot \nabla T =0 \f$ with an SUPG
  * stabilization
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -122,7 +122,7 @@ public:
  * @brief Class that assembles the transient time arising from BDF time
  * integration for the VOF equations. For example, if a BDF1 scheme is
  * chosen, the following is assembled
- * $$\frac{\mathbf{T}^{t+\Delta t}-\mathbf{T}^{t}{\Delta t}
+ * \f$\frac{\mathbf{T}^{t+\Delta t}-\mathbf{T}^{t}}{\Delta t}\f$
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/solvers/vof_filter.h
+++ b/include/solvers/vof_filter.h
@@ -21,7 +21,7 @@
 #include <core/parameters_multiphysics.h>
 
 /**
- * @brief VolumeOfFluidFilterBase class allows phase fraction filtering
+ * @brief Class that allows phase fraction filtering
  */
 class VolumeOfFluidFilterBase
 {
@@ -48,7 +48,7 @@ public:
 };
 
 /**
- * @brief VolumeOfFluidNoFilter class is used as a default when no
+ * @brief Class that is used as a default when no
  * filter is applied to the phase fraction
  */
 class VolumeOfFluidNoFilter : public VolumeOfFluidFilterBase
@@ -70,9 +70,9 @@ public:
 };
 
 /**
- * @brief VolumeOfFluidTanhFilter class is used to calculate
- * a filtered phase for VOF simulations. The filtered phase is defined as
- * $$\phi_f = 0.5 \tanh(\beta(\phi-0.5)) + 0.5$$.
+ * @brief Class used to calculate a filtered phase for VOF simulations.
+ * The filtered phase is defined as
+ * \f$\phi_f = 0.5 \tanh(\beta(\phi-0.5)) + 0.5\f$.
  */
 class VolumeOfFluidTanhFilter : public VolumeOfFluidFilterBase
 {

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -38,8 +38,7 @@ using namespace dealii;
 
 
 /**
- * @brief VOFScratchData class
- * stores the information required by the assembly procedure
+ * @brief Class that stores the information required by the assembly procedure
  * for a VOF free surface equation. Consequently, this class
  * calculates the phase values (values, gradients, laplacians) and the shape
  * method (values, gradients, laplacians) at all the gauss points for all


### PR DESCRIPTION
# Description of the problem

There were several links pointing to wrong classes and the latex equations were not being displayed correctly.

# Description of the solution

This PR fixes this issues for the current documentation. 

# Comments

This will give an idea of the format of the equations, plus it clearly shows which equations need to be rewritten with Latex. 
