### PR TITLE
Add L2 and Linf norm to non-linear solvers

### DIFF
--- a/include/core/inexact_newton_non_linear_solver.h
+++ b/include/core/inexact_newton_non_linear_solver.h
@@ -134,10 +134,15 @@ InexactNewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
 
           if (this->params.verbosity != Parameters::Verbosity::quiet)
             {
-              solver->pcout << "\t\talpha = " << std::setw(6) << alpha
+              solver->pcout << "\talpha = " << std::setw(6) << alpha
                             << std::setw(0) << " res = "
                             << std::setprecision(this->params.display_precision)
-                            << current_res << std::endl;
+                            << std::setw(6) << current_res << std::setw(6)
+                            << "\tL^2(dx) = " << std::setw(6)
+                            << newton_update.l2_norm() << std::setw(6)
+                            << "\tL^infty(dx) = "
+                            << std::setprecision(this->params.display_precision)
+                            << newton_update.linfty_norm() << std::endl;
             }
 
           // If it's not the first iteration of alpha check if the residual is

--- a/include/core/newton_non_linear_solver.h
+++ b/include/core/newton_non_linear_solver.h
@@ -127,10 +127,15 @@ NewtonNonLinearSolver<VectorType>::solve(const bool is_initial_step)
 
           if (this->params.verbosity != Parameters::Verbosity::quiet)
             {
-              solver->pcout << "\t\talpha = " << std::setw(6) << alpha
+              solver->pcout << "\talpha = " << std::setw(6) << alpha
                             << std::setw(0) << " res = "
                             << std::setprecision(this->params.display_precision)
-                            << current_res << std::endl;
+                            << std::setw(6) << current_res << std::setw(6)
+                            << "\tL^2(dx) = " << std::setw(6)
+                            << newton_update.l2_norm() << std::setw(6)
+                            << "\tL^infty(dx) = "
+                            << std::setprecision(this->params.display_precision)
+                            << newton_update.linfty_norm() << std::endl;
             }
 
           // If it's not the first iteration of alpha check if the residual is


### PR DESCRIPTION
# Description of the problem

- The non-linear solver would output the norm of the residual, but not the norm of the correction vector. This did not give full indication of the convergence of the equations

# Description of the solution

- Add L² and L^\infty norm of the correction vector in the non-linear solver and fix formatting a little bit

# How Has This Been Tested?

- Ran on a few examples and the results are interesting.
