### PR TITLE
Dem histogram distribution

### DIFF
--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -66,18 +66,19 @@ In this subsection, gravitational acceleration, and the physical properties of t
     If the particles in a simulation are monodispersed and have the same physical properties, the ``number of particle types`` should be equal to zero. For polydispersed systems, the ``number of particle types`` is selected equal to the number of particles types in the simulation. For each particle type, a separate subsection ``particle type n`` should be defined (n starts from zero to ``number of particle types`` - 1) which contains all the physical properties related to that particle type.
 
 * The ``size distribution type`` parameter specifies the size distribution for each particle type. For each particle type, three ``size distribution type`` can be defined: ``uniform``, ``normal`` and ``custom``.
+
   - For the ``uniform`` size distribution, the diameter of the particles is constant.
   - For the ``normal`` size distribution, the particle diameters are sampled from a normal distribution with an average diameter and a standard deviation.
   - For the ``custom`` size distribution, particle diameters are sampled from a list of diameters with a corresponding list of probabilities.
 
 .. note::
-    In the ``custom`` size distribution, the probability values are based on the volume taken by all the particles of the associated diameter, not to the total number of particles. For example, if a probability is equal to ``0.5`` , this means that haft of the total volume of inserted particles will be occupied by particle with the associated diameter value.
+    In the ``custom`` size distribution, the probability values are based on the volume fraction taken by all the particles of the associated diameter, not to the total number of particles. For example, if a probability is equal to ``0.5`` , this means that half of the total volume of inserted particles will be occupied by particle with the associated diameter value.
 
 * The ``diameter`` parameter defines the diameter of the particles in a ``uniform`` distribution. In the case of a ``normal`` distribution, this parameter indicates the average diameter.
 
 * For a ``normal`` distribution, the ``standard deviation`` parameter should be defined to indicate the standard deviation on the particle size distribution.
 
-* For a ``custom`` distribution, the ``custom diameters`` defines the different diameter values used when generating particles. The ``custom probabilities`` defines the probabilities corresponding to each diameter value previously declared based on volume, not on the number of particles. Both list must have the same length.
+* For a ``custom`` distribution, the ``custom diameters`` parameter defines the different diameter values used when generating particles. The ``custom probabilities`` parameter defines the probabilities corresponding to each diameter value previously declared based on volume fraction, not on the number of particles. Both list must have the same length.
 
 * The ``number of particles`` parameter defines the number of particles for each type.
 

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -22,15 +22,15 @@ In this subsection, gravitational acceleration, and the physical properties of t
     # Entering particle type 0
     subsection particle type 0
 
-      # Choices are uniform, normal or histogram
+      # Choices are uniform, normal or custom
       set size distribution type            = uniform
 
       # If distribution type = uniform or normal
       set diameter                          = 0.001
 
-      # If distribution type = histogram
-      set histogram diameters list          = 0.001 , 0.0005
-      set histogram probabilities list      = 0.6   , 0.4
+      # If distribution type = custom
+      set custom diameters list          = 0.001 , 0.0005
+      set custom probabilities list      = 0.6   , 0.4
 
       # If distribution type = normal
       set standard deviation                = 0.0
@@ -65,16 +65,19 @@ In this subsection, gravitational acceleration, and the physical properties of t
 .. note::
     If the particles in a simulation are monodispersed and have the same physical properties, the ``number of particle types`` should be equal to zero. For polydispersed systems, the ``number of particle types`` is selected equal to the number of particles types in the simulation. For each particle type, a separate subsection ``particle type n`` should be defined (n starts from zero to ``number of particle types`` - 1) which contains all the physical properties related to that particle type.
 
-* The ``size distribution type`` parameter specifies the size distribution for each particle type. The acceptable choices are ``uniform`` and ``normal`` distributions.
+* The ``size distribution type`` parameter specifies the size distribution for each particle type. For each particle type, three ``size distribution type`` can be defined: ``uniform``, ``normal`` and ``custom``.
+  - For the ``uniform`` size distribution, the diameter of the particles is constant.
+  - For the ``normal`` size distribution, the particle diameters are sampled from a normal distribution with an average diameter and a standard deviation.
+  - For the ``custom`` size distribution, particle diameters are sampled from a list of diameters with a corresponding list of probabilities.
 
 .. note::
-    For each particle type, three ``size distribution type``s can be defined: ``uniform``, ``normal`` and ``histogram``. In ``uniform`` size distribution, the diameter of the particles is constant. In ``normal`` size distribution, the particle diameters are sampled from a normal distribution with an average diameter and a standard deviation of ``standard deviation``.  In the "histogram" size distribution, particle diameters are sampled from a list of diameters and a probability for each diameter value.
+    In the ``custom`` size distribution, the probability values are based on the volume taken by all the particles of the associated diameter, not to the total number of particles. For example, if a probability is equal to ``0.5`` , this means that haft of the total volume of inserted particles will be occupied by particle with the associated diameter value.
 
 * The ``diameter`` parameter defines the diameter of the particles in a ``uniform`` distribution. In the case of a ``normal`` distribution, this parameter indicates the average diameter.
 
 * For a ``normal`` distribution, the ``standard deviation`` parameter should be defined to indicate the standard deviation on the particle size distribution.
 
-* For a ``histogram`` distribution, the ``histogram diameters list`` defines each diameter to choose from when generating the diameter values. The ``histogram probabilities list`` defines the probability that a diameter value will be chosen for one particles. Both list must have the same length.
+* For a ``custom`` distribution, the ``custom diameters`` defines the different diameter values used when generating particles. The ``custom probabilities`` defines the probabilities corresponding to each diameter value previously declared based on volume, not on the number of particles. Both list must have the same length.
 
 * The ``number of particles`` parameter defines the number of particles for each type.
 

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -29,8 +29,8 @@ In this subsection, gravitational acceleration, and the physical properties of t
       set diameter                          = 0.001
 
       # If distribution type = custom
-      set custom diameters list          = 0.001 , 0.0005
-      set custom probabilities list      = 0.6   , 0.4
+      set custom diameters                  = 0.001 , 0.0005
+      set custom probabilities              = 0.6   , 0.4
 
       # If distribution type = normal
       set standard deviation                = 0.0

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -29,8 +29,8 @@ In this subsection, gravitational acceleration, and the physical properties of t
       set diameter                          = 0.001
 
       # If distribution type = histogram
-      set histogram diameters list           = 0.001
-      set histogram probabilities list      = 1.
+      set histogram diameters list          = 0.001 , 0.0005
+      set histogram probabilities list      = 0.6   , 0.4
 
       # If distribution type = normal
       set standard deviation                = 0.0
@@ -74,7 +74,7 @@ In this subsection, gravitational acceleration, and the physical properties of t
 
 * For a ``normal`` distribution, the ``standard deviation`` parameter should be defined to indicate the standard deviation on the particle size distribution.
 
-* For a ``histogram`` distribution, the ``histogram diameters list`` defines each diameter to choose from when generating the diameter values. The ``histogram probabilities list`` defines the probability that a diameter value will be chosen for one particles.
+* For a ``histogram`` distribution, the ``histogram diameters list`` defines each diameter to choose from when generating the diameter values. The ``histogram probabilities list`` defines the probability that a diameter value will be chosen for one particles. Both list must have the same length.
 
 * The ``number of particles`` parameter defines the number of particles for each type.
 

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -21,56 +21,38 @@ In this subsection, gravitational acceleration, and the physical properties of t
 
     # Entering particle type 0
     subsection particle type 0
-      # Size distribution of particle type 0
+
+      # Choices are uniform, normal or histogram
       set size distribution type            = uniform
 
-      # Particle diameter
-      set diameter                          = 0.005
+      # If distribution type = uniform or normal
+      set diameter                          = 0.001
 
-      # Standard deviation
+      # If distribution type = histogram
+      set histogram diameters list           = 0.001
+      set histogram probabilities list      = 1.
+
+      # If distribution type = normal
       set standard deviation                = 0.0
 
-      # Number of particles in type 0
-      set number of particles               = 132300
-
-      # Particle density
-      set density particles                 = 2000
-
-      # Young's modulus of particle
+      # For every distribution types
+      set number of particles               = 0
+      set density particles                 = 1000
       set young modulus particles           = 1000000
-
-      # Poisson ratio of particle
       set poisson ratio particles           = 0.3
-
-      # Coefficient of restitution of particle
-      set restitution coefficient particles = 0.95
-
-      # Coefficient of friction of particle
-      set friction coefficient particles    = 0.05
-
-      # Coefficient of rolling friction of particle
+      set restitution coefficient particles = 0.1
+      set friction coefficient particles    = 0.1
       set rolling friction particles        = 0.1
-
-      # Surface energy of particle
       set surface energy particles          = 0.0
+
     end
 
-    # Young's modulus of wall
+    # Wall properties
     set young modulus wall           = 1000000
-
-    # Poisson ratio of wall
     set poisson ratio wall           = 0.3
-
-    # Coefficient of restitution of wall
-    set restitution coefficient wall = 0.95
-
-    # Coefficient of friction of wall
-    set friction coefficient wall    = 0.05
-
-    # Coefficient of rolling friction of wall
+    set restitution coefficient wall = 0.1
+    set friction coefficient wall    = 0.1
     set rolling friction wall        = 0.1
-
-    # Surface energy of wall
     set surface energy wall          = 0.0
   end
 
@@ -86,11 +68,13 @@ In this subsection, gravitational acceleration, and the physical properties of t
 * The ``size distribution type`` parameter specifies the size distribution for each particle type. The acceptable choices are ``uniform`` and ``normal`` distributions.
 
 .. note::
-    For each particle type, two ``size distribution type``s can be defined: ``uniform`` and ``normal``. In ``uniform`` size distribution, the diameter of the particles is constant, while in ``normal`` size distribution, the particle diameters are sampled from a normal distribution with an average of ``average diameter`` and standard deviation of ``standard deviation``.
+    For each particle type, three ``size distribution type``s can be defined: ``uniform``, ``normal`` and ``histogram``. In ``uniform`` size distribution, the diameter of the particles is constant. In ``normal`` size distribution, the particle diameters are sampled from a normal distribution with an average diameter and a standard deviation of ``standard deviation``.  In the "histogram" size distribution, particle diameters are sampled from a list of diameters and a probability for each diameter value.
 
 * The ``diameter`` parameter defines the diameter of the particles in a ``uniform`` distribution. In the case of a ``normal`` distribution, this parameter indicates the average diameter.
 
 * For a ``normal`` distribution, the ``standard deviation`` parameter should be defined to indicate the standard deviation on the particle size distribution.
+
+* For a ``histogram`` distribution, the ``histogram diameters list`` defines each diameter to choose from when generating the diameter values. The ``histogram probabilities list`` defines the probability that a diameter value will be chosen for one particles.
 
 * The ``number of particles`` parameter defines the number of particles for each type.
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1392,26 +1392,31 @@ namespace Parameters
 
 
   /**
-   * @brief Return the tensor of entry @p entry_string. If the entry is specified in the .prm file,
-   * then the changed value is returned, otherwise the default value is
-   * returned. If the entry is not equivalent to a Tensor<1,3>, an error will be
-   * thrown. This function can be use for Point<3> variables.
+   * @brief Return the tensor of entry @p entry_string. If the entry is specified
+   * in the .prm file, then the changed value is returned, otherwise the default
+   * value is returned. If the entry is not equivalent to a Tensor<1,3>, an
+   * error will be thrown. This function can be use for Point<3> variables.
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    * @param entry_string A declare string in the parameter file.
+   *
+   * @return A tensor<1,3> corresponding to the entry_string in the prm file.
    */
   Tensor<1, 3>
   entry_string_to_tensor3(ParameterHandler  &prm,
                           const std::string &entry_string);
 
   /**
-   * @brief Return the vector of size N of entry @entry_string. If the entry is specified in the .prm file,
-   * then the changed value is returned, otherwise the default value is
-   * returned. If the entry is not equivalent to a vector, an error will be
-   * thrown.
+   * @brief Return the vector of size N of entry @entry_string. If the entry is
+   * specified in the .prm file, then the changed value is returned, otherwise
+   * the default value is returned. If the entry is not equivalent to a vector,
+   * an error will be thrown.
    *
-   * @param prm A parameter handler which is currently used to parse the simulation information
+   * @param prm A parameter handler which is currently used to parse the simulation
+   * information.
    * @param entry_string A declare string in the parameter file.
+   *
+   * @return A std::vector<double> corresponding to the entry_string in the prm file.
    */
   std::vector<double>
   entry_string_to_vector(ParameterHandler  &prm,

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1404,5 +1404,17 @@ namespace Parameters
   entry_string_to_tensor3(ParameterHandler  &prm,
                           const std::string &entry_string);
 
+  /**
+   * @brief Return the vector of size N of entry @entry_string. If the entry is specified in the .prm file,
+   * then the changed value is returned, otherwise the default value is
+   * returned. If the entry is not equivalent to a vector, an error will be
+   * thrown.
+   *
+   * @param prm A parameter handler which is currently used to parse the simulation information
+   * @param entry_string A declare string in the parameter file.
+   */
+  std::vector<double>
+  entry_string_to_vector(ParameterHandler  &prm,
+                         const std::string &entry_string);
 } // namespace Parameters
 #endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1393,9 +1393,9 @@ namespace Parameters
 
   /**
    * @brief Return the tensor of entry @p entry_string. If the entry is specified
-   * in the .prm file, then the changed value is returned, otherwise the default
-   * value is returned. If the entry is not equivalent to a Tensor<1,3>, an
-   * error will be thrown. This function can be use for Point<3> variables.
+   * in the parameter file, then the changed value is returned, otherwise the
+   * default value is returned. If the entry is not equivalent to a Tensor<1,3>,
+   * an error will be thrown. This function can be use for Point<3> variables.
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    * @param entry_string A declare string in the parameter file.
@@ -1419,7 +1419,7 @@ namespace Parameters
    * @return A std::vector<double> corresponding to the entry_string in the prm file.
    */
   std::vector<double>
-  entry_string_to_vector(ParameterHandler  &prm,
-                         const std::string &entry_string);
+  convert_string_to_vector(ParameterHandler  &prm,
+                           const std::string &entry_string);
 } // namespace Parameters
 #endif

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -75,8 +75,8 @@ namespace Parameters
       std::unordered_map<unsigned int, std::vector<double>>
         particle_custom_diameter;
 
-      // Probability of each diameter value based on volume for the custom
-      // distribution for each particle type
+      // Probability of each diameter value based on volume fraction for the
+      // custom distribution for each particle type
       std::unordered_map<unsigned int, std::vector<double>>
         particle_custom_probability;
 

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -49,12 +49,11 @@ namespace Parameters
       viscous_resistance
     };
 
-    // Size distribution type
     enum class SizeDistributionType
     {
       uniform,
       normal,
-      histogram
+      custom
     };
 
     struct LagrangianPhysicalProperties
@@ -72,15 +71,14 @@ namespace Parameters
       // Size standard deviation of each particle type
       std::unordered_map<unsigned int, double> particle_size_std;
 
-      // List of diameters for the histogram distribution for each particle
-      // types
+      // List of diameters for the custom distribution for each particle type
       std::unordered_map<unsigned int, std::vector<double>>
-        particle_histogram_diameter;
+        particle_custom_diameter;
 
-      // Probability of each diameter value for the histogram distribution for
-      // each particle types for histogram
+      // Probability of each diameter value based on volume for the custom
+      // distribution for each particle type
       std::unordered_map<unsigned int, std::vector<double>>
-        particle_histogram_probability;
+        particle_custom_probability;
 
       // Distribution type of each particle type
       std::vector<SizeDistributionType> distribution_type;
@@ -147,10 +145,10 @@ namespace Parameters
         std::unordered_map<unsigned int, double> &particle_size_std,
         std::vector<SizeDistributionType>        &distribution_type,
         std::unordered_map<unsigned int, std::vector<double>>
-          &particle_histogram_diameter,
+          &particle_custom_diameter,
         std::unordered_map<unsigned int, std::vector<double>>
-                                              &particle_histogram_probability,
-        std::unordered_map<unsigned int, int> &number,
+                                                 &particle_custom_probability,
+        std::unordered_map<unsigned int, int>    &number,
         std::unordered_map<unsigned int, double> &density_particle,
         std::unordered_map<unsigned int, double> &youngs_modulus_particle,
         std::unordered_map<unsigned int, double> &poisson_ratio_particle,

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -53,7 +53,8 @@ namespace Parameters
     enum class SizeDistributionType
     {
       uniform,
-      normal
+      normal,
+      histogram
     };
 
     struct LagrangianPhysicalProperties
@@ -70,6 +71,16 @@ namespace Parameters
 
       // Size standard deviation of each particle type
       std::unordered_map<unsigned int, double> particle_size_std;
+
+      // List of diameters for the histogram distribution for each particle
+      // types
+      std::unordered_map<unsigned int, std::vector<double>>
+        particle_histogram_diameter;
+
+      // Probability of each diameter value for the histogram distribution for
+      // each particle types for histogram
+      std::unordered_map<unsigned int, std::vector<double>>
+        particle_histogram_probability;
 
       // Distribution type of each particle type
       std::vector<SizeDistributionType> distribution_type;
@@ -135,7 +146,11 @@ namespace Parameters
         std::unordered_map<unsigned int, double> &particle_average_diameter,
         std::unordered_map<unsigned int, double> &particle_size_std,
         std::vector<SizeDistributionType>        &distribution_type,
-        std::unordered_map<unsigned int, int>    &number,
+        std::unordered_map<unsigned int, std::vector<double>>
+          &particle_histogram_diameter,
+        std::unordered_map<unsigned int, std::vector<double>>
+                                              &particle_histogram_probability,
+        std::unordered_map<unsigned int, int> &number,
         std::unordered_map<unsigned int, double> &density_particle,
         std::unordered_map<unsigned int, double> &youngs_modulus_particle,
         std::unordered_map<unsigned int, double> &poisson_ratio_particle,
@@ -470,4 +485,4 @@ namespace Parameters
 
   } // namespace Lagrangian
 } // namespace Parameters
-#endif /* PARAMETERS_H_ */
+#endif /* lethe_parameters_lagrangian_h */

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -31,7 +31,7 @@ public:
   /**
    * @brief Carries out the size sampling of particles. This is the base class of
    * NormalDistribution, UniformDistribution, LogNormalDistribution and
-   * HistogramDistribution classes.
+   * CustomDistribution classes.
    * @param particle_number Number of particle inserted at a given insertion time step.
    */
   virtual void
@@ -96,12 +96,12 @@ private:
   /**
    * Average diameter of the normal distribution.
    */
-  double diameter_average;
+  const double diameter_average;
 
   /**
    * Standard deviation of distribution of the normal distribution.
    */
-  double standard_deviation;
+  const double standard_deviation;
 };
 
 class UniformDistribution : public Distribution
@@ -116,7 +116,7 @@ public:
   UniformDistribution(const double &d_values);
 
   /**
-   * @brief Carries out the size sampling of every particles inserted at a insertion
+   * @brief Carries out the size sampling of every particles inserted at an insertion
    * time step for the uniform distribution.
    *
    * @param particle_number Number of particle inserted at a given insertion time step.
@@ -144,26 +144,26 @@ private:
   /**
    *  The diameter value of the distribution.
    */
-  double diameter_value;
+  const double diameter_value;
 };
 
-class HistogramDistribution : public Distribution
+class CustomDistribution : public Distribution
 {
 public:
   /**
    * @brief The constructor stores the parameters necessary to define the histogram
    * distribution.
-   * @param d_list
-   * @param d_probabilities
+   * @param d_list Vector of diameter values
+   * @param d_probabilities Vector of probability values based on volume with respect to each diameter value
    */
-  HistogramDistribution(const std::vector<double> &d_list,
-                        const std::vector<double> &d_probabilities);
+  CustomDistribution(const std::vector<double> &d_list,
+                     const std::vector<double> &d_probabilities);
 
   /**
-   * @brief Carries out the size sampling of each particle inserted at a insertion
-   * time step for a custom distribution.
+   * @brief Carries out the size sampling of each particle inserted at an insertion
+   * time step for the histogram distribution.
    *
-   * @param particle_number Number of particle inserted at a given insertion time step.
+   * @param particle_number Number of particles inserted at a given insertion time step.
    */
   void
   particle_size_sampling(const unsigned int &particle_number) override;
@@ -186,10 +186,15 @@ public:
 
 private:
   /**
-   *
+   * Vector containing all the diameters values.
    */
-  std::vector<double> diameter_custom_values;
-  // Cumulative probability of each diameter value.
+  const std::vector<double> diameter_custom_values;
+
+  /**
+   * Vector containing cummulative probabilities associated with de
+   * diameter_custom_values vector. The probabilities are based on the volume,
+   * not the number of particles.
+   */
   std::vector<double> diameter_custom_cumm_prob;
 };
 

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -14,6 +14,7 @@
  * ---------------------------------------------------------------------
  *
  */
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -35,7 +36,7 @@ public:
    * @param particle_number Number of particle inserted at a given insertion time step.
    */
   virtual void
-  particle_size_sampling(const unsigned int particle_number) = 0;
+  particle_size_sampling(const unsigned int &particle_number) = 0;
 
   /**
    * @brief Return the minimum diameter for a certain distribution.
@@ -60,17 +61,17 @@ public:
    * @param d_averages Average diameters for each type of particle.
    * @param d_standard_deviations Standard deviation of the diameter for each type of particle.
    */
-  NormalDistribution(const double d_averages,
-                     const double d_standard_deviations);
+  NormalDistribution(const double &d_averages,
+                     const double &d_standard_deviations);
 
   /**
    * @brief Carries out the size sampling of each particle inserted at a insertion
-   * time step.
+   * time step for the normal distribution.
    *
    * @param particle_number Number of particle inserted at a given insertion time step.
    */
   void
-  particle_size_sampling(const unsigned int particle_number) override;
+  particle_size_sampling(const unsigned int &particle_number) override;
 
   /**
    * @brief Return @diameter_values.
@@ -100,16 +101,16 @@ public:
    *
    * @param d_values Diameter values for each particle type.
    */
-  UniformDistribution(const double d_values);
+  UniformDistribution(const double &d_values);
 
   /**
    * @brief Carries out the size sampling of every particles inserted at a insertion
-   * time step.
+   * time step for the uniform distribution.
    *
    * @param particle_number Number of particle inserted at a given insertion time step.
    */
   void
-  particle_size_sampling(const unsigned int particle_number) override;
+  particle_size_sampling(const unsigned int &particle_number) override;
 
   /**
    * @brief Return @diameter_values.
@@ -126,6 +127,48 @@ public:
 private:
   // Diameter values.
   double diameter_values;
+};
+
+class HistogramDistribution : public Distribution
+{
+public:
+  /**
+   * @brief The constructor stores the parameters necessary to define the histogram
+   * distribution.
+   * @param d_list
+   * @param d_probabilities
+   * @param number_of_particle_types
+   */
+  HistogramDistribution(const std::vector<double> &d_list,
+                        const std::vector<double> &d_probabilities);
+
+  /**
+   * @brief Carries out the size sampling of each particle inserted at a insertion
+   * time step for the histogram distribution.
+   *
+   * @param particle_number Number of particle inserted at a given insertion time step.
+   * @param particle_type The type of particle being inserted.
+   */
+  void
+  particle_size_sampling(const unsigned int &particle_number) override;
+
+  /**
+   * @brief Return the minimal diameter value from the @diameter_hist_value vector.
+   */
+  double
+  find_min_diameter() override;
+
+  /**
+   * @brief Return the maximal diameter value from the @diameter_hist_value vector.
+   */
+  double
+  find_max_diameter() override;
+
+private:
+  // List of diameters values.
+  std::vector<double> diameter_hist_values;
+  // Cumulative probability of each diameter value.
+  std::vector<double> diameter_hist_cumm_prob;
 };
 
 #endif /* distributions_h */

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -30,8 +30,7 @@ public:
 
   /**
    * @brief Carries out the size sampling of particles. This is the base class of
-   * NormalDistribution, UniformDistribution, LogNormalDistribution and
-   * CustomDistribution classes.
+   * NormalDistribution, UniformDistribution and CustomDistribution classes.
    * @param particle_number Number of particle inserted at a given insertion time step.
    */
   virtual void
@@ -61,8 +60,9 @@ public:
    * @brief The constructor stores the parameters necessary to define the normal
    * distribution.
    *
-   * @param d_average Average diameters for each type of particle.
-   * @param d_standard_deviation Standard deviation of the diameter for each type of particle.
+   * @param d_average Average diameters for a certain normal distribution.
+   * @param d_standard_deviation Standard deviation of the diameter for a certain
+   * normal distribution.
    */
   NormalDistribution(const double &d_average,
                      const double &d_standard_deviation);
@@ -153,8 +153,9 @@ public:
   /**
    * @brief The constructor stores the parameters necessary to define the histogram
    * distribution.
-   * @param d_list Vector of diameter values
-   * @param d_probabilities Vector of probability values based on volume with respect to each diameter value
+   * @param d_list Vector of diameter values.
+   * @param d_probabilities Vector of probability values based on volume fraction
+   * with respect to each diameter value.
    */
   CustomDistribution(const std::vector<double> &d_list,
                      const std::vector<double> &d_probabilities);
@@ -163,7 +164,8 @@ public:
    * @brief Carries out the size sampling of each particle inserted at an insertion
    * time step for the histogram distribution.
    *
-   * @param particle_number Number of particles inserted at a given insertion time step.
+   * @param particle_number Number of particles inserted at a given insertion time
+   * step.
    */
   void
   particle_size_sampling(const unsigned int &particle_number) override;
@@ -191,11 +193,11 @@ private:
   const std::vector<double> diameter_custom_values;
 
   /**
-   * Vector containing cummulative probabilities associated with de
-   * diameter_custom_values vector. The probabilities are based on the volume,
-   * not the number of particles.
+   * Vector containing cumulative probabilities associated with de
+   * diameter_custom_values vector. The probabilities are based on the volume
+   * fraction, not the number of particles.
    */
-  std::vector<double> diameter_custom_cumm_prob;
+  std::vector<double> diameter_custom_cumu_prob;
 };
 
 #endif /* distributions_h */

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -14,7 +14,6 @@
  * ---------------------------------------------------------------------
  *
  */
-#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -40,12 +39,16 @@ public:
 
   /**
    * @brief Return the minimum diameter for a certain distribution.
+   *
+   * @return The minimum diameter of a certain distribution.
    */
   virtual double
   find_min_diameter() = 0;
 
   /**
    * @brief Return the maximum diameter for a certain distribution.
+   *
+   * @return The maximum diameter of a certain distribution.
    */
   virtual double
   find_max_diameter() = 0;
@@ -56,16 +59,16 @@ class NormalDistribution : public Distribution
 public:
   /**
    * @brief The constructor stores the parameters necessary to define the normal
-   * distribution
+   * distribution.
    *
-   * @param d_averages Average diameters for each type of particle.
-   * @param d_standard_deviations Standard deviation of the diameter for each type of particle.
+   * @param d_average Average diameters for each type of particle.
+   * @param d_standard_deviation Standard deviation of the diameter for each type of particle.
    */
-  NormalDistribution(const double &d_averages,
-                     const double &d_standard_deviations);
+  NormalDistribution(const double &d_average,
+                     const double &d_standard_deviation);
 
   /**
-   * @brief Carries out the size sampling of each particle inserted at a insertion
+   * @brief Carries out the size sampling of each particle inserted at an insertion
    * time step for the normal distribution.
    *
    * @param particle_number Number of particle inserted at a given insertion time step.
@@ -74,22 +77,31 @@ public:
   particle_size_sampling(const unsigned int &particle_number) override;
 
   /**
-   * @brief Return @diameter_values.
+   * @brief Find the minimum diameter a normal distribution.
+   *
+   * @return The minimum diameter of a normal distribution.
    */
   double
   find_min_diameter() override;
 
   /**
-   * @brief Return @diameter_values.
+   * @brief Find the maximum diameter of the normal distribution.
+   *
+   * @return The maximum diameter of the normal distribution.
    */
   double
   find_max_diameter() override;
 
 private:
-  // Average diameters.
-  double diameter_averages;
-  // Standard deviation of the diameter.
-  double standard_deviations;
+  /**
+   * Average diameter of the normal distribution.
+   */
+  double diameter_average;
+
+  /**
+   * Standard deviation of distribution of the normal distribution.
+   */
+  double standard_deviation;
 };
 
 class UniformDistribution : public Distribution
@@ -97,7 +109,7 @@ class UniformDistribution : public Distribution
 public:
   /**
    * @brief The constructor store the parameters necessary to define the uniform
-   * distribution
+   * distribution.
    *
    * @param d_values Diameter values for each particle type.
    */
@@ -113,20 +125,26 @@ public:
   particle_size_sampling(const unsigned int &particle_number) override;
 
   /**
-   * @brief Return @diameter_values.
+   * @brief Find the minimum diameter of the uniform distribution.
+   *
+   * @return The diameter of the distribution.
    */
   double
   find_min_diameter() override;
 
   /**
-   * @brief Return @diameter_values.
+   * @brief Find the maximum diameter of the uniform distribution.
+   *
+   * @return The diameter of the distribution.
    */
   double
   find_max_diameter() override;
 
 private:
-  // Diameter values.
-  double diameter_values;
+  /**
+   *  The diameter value of the distribution.
+   */
+  double diameter_value;
 };
 
 class HistogramDistribution : public Distribution
@@ -137,38 +155,42 @@ public:
    * distribution.
    * @param d_list
    * @param d_probabilities
-   * @param number_of_particle_types
    */
   HistogramDistribution(const std::vector<double> &d_list,
                         const std::vector<double> &d_probabilities);
 
   /**
    * @brief Carries out the size sampling of each particle inserted at a insertion
-   * time step for the histogram distribution.
+   * time step for a custom distribution.
    *
    * @param particle_number Number of particle inserted at a given insertion time step.
-   * @param particle_type The type of particle being inserted.
    */
   void
   particle_size_sampling(const unsigned int &particle_number) override;
 
   /**
-   * @brief Return the minimal diameter value from the @diameter_hist_value vector.
+   * @brief Find the minimum diameter of the custom distribution.
+   *
+   * @return The minimum diameter of the distribution.
    */
   double
   find_min_diameter() override;
 
   /**
-   * @brief Return the maximal diameter value from the @diameter_hist_value vector.
+   * @brief Find the maximum diameter of the custom distribution.
+   *
+   * @return The minimum diameter of the distribution.
    */
   double
   find_max_diameter() override;
 
 private:
-  // List of diameters values.
-  std::vector<double> diameter_hist_values;
+  /**
+   *
+   */
+  std::vector<double> diameter_custom_values;
   // Cumulative probability of each diameter value.
-  std::vector<double> diameter_hist_cumm_prob;
+  std::vector<double> diameter_custom_cumm_prob;
 };
 
 #endif /* distributions_h */

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3363,7 +3363,8 @@ namespace Parameters
   }
 
   std::vector<double>
-  entry_string_to_vector(ParameterHandler &prm, const std::string &entry_string)
+  convert_string_to_vector(ParameterHandler  &prm,
+                           const std::string &entry_string)
   {
     std::string              full_str = prm.get(entry_string);
     std::vector<std::string> vector_of_string(

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3370,8 +3370,7 @@ namespace Parameters
       Utilities::split_string_list(full_str));
 
     std::vector<double> vector_of_double =
-      Utilities::string_to_double(vector_of_string); // The error is thrown here
-
+      Utilities::string_to_double(vector_of_string);
 
     return vector_of_double;
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3362,6 +3362,20 @@ namespace Parameters
     return output_tensor;
   }
 
+  std::vector<double>
+  entry_string_to_vector(ParameterHandler &prm, const std::string &entry_string)
+  {
+    std::string              full_str = prm.get(entry_string);
+    std::vector<std::string> vector_of_string(
+      Utilities::split_string_list(full_str));
+
+    std::vector<double> vector_of_double =
+      Utilities::string_to_double(vector_of_string); // The error is thrown here
+
+
+    return vector_of_double;
+  }
+
   template class Laser<2>;
   template class Laser<3>;
   template class IBParticles<2>;

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -76,7 +76,7 @@ namespace Parameters
       particle_custom_diameter.at(particle_type) =
         convert_string_to_vector(prm, "custom diameters");
       particle_custom_probability.at(particle_type) =
-        convert_string_to_vector(prm, "custom probabilities");
+        convert_string_to_vector(prm, "custom volume fractions");
 
       double probability_sum =
         std::reduce(particle_custom_probability.at(particle_type).begin(),
@@ -86,7 +86,7 @@ namespace Parameters
       if (std::abs(probability_sum - 1.0) > 1.e-12)
         {
           throw(std::runtime_error(
-            "Invalid custom probabilities. The sum of probabilities should be equal to 1.0 "));
+            "Invalid custom volume fraction. The sum of volume fractions should be equal to 1.0 "));
         }
       const std::string size_distribution_type_str =
         prm.get("size distribution type");

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -19,11 +19,11 @@ namespace Parameters
                         Patterns::Double(),
                         "Particle diameter");
       prm.declare_entry("histogram diameters list",
-                        "0.001",
+                        "0.001 , 0.0005",
                         Patterns::List(Patterns::Double()),
                         "Diameter values for a histogram distribution");
       prm.declare_entry("histogram probabilities list",
-                        "1.",
+                        "0.6 , 0.4",
                         Patterns::List(Patterns::Double()),
                         "Probabilities of each diameter");
       prm.declare_entry("standard deviation",

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -18,14 +18,14 @@ namespace Parameters
                         "0.001",
                         Patterns::Double(),
                         "Particle diameter");
-      prm.declare_entry("histogram diameter list",
+      prm.declare_entry("histogram diameters list",
                         "0.001",
                         Patterns::List(Patterns::Double()),
-                        "Particle diameter");
-      prm.declare_entry("histogram diameter probabilities",
+                        "Diameter values for a histogram distribution");
+      prm.declare_entry("histogram probabilities list",
                         "1.",
                         Patterns::List(Patterns::Double()),
-                        "Particle diameter");
+                        "Probabilities of each diameter");
       prm.declare_entry("standard deviation",
                         "0",
                         Patterns::Double(),
@@ -43,7 +43,7 @@ namespace Parameters
                         Patterns::Double(),
                         "Particle Young's modulus");
       prm.declare_entry("poisson ratio particles",
-                        "0.1",
+                        "0.3",
                         Patterns::Double(),
                         "Particle Poisson ratio");
       prm.declare_entry("restitution coefficient particles",
@@ -73,9 +73,9 @@ namespace Parameters
       particle_size_std.at(particle_type) =
         prm.get_double("standard deviation");
       particle_histogram_diameter.at(particle_type) =
-        entry_string_to_vector(prm, "histogram diameter list");
+        entry_string_to_vector(prm, "histogram diameters list");
       particle_histogram_probability.at(particle_type) =
-        entry_string_to_vector(prm, "histogram diameter probabilities");
+        entry_string_to_vector(prm, "histogram probabilities list");
 
       double probability_sum =
         std::reduce(particle_histogram_probability.at(particle_type).begin(),
@@ -163,7 +163,7 @@ namespace Parameters
                           Patterns::Double(),
                           "Young's modulus of wall");
         prm.declare_entry("poisson ratio wall",
-                          "1000000.",
+                          "0.3",
                           Patterns::Double(),
                           "Poisson's ratio of wall");
         prm.declare_entry("restitution coefficient wall",

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -23,7 +23,7 @@ namespace Parameters
                         Patterns::List(Patterns::Double()),
                         "Diameter values for a custom distribution");
       prm.declare_entry(
-        "custom probabilities",
+        "custom volume fractions",
         "0.6 , 0.4",
         Patterns::List(Patterns::Double()),
         "Probabilities of each diameter of the custom distribution based on the volume fraction");
@@ -74,9 +74,9 @@ namespace Parameters
       particle_size_std.at(particle_type) =
         prm.get_double("standard deviation");
       particle_custom_diameter.at(particle_type) =
-        entry_string_to_vector(prm, "custom diameters");
+        convert_string_to_vector(prm, "custom diameters");
       particle_custom_probability.at(particle_type) =
-        entry_string_to_vector(prm, "custom probabilities");
+        convert_string_to_vector(prm, "custom probabilities");
 
       double probability_sum =
         std::reduce(particle_custom_probability.at(particle_type).begin(),

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -83,12 +83,10 @@ namespace Parameters
                     particle_custom_probability.at(particle_type).end());
 
       // We make sure that the cumulative probability is equal to 1.
-      if (probability_sum != 1.0)
+      if (std::abs(probability_sum - 1.0) < 1.e-14)
         {
-          for (double &i : particle_custom_probability.at(particle_type))
-            {
-              i = i / probability_sum;
-            }
+          throw(std::runtime_error(
+            "Invalid custom probabilities. The sum of probabilities should be equal to 1.0 "));
         }
       const std::string size_distribution_type_str =
         prm.get("size distribution type");

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -83,7 +83,7 @@ namespace Parameters
                     particle_custom_probability.at(particle_type).end());
 
       // We make sure that the cumulative probability is equal to 1.
-      if (std::abs(probability_sum - 1.0) < 1.e-14)
+      if (std::abs(probability_sum - 1.0) > 1.e-12)
         {
           throw(std::runtime_error(
             "Invalid custom probabilities. The sum of probabilities should be equal to 1.0 "));

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -232,14 +232,14 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
         }
       else if (parameters.lagrangian_physical_properties.distribution_type.at(
                  type_number) ==
-               Parameters::Lagrangian::SizeDistributionType::histogram)
+               Parameters::Lagrangian::SizeDistributionType::custom)
         {
           distribution_object_container[type_number] =
-            std::make_shared<HistogramDistribution>(
+            std::make_shared<CustomDistribution>(
+              parameters.lagrangian_physical_properties.particle_custom_diameter
+                .at(type_number),
               parameters.lagrangian_physical_properties
-                .particle_histogram_diameter.at(type_number),
-              parameters.lagrangian_physical_properties
-                .particle_histogram_probability.at(type_number));
+                .particle_custom_probability.at(type_number));
         }
       maximum_particle_diameter = std::max(
         maximum_particle_diameter,

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -230,6 +230,17 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
               parameters.lagrangian_physical_properties.particle_size_std.at(
                 type_number));
         }
+      else if (parameters.lagrangian_physical_properties.distribution_type.at(
+                 type_number) ==
+               Parameters::Lagrangian::SizeDistributionType::histogram)
+        {
+          distribution_object_container[type_number] =
+            std::make_shared<HistogramDistribution>(
+              parameters.lagrangian_physical_properties
+                .particle_histogram_diameter.at(type_number),
+              parameters.lagrangian_physical_properties
+                .particle_histogram_probability.at(type_number));
+        }
       maximum_particle_diameter = std::max(
         maximum_particle_diameter,
         distribution_object_container[type_number]->find_max_diameter());

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -98,7 +98,7 @@ CustomDistribution::CustomDistribution(
       cumulative_probability_vector.push_back(cumulative_value);
     }
 
-  diameter_custom_cumm_prob = cumulative_probability_vector;
+  diameter_custom_cumu_prob = cumulative_probability_vector;
 }
 
 void
@@ -114,11 +114,11 @@ CustomDistribution::particle_size_sampling(const unsigned int &particle_number)
   for (unsigned int i = 0; i < particle_number; ++i)
     {
       // Search to find the appropriate diameter index
-      auto it = std::upper_bound(diameter_custom_cumm_prob.begin(),
-                                 diameter_custom_cumm_prob.end(),
+      auto it = std::upper_bound(diameter_custom_cumu_prob.begin(),
+                                 diameter_custom_cumu_prob.end(),
                                  dis(gen));
 
-      unsigned int index = std::distance(diameter_custom_cumm_prob.begin(), it);
+      unsigned int index = std::distance(diameter_custom_cumu_prob.begin(), it);
 
       this->particle_sizes.push_back(diameter_custom_values[index]);
     }

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -4,10 +4,9 @@
 
 NormalDistribution::NormalDistribution(const double &d_average,
                                        const double &d_standard_deviation)
-{
-  diameter_average   = d_average;
-  standard_deviation = d_standard_deviation;
-}
+  : diameter_average(d_average)
+  , standard_deviation(d_standard_deviation)
+{}
 
 void
 NormalDistribution::particle_size_sampling(const unsigned int &particle_number)
@@ -44,9 +43,8 @@ NormalDistribution::find_max_diameter()
 }
 
 UniformDistribution::UniformDistribution(const double &d_values)
-{
-  diameter_value = d_values;
-}
+  : diameter_value(d_values)
+{}
 
 void
 UniformDistribution::particle_size_sampling(const unsigned int &particle_number)
@@ -61,20 +59,20 @@ UniformDistribution::particle_size_sampling(const unsigned int &particle_number)
 double
 UniformDistribution::find_min_diameter()
 {
-  return this->diameter_values;
+  return this->diameter_value;
 }
 
 double
 UniformDistribution::find_max_diameter()
 {
-  return this->diameter_values;
+  return this->diameter_value;
 }
 
-HistogramDistribution::HistogramDistribution(
+CustomDistribution::CustomDistribution(
   const std::vector<double> &d_list,
   const std::vector<double> &d_probabilities)
+  : diameter_custom_cumm_prob(d_list)
 {
-  diameter_cust_values = d_list;
   std::vector<double> cumulative_probability_vector;
   cumulative_probability_vector.reserve(d_probabilities.size());
 
@@ -85,12 +83,11 @@ HistogramDistribution::HistogramDistribution(
       cumulative_probability_vector.push_back(cumulative_value);
     }
 
-  diameter_cust_cumm_prob = cumulative_probability_vector;
+  diameter_custom_cumm_prob = cumulative_probability_vector;
 }
 
 void
-HistogramDistribution::particle_size_sampling(
-  const unsigned int &particle_number)
+CustomDistribution::particle_size_sampling(const unsigned int &particle_number)
 {
   this->particle_sizes.clear();
   this->particle_sizes.reserve(particle_number);
@@ -102,26 +99,26 @@ HistogramDistribution::particle_size_sampling(
   for (unsigned int i = 0; i < particle_number; ++i)
     {
       // Search to find the appropriate diameter index
-      auto it = std::upper_bound(diameter_cust_cumm_prob.begin(),
-                                 diameter_cust_cumm_prob.end(),
+      auto it = std::upper_bound(diameter_custom_cumm_prob.begin(),
+                                 diameter_custom_cumm_prob.end(),
                                  dis(gen));
 
-      unsigned int index = std::distance(diameter_cust_cumm_prob.begin(), it);
+      unsigned int index = std::distance(diameter_custom_cumm_prob.begin(), it);
 
-      this->particle_sizes.push_back(diameter_cust_values[index]);
+      this->particle_sizes.push_back(diameter_custom_values[index]);
     }
 }
 
 double
-HistogramDistribution::find_min_diameter()
+CustomDistribution::find_min_diameter()
 {
-  return *std::min_element(diameter_cust_values.begin(),
-                           diameter_cust_values.end());
+  return *std::min_element(diameter_custom_values.begin(),
+                           diameter_custom_values.end());
 }
 
 double
-HistogramDistribution::find_max_diameter()
+CustomDistribution::find_max_diameter()
 {
-  return *std::max_element(diameter_cust_values.begin(),
-                           diameter_cust_values.end());
+  return *std::max_element(diameter_custom_values.begin(),
+                           diameter_custom_values.end());
 }

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -1,3 +1,5 @@
+#include <core/utilities.h>
+
 #include <dem/distributions.h>
 
 #include <algorithm>
@@ -71,14 +73,27 @@ UniformDistribution::find_max_diameter()
 CustomDistribution::CustomDistribution(
   const std::vector<double> &d_list,
   const std::vector<double> &d_probabilities)
-  : diameter_custom_cumm_prob(d_list)
+  : diameter_custom_values(d_list)
 {
-  std::vector<double> cumulative_probability_vector;
-  cumulative_probability_vector.reserve(d_probabilities.size());
+  std::vector<double> cumulative_probability_vector, n_i_vector;
+  double              n_tot = 0.;
 
-  double cumulative_value;
-  for (double i_probability : d_probabilities)
+  cumulative_probability_vector.reserve(d_probabilities.size());
+  n_i_vector.reserve(d_probabilities.size());
+
+  for (unsigned int i = 0; i < diameter_custom_values.size(); ++i)
     {
+      n_i_vector.push_back(d_probabilities[i] / Utilities::fixed_power<3>(
+                                                  diameter_custom_values[i]));
+      n_tot += n_i_vector[i];
+    }
+
+  double i_probability;
+  double cumulative_value = 0.;
+
+  for (unsigned int i = 0; i < diameter_custom_values.size(); ++i)
+    {
+      i_probability = n_i_vector[i] / n_tot;
       cumulative_value += i_probability;
       cumulative_probability_vector.push_back(cumulative_value);
     }


### PR DESCRIPTION
# Description of the new feature

- It`s now possible to insertion particles with a list of diameters and a list of probabilities. This will be really useful for particle not following a conventional size distribution. 

# Description of the solution

- A new distribution type has been added. 

# How Has This Been Tested?

- The small-rotating scale loading prm file has been modified to test the implementation. 
- All the previous test have been tested and have succeed on my machine. 

# Documentation

- The lagrangian_physical_properties.rst file have been updated following the same approach used with in insertion_info.rst file.
- Some default parameters in the documentation were not good. 

# Future changes

- I could add a test for this new distribution, but we are not using a random seed for the diameter generation, thus I'm not sure if this would work in a test.

