### PR TITLE
Fix volume fraction and seed in parallel to prevent artificial structure

### DIFF
--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -90,7 +90,7 @@ namespace Parameters
                     particle_custom_probability.at(particle_type).end());
 
       // We make sure that the cumulative probability is equal to 1.
-      if (std::abs(probability_sum - 1.0) > 1.e-12)
+      if (std::abs(probability_sum - 1.0) > 1.e-5)
         {
           throw(std::runtime_error(
             "Invalid custom volume fraction. The sum of volume fractions should be equal to 1.0 "));

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -230,7 +230,8 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
               parameters.lagrangian_physical_properties.particle_size_std.at(
                 particle_type),
               parameters.lagrangian_physical_properties
-                .seed_for_distributions[particle_type]);
+                  .seed_for_distributions[particle_type] +
+                this_mpi_process);
         }
       else if (parameters.lagrangian_physical_properties.distribution_type.at(
                  particle_type) ==
@@ -243,7 +244,8 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
               parameters.lagrangian_physical_properties
                 .particle_custom_probability.at(particle_type),
               parameters.lagrangian_physical_properties
-                .seed_for_distributions[particle_type]);
+                  .seed_for_distributions[particle_type] +
+                this_mpi_process);
         }
       maximum_particle_diameter = std::max(
         maximum_particle_diameter,


### PR DESCRIPTION
# Description of the problems

- Volume fraction in the parsing function was to restrictive. 
- When using multiple core, patterns could occur in the insertion box since the N_th particle inserted by proc 0 would have the same diameter as the N_th particle inserted by proc 1 and so forth.

# Description of the solution

- Criterion is now 1e-5.
- We add "this_mpi_process" to the Pseudo-random seed when constructing the distribution object to break the patterns.
