### PR TITLE
Installation instructions linux

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,7 +28,7 @@ Lethe is named after the river of forgetfulness, which, according to
    in order to forget their earthly life.
 
 Lethe is described `here <https://doi.org/10.1016/j.softx.2020.100579>`_.
-It originally began as a weekend project, but slowly grew into a robust and performative CFD, DEM and CFD-DEM
+It originally began as a weekend project, but slowly grew into robust and efficient CFD, DEM and CFD-DEM
 software. Lethe is under active development.
 
 .. note::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,9 +28,8 @@ Lethe is named after the river of forgetfulness, which, according to
    in order to forget their earthly life.
 
 Lethe is described `here <https://doi.org/10.1016/j.softx.2020.100579>`_.
-It originally began as a weekend project, but slowly grew into CFD
-software used in actual research.
-It is still an immature project, but is under active development.
+It originally began as a weekend project, but slowly grew into CFD, DEM and CFD-DEM
+software used in actual research. Lethe is under active development.
 
 .. note::
    Lethe would not exist without the dedicated work of the deal.II

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,8 +28,8 @@ Lethe is named after the river of forgetfulness, which, according to
    in order to forget their earthly life.
 
 Lethe is described `here <https://doi.org/10.1016/j.softx.2020.100579>`_.
-It originally began as a weekend project, but slowly grew into CFD, DEM and CFD-DEM
-software used in actual research. Lethe is under active development.
+It originally began as a weekend project, but slowly grew into a robust and performative CFD, DEM and CFD-DEM
+software. Lethe is under active development.
 
 .. note::
    Lethe would not exist without the dedicated work of the deal.II

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -8,21 +8,17 @@ Regular Installation on Linux
 .. important::
   Distributions on which compatibility was tested are: Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro 
 
-* Dependencies: deal.II library (`deal.II website <https://www.dealii.org/>`_) and its dependencies (MPI, numdiff, p4est, trilinos and METIS)
-  * Lethe requires a modern version of the deal.II library. At the time of this writing, ``deal.II 9.5`` (the last major release) and ``deal.II 9.6pre`` (the ``master`` branch version) is supported.
-  * The compatibility with both deal.II versions is ensured by Continuous Integration (CI) using Github Actions.
-  * A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. We work hard to ensure compatibility with the latest deal.II version and we do not modify the library except through pull requests on the official deal.II repository.
+Lethe requires a modern version of the `deal.II library <https://www.dealii.org/>`_ and its dependencies (MPI, numdiff, p4est, trilinos and METIS). At the time of this writing, ``deal.II 9.5`` and ``deal.II 9.6pre`` (the ``master`` branch version) are supported. A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. 
 
-* There are two ways to install deal.II and its dependency:
-  1. Through candi (recommended way for developers)
-  2. Through the system package manager (recommended way for users)
+**Lethe installation steps:**
+  
+1. Installation of deal.II 
+2. Installation of Lethe
 
-.. warning:: 
-  Lethe cannot be installed if deal.II has not been configured with p4est, trilinos and METIS. Although Lethe can be run in serial and parallel mode (through MPI), it uses p4est, METIS and trilinos for mesh decomposition and the linear solvers respectively.
-
-* Lethe installation steps:
-  1. Installation of deal.II through package manager or through candi
-  2. Installation of Lethe
+**Installing deal.II and its dependency:**
+  
+1. Through candi (recommended for developers)
+2. Through the system package manager (recommended for users)
 
 Installing deal.II using apt (Step #1)
 -----------------------------------------
@@ -65,7 +61,7 @@ To install the dependencies (MPI, p4est, trilinos and METIS) all together using 
 
 Clone the candi git repository in a folder of your choice  (e.g. ``/home/username/software``). Edit the ``candi.cfg`` file to alter which dependencies are compiled. This should notably be used to force the installation of the deal.II master version directly instead of the current stable version by setting the ``STABLE_BUILD=false``.
 
-We recommend installing the following packages (which are specified after line 57):
+The following packages (which are specified after line 57) should be installed:
   
   .. code-block:: text
     

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -15,155 +15,14 @@ Regular Installation on Linux
 
 * There are two ways to install deal.II and its dependency:
   1. Through candi (recommended way for developers)
-  2. Through the system package manager.
+  2. Through the system package manager (recommended way for users)
 
 .. warning:: 
   Lethe cannot be installed if deal.II has not been configured with p4est, trilinos and METIS. Although Lethe can be run in serial and parallel mode (through MPI), it uses p4est, METIS and trilinos for mesh decomposition and the linear solvers respectively.
 
 * Lethe installation steps:
-  1. Installation of deal.II through candi
-  2. (Alternative) Installation of deal.II through package manager
-  3. Installation of Lethe
-
-Installing deal.II using Candi (Step #1)
------------------------------------------
-
-To install the dependencies (MPI, p4est, trilinos and METIS) all together using candi, the `procedure <https://github.com/dealii/candi.git>`_ on the candi repository can be followed.
-
-Clone the candi git repository in a folder of your choice  (e.g. ``/home/username/software``). You can edit the ``candi.cfg`` file if you want to alter which dependencies are compiled. This can notably be used to force the installation of the deal.II master version directly instead of the current stable version by setting the ``STABLE_BUILD=false``
-
-From the candi folder, the installation of candi can be launched using:
-
-.. code-block:: text
-  :class: copy-button
-
-  ./candi.sh -j $num_proc --prefix=$path
-
-
-where ``$num_proc`` is the number of threads you want to use to compile deal.II and ``$path`` the installation prefix that is desired (e.g. ``/home/username/software/candi``). 
-
-.. warning:: 
-  For a computer with 8Gb of RAM, 1 thread (``num_proc=1``) should be used. For 16 Gb, 4 threads is reasonable. For 32 Gb, 16 threads or more can be used.
-
-
-After installation, you should have a ``deal.II-candi`` folder in the installation prefix directory, with the dealii folder of the desired version (see section :ref:`update-dealii`), as well as the required dependencies (p4est, trilinos, etc.).
-
-After installation, add an environment variable to your ``.bashrc`` either manually or through the following command:
-
-.. code-block:: text
-  :class: copy-button
-
-  echo "export DEAL_II_DIR=/home/username/deal.ii-candi/deal.II-<version>" >> ~/.bashrc
-
-Installing deal.II Manually (Step #1)
---------------------------------------
-.. note:: 
-  If you have installed deal.II through candi, you can skip right away to :ref:`install-lethe`
-
-We first need to install the deal.II dependencies.
-
-
-MPI
-~~~~~
-
-MPI, for Message Passing Interface, is required for the installation of all components of Lethe. Therefore it should be the first thing you install. On Debian Linux-based OS, MPI can be installed directly from your package manager. 
-
-As an example, in Ubuntu:
-
-.. code-block:: text
-  :class: copy-button
-
-  sudo apt-get install libopenmpi-dev openmpi-bin openmpi-common
-
-In Manjaro or other arch based linux distribution:
-
-.. code-block:: text
-  :class: copy-button
-
-  sudo pacman -Sy openmpi
-
-
-Numdiff
-~~~~~~~~
-
-numdiff is used within the automatic testing procedure of Lethe to compare files obtained through floating point arithmetic. Without numdiff, Lethe automatic tests may fail when they should not. numdiff can be installed directly from your package manager.
-
-.. code-block:: text
-  :class: copy-button
-
-  sudo apt-get install numdiff
-
-Regrettably, numdiff is not available in the pacman package manager. It can be downloaded from the following `website <http://www.nongnu.org/numdiff/>`_. If you are using an arch distribution, we assume that you will already know how to carry on with the installation of numdiff.
-
-P4est
-~~~~~~~
-
-To install p4est, the usual `installation <https://www.dealii.org/current/external-libs/p4est.html>`_ of deal.II can be followed.
-
-
-
-Trilinos
-~~~~~~~~~
-
-The installation of trilinos should be done using the `installation procedure <https://www.dealii.org/current/external-libs/trilinos.html>`_ of deal.II.
-
-
-
-METIS
-~~~~~~~
-
-METIS is used for mesh partitioning for parallel computing purposes, specifically in cases with simplex grids. It can be downloaded in this `link <http://glaros.dtc.umn.edu/gkhome/metis/metis/download>`_ or through candi.
-
-
-
-Installation of deal.II
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Clone deal.II from the `deal.ii official repository <https://github.com/dealii/dealii>`_
-
-.. code-block:: text
-  :class: copy-button
-
-  git clone https://github.com/dealii/dealii 
-
-Configure deal.II in a build folder at the same level as the source code
-
-.. code-block:: text
-  :class: copy-button
-
-  mkdir build
-  cd build
-
-Depending on how you have installed p4est, Trilinos and METIS, you may need to specify the installation folder of the three libraries
-
-.. code-block:: text
-  :class: copy-button
-
-  cmake ../dealii -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=path/to/your/trilinos/installation -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=path/to/your/p4est/installation  -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=path/to/your/metis/installation -DCMAKE_INSTALL_PREFIX=/path/to/desired/installation`
-
-Compile deal.II
-
-.. code-block:: text
-  :class: copy-button
-
-  make -j<nprocessor> install
-
-Create an environment variable for the deal.II directory
-
-.. code-block:: text
-  :class: copy-button
-
-  export DEAL_II_DIR=/path/to/dealii/installation
-
-It is generally recommended to add the variable to your bashrc so it is always loaded:
-
-.. code-block:: text
-  :class: copy-button
-
-  echo "export DEAL_II_DIR=/path/to/dealii/installation" >> ~/.bashrc
-
-.. _install-lethe:
-
+  1. Installation of deal.II through package manager or through candi
+  2. Installation of Lethe
 
 Installing deal.II using apt (Step #1)
 -----------------------------------------
@@ -199,6 +58,68 @@ This should output several information about the installed version. Everything w
   If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 
+Installing deal.II using Candi (Step #1)
+-----------------------------------------
+
+To install the dependencies (MPI, p4est, trilinos and METIS) all together using candi, the `procedure <https://github.com/dealii/candi.git>`_ on the candi repository can be followed.
+
+Clone the candi git repository in a folder of your choice  (e.g. ``/home/username/software``). Edit the ``candi.cfg`` file to alter which dependencies are compiled. This should notably be used to force the installation of the deal.II master version directly instead of the current stable version by setting the ``STABLE_BUILD=false``.
+
+We recommend installing the following packages (which are specified after line 57):
+  
+  .. code-block:: test
+    PACKAGES="load:dealii-prepare"
+    PACKAGES="${PACKAGES} once:numdiff"
+    PACKAGES="${PACKAGES} once:opencascade"
+    PACKAGES="${PACKAGES} once:parmetis"
+    PACKAGES="${PACKAGES} once:p4est"
+    PACKAGES="${PACKAGES} once:trilinos"
+    PACKAGES="${PACKAGES} dealii"
+
+Other packages can be disabled by simply commenting out the lines (adding an ``#`` at the beggining of the lines)
+
+To ensure that the the lethe test suite works, deal.II must be configured with p4est version 2.2.1. In the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with a text editor and change the following lines:
+
+  .. tip::
+    We are simply uncommenting line 7, and commenting lines 9 to 12, to change the p4est version.
+
+  +--------+------------------------------------------------+-----------------------------------------------+
+  | line # | initial parameter                              | changed parameter                             |
+  +========+================================================+===============================================+
+  |     7  | ``#VERSION=2.2;CHECKSUM=6943949a...``          | ``VERSION=2.2;CHECKSUM=6943949a...``          |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     9  | ``VERSION=2.3.2``                              | ``#VERSION=2.3.2``                            |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     10 | ``CHECKSUM=076df9e...``                        | ``#CHECKSUM=076df9e...``                      |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     11 | ``CHECKSUM="${CHECKSUM} b41c8ef29ca...``       | ``#CHECKSUM="${CHECKSUM} b41c8ef29ca...``     |
+  +--------+------------------------------------------------+-----------------------------------------------+
+  |     12 | ``CHECKSUM="${CHECKSUM} 0ea6e4806b6...``       | ``#CHECKSUM="${CHECKSUM} 0ea6e4806b6...``     |
+  +--------+------------------------------------------------+-----------------------------------------------+
+
+
+From the candi folder, the installation of candi can be launched using:
+
+.. code-block:: text
+  :class: copy-button
+
+  ./candi.sh -j $num_proc --prefix=$path
+
+
+where ``$num_proc`` is the number of threads you want to use to compile deal.II and ``$path`` the installation prefix that is desired (e.g. ``/home/username/software/candi``). 
+
+.. tip:: 
+  For a computer with 8Gb of RAM, 1 thread (``num_proc=1``) should be used. For 16 Gb, 4 threads is reasonable. For 32 Gb, 16 threads or more can be used.
+
+
+After installation, you should have a ``deal.II-candi`` folder in the installation prefix directory, with the dealii folder of the desired version (see section :ref:`update-dealii`), as well as the required dependencies (p4est, trilinos, etc.).
+
+After installation, add the following lines variable to your ``.bashrc`` :
+
+.. code-block:: text
+  :class: copy-button
+    source cand/install/prefix/configuration/enable.sh
+    export DEAL_II_DIR=cand/install/prefix/deal.II-<version> >> ~/.bashrc
 
 Installing Lethe (Step #2)
 -------------------------------
@@ -251,6 +172,10 @@ Lethe comes pre-packaged with an extensive test suit for all of its modules. It 
 
 where $numprocs can be the number of physical cores on your machine.
 
+.. warning:: 
+  The lethe test suites requires that deal.II be configured with p4est 2.2.1, otherwise the test which include restart files will fail.
+
+
 .. _update-dealii:
 
 Updating deal.II
@@ -279,7 +204,7 @@ In the candi folder (for instance, ``/home/username/software/candi``), modify th
   :class: copy-button
 
   # Install the following deal.II version:
-  DEAL_II_VERSION=v9.3.0
+  DEAL_II_VERSION=v9.5.0
 
   # Would you like to build stable version of deal.II?
   # If STABLE_BUILD=false, then the development version of deal.II will be  

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -6,16 +6,16 @@ Regular Installation on Linux
    :height: 100px
 
 .. important::
-  Distributions on which compatibility was tested are: Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro 
+  Distributions on which compatibility was tested are: Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro.
 
-Lethe requires a modern version of the `deal.II library <https://www.dealii.org/>`_ and its dependencies (MPI, numdiff, p4est, trilinos and METIS). At the time of this writing, ``deal.II 9.5`` and ``deal.II 9.6pre`` (the ``master`` branch version) are supported. A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. 
+Lethe requires a modern version of the `deal.II library <https://www.dealii.org/>`_ and its dependencies (MPI, numdiff, p4est, trilinos and METIS). At the time of this writing, ``deal.II 9.5`` and ``deal.II 9.6pre`` (the ``master`` branch version) are supported. A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by the Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. 
 
 **Lethe installation steps:**
   
-1. Installating deal.II  
+1. Installing deal.II  
 2. :ref:`install-lethe`
 
-**Installing deal.II and its dependency:**
+**Installing deal.II and its dependencies:**
   
 1. :ref:`install-deal.II-apt` (recommended for users)
 2. :ref:`install-deal.II-candi` (recommended for developers) 
@@ -81,7 +81,7 @@ The following packages (which are specified after line 57) should be installed:
 
 Other packages can be disabled by simply commenting out the lines (adding an ``#`` at the beggining of the lines)
 
-To ensure that the the lethe test suite works, deal.II must be configured with p4est version 2.2.1. In the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with a text editor and change the following lines:
+To ensure that the the Lethe test suite works, deal.II must be configured with p4est version 2.2.1. In the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with a text editor and change the following lines:
 
   .. tip::
     We are simply uncommenting line 7, and commenting lines 9 to 12, to change the p4est version.
@@ -131,7 +131,7 @@ After installation, add the following lines variable to your ``.bashrc`` :
 Installing Lethe 
 -------------------------------
 
-Clone lethe from the `Lethe official repository <https://github.com/lethe-cfd/lethe>`_.
+Clone Lethe from the `Lethe official repository <https://github.com/lethe-cfd/lethe>`_.
 
 .. code-block:: text
   :class: copy-button
@@ -185,7 +185,7 @@ where $numprocs can be the number of physical cores on your machine.
 
 .. _install-deal.II-manually:
 
-Installating deal.II manually 
+Installing deal.II manually 
 -----------------------------------------
 
 Clone deal.II from the `deal.ii official repository <https://github.com/dealii/dealii>`_

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -67,7 +67,8 @@ Clone the candi git repository in a folder of your choice  (e.g. ``/home/usernam
 
 We recommend installing the following packages (which are specified after line 57):
   
-  .. code-block:: test
+  .. code-block:: text
+    
     PACKAGES="load:dealii-prepare"
     PACKAGES="${PACKAGES} once:numdiff"
     PACKAGES="${PACKAGES} once:opencascade"
@@ -118,6 +119,7 @@ After installation, add the following lines variable to your ``.bashrc`` :
 
 .. code-block:: text
   :class: copy-button
+    
     source cand/install/prefix/configuration/enable.sh
     export DEAL_II_DIR=cand/install/prefix/deal.II-<version> >> ~/.bashrc
 

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -6,70 +6,31 @@ Regular Installation on Linux
    :height: 100px
 
 .. important::
-  Distributions compatibility: Ubuntu 18.04 LTS, Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro
+  Distributions on which compatibility was tested are: Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Centos 7 and Manjaro 
 
 * Dependencies: deal.II library (`deal.II website <https://www.dealii.org/>`_) and its dependencies (MPI, numdiff, p4est, trilinos and METIS)
-  * Lethe requires a modern version of the deal.II library. At the time of this writing, only the ``deal.II 9.6pre`` (the ``master`` branch version) is supported.
-  * The compatibility with this branch is ensured by Continuous Integration (CI) using Github Actions.
+  * Lethe requires a modern version of the deal.II library. At the time of this writing, ``deal.II 9.5`` (the last major release) and ``deal.II 9.6pre`` (the ``master`` branch version) is supported.
+  * The compatibility with both deal.II versions is ensured by Continuous Integration (CI) using Github Actions.
   * A `dealii fork <https://github.com/lethe-cfd/dealii>`_ is maintained by Lethe team. This fork does not include any modification to deal.II library, but it is the latest version with which Lethe was tested. We work hard to ensure compatibility with the latest deal.II version and we do not modify the library except through pull requests on the official deal.II repository.
+
+* There are two ways to install deal.II and its dependency:
+  1. Through candi (recommended way for developers)
+  2. Through the system package manager.
 
 .. warning:: 
   Lethe cannot be installed if deal.II has not been configured with p4est, trilinos and METIS. Although Lethe can be run in serial and parallel mode (through MPI), it uses p4est, METIS and trilinos for mesh decomposition and the linear solvers respectively.
 
 * Lethe installation steps:
-  1. Installation of deal.II dependencies (MPI, numdiff, p4est, trilinos and METIS)
-  2. Installation of the deal.II library
+  1. Installation of deal.II through candi
+  2. (Alternative) Installation of deal.II through package manager
   3. Installation of Lethe
-
-* Methods to install deal.II and its dependencies:
-  1. Through Advanced Packaging Tool (apt): **this is by far the easiest way to proceed**, since it requires much less manual intervention.
-
-  2. through candi shell script (`candi github page <https://github.com/dealii/candi>`_). Even if you do not want to use candi to install deal.II, you can use it for the dependencies.
-
-  3. manually
-
-.. warning::
-  On a single core computer with 8GB of RAM, count up to 8 hours for a first installation, and 3 hours for a deal.II update. On a machine with 16 cores and 32GB of RAM, this process will take less than an hour or so. The installation of deal.II and its dependencies (especially trilinos), can be extremely RAM consuming. Installation on a machine with less than 8GB of RAM is difficult at best, impossible at worst.
-
-Installing deal.II using apt (Step #1)
------------------------------------------
-
-This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
-
-In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
-
-.. code-block:: text
-  :class: copy-button
-
-  sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
-  sudo apt update
-
-To install deal.II, run:
-
-.. code-block:: text
-  :class: copy-button
-
-  sudo apt-get install libdeal.ii-dev
-
-To verify if the correct version of deal.II is installed, run:
-
-.. code-block:: text
-  :class: copy-button
-
-  apt show libdeal.ii-dev
-
-This should output several information about the installed version. Everything worked as expected if ``deal.ii-9.5.1`` is output
-
-.. note::
-
-  If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 Installing deal.II using Candi (Step #1)
 -----------------------------------------
 
 To install the dependencies (MPI, p4est, trilinos and METIS) all together using candi, the `procedure <https://github.com/dealii/candi.git>`_ on the candi repository can be followed.
 
-Clone the candi git repository in a folder of your choice  (e.g. ``/home/username/software``). You can edit the ``candi.cfg`` file if you want to alter which dependencies are compiled. This can notably be used to force the installation of the deal.II master version instead of the current stable version by setting the ``STABLE_BUILD=false``
+Clone the candi git repository in a folder of your choice  (e.g. ``/home/username/software``). You can edit the ``candi.cfg`` file if you want to alter which dependencies are compiled. This can notably be used to force the installation of the deal.II master version directly instead of the current stable version by setting the ``STABLE_BUILD=false``
 
 From the candi folder, the installation of candi can be launched using:
 
@@ -202,6 +163,42 @@ It is generally recommended to add the variable to your bashrc so it is always l
   echo "export DEAL_II_DIR=/path/to/dealii/installation" >> ~/.bashrc
 
 .. _install-lethe:
+
+
+Installing deal.II using apt (Step #1)
+-----------------------------------------
+
+This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
+
+In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
+  sudo apt update
+
+To install deal.II, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libdeal.ii-dev
+
+To verify if the correct version of deal.II is installed, run:
+
+.. code-block:: text
+  :class: copy-button
+
+  apt show libdeal.ii-dev
+
+This should output several information about the installed version. Everything worked as expected if ``deal.ii-9.5.1`` is output
+
+.. note::
+
+  If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
+
+
 
 Installing Lethe (Step #2)
 -------------------------------

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -22,8 +22,6 @@ Lethe requires a modern version of the `deal.II library <https://www.dealii.org/
 3. :ref:`install-deal.II-manually` (recommended for exerimented developers) 
 
 
-
-
 .. _install-deal.II-apt:
 
 Installing deal.II using apt 
@@ -185,7 +183,7 @@ where $numprocs can be the number of physical cores on your machine.
   The lethe test suites requires that deal.II be configured with p4est 2.2.1, otherwise the test which include restart files will fail.
 
 
-.. _instal-deal.II-manually:
+.. _install-deal.II-manually:
 
 Installating deal.II manually 
 -----------------------------------------

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -12,15 +12,21 @@ Lethe requires a modern version of the `deal.II library <https://www.dealii.org/
 
 **Lethe installation steps:**
   
-1. Installation of deal.II 
-2. Installation of Lethe
+1. Installating deal.II  
+2. :ref:`install-lethe`
 
 **Installing deal.II and its dependency:**
   
-1. Through candi (recommended for developers)
-2. Through the system package manager (recommended for users)
+1. :ref:`install-deal.II-apt` (recommended for users)
+2. :ref:`install-deal.II-candi` (recommended for developers) 
+3. :ref:`install-deal.II-manually` (recommended for exerimented developers) 
 
-Installing deal.II using apt (Step #1)
+
+
+
+.. _install-deal.II-apt:
+
+Installing deal.II using apt 
 -----------------------------------------
 
 This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
@@ -54,7 +60,9 @@ This should output several information about the installed version. Everything w
   If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 
-Installing deal.II using Candi (Step #1)
+.. _install-deal.II-candi:
+
+Installing deal.II using Candi 
 -----------------------------------------
 
 To install the dependencies (MPI, p4est, trilinos and METIS) all together using candi, the `procedure <https://github.com/dealii/candi.git>`_ on the candi repository can be followed.
@@ -119,7 +127,10 @@ After installation, add the following lines variable to your ``.bashrc`` :
     source cand/install/prefix/configuration/enable.sh
     export DEAL_II_DIR=cand/install/prefix/deal.II-<version> >> ~/.bashrc
 
-Installing Lethe (Step #2)
+
+.. _install-lethe:
+
+Installing Lethe 
 -------------------------------
 
 Clone lethe from the `Lethe official repository <https://github.com/lethe-cfd/lethe>`_.
@@ -158,7 +169,7 @@ Then you can compile:
 
   make -j<numprocs>
 
-Testing Your Installation (Step #3)
+Testing Your Installation 
 -------------------------------------
 
 Lethe comes pre-packaged with an extensive test suit for all of its modules. It can be used to test the validity of your installation. Within the build folder, the test suite can be launched with the following command:
@@ -172,6 +183,55 @@ where $numprocs can be the number of physical cores on your machine.
 
 .. warning:: 
   The lethe test suites requires that deal.II be configured with p4est 2.2.1, otherwise the test which include restart files will fail.
+
+
+.. _instal-deal.II-manually:
+
+Installating deal.II manually 
+-----------------------------------------
+
+Clone deal.II from the `deal.ii official repository <https://github.com/dealii/dealii>`_
+
+.. code-block:: text
+  :class: copy-button
+
+  git clone https://github.com/dealii/dealii 
+
+Configure deal.II in a build folder at the same level as the source code
+
+.. code-block:: text
+  :class: copy-button
+
+  mkdir build
+  cd build
+
+Depending on how you have installed p4est, Trilinos and METIS, you may need to specify the installation folder of the three libraries
+
+.. code-block:: text
+  :class: copy-button
+
+  cmake ../dealii -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=path/to/your/trilinos/installation -DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=path/to/your/p4est/installation  -DDEAL_II_WITH_METIS=ON -DMETIS_DIR=path/to/your/metis/installation -DCMAKE_INSTALL_PREFIX=/path/to/desired/installation`
+
+Compile deal.II
+
+.. code-block:: text
+  :class: copy-button
+
+  make -j<nprocessor> install
+
+Create an environment variable for the deal.II directory
+
+.. code-block:: text
+  :class: copy-button
+
+  export DEAL_II_DIR=/path/to/dealii/installation
+
+It is generally recommended to add the variable to your bashrc so it is always loaded:
+
+.. code-block:: text
+  :class: copy-button
+
+  echo "export DEAL_II_DIR=/path/to/dealii/installation" >> ~/.bashrc
 
 
 .. _update-dealii:

--- a/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
@@ -29,7 +29,7 @@ subsection mesh
   set type               = dealii
   set grid type          = hyper_cube
   set grid arguments     = 0 : 1 : true
-  set initial refinement = 8
+  set initial refinement = 6
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
@@ -29,7 +29,7 @@ subsection mesh
   set type               = dealii
   set grid type          = hyper_cube
   set grid arguments     = 0 : 1 : true
-  set initial refinement = 6
+  set initial refinement = 8
 end
 
 #---------------------------------------------------


### PR DESCRIPTION
# Description of the problem

- The installation instructions on Linux were a bit dated. 

# Description of the solution
- I updated them to simplify them. I removed the whole deal.II manual installation thingy because it is rarely needed anymore. If you need it, you most likely already know how to do it. I feel the new instructions are really simpler.

