### PR TITLE
Doxygen main page diagram

### DIFF
--- a/doc/doxygen/doxygen-config-file
+++ b/doc/doxygen/doxygen-config-file
@@ -17,7 +17,7 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Developer documentation for the Lethe open-source library"
 PROJECT_NUMBER         =
-PROJECT_BRIEF          =
+PROJECT_BRIEF          = 
 PROJECT_LOGO           = ./logo.png
 OUTPUT_DIRECTORY       =
 CREATE_SUBDIRS         = NO
@@ -131,7 +131,7 @@ WARN_LOGFILE           = DoxygenWarningLog.txt
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT = ../../include 
+INPUT = ../../include ./main.h  ../../source
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
@@ -198,11 +198,11 @@ USE_MDFILE_AS_MAINPAGE =
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
 #---------------------------------------------------------------------------
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 INLINE_SOURCES         = NO
-STRIP_CODE_COMMENTS    = YES
+STRIP_CODE_COMMENTS    = NO
 REFERENCED_BY_RELATION = NO
-REFERENCES_RELATION    = NO
+REFERENCES_RELATION    = YES
 REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
@@ -264,7 +264,7 @@ HTML_FORMULA_FORMAT    = png
 FORMULA_FONTSIZE       = 10
 FORMULA_TRANSPARENT    = YES
 FORMULA_MACROFILE      =
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 MATHJAX_FORMAT         = HTML-CSS
 MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 MATHJAX_EXTENSIONS     =
@@ -287,7 +287,7 @@ MAKEINDEX_CMD_NAME     = makeindex
 LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
-EXTRA_PACKAGES         = amsmath amsfonts mathtools @_extra_packages@
+EXTRA_PACKAGES         = amsmath amsfonts mathtools
 LATEX_HEADER           =
 LATEX_FOOTER           =
 LATEX_EXTRA_STYLESHEET =

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -1,0 +1,64 @@
+/**
+ * @mainpage
+ * 
+ * An outline of the main classes in Lethe and how they interact is given by the following 
+ * clickable graph:
+ *
+ * @dot
+ *    digraph main_classes {
+      graph [bgcolor="transparent", align=true, ranksep=1.5];
+      node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="royalblue", fillcolor="white", style="filled"];
+      edge [color="royalblue", weight=10];
+      rankdir="LR";
+      size = "16,10";
+      
+      physics_solver [label="PhysicsSolver", href="https://lethe-cfd.github.io/lethe/html_doxygen/classPhysicsSolver.html"];
+    
+      navier_stokes_base [label="NavierStokesBase",href="https://lethe-cfd.github.io/lethe/html_doxygen/classNavierStokesBase.html"];
+
+      auxiliary_physics [label="AuxiliaryPhysics",href="https://lethe-cfd.github.io/lethe/html_doxygen/classAuxiliaryPhysics.html"];
+
+      physics_solver:e -> navier_stokes_base:w [dir=back];
+      physics_solver:e -> auxiliary_physics:w [dir=back];
+
+      navier_stokes_base_1 [label=<<B>GLSNavierStokesSolver</B> <br/>(lethe-fluid)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSNavierStokesSolver.html", tooltip="GLSNavierStokesSolver"];
+      navier_stokes_base_2 [label=<<B>GDNavierStokesSolver</B> <br/> (lethe-fluid-block)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGDNavierStokesSolver.html", tooltip="GDNavierStokesSolver"];
+      navier_stokes_base_3 [label=<<B>MFNavierStokesSolver</B> <br/> (lethe-fluid-matrix-free)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classMFNavierStokesSolver.html", tooltip="MFNavierStokesSolver"];
+
+      navier_stokes_base:e -> navier_stokes_base_1:w [dir=back];
+      navier_stokes_base:e -> navier_stokes_base_2:w [dir=back];
+      navier_stokes_base:e -> navier_stokes_base_3:w [dir=back];
+
+      auxiliary_physics_1 [label="VolumeOfFluid",href="https://lethe-cfd.github.io/lethe/html_doxygen/classVolumeOfFluid.html"];
+      auxiliary_physics_2 [label="CahnHilliard",href="https://lethe-cfd.github.io/lethe/html_doxygen/classCahnHilliard.html"];
+      auxiliary_physics_3 [label="HeatTransfer",href="https://lethe-cfd.github.io/lethe/html_doxygen/classHeatTransfer.html"];
+      auxiliary_physics_4 [label="Tracer",href="https://lethe-cfd.github.io/lethe/html_doxygen/classTracer.html"];
+
+      auxiliary_physics:e -> auxiliary_physics_1:w [dir=back];
+      auxiliary_physics:e -> auxiliary_physics_2:w [dir=back];
+      auxiliary_physics:e -> auxiliary_physics_3:w [dir=back];
+      auxiliary_physics:e -> auxiliary_physics_4:w [dir=back];
+
+      navier_stokes_base_1_1 [label=<<B>GLSVANSSolver</B> <br/>(lethe-fluid-vans)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSVANSSolver.html", tooltip="GLSVANSSolver"];
+      navier_stokes_base_1_2 [label=<<B>GLSSharpNavierStokesSolver</B> <br/>(lethe-fluid-sharp)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSSharpNavierStokesSolver.html", tooltip="GLSSharpNavierStokesSolver"];
+      navier_stokes_base_1_3 [label=<<B>GLSNitscheNavierStokesSolver</B> <br/>(lethe-fluid-nitsche)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSNitscheNavierStokesSolver.html", tooltip="GLSNitscheNavierStokesSolver"];
+
+      navier_stokes_base_1:e -> navier_stokes_base_1_1:w [dir=back];
+      navier_stokes_base_1:e -> navier_stokes_base_1_2:w [dir=back];
+      navier_stokes_base_1:e -> navier_stokes_base_1_3:w [dir=back];      
+      
+      navier_stokes_base_1_1_1 [label=<<B>CFDDEMSolver</B> <br/>(lethe-fluid-particles)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classNavierStokesBase.html", tooltip="CFDDEMSolver"];
+
+      navier_stokes_base_1_1:e -> navier_stokes_base_1_1_1:w [dir=back];
+
+      dem_solver [label=<<B>DEM</B> <br/>(lethe-particles)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classDEMSolver.html", tooltip="DEM"];
+
+      rpt_solver_1 [label=<<B>RPT</B> <br/>(lethe-rpt-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPT.html", tooltip="RPT"];
+      rpt_solver_2 [label=<<B>RPTCellReconstruction</B> <br/>(lethe-rpt-cell-reconstruction-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPTCellReconstruction.html", tooltip="RPTCellReconstruction"];
+      rpt_solver_3 [label=<<B>RPTFEMReconstruction</B> <br/>(lethe-rpt-fem-reconstruction-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPTFEMReconstruction.html", tooltip="RPTFEMReconstruction"];
+      rpt_solver_4 [label=<<B>RPTL2Projection</B> <br/>(lethe-rpt-l2-projection-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPTL2Projection.html", tooltip="RPTL2Projection"];
+    }
+ * @enddot
+ */

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -1,7 +1,7 @@
 /**
  * @mainpage
- * 
- * An outline of the main classes in Lethe and how they interact is given by the following 
+ *
+ * An outline of the main classes in Lethe and how they interact is given by the following
  * clickable graph:
  *
  * @dot
@@ -13,9 +13,9 @@
       edge [color="royalblue", weight=10];
       rankdir="LR";
       size = "16,10";
-      
+
       physics_solver [label="PhysicsSolver", href="https://lethe-cfd.github.io/lethe/html_doxygen/classPhysicsSolver.html"];
-    
+
       navier_stokes_base [label="NavierStokesBase",href="https://lethe-cfd.github.io/lethe/html_doxygen/classNavierStokesBase.html"];
 
       auxiliary_physics [label="AuxiliaryPhysics",href="https://lethe-cfd.github.io/lethe/html_doxygen/classAuxiliaryPhysics.html"];
@@ -47,8 +47,8 @@
 
       navier_stokes_base_1:e -> navier_stokes_base_1_1:w [dir=back];
       navier_stokes_base_1:e -> navier_stokes_base_1_2:w [dir=back];
-      navier_stokes_base_1:e -> navier_stokes_base_1_3:w [dir=back];      
-      
+      navier_stokes_base_1:e -> navier_stokes_base_1_3:w [dir=back];
+
       navier_stokes_base_1_1_1 [label=<<B>CFDDEMSolver</B> <br/>(lethe-fluid-particles)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classNavierStokesBase.html", tooltip="CFDDEMSolver"];
 
       navier_stokes_base_1_1:e -> navier_stokes_base_1_1_1:w [dir=back];

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -49,7 +49,7 @@
       navier_stokes_base_1:e -> navier_stokes_base_1_2:w [dir=back];
       navier_stokes_base_1:e -> navier_stokes_base_1_3:w [dir=back];
 
-      navier_stokes_base_1_1_1 [label=<<B>CFDDEMSolver</B> <br/>(lethe-fluid-particles)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classNavierStokesBase.html", tooltip="CFDDEMSolver"];
+      navier_stokes_base_1_1_1 [label=<<B>CFDDEMSolver</B> <br/>(lethe-fluid-particles)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classCFDDEMSolver.html", tooltip="CFDDEMSolver"];
 
       navier_stokes_base_1_1:e -> navier_stokes_base_1_1_1:w [dir=back];
 


### PR DESCRIPTION
# Description of the problem

The main page of the doxygen documentation was empty.

# Description of the solution

A diagram was created with the main classes related to the Lethe applications. In addition some minor configuration settings were changed to support: equations and line numbers.

# Comments

At the moment all the links in the old documentation are broken. I will fix this in my next PR. 
