### PR TITLE
Add heat flux postprocessor

### DIFF
--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -32,6 +32,7 @@
 #include <solvers/heat_transfer_assemblers.h>
 #include <solvers/heat_transfer_scratch_data.h>
 #include <solvers/multiphysics_interface.h>
+#include <solvers/postprocessors.h>
 
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -550,6 +551,11 @@ private:
   // - the convective heat flux on a boundary: h(T-T_inf)
   // - the total fluxes on the nitsche immersed boundaries (if active)
   TableHandler heat_flux_table;
+
+  // Heat flux postprocessing
+  std::vector<std::shared_ptr<ThermalConductivityModel>>
+                                          thermal_conductivity_models;
+  std::vector<HeatFluxPostprocessor<dim>> heat_flux_postprocessors;
 };
 
 

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -71,6 +71,9 @@ public:
     , triangulation(p_triangulation)
     , simulation_control(p_simulation_control)
     , dof_handler(*triangulation)
+    , thermal_conductivity_models(
+        p_simulation_parameters.physical_properties_manager
+          .get_thermal_conductivity_vector())
 
   {
     if (simulation_parameters.mesh.simplex)

--- a/include/solvers/postprocessors.h
+++ b/include/solvers/postprocessors.h
@@ -533,7 +533,7 @@ public:
     , thermal_conductivity_model(p_thermal_conductivity_model)
     , material_id(p_material_id)
   {}
-  
+
   virtual void
   evaluate_scalar_field(
     const DataPostprocessorInputs::Scalar<dim> &inputs,

--- a/include/solvers/postprocessors.h
+++ b/include/solvers/postprocessors.h
@@ -533,6 +533,7 @@ public:
     , thermal_conductivity_model(p_thermal_conductivity_model)
     , material_id(p_material_id)
   {}
+  
   virtual void
   evaluate_scalar_field(
     const DataPostprocessorInputs::Scalar<dim> &inputs,

--- a/include/solvers/postprocessors.h
+++ b/include/solvers/postprocessors.h
@@ -508,4 +508,66 @@ public:
 private:
   std::shared_ptr<DensityModel> density_model;
 };
+
+
+/**
+ * @class Calculates heat flux of a material at every quadrature point.
+ * @param p_thermal_conductivity_model Thermal conductivity model of the material
+ * @param p_material_string Type of material: "f" (fluid) or "s" (solid)
+ * @param p_material_id ID corresponding to the material (by convention, fluids
+ * come before solids)
+ * @param p_id Either fluid ID or solid ID (as initialized in the physical properties)
+ */
+template <int dim>
+class HeatFluxPostprocessor : public DataPostprocessorVector<dim>
+{
+public:
+  HeatFluxPostprocessor(
+    std::shared_ptr<ThermalConductivityModel> p_thermal_conductivity_model,
+    const std::string                         p_material_string = "f",
+    const unsigned int                        p_material_id     = 0,
+    const unsigned int                        p_id              = 0)
+    : DataPostprocessorVector<dim>("heat_flux_" + p_material_string +
+                                     Utilities::to_string(p_id, 2),
+                                   update_values | update_gradients)
+    , thermal_conductivity_model(p_thermal_conductivity_model)
+    , material_id(p_material_id)
+  {}
+  virtual void
+  evaluate_scalar_field(
+    const DataPostprocessorInputs::Scalar<dim> &inputs,
+    std::vector<Vector<double>> &computed_quantities) const override
+  {
+    const unsigned int n_quadrature_points = computed_quantities.size();
+    AssertDimension(inputs.solution_gradients.size(), n_quadrature_points);
+
+    std::map<field, double>     field_values;
+    Vector<double>              null_vector(dim);
+    std::vector<Vector<double>> null_computed_quantities(n_quadrature_points,
+                                                         null_vector);
+
+    const auto cell = inputs.template get_cell<dim>();
+
+    if (cell->material_id() == material_id)
+      for (unsigned int q = 0; q < n_quadrature_points; ++q)
+        {
+          AssertDimension(computed_quantities[q].size(), dim);
+          field_values[field::temperature] = inputs.solution_values[q];
+
+          for (unsigned int i = 0; i < dim; ++i)
+            {
+              computed_quantities[q][i] =
+                -thermal_conductivity_model->value(field_values) *
+                inputs.solution_gradients[q][i];
+            }
+        }
+    // Apply null values to irrelevant subdomain
+    else
+      computed_quantities = null_computed_quantities;
+  }
+
+private:
+  std::shared_ptr<ThermalConductivityModel> thermal_conductivity_model;
+  unsigned int                              material_id;
+};
 #endif

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -690,9 +690,9 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
     this->simulation_parameters.physical_properties_manager
       .get_thermal_conductivity_vector();
 
-  const double n_fluids = this->simulation_parameters
+  const unsigned int n_fluids = this->simulation_parameters
                             .physical_properties_manager.get_number_of_fluids();
-  const double n_solids = this->simulation_parameters
+  const unsigned int n_solids = this->simulation_parameters
                             .physical_properties_manager.get_number_of_solids();
 
   // Postprocess heat fluxes

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -685,11 +685,7 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
 {
   data_out.add_data_vector(dof_handler, present_solution, "temperature");
 
-  // Get thermal conductivity models
-  thermal_conductivity_models =
-    this->simulation_parameters.physical_properties_manager
-      .get_thermal_conductivity_vector();
-
+  // Get number of fluids and solids
   const unsigned int n_fluids =
     this->simulation_parameters.physical_properties_manager
       .get_number_of_fluids();
@@ -713,7 +709,7 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
   for (unsigned int m_id = n_fluids; m_id < n_fluids + n_solids; ++m_id)
     {
       heat_flux_postprocessors.push_back(HeatFluxPostprocessor<dim>(
-        thermal_conductivity_models[m_id], "s", m_id, m_id - n_fluids));
+        thermal_conductivity_models[m_id], "s", m_id - n_fluids, m_id));
       data_out.add_data_vector(this->dof_handler,
                                this->present_solution,
                                heat_flux_postprocessors[m_id]);

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -690,10 +690,12 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
     this->simulation_parameters.physical_properties_manager
       .get_thermal_conductivity_vector();
 
-  const unsigned int n_fluids = this->simulation_parameters
-                            .physical_properties_manager.get_number_of_fluids();
-  const unsigned int n_solids = this->simulation_parameters
-                            .physical_properties_manager.get_number_of_solids();
+  const unsigned int n_fluids =
+    this->simulation_parameters.physical_properties_manager
+      .get_number_of_fluids();
+  const unsigned int n_solids =
+    this->simulation_parameters.physical_properties_manager
+      .get_number_of_solids();
 
   // Postprocess heat fluxes
   heat_flux_postprocessors.clear();

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -679,12 +679,43 @@ HeatTransfer<dim>::copy_local_rhs_to_global_rhs(
                                               system_rhs);
 }
 
-
 template <int dim>
 void
 HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
 {
   data_out.add_data_vector(dof_handler, present_solution, "temperature");
+
+  // Get thermal conductivity models
+  thermal_conductivity_models =
+    this->simulation_parameters.physical_properties_manager
+      .get_thermal_conductivity_vector();
+
+  const double n_fluids = this->simulation_parameters
+                            .physical_properties_manager.get_number_of_fluids();
+  const double n_solids = this->simulation_parameters
+                            .physical_properties_manager.get_number_of_solids();
+
+  // Postprocess heat fluxes
+  heat_flux_postprocessors.clear();
+  heat_flux_postprocessors.reserve(n_fluids + n_solids);
+  // Heat fluxes in fluids
+  for (unsigned int f_id = 0; f_id < n_fluids; ++f_id)
+    {
+      heat_flux_postprocessors.push_back(HeatFluxPostprocessor<dim>(
+        thermal_conductivity_models[f_id], "f", f_id, f_id));
+      data_out.add_data_vector(this->dof_handler,
+                               this->present_solution,
+                               heat_flux_postprocessors[f_id]);
+    }
+  // Heat fluxes in solids
+  for (unsigned int m_id = n_fluids; m_id < n_fluids + n_solids; ++m_id)
+    {
+      heat_flux_postprocessors.push_back(HeatFluxPostprocessor<dim>(
+        thermal_conductivity_models[m_id], "s", m_id, m_id - n_fluids));
+      data_out.add_data_vector(this->dof_handler,
+                               this->present_solution,
+                               heat_flux_postprocessors[m_id]);
+    }
 }
 
 template <int dim>


### PR DESCRIPTION
# Description of the problem

- In the context of conjugated heat transfer simulations, there was no way to get the local heat fluxes of the domain.

# Description of the solution

- A new `DataPostprocessorVector` child class was made, namely, `HeatFluxPostprocessor`. This class postprocesses the local heat fluxes of the fluids and solids of the domain. The values for each fluid and solid is outputed individually.

# How Has This Been Tested?

- CI 

# Comments

An example using this HeatFluxPostprocessor values will be made soon.
