### PR TITLE
Fix documentation hyperlinks

### DIFF
--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.7
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         with:
           branch: gh-pages
           folder: doc/aggregate

--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -35,14 +35,14 @@ jobs:
         run: |
           cd doc
           make html
-          cp -r build/html/ aggregate/html_documentation
+          cp -r build/html/ aggregate/documentation
 
           cd doxygen
           doxygen doxygen-config-file
           cd ..
           ls -lh
           ls -lh doxygen
-          cp -r doxygen/html/ aggregate/html_doxygen/
+          cp -r doxygen/html/ aggregate/doxygen/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -52,7 +52,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.7
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         with:
           branch: gh-pages
           folder: doc/aggregate

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ dedicated solvers like Lethe could not exist.
 ## Documentation
 
 Documentation, tutorials, and more can be found 
-[here](https://lethe-cfd.github.io/lethe/html_documentation/index.html).
+[here](https://lethe-cfd.github.io/lethe/documentation/index.html).
 
 Developer documentation based on Doxygen can be found 
-[here](https://lethe-cfd.github.io/lethe/html_doxygen/index.html)
+[here](https://lethe-cfd.github.io/lethe/doxygen/index.html)
 
 ## Installation
 
 Follow the instructions in the
-[documentation](https://lethe-cfd.github.io/lethe/installation/installation.html).
+[documentation](https://lethe-cfd.github.io/lethe/documentation/installation/installation.html).
 
 ## Authors
 

--- a/doc/aggregate/index.html
+++ b/doc/aggregate/index.html
@@ -1,5 +1,5 @@
 <br>
-<a href="./html_documentation/index.html" target="_blank">Lethe documentation</a>
+<a href="./documentation/index.html" target="_blank">Lethe documentation</a>
 <br>
 <br>
-<a href="./html_doxygen/index.html" target="_blank">Developer documentation (doxygen)</a>
+<a href="./doxygen/index.html" target="_blank">Developer documentation (doxygen)</a>

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -14,51 +14,51 @@
       rankdir="LR";
       size = "16,10";
 
-      physics_solver [label="PhysicsSolver", href="https://lethe-cfd.github.io/lethe/html_doxygen/classPhysicsSolver.html"];
+      physics_solver [label="PhysicsSolver", href="https://lethe-cfd.github.io/lethe/doxygen/classPhysicsSolver.html"];
 
-      navier_stokes_base [label="NavierStokesBase",href="https://lethe-cfd.github.io/lethe/html_doxygen/classNavierStokesBase.html"];
+      navier_stokes_base [label="NavierStokesBase",href="https://lethe-cfd.github.io/lethe/doxygen/classNavierStokesBase.html"];
 
-      auxiliary_physics [label="AuxiliaryPhysics",href="https://lethe-cfd.github.io/lethe/html_doxygen/classAuxiliaryPhysics.html"];
+      auxiliary_physics [label="AuxiliaryPhysics",href="https://lethe-cfd.github.io/lethe/doxygen/classAuxiliaryPhysics.html"];
 
       physics_solver:e -> navier_stokes_base:w [dir=back];
       physics_solver:e -> auxiliary_physics:w [dir=back];
 
-      navier_stokes_base_1 [label=<<B>GLSNavierStokesSolver</B> <br/>(lethe-fluid)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSNavierStokesSolver.html", tooltip="GLSNavierStokesSolver"];
-      navier_stokes_base_2 [label=<<B>GDNavierStokesSolver</B> <br/> (lethe-fluid-block)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGDNavierStokesSolver.html", tooltip="GDNavierStokesSolver"];
-      navier_stokes_base_3 [label=<<B>MFNavierStokesSolver</B> <br/> (lethe-fluid-matrix-free)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classMFNavierStokesSolver.html", tooltip="MFNavierStokesSolver"];
+      navier_stokes_base_1 [label=<<B>GLSNavierStokesSolver</B> <br/>(lethe-fluid)>,href="https://lethe-cfd.github.io/lethe/doxygen/classGLSNavierStokesSolver.html", tooltip="GLSNavierStokesSolver"];
+      navier_stokes_base_2 [label=<<B>GDNavierStokesSolver</B> <br/> (lethe-fluid-block)>,href="https://lethe-cfd.github.io/lethe/doxygen/classGDNavierStokesSolver.html", tooltip="GDNavierStokesSolver"];
+      navier_stokes_base_3 [label=<<B>MFNavierStokesSolver</B> <br/> (lethe-fluid-matrix-free)>,href="https://lethe-cfd.github.io/lethe/doxygen/classMFNavierStokesSolver.html", tooltip="MFNavierStokesSolver"];
 
       navier_stokes_base:e -> navier_stokes_base_1:w [dir=back];
       navier_stokes_base:e -> navier_stokes_base_2:w [dir=back];
       navier_stokes_base:e -> navier_stokes_base_3:w [dir=back];
 
-      auxiliary_physics_1 [label="VolumeOfFluid",href="https://lethe-cfd.github.io/lethe/html_doxygen/classVolumeOfFluid.html"];
-      auxiliary_physics_2 [label="CahnHilliard",href="https://lethe-cfd.github.io/lethe/html_doxygen/classCahnHilliard.html"];
-      auxiliary_physics_3 [label="HeatTransfer",href="https://lethe-cfd.github.io/lethe/html_doxygen/classHeatTransfer.html"];
-      auxiliary_physics_4 [label="Tracer",href="https://lethe-cfd.github.io/lethe/html_doxygen/classTracer.html"];
+      auxiliary_physics_1 [label="VolumeOfFluid",href="https://lethe-cfd.github.io/lethe/doxygen/classVolumeOfFluid.html"];
+      auxiliary_physics_2 [label="CahnHilliard",href="https://lethe-cfd.github.io/lethe/doxygen/classCahnHilliard.html"];
+      auxiliary_physics_3 [label="HeatTransfer",href="https://lethe-cfd.github.io/lethe/doxygen/classHeatTransfer.html"];
+      auxiliary_physics_4 [label="Tracer",href="https://lethe-cfd.github.io/lethe/doxygen/classTracer.html"];
 
       auxiliary_physics:e -> auxiliary_physics_1:w [dir=back];
       auxiliary_physics:e -> auxiliary_physics_2:w [dir=back];
       auxiliary_physics:e -> auxiliary_physics_3:w [dir=back];
       auxiliary_physics:e -> auxiliary_physics_4:w [dir=back];
 
-      navier_stokes_base_1_1 [label=<<B>GLSVANSSolver</B> <br/>(lethe-fluid-vans)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSVANSSolver.html", tooltip="GLSVANSSolver"];
-      navier_stokes_base_1_2 [label=<<B>GLSSharpNavierStokesSolver</B> <br/>(lethe-fluid-sharp)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSSharpNavierStokesSolver.html", tooltip="GLSSharpNavierStokesSolver"];
-      navier_stokes_base_1_3 [label=<<B>GLSNitscheNavierStokesSolver</B> <br/>(lethe-fluid-nitsche)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classGLSNitscheNavierStokesSolver.html", tooltip="GLSNitscheNavierStokesSolver"];
+      navier_stokes_base_1_1 [label=<<B>GLSVANSSolver</B> <br/>(lethe-fluid-vans)>,href="https://lethe-cfd.github.io/lethe/doxygen/classGLSVANSSolver.html", tooltip="GLSVANSSolver"];
+      navier_stokes_base_1_2 [label=<<B>GLSSharpNavierStokesSolver</B> <br/>(lethe-fluid-sharp)>,href="https://lethe-cfd.github.io/lethe/doxygen/classGLSSharpNavierStokesSolver.html", tooltip="GLSSharpNavierStokesSolver"];
+      navier_stokes_base_1_3 [label=<<B>GLSNitscheNavierStokesSolver</B> <br/>(lethe-fluid-nitsche)>,href="https://lethe-cfd.github.io/lethe/doxygen/classGLSNitscheNavierStokesSolver.html", tooltip="GLSNitscheNavierStokesSolver"];
 
       navier_stokes_base_1:e -> navier_stokes_base_1_1:w [dir=back];
       navier_stokes_base_1:e -> navier_stokes_base_1_2:w [dir=back];
       navier_stokes_base_1:e -> navier_stokes_base_1_3:w [dir=back];
 
-      navier_stokes_base_1_1_1 [label=<<B>CFDDEMSolver</B> <br/>(lethe-fluid-particles)>,href="https://lethe-cfd.github.io/lethe/html_doxygen/classCFDDEMSolver.html", tooltip="CFDDEMSolver"];
+      navier_stokes_base_1_1_1 [label=<<B>CFDDEMSolver</B> <br/>(lethe-fluid-particles)>,href="https://lethe-cfd.github.io/lethe/doxygen/classCFDDEMSolver.html", tooltip="CFDDEMSolver"];
 
       navier_stokes_base_1_1:e -> navier_stokes_base_1_1_1:w [dir=back];
 
-      dem_solver [label=<<B>DEM</B> <br/>(lethe-particles)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classDEMSolver.html", tooltip="DEM"];
+      dem_solver [label=<<B>DEM</B> <br/>(lethe-particles)>, href="https://lethe-cfd.github.io/lethe/doxygen/classDEMSolver.html", tooltip="DEM"];
 
-      rpt_solver_1 [label=<<B>RPT</B> <br/>(lethe-rpt-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPT.html", tooltip="RPT"];
-      rpt_solver_2 [label=<<B>RPTCellReconstruction</B> <br/>(lethe-rpt-cell-reconstruction-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPTCellReconstruction.html", tooltip="RPTCellReconstruction"];
-      rpt_solver_3 [label=<<B>RPTFEMReconstruction</B> <br/>(lethe-rpt-fem-reconstruction-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPTFEMReconstruction.html", tooltip="RPTFEMReconstruction"];
-      rpt_solver_4 [label=<<B>RPTL2Projection</B> <br/>(lethe-rpt-l2-projection-3d)>, href="https://lethe-cfd.github.io/lethe/html_doxygen/classRPTL2Projection.html", tooltip="RPTL2Projection"];
+      rpt_solver_1 [label=<<B>RPT</B> <br/>(lethe-rpt-3d)>, href="https://lethe-cfd.github.io/lethe/doxygen/classRPT.html", tooltip="RPT"];
+      rpt_solver_2 [label=<<B>RPTCellReconstruction</B> <br/>(lethe-rpt-cell-reconstruction-3d)>, href="https://lethe-cfd.github.io/lethe/doxygen/classRPTCellReconstruction.html", tooltip="RPTCellReconstruction"];
+      rpt_solver_3 [label=<<B>RPTFEMReconstruction</B> <br/>(lethe-rpt-fem-reconstruction-3d)>, href="https://lethe-cfd.github.io/lethe/doxygen/classRPTFEMReconstruction.html", tooltip="RPTFEMReconstruction"];
+      rpt_solver_4 [label=<<B>RPTL2Projection</B> <br/>(lethe-rpt-l2-projection-3d)>, href="https://lethe-cfd.github.io/lethe/doxygen/classRPTL2Projection.html", tooltip="RPTL2Projection"];
     }
  * @enddot
  */

--- a/doc/source/examples/dem/dem.rst
+++ b/doc/source/examples/dem/dem.rst
@@ -33,35 +33,35 @@ We organize the DEM examples from the simplest to the most complicated example:
       rankdir="LR";
       size = "9,9";
       
-      dem [label="Discrete Element \nMethod (DEM)", href="https://lethe-cfd.github.io/lethe/examples/dem/dem.html"];
+      dem [label="Discrete Element \nMethod (DEM)", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/dem.html"];
 
-      dem_1 [label="Bouncing Particle", href="https://lethe-cfd.github.io/lethe/examples/dem/bouncing-particle/bouncing-particle.html"];
+      dem_1 [label="Bouncing Particle", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/bouncing-particle/bouncing-particle.html"];
 
-      dem_2 [label="Oblique Wall Impact", href="https://lethe-cfd.github.io/lethe/examples/dem/oblique-wall-impact/oblique-wall-impact.html"];
+      dem_2 [label="Oblique Wall Impact", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/oblique-wall-impact/oblique-wall-impact.html"];
 
-      dem_3 [label="Packing in Circle", href="https://lethe-cfd.github.io/lethe/examples/dem/packing-in-circle/packing-in-circle.html"];
+      dem_3 [label="Packing in Circle", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/packing-in-circle/packing-in-circle.html"];
 
-      dem_4 [label="Packing in Ball", href="https://lethe-cfd.github.io/lethe/examples/dem/packing-in-ball/packing-in-ball.html"];
+      dem_4 [label="Packing in Ball", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/packing-in-ball/packing-in-ball.html"];
 
-      dem_5 [label="Small Scale Rotating Drum", href="https://lethe-cfd.github.io/lethe/examples/dem/small-scale-rotating-drum/small-scale-rotating-drum.html"];
+      dem_5 [label="Small Scale Rotating Drum", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/small-scale-rotating-drum/small-scale-rotating-drum.html"];
     
-      dem_6 [label="Small Scale Rotating Drum Post-processing", href="https://lethe-cfd.github.io/lethe/examples/dem/small-scale-rotating-drum-post-processing/small-scale-rotating-drum-post-processing.html"];
+      dem_6 [label="Small Scale Rotating Drum Post-processing", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/small-scale-rotating-drum-post-processing/small-scale-rotating-drum-post-processing.html"];
 
-      dem_7 [label="Rotating Drum", href="https://lethe-cfd.github.io/lethe/examples/dem/rotating-drum/rotating-drum.html"];
+      dem_7 [label="Rotating Drum", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/rotating-drum/rotating-drum.html"];
 
-      dem_8 [label="Rotating Drum with Post-processing", href="https://lethe-cfd.github.io/lethe/examples/dem/rotating-drum-with-post-processing/rotating-drum-with-post-processing.html"];
+      dem_8 [label="Rotating Drum with Post-processing", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/rotating-drum-with-post-processing/rotating-drum-with-post-processing.html"];
 
-      dem_9 [label="Rotation of Box", href="https://lethe-cfd.github.io/lethe/examples/dem/rotation-of-box/rotation-of-box.html"];
+      dem_9 [label="Rotation of Box", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/rotation-of-box/rotation-of-box.html"];
 
-      dem_10 [label="Silo", href="https://lethe-cfd.github.io/lethe/examples/dem/silo/silo.html"]; 
+      dem_10 [label="Silo", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/silo/silo.html"]; 
 
-      dem_11 [label="Rectangular Hopper", href="https://lethe-cfd.github.io/lethe/examples/dem/rectangular-hopper/rectangular-hopper.html"];
+      dem_11 [label="Rectangular Hopper", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/rectangular-hopper/rectangular-hopper.html"];
 
-      dem_12 [label="Granular Dam-Break", href="https://lethe-cfd.github.io/lethe/examples/dem/granular-dam-break/granular-dam-break.html"];
+      dem_12 [label="Granular Dam-Break", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/granular-dam-break/granular-dam-break.html"];
 
-      dem_13 [label="Bunny Drill", href="https://lethe-cfd.github.io/lethe/examples/dem/bunny-drill/bunny-drill.html"];
+      dem_13 [label="Bunny Drill", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/bunny-drill/bunny-drill.html"];
 
-      dem_14 [label="Granular Mixer", href="https://lethe-cfd.github.io/lethe/examples/dem/granular-mixer/granular-mixer.html"];
+      dem_14 [label="Granular Mixer", href="https://lethe-cfd.github.io/lethe/documentation/examples/dem/granular-mixer/granular-mixer.html"];
 
       
 

--- a/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
+++ b/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
@@ -242,7 +242,7 @@ For :math:`Re \geq 700`, however, it is often necessary to set ``ilu precondtion
     end
 	
 .. tip::
-	It is important to note that the ``minimum residual`` of the linear solver is smaller than the ``tolerance`` of the nonlinear solver. The reader can consult the `Parameters Guide <https://lethe-cfd.github.io/lethe/parameters/cfd/linear_solver_control.html>`_ for more information.
+	It is important to note that the ``minimum residual`` of the linear solver is smaller than the ``tolerance`` of the nonlinear solver. The reader can consult the `Parameters Guide <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/linear_solver_control.html>`_ for more information.
 
 
 -----------------------

--- a/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
+++ b/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
@@ -161,7 +161,7 @@ The boundary conditions are defined as presented above:
        end
      end
 	
-The boundary 0, corresponding to the NACA0012 surface, is a ``noslip`` boundary condition that sets the velocity to zero on the boundary. Boundary 1 is the inlet where the velocity field was chosen to be horizontal and unitary to ensure that :math:`Re = 1000` is correct. It is represented in green on the figure. Boundary 2, in black on the image, corresponds to the upper and lower walls which are endowed with a ``slip`` boundary condition. Finally, boundary 3 is of type ``outlet`` with a parameter :math:`\beta = 1.3`. The reader is referred to the `Parameters Guide <https://lethe-cfd.github.io/lethe/parameters/cfd/linear_solver_control.html>`_ for more information about the :math:`\beta` parameter.
+The boundary 0, corresponding to the NACA0012 surface, is a ``noslip`` boundary condition that sets the velocity to zero on the boundary. Boundary 1 is the inlet where the velocity field was chosen to be horizontal and unitary to ensure that :math:`Re = 1000` is correct. It is represented in green on the figure. Boundary 2, in black on the image, corresponds to the upper and lower walls which are endowed with a ``slip`` boundary condition. Finally, boundary 3 is of type ``outlet`` with a parameter :math:`\beta = 1.3`. The reader is referred to the `Parameters Guide <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/linear_solver_control.html>`_ for more information about the :math:`\beta` parameter.
 
 Non-linear Solver
 ~~~~~~~~~~~~~~~~~
@@ -202,7 +202,7 @@ Again, in order to reduce the computational time, the ``minimum residual`` for t
 	
 	
 .. tip::
-	It is important to note that the ``minimum residual`` of the linear solver is smaller than the ``tolerance`` of the non-linear solver. The reader can consult the `Parameters Guide <https://lethe-cfd.github.io/lethe/parameters/cfd/linear_solver_control.html>`_ for more information.
+	It is important to note that the ``minimum residual`` of the linear solver is smaller than the ``tolerance`` of the non-linear solver. The reader can consult the `Parameters Guide <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/linear_solver_control.html>`_ for more information.
 
 
 -----------------------

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
@@ -155,7 +155,7 @@ FEM Interpolation
 
 .. note::
 
-  In `Example 2 <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html>`_ we have used second order element for velocity. In this problem, since we are using immersed boundary conditions, moving to higher order polynomials would not enhance the order of convergence as the solid boundary is not represented with high accuracy.
+  In `Example 2 <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html>`_ we have used second order element for velocity. In this problem, since we are using immersed boundary conditions, moving to higher order polynomials would not enhance the order of convergence as the solid boundary is not represented with high accuracy.
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-transient-flow-around-ahmed-body/2d-transient-flow-around-ahmed-body.rst
+++ b/doc/source/examples/incompressible-flow/2d-transient-flow-around-ahmed-body/2d-transient-flow-around-ahmed-body.rst
@@ -51,7 +51,7 @@ The basic geometry for the Ahmed body is given below, as defined in Ahmed et al.
 Parameter File
 --------------
 
-First, we import the mesh as in the `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_. 
+First, we import the mesh as in the `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_. 
 
 Mesh
 ~~~~~
@@ -79,7 +79,7 @@ Geometry parameters can be adapted in the "Parameters" section of the ``.geo`` f
     xmax = 2500/unit;
     ymax = 1000/unit;
 
-The initial `Mesh <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh.html>`_ is built with `Gmsh <https://gmsh.info/#Download>`_. It is defined as transfinite at the body boundary layer and between the body and the road, and free for the rest of the domain. The mesh is dynamically refined throughout the simulation. This will be explained later in this example.
+The initial `Mesh <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh.html>`_ is built with `Gmsh <https://gmsh.info/#Download>`_. It is defined as transfinite at the body boundary layer and between the body and the road, and free for the rest of the domain. The mesh is dynamically refined throughout the simulation. This will be explained later in this example.
 
 The input mesh ``Ahmed-Body-20-2D.msh`` is in the same folder as the ``.prm`` file. The mesh subsection is set to use this file.
 
@@ -92,11 +92,11 @@ The input mesh ``Ahmed-Body-20-2D.msh`` is in the same folder as the ``.prm`` fi
 
 .. note::
 
-    For further information about `Mesh <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh.html>`_ generation, we refer to the reader to the :doc:`../../../tools/gmsh/gmsh` page of this documentation, or the `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ on the deal.ii documentation and the `Gmsh <https://gmsh.info/#Download>`_ website.
+    For further information about `Mesh <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh.html>`_ generation, we refer to the reader to the :doc:`../../../tools/gmsh/gmsh` page of this documentation, or the `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ on the deal.ii documentation and the `Gmsh <https://gmsh.info/#Download>`_ website.
 
 Initial and Boundary Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The `Initial Condition <https://lethe-cfd.github.io/lethe/parameters/cfd/initial_conditions.html>`_ and `Boundary Conditions <https://lethe-cfd.github.io/lethe/parameters/cfd/boundary_conditions_cfd.html>`_ are defined as in `Example 3 <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_.
+The `Initial Condition <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/initial_conditions.html>`_ and `Boundary Conditions <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/boundary_conditions_cfd.html>`_ are defined as in `Example 3 <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_.
 
 .. code-block:: text
 
@@ -131,7 +131,7 @@ The `Initial Condition <https://lethe-cfd.github.io/lethe/parameters/cfd/initial
 
 Simulation Control
 ~~~~~~~~~~~~~~~~~~
-Time integration is defined by a 1st order backward differentiation (``bdf1``), for a 4 seconds simulation (``time end``) with a 0.01 second ``time step``. The ``output path`` is defined to save obtained results in a sub-directory, as stated in `Simulation Control <https://lethe-cfd.github.io/lethe/parameters/cfd/simulation_control.html>`_:
+Time integration is defined by a 1st order backward differentiation (``bdf1``), for a 4 seconds simulation (``time end``) with a 0.01 second ``time step``. The ``output path`` is defined to save obtained results in a sub-directory, as stated in `Simulation Control <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/simulation_control.html>`_:
 
 .. code-block:: text
 
@@ -174,7 +174,7 @@ Alternatively, specify the path to the ``lethe-fluid`` in your ``build/applicati
 
       mpirun -np 6 ../build/applications/lethe-fluid/lethe-fluid ahmed.prm
 
-Guidelines for parameters other than the previous mentioned are found at the `Parameters guide <https://lethe-cfd.github.io/lethe/parameters/parameters.html>`_.
+Guidelines for parameters other than the previous mentioned are found at the `Parameters guide <https://lethe-cfd.github.io/lethe/documentation/parameters/parameters.html>`_.
 
 
 -------

--- a/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
@@ -26,7 +26,7 @@ Files Used in This Example
 Description of the Case
 -----------------------
 
-We simulate the flow around a fixed cylinder with a constant upstream fluid velocity. We re-use the geometry and mesh presented in `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_, which were taken from Blais *et al.* `[1] <https://doi.org/10.1016/j.compchemeng.2015.10.019>`_:
+We simulate the flow around a fixed cylinder with a constant upstream fluid velocity. We re-use the geometry and mesh presented in `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_, which were taken from Blais *et al.* `[1] <https://doi.org/10.1016/j.compchemeng.2015.10.019>`_:
 
 .. image:: images/geometry-description.png
     :alt: The geometry
@@ -75,7 +75,7 @@ The interpolation orders for the velocity and pressure are set to Q2-Q1 in the `
 Mesh
 ~~~~~
 
-The initial mesh is generated with `Gmsh <https://gmsh.info/#Download>`_ and imported as described in  `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_.
+The initial mesh is generated with `Gmsh <https://gmsh.info/#Download>`_ and imported as described in  `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_.
 
 .. code-block:: text
 
@@ -104,12 +104,12 @@ While the discretization in the wake of the cylinder has less impact on the forc
       set fraction coarsening  = 0.01
     end
 
-Here, we are using the pressure as the variable for the `Kelly error estimator <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh_adaptation_control.html>`_, unlike the previous examples which were using the velocity. Indeed, we have observed that the refinement has less tendency to follow the vortices as they move through the wake with the pressure as the refinement indicator than if we select the velocity. Additionally, the ``fraction refinement`` and ``fraction coarsening`` are set to lower values than the previous examples (i.e., respectively 0.02 and 0.01) to enable a gradual growth of the mesh size.
+Here, we are using the pressure as the variable for the `Kelly error estimator <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh_adaptation_control.html>`_, unlike the previous examples which were using the velocity. Indeed, we have observed that the refinement has less tendency to follow the vortices as they move through the wake with the pressure as the refinement indicator than if we select the velocity. Additionally, the ``fraction refinement`` and ``fraction coarsening`` are set to lower values than the previous examples (i.e., respectively 0.02 and 0.01) to enable a gradual growth of the mesh size.
 
 
 Initial and Boundary Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The `Initial Condition <https://lethe-cfd.github.io/lethe/parameters/cfd/initial_conditions.html>`_ and `Boundary Conditions <https://lethe-cfd.github.io/lethe/parameters/cfd/boundary_conditions_cfd.html>`_ are defined as in `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_.
+The `Initial Condition <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/initial_conditions.html>`_ and `Boundary Conditions <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/boundary_conditions_cfd.html>`_ are defined as in `2D Flow around a cylinder <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html>`_.
 
 .. code-block:: text
 
@@ -145,7 +145,7 @@ The `Initial Condition <https://lethe-cfd.github.io/lethe/parameters/cfd/initial
 Physical Properties
 ~~~~~~~~~~~~~~~~~~~
 
-The Reynolds number must be high enough to capture a transient flow and study the evolution of the drag and lift coefficients in time. Therefore, we set Re = 200 through the value of the kinematic viscosity in the same manner as for the `2D Lid-driven cavity flow <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-lid%E2%80%90driven-cavity-flow/lid%E2%80%90driven-cavity-flow.html>`_. Since :math:`U_\infty = 1` and the :math:`D = 1`, we have :math:`Re=\frac{1}{\nu}`, where :math:`\nu` is the kinematic viscosity.
+The Reynolds number must be high enough to capture a transient flow and study the evolution of the drag and lift coefficients in time. Therefore, we set Re = 200 through the value of the kinematic viscosity in the same manner as for the `2D Lid-driven cavity flow <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-lid%E2%80%90driven-cavity-flow/lid%E2%80%90driven-cavity-flow.html>`_. Since :math:`U_\infty = 1` and the :math:`D = 1`, we have :math:`Re=\frac{1}{\nu}`, where :math:`\nu` is the kinematic viscosity.
 
 .. code-block:: text
 
@@ -207,14 +207,14 @@ As we set ``calculation frequency`` to 1, the forces on each boundary are comput
 
 .. warning::
 
-  The computational cost of writing this output file at each time step by setting ``output frequency`` to 1 can be significant, as explained in `Force and torque calculation <https://lethe-cfd.github.io/lethe/parameters/cfd/force_and_torque.html>`_. It is a good practice to set ``output frequency`` to higher values, such as 10-100, to reduce the computational cost.
+  The computational cost of writing this output file at each time step by setting ``output frequency`` to 1 can be significant, as explained in `Force and torque calculation <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/force_and_torque.html>`_. It is a good practice to set ``output frequency`` to higher values, such as 10-100, to reduce the computational cost.
 
 
 ----------------------
 Running the Simulation
 ----------------------
 
-The simulation is launched in parallel using 10 CPUs, as explained in `2D Transient flow around an Ahmed body <https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-transient-around-ahmed-body/2d-transient-around-ahmed-body.html>`_ :
+The simulation is launched in parallel using 10 CPUs, as explained in `2D Transient flow around an Ahmed body <https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-transient-around-ahmed-body/2d-transient-around-ahmed-body.html>`_ :
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/incompressible-flow.rst
+++ b/doc/source/examples/incompressible-flow/incompressible-flow.rst
@@ -34,7 +34,7 @@ Incompressible Flow
       image_1 [image="./map_images/3d-mixer-using-single-rotating-frame.png", label="", fixedsize=true, width=2, height=3]
       }
 
-      incompressible_flow [label="Incompressible \nFlow", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/incompressible-flow.html"];
+      incompressible_flow [label="Incompressible \nFlow", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/incompressible-flow.html"];
 
       {
       node [color=none];
@@ -43,31 +43,31 @@ Incompressible Flow
       
       incompressible_1 [label="2D"]; 
 
-      incompressible_1_1 [label="Lid-Driven Cavity Flow",href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-lid%E2%80%90driven-cavity-flow/lid%E2%80%90driven-cavity-flow.html"];
+      incompressible_1_1 [label="Lid-Driven Cavity Flow",href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-lid%E2%80%90driven-cavity-flow/lid%E2%80%90driven-cavity-flow.html"];
 
-      incompressible_1_2 [label="Flow around a Cylinder", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html"];
+      incompressible_1_2 [label="Flow around a Cylinder", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-flow-around-cylinder/2d-flow-around-cylinder.html"];
 
-      incompressible_1_3 [label="Taylor-Couette Flow", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html"];
+      incompressible_1_3 [label="Taylor-Couette Flow", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html"];
 
-      incompressible_1_4 [label="Flow past a Backward-Facing Step", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.html"];
+      incompressible_1_4 [label="Flow past a Backward-Facing Step", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.html"];
 
-      incompressible_1_5 [label="Transient Flow around an Ahmed Body", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-transient-around-ahmed-body/2d-transient-around-ahmed-body.html"];
+      incompressible_1_5 [label="Transient Flow around an Ahmed Body", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-transient-around-ahmed-body/2d-transient-around-ahmed-body.html"];
 
-      incompressible_1_6 [label="Transient Flow around a Cylinder", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.html"];
+      incompressible_1_6 [label="Transient Flow around a Cylinder", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.html"];
 
-      incompressible_1_7 [label="Flow around NACA0012 \nat low Reynolds Number", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.html", tooltip="Flow around NACA0012 at low Reynolds number"];
+      incompressible_1_7 [label="Flow around NACA0012 \nat low Reynolds Number", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.html", tooltip="Flow around NACA0012 at low Reynolds number"];
 
-      incompressible_1_8 [label="Taylor-Couette Flow Using \nNitsche Immersed Boundary", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.html", tooltip="Taylor-Couette flow using Nitsche immersed boundary"];
+      incompressible_1_8 [label="Taylor-Couette Flow Using \nNitsche Immersed Boundary", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.html", tooltip="Taylor-Couette flow using Nitsche immersed boundary"];
 
       incompressible_2 [label="3D",shape=polygon,sides=4]; 
 
-      incompressible_2_1 [label="Flow around a Sphere", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/3d-flow-around-sphere/flow-around-sphere.html"];
+      incompressible_2_1 [label="Flow around a Sphere", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/3d-flow-around-sphere/flow-around-sphere.html"];
       
-      incompressible_2_2 [label="Flow over Periodic Hills", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.html"];
+      incompressible_2_2 [label="Flow over Periodic Hills", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.html"];
 
-      incompressible_2_3 [label="Ribbon Mixer Using a Single \n Rotating Reference Frame", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.html", tooltip="Ribbon mixer using a single rotating reference frame"];
+      incompressible_2_3 [label="Ribbon Mixer Using a Single \n Rotating Reference Frame", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.html", tooltip="Ribbon mixer using a single rotating reference frame"];
 
-      incompressible_2_4 [label="Mixer with Pitched-Blade Turbine Impeller \nUsing Nitsche Immersed Boundary", href="https://lethe-cfd.github.io/lethe/examples/incompressible-flow/3d-nitsche-mixer-with-pbt-impeller/nitsche-mixer-with-pbt-impeller.html", tooltip="Mixer with pitched-blade turbine impeller using Nitsche immersed boundary"];
+      incompressible_2_4 [label="Mixer with Pitched-Blade Turbine Impeller \nUsing Nitsche Immersed Boundary", href="https://lethe-cfd.github.io/lethe/documentation/examples/incompressible-flow/3d-nitsche-mixer-with-pbt-impeller/nitsche-mixer-with-pbt-impeller.html", tooltip="Mixer with pitched-blade turbine impeller using Nitsche immersed boundary"];
 
       incompressible_flow:e -> incompressible_1:w;
       incompressible_flow:e -> incompressible_2:w;

--- a/doc/source/examples/multiphysics/air-bubble-compression/air-bubble-compression.rst
+++ b/doc/source/examples/multiphysics/air-bubble-compression/air-bubble-compression.rst
@@ -206,7 +206,7 @@ Physical Properties
 ~~~~~~~~~~~~~~~~~~~~
 
 In the ``physical properties`` subsection, we define the properties of the fluids. For air, represented by ``fluid 0``, the ``isothermal_ideal_gas`` density model is used to account for the fluid's compressibility.
-We refer the reader to the `Physical Properties - Density Models <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#density-models>`_ documentation for further explanation on the isothermal compressible density model.
+We refer the reader to the `Physical Properties - Density Models <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/physical_properties.html#density-models>`_ documentation for further explanation on the isothermal compressible density model.
 The properties of air and water at :math:`25 \, \text{°C}` are used in this example.
 
 .. code-block:: text

--- a/doc/source/examples/multiphysics/laser-heating/laser-heating.rst
+++ b/doc/source/examples/multiphysics/laser-heating/laser-heating.rst
@@ -112,7 +112,7 @@ In the ``laser parameters`` section, the parameters of the laser model are defin
     q(x,y,z) = \frac{\eta \alpha P}{\pi r^2 \mu} \exp{\left(-\eta \frac{r^2}{R^2}\right)} \exp{\left(- \frac{|z|}{\mu}\right)}
 
 
-where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r` and :math:`z` denote concentration factor, absorptivity, laser power, beam radius, penetration depth, radial distance from the laser focal point, and axial distance from the laser focal point, respectively. These parameters are explained in more detail in the `laser parameters <https://lethe-cfd.github.io/lethe/parameters/cfd/laser_heat_source.html>`_.
+where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r` and :math:`z` denote concentration factor, absorptivity, laser power, beam radius, penetration depth, radial distance from the laser focal point, and axial distance from the laser focal point, respectively. These parameters are explained in more detail in the `laser parameters <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/laser_heat_source.html>`_.
 
 
 .. note:: 
@@ -140,7 +140,7 @@ where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r`
 Mesh Adaptation
 ~~~~~~~~~~~~~~~
 
-In the ``mesh adaptation`` subsection, we choose a mesh refinement based on the variable ``temperature``. Mesh adaptation is explained in more detail in `mesh adaptation control <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh_adaptation_control.html>`_
+In the ``mesh adaptation`` subsection, we choose a mesh refinement based on the variable ``temperature``. Mesh adaptation is explained in more detail in `mesh adaptation control <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh_adaptation_control.html>`_
 
 
 .. code-block:: text

--- a/doc/source/examples/multiphysics/laser-melt-pool/laser-melt-pool.rst
+++ b/doc/source/examples/multiphysics/laser-melt-pool/laser-melt-pool.rst
@@ -170,7 +170,7 @@ In the ``laser parameters`` section, the parameters of the laser model are defin
     q(x,y,z) = \frac{\eta \alpha P}{\pi r^2 \mu} \exp{\left(-\eta \frac{r^2}{R^2}\right)} \exp{\left(- \frac{|z|}{\mu}\right)}
 
 
-where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r` and :math:`z` denote concentration factor, absorptivity, laser power, beam radius, penetration depth, radial distance from the laser focal point, and axial distance from the laser focal point, respectively. These parameters are explained in more detail in `laser parameters <https://lethe-cfd.github.io/lethe/parameters/cfd/laser_heat_source.html>`_.
+where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r` and :math:`z` denote concentration factor, absorptivity, laser power, beam radius, penetration depth, radial distance from the laser focal point, and axial distance from the laser focal point, respectively. These parameters are explained in more detail in `laser parameters <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/laser_heat_source.html>`_.
 
 
 .. note:: 
@@ -199,7 +199,7 @@ where :math:`\eta`, :math:`\alpha`, :math:`P`, :math:`R`, :math:`\mu`, :math:`r`
 Physical Properties
 ~~~~~~~~~~~~~~~~~~~
 
-The laser heat source locally melts the material, which is initially in the solid phase according to the definition of the ``solidus temperature``. Hence, the physical properties should be defined using ``phase_change`` models. Interested readers may find more information on phase change model in the `Stefan problem example <https://lethe-cfd.github.io/lethe/examples/multiphysics/stefan-problem/stefan-problem.html>`_ . In the ``physical properties`` subsection, the physical properties of the different phases of the fluid are defined:
+The laser heat source locally melts the material, which is initially in the solid phase according to the definition of the ``solidus temperature``. Hence, the physical properties should be defined using ``phase_change`` models. Interested readers may find more information on phase change model in the `Stefan problem example <https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/stefan-problem/stefan-problem.html>`_ . In the ``physical properties`` subsection, the physical properties of the different phases of the fluid are defined:
 
 
 .. code-block:: text

--- a/doc/source/examples/multiphysics/multiphysics.rst
+++ b/doc/source/examples/multiphysics/multiphysics.rst
@@ -20,47 +20,47 @@ Multiphysics
       rankdir="LR";
       size = "9,9";
 
-      multiphysics [label="Multiphysics", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/multiphysics.html"];
+      multiphysics [label="Multiphysics", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/multiphysics.html"];
 
-      multiphysics_1 [label="VOF", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/vof.html"];  
+      multiphysics_1 [label="VOF", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/vof.html"];  
 
-      multiphysics_1_1 [label="Dam-Break", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/dam-break/dam-break.html"];
+      multiphysics_1_1 [label="Dam-Break", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/dam-break/dam-break.html"];
 
-      multiphysics_1_2 [label="Rayleigh-Taylor Instability", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.html"];
+      multiphysics_1_2 [label="Rayleigh-Taylor Instability", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.html"];
 
-      multiphysics_1_3 [label="Static Bubble", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/static-bubble/static-bubble.html"];
+      multiphysics_1_3 [label="Static Bubble", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/static-bubble/static-bubble.html"];
 
-      multiphysics_1_4 [label="Rising Bubble", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/rising-bubble/rising-bubble.html"];
+      multiphysics_1_4 [label="Rising Bubble", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/rising-bubble/rising-bubble.html"];
 
-      multiphysics_1_5 [label="Sloshing in a Rectangular Tank", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/sloshing-in-rectangular-tank/sloshing-in-rectangular-tank.html"];
+      multiphysics_1_5 [label="Sloshing in a Rectangular Tank", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/sloshing-in-rectangular-tank/sloshing-in-rectangular-tank.html"];
 
-      multiphysics_1_6 [label="Capillary Wave", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/capillary-wave/capillary-wave.html"];
+      multiphysics_1_6 [label="Capillary Wave", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/capillary-wave/capillary-wave.html"];
 
-      multiphysics_1_7 [label="3D Dam-Break with an Obstacle", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/3d-dam-break/3d-dam-break.html"];
+      multiphysics_1_7 [label="3D Dam-Break with an Obstacle", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/3d-dam-break/3d-dam-break.html"];
 
-      multiphysics_1_8 [label="Water Injection in a Closed Cell", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.html"];
+      multiphysics_1_8 [label="Water Injection in a Closed Cell", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.html"];
 
-      multiphysics_1_9 [label="Air Bubble Compression", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/air-bubble-compression/air-bubble-compression.html"];
+      multiphysics_1_9 [label="Air Bubble Compression", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/air-bubble-compression/air-bubble-compression.html"];
 
-      multiphysics_2 [label="Heat Transfer", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/heat-transfer.html"];
+      multiphysics_2 [label="Heat Transfer", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/heat-transfer.html"];
 
-      multiphysics_2_1 [label="Rayleigh-Bénard Convection", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection.html"];
+      multiphysics_2_1 [label="Rayleigh-Bénard Convection", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection.html"];
 
-      multiphysics_2_2 [label="Stefan Problem: Melting of a Solid", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/stefan-problem/stefan-problem.html"];
+      multiphysics_2_2 [label="Stefan Problem: Melting of a Solid", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/stefan-problem/stefan-problem.html"];
 
-      multiphysics_2_3 [label="Warming up a Viscous Fluid", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.html"];
+      multiphysics_2_3 [label="Warming up a Viscous Fluid", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.html"];
 
-      multiphysics_2_4 [label="Melting Cavity", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/melting-cavity/melting-cavity.html"];
+      multiphysics_2_4 [label="Melting Cavity", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/melting-cavity/melting-cavity.html"];
 
-      multiphysics_2_5 [label="Laser Heating", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/laser-heating/laser-heating.html"];
+      multiphysics_2_5 [label="Laser Heating", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/laser-heating/laser-heating.html"];
 
-      multiphysics_2_6 [label="Laser Melt Pool", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/laser-melt-pool/laser-melt-pool.html"];
+      multiphysics_2_6 [label="Laser Melt Pool", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/laser-melt-pool/laser-melt-pool.html"];
 
-      multiphysics_2_7 [label="Concentric Heat Exchanger", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.html"];
+      multiphysics_2_7 [label="Concentric Heat Exchanger", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.html"];
 
-      multiphysics_3 [label="Tracer", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/tracer.html"];  
+      multiphysics_3 [label="Tracer", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/tracer.html"];  
 
-      multiphysics_3_1 [label="Tracer through CAD Junction in Simplex", href="https://lethe-cfd.github.io/lethe/examples/multiphysics/tracer-through-cad-junction/tracer-through-cad-junction.html"];
+      multiphysics_3_1 [label="Tracer through CAD Junction in Simplex", href="https://lethe-cfd.github.io/lethe/documentation/examples/multiphysics/tracer-through-cad-junction/tracer-through-cad-junction.html"];
 
       multiphysics -> multiphysics_1:w;
       multiphysics -> multiphysics_2:w;

--- a/doc/source/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.rst
+++ b/doc/source/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.rst
@@ -174,7 +174,7 @@ Physical Properties
 ~~~~~~~~~~~~~~~~~~~~
 
 In the ``physical properties`` subsection, we define the properties of the fluids. For air, represented by ``fluid 0``, the ``isothermal_ideal_gas`` density model is used to account for the fluid's compressibility.
-We refer the reader to the `Physical Properties - Density Models <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#density-models>`_ documentation for further explanation on the isothermal compressible density model.
+We refer the reader to the `Physical Properties - Density Models <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/physical_properties.html#density-models>`_ documentation for further explanation on the isothermal compressible density model.
 The properties of air and water at :math:`25 \, \text{°C}` are used in this example.
 
 .. code-block:: text

--- a/doc/source/examples/rpt/rpt.rst
+++ b/doc/source/examples/rpt/rpt.rst
@@ -20,13 +20,13 @@ Radioactive Particle Tracking (RPT)
       rankdir="LR";
       size = "9,9";
 
-      rpt [label="Radioactive Particle \nTracking (RPT)", href="https://lethe-cfd.github.io/lethe/examples/rpt/rpt.html"];
+      rpt [label="Radioactive Particle \nTracking (RPT)", href="https://lethe-cfd.github.io/lethe/documentation/examples/rpt/rpt.html"];
 
-      rpt_1 [label="Photon Count Calculation \nin a Cylindrical Vessel", href="https://lethe-cfd.github.io/lethe/examples/rpt/photon-count-calculation-in-a-cylindrical-vessel/photon-count-calculation-in-a-cylindrical-vessel.html", tooltip="Photon count calculation in a cylindrical vessel"];
+      rpt_1 [label="Photon Count Calculation \nin a Cylindrical Vessel", href="https://lethe-cfd.github.io/lethe/documentation/examples/rpt/photon-count-calculation-in-a-cylindrical-vessel/photon-count-calculation-in-a-cylindrical-vessel.html", tooltip="Photon count calculation in a cylindrical vessel"];
 
-      rpt_2 [label="Tuning Count Calculation Model \nParameters with NOMAD", href="https://lethe-cfd.github.io/lethe/examples/rpt/tuning-parameters-with-nomad/tuning-parameters-with-nomad.html", tooltip="Tuning count calculation model parameters with NOMAD"];
+      rpt_2 [label="Tuning Count Calculation Model \nParameters with NOMAD", href="https://lethe-cfd.github.io/lethe/documentation/examples/rpt/tuning-parameters-with-nomad/tuning-parameters-with-nomad.html", tooltip="Tuning count calculation model parameters with NOMAD"];
 
-      rpt_3 [label="Particle FEM reconstruction", href="https://lethe-cfd.github.io/lethe/examples/rpt/particle-fem-reconstruction/particle-fem-reconstruction.html", tooltip="Particle FEM reconstruction"];
+      rpt_3 [label="Particle FEM reconstruction", href="https://lethe-cfd.github.io/lethe/documentation/examples/rpt/particle-fem-reconstruction/particle-fem-reconstruction.html", tooltip="Particle FEM reconstruction"];
 
       rpt -> rpt_1:w;
       rpt -> rpt_2:w;  

--- a/doc/source/examples/sharp-immersed-boundary/sharp-immersed-boundary.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sharp-immersed-boundary.rst
@@ -20,29 +20,29 @@ Sharp Immersed Boundary Solver
       rankdir="LR";
       size = "9,9";
       
-      sharp_immersed_boundary_solver [label="Sharp Immersed \nBoundary", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/sharp-immersed-boundary.html"];
+      sharp_immersed_boundary_solver [label="Sharp Immersed \nBoundary", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/sharp-immersed-boundary.html"];
 
-      sharp_1 [label="Resolved CFD-DEM", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/resolved-cfd-dem.html"];
+      sharp_1 [label="Resolved CFD-DEM", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/resolved-cfd-dem.html"];
 
-      sharp_1_1 [label="Sedimentation of One Particle", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.html"];
+      sharp_1_1 [label="Sedimentation of One Particle", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.html"];
 
-      sharp_1_2 [label="Sedimentation of 64 Particles", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.html"];
+      sharp_1_2 [label="Sedimentation of 64 Particles", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.html"];
 
-      sharp_2 [label="Incompressible Flow", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/incompressible-flow.html"];
+      sharp_2 [label="Incompressible Flow", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/incompressible-flow.html"];
 
-      sharp_2_1 [label="Flow around a Cylinder Using \nthe Sharp Interface Method", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.html", tooltip="Flow around a cylinder using the sharp interface method"];
+      sharp_2_1 [label="Flow around a Cylinder Using \nthe Sharp Interface Method", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.html", tooltip="Flow around a cylinder using the sharp interface method"];
 
-      sharp_2_2 [label="Non-Newtonian Flow \npast a Sphere", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.html", tooltip="Non-Newtonian flow past a sphere"];
+      sharp_2_2 [label="Non-Newtonian Flow \npast a Sphere", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.html", tooltip="Non-Newtonian flow past a sphere"];
 
-      sharp_2_3 [label="3D Mixer with Pitched-Blade \nTurbine Impeller Using Composite \nSharp-Immersed Boundary", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/3d-composite-mixer-with-pbt-impeller.html", tooltip="3D Mixer with pitched-blade turbine impeller using Composite Sharp-immersed boundary"];
+      sharp_2_3 [label="3D Mixer with Pitched-Blade \nTurbine Impeller Using Composite \nSharp-Immersed Boundary", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/3d-composite-mixer-with-pbt-impeller.html", tooltip="3D Mixer with pitched-blade turbine impeller using Composite Sharp-immersed boundary"];
 
-      sharp_2_4 [label="3D Mixer with Pitched-Blade Turbine \nImpeller Using OpenCascade \nSharp-Immersed Boundary", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/3d-opencascade-mixer-with-pbt-impeller/3d-opencascade-mixer-with-pbt-impeller.html", tooltip="3D Mixer with pitched-blade turbine impeller using OpenCascade Sharp-immersed boundary"];
+      sharp_2_4 [label="3D Mixer with Pitched-Blade Turbine \nImpeller Using OpenCascade \nSharp-Immersed Boundary", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/3d-opencascade-mixer-with-pbt-impeller/3d-opencascade-mixer-with-pbt-impeller.html", tooltip="3D Mixer with pitched-blade turbine impeller using OpenCascade Sharp-immersed boundary"];
       
-      sharp_2_5 [label="Inclined 3D Mixer with Pitched-Blade \nTurbine Impeller Using Composite \nSharp-Immersed Boundary", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/inclined-3d-composite-mixer-with-pbt-impeller.html", tooltip="Inclined 3D mixer with pitched-blade turbine impeller using composite sharp-immersed boundary"];
+      sharp_2_5 [label="Inclined 3D Mixer with Pitched-Blade \nTurbine Impeller Using Composite \nSharp-Immersed Boundary", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/inclined-3d-composite-mixer-with-pbt-impeller.html", tooltip="Inclined 3D mixer with pitched-blade turbine impeller using composite sharp-immersed boundary"];
       
-      sharp_3 [label="Geometry Definition", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/geometry-definition.html"];
+      sharp_3 [label="Geometry Definition", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/geometry-definition.html"];
       
-      sharp_3_1 [label="Simple Plane Model From Composite", href="https://lethe-cfd.github.io/lethe/examples/sharp-immersed-boundary/sharp-immersed-boundary/simple-plane-model-from-composite.html", tooltip="Simple Plane Model From Composite"];
+      sharp_3_1 [label="Simple Plane Model From Composite", href="https://lethe-cfd.github.io/lethe/documentation/examples/sharp-immersed-boundary/sharp-immersed-boundary/simple-plane-model-from-composite.html", tooltip="Simple Plane Model From Composite"];
 
       sharp_immersed_boundary -> sharp_1:w;
       sharp_immersed_boundary -> sharp_2:w;

--- a/doc/source/examples/unresolved-cfd-dem/unresolved-cfd-dem.rst
+++ b/doc/source/examples/unresolved-cfd-dem/unresolved-cfd-dem.rst
@@ -24,17 +24,17 @@ This section includes examples related to multiphase fluid-solid flows. We organ
       rankdir="LR";
       size = "9,9";
 
-      unresolved_cfd_dem [label="Unresolved \nCFD-DEM", href="https://lethe-cfd.github.io/lethe/examples/unresolved-cfd-dem/unresolved-cfd-dem.html"];
+      unresolved_cfd_dem [label="Unresolved \nCFD-DEM", href="https://lethe-cfd.github.io/lethe/documentation/examples/unresolved-cfd-dem/unresolved-cfd-dem.html"];
 
-      cfd_dem_1 [label="Cylindrical Packed Bed", href="https://lethe-cfd.github.io/lethe/examples/unresolved-cfd-dem/cylindrical-packed-bed/cylindrical-packed-bed.html"];
+      cfd_dem_1 [label="Cylindrical Packed Bed", href="https://lethe-cfd.github.io/lethe/documentation/examples/unresolved-cfd-dem/cylindrical-packed-bed/cylindrical-packed-bed.html"];
 
-      cfd_dem_2 [label="Gas-Solid Fluidized Bed", href="https://lethe-cfd.github.io/lethe/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.html"];
+      cfd_dem_2 [label="Gas-Solid Fluidized Bed", href="https://lethe-cfd.github.io/lethe/documentation/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.html"];
 
-      cfd_dem_3 [label="Gas-Solid Spouted Bed", href="https://lethe-cfd.github.io/lethe/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.html"];
+      cfd_dem_3 [label="Gas-Solid Spouted Bed", href="https://lethe-cfd.github.io/lethe/documentation/examples/unresolved-cfd-dem/gas-solid-spouted-bed/gas-solid-spouted-bed.html"];
 
-      cfd_dem_4 [label="Liquid-Solid Fluidized Bed", href="https://lethe-cfd.github.io/lethe/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.html"];
+      cfd_dem_4 [label="Liquid-Solid Fluidized Bed", href="https://lethe-cfd.github.io/lethe/documentation/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.html"];
 
-      cfd_dem_5 [label="Boycott Effect", href="https://lethe-cfd.github.io/lethe/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.html"];
+      cfd_dem_5 [label="Boycott Effect", href="https://lethe-cfd.github.io/lethe/documentation/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.html"];
       
       unresolved_cfd_dem -> cfd_dem_1:w;
       unresolved_cfd_dem -> cfd_dem_2:w;

--- a/doc/source/parameters/cfd/mesh_adaptation_control.rst
+++ b/doc/source/parameters/cfd/mesh_adaptation_control.rst
@@ -60,7 +60,7 @@ This subsection controls the mesh adaptation method, with default values given b
 	* For steady-state simulation in which the steady-state problem is solved on successively refined meshes, the user should have ``set frequency = 1``, which is the default value.
 
 * The minimal and maximal refinement level reachable for a cell are controlled respectively with the ``min refinement`` and ``max refinement`` parameters.
-   * for ``deal.ii`` meshes, if the ``min refinement level`` is equal to the ``initial refinement`` (see `Mesh paramater <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh.html>`_), no cell will be coarser than the initial mesh.
+   * for ``deal.ii`` meshes, if the ``min refinement level`` is equal to the ``initial refinement`` (see `Mesh paramater <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh.html>`_), no cell will be coarser than the initial mesh.
    * for ``gmsh`` imported meshes, if ``set min refinement level = 0``, no cell will be coarser than the initial mesh.
 
 .. tip:: 

--- a/doc/source/parameters/cfd/multiphysics.rst
+++ b/doc/source/parameters/cfd/multiphysics.rst
@@ -53,7 +53,7 @@ This subsection defines the multiphysics interface of Lethe and enables the solu
 
 * ``VOF``: enables multiphase flow simulations, with two fluids separated by a free surface, using the Volume-of-Fluid method. 
 
-  See :doc:`volume_of_fluid` for advanced VOF parameters, :doc:`initial_conditions` for the definition of the VOF conditions and `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/parameters/cfd/physical_properties.html#two-phase-simulations>`_ for the definition of the physical properties of both fluids.
+  See :doc:`volume_of_fluid` for advanced VOF parameters, :doc:`initial_conditions` for the definition of the VOF conditions and `Physical properties - two phase simulations <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/physical_properties.html#two-phase-simulations>`_ for the definition of the physical properties of both fluids.
 
 .. seealso::
 

--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -10,7 +10,7 @@ Floating meshes (solid objects) are finite (limited) auxiliary objects that can 
 .. note:: 
     At the moment, solid objects (floating meshes) in Lethe have to be defined using triangular (simplex) meshes. Only triangular 2D meshes of 3D surfaces in 3D DEM simulations are presently supported. Quadrilateral 2D meshes of 3D surfaces and 1D mesh of 2D surfaces are not supported at the moment.
 
-This subsection explains the solid objects (floating meshes) information. First of all, the ``number of solids`` is specified. Then, for each solid object, we need a ``mesh`` subsection. In these subsections, the ``type``, ``initial refinement``, and other properties of the objects are defined. Note that ``simplex`` must be ``true`` for all the objects since the solid objects are defined using simplex meshes. For more information on mesh subsection, visit `CFD mesh <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh.html>`_
+This subsection explains the solid objects (floating meshes) information. First of all, the ``number of solids`` is specified. Then, for each solid object, we need a ``mesh`` subsection. In these subsections, the ``type``, ``initial refinement``, and other properties of the objects are defined. Note that ``simplex`` must be ``true`` for all the objects since the solid objects are defined using simplex meshes. For more information on mesh subsection, visit `CFD mesh <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh.html>`_
 
 .. code-block:: text
 

--- a/doc/source/parameters/dem/mesh.rst
+++ b/doc/source/parameters/dem/mesh.rst
@@ -2,7 +2,7 @@
 Mesh
 ====
 
-The mesh subsection of DEM simulations is almost identical to the `CFD <https://lethe-cfd.github.io/lethe/parameters/cfd/mesh.html>`_ in Lethe. There are two additional parameters mainly used in DEM and CFD-DEM simulations. These parameters are ``check diamond cells`` and ``expand particle-wall contact search``.
+The mesh subsection of DEM simulations is almost identical to the `CFD <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/mesh.html>`_ in Lethe. There are two additional parameters mainly used in DEM and CFD-DEM simulations. These parameters are ``check diamond cells`` and ``expand particle-wall contact search``.
 
 .. code-block:: text
 

--- a/doc/source/parameters/dem/simulation_control.rst
+++ b/doc/source/parameters/dem/simulation_control.rst
@@ -2,7 +2,7 @@
 Simulation Control
 ==================
 
-The Simulation Control subsection of DEM simulations is identical to the `CFD <https://lethe-cfd.github.io/lethe/parameters/cfd/simulation_control.html>`_ in Lethe.
+The Simulation Control subsection of DEM simulations is identical to the `CFD <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/simulation_control.html>`_ in Lethe.
 
 .. note::
     A constant ``time step`` must be defined in the DEM solver. Lethe-DEM does not support adaptative time step scaling method.

--- a/doc/source/theory/unresolved_cfd-dem/unresolved_cfd-dem.rst
+++ b/doc/source/theory/unresolved_cfd-dem/unresolved_cfd-dem.rst
@@ -55,7 +55,7 @@ where:
 .. note::
     Since pressure in Lethe does not account for the hydrostatic pressure, i.e., the gravity term is not taken into account in the Navier-Stokes equations (see :doc:`../fluid_dynamics/navier-stokes`), we explicitly insert :math:`\mathbf{f}_{Ar,i}` in :math:`\mathbf{f}_{pf,i}`.
 
-In unresolved CFD-DEM, the drag force is calculated using correlations (frequently called drag models). The drag models implemented in Lethe are described in the `unresolved CFD-DEM parameters guide <https://lethe-cfd.github.io/lethe/parameters/unresolved_cfd-dem/cfd_dem.html>`_.
+In unresolved CFD-DEM, the drag force is calculated using correlations (frequently called drag models). The drag models implemented in Lethe are described in the `unresolved CFD-DEM parameters guide <https://lethe-cfd.github.io/lethe/documentation/parameters/unresolved_cfd-dem/cfd_dem.html>`_.
 
 Volume Average Navier-Stokes
 -----------------------------


### PR DESCRIPTION
# Description of the problem

Several documentations hyperlinks were broken due to the recent changes with doxygen. 

# Description of the solution

The hyperlinks were corrected, and the page name for both the documentation and doxygen is now clean. 