### PR TITLE
Fix xyz printing to be more efficient

### DIFF
--- a/source/dem/visualization.cc
+++ b/source/dem/visualization.cc
@@ -87,7 +87,10 @@ Visualization<dim>::print_xyz(
   const ConditionalOStream                &pcout)
 {
   pcout << "id, type, dp, x, y, z " << std::endl;
-  usleep(100);
+  // Agressively force synchronization of the header line
+  usleep(500);
+  MPI_Barrier(mpi_communicator);
+  usleep(500);
   MPI_Barrier(mpi_communicator);
 
 
@@ -129,7 +132,7 @@ Visualization<dim>::print_xyz(
                         << std::endl;
             }
         }
-      usleep(100);
+      usleep(500);
       MPI_Barrier(mpi_communicator);
     }
 }


### PR DESCRIPTION
# Description of the problem

- The parallel periodic DEM test keeps on breaking, so I am adding a longer time to make it safer and more robust
