### PR TITLE
Make rotating frame a distinct velocity source parameter

### DIFF
--- a/applications_tests/lethe-fluid/rigid-body-rotation_gls.prm
+++ b/applications_tests/lethe-fluid/rigid-body-rotation_gls.prm
@@ -113,8 +113,8 @@ end
 #--------------------------------------------------
 
 subsection velocity source
-  set type    = srf
-  set omega_z = -1
+  set rotating frame type    = srf
+  set omega_z                = -1
 end
 
 #---------------------------------------------------

--- a/doc/source/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.rst
+++ b/doc/source/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.rst
@@ -190,11 +190,11 @@ Velocity Source
 .. code-block:: text
 
     subsection velocity source
-        set type    = srf
-        set omega_z = -10
+        set rotating frame type    = srf
+        set omega_z                = -10
     end
 
-In the ``velocity source`` subsection, we specify with ``type = srf`` that we are in a single rotating reference frame. Since a centrifugal and a Coriolis force are induced by the rotating movement of the system, we are in a non-Galilean reference frame. These two additional force contributions must be taken into account in the Navier-Stokes equations and by setting the ``type`` parameter to ``srf`` we do so. The ``omega_z`` parameter represents the angular velocity of the reference frame.
+In the ``velocity source`` subsection, we specify with ``rotating frame type = srf`` that we are in a single rotating reference frame. Since a centrifugal and a Coriolis force are induced by the rotating movement of the system, we are in a non-Galilean reference frame. These two additional force contributions must be taken into account in the Navier-Stokes equations and by setting the ``rotating frame type`` parameter to ``srf`` we do so. The ``omega_z`` parameter represents the angular velocity of the reference frame.
 
 Forces
 ~~~~~~

--- a/doc/source/parameters/cfd/velocity_source.rst
+++ b/doc/source/parameters/cfd/velocity_source.rst
@@ -9,13 +9,13 @@ The default values are:
 .. code-block:: text
 
   subsection velocity source
-    set type    = none
+    set rotating frame type    = none
     set omega_x = 0
     set omega_y = 0
     set omega_z = 0
   end
 
-* The ``type`` parameter specifies the type of reference frame that is selected. The options are ``none`` for an Eulerian reference frame or ``srf`` for a single rotating frame. By selecting ``srf`` the additional contributions of the centrifugal force and Coriolis force induced by the rotating movement are taken into account in the Navier-Stokes equations.
+* The ``rotating frame type`` parameter specifies the type of reference frame that is selected. The options are ``none`` for an Eulerian reference frame or ``srf`` for a single rotating frame. By selecting ``srf`` the additional contributions of the centrifugal force and Coriolis force induced by the rotating movement are taken into account in the Navier-Stokes equations.
 
 * The ``omega_x`` parameter is a double representing the :math:`x` component of the angular velocity of the reference frame.
 

--- a/doc/source/parameters/cfd/velocity_source.rst
+++ b/doc/source/parameters/cfd/velocity_source.rst
@@ -10,9 +10,9 @@ The default values are:
 
   subsection velocity source
     set rotating frame type    = none
-    set omega_x = 0
-    set omega_y = 0
-    set omega_z = 0
+    set omega_x                = 0
+    set omega_y                = 0
+    set omega_z                = 0
   end
 
 * The ``rotating frame type`` parameter specifies the type of reference frame that is selected. The options are ``none`` for an Eulerian reference frame or ``srf`` for a single rotating frame. By selecting ``srf`` the additional contributions of the centrifugal force and Coriolis force induced by the rotating movement are taken into account in the Navier-Stokes equations.

--- a/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
@@ -45,8 +45,8 @@ end
 #--------------------------------------------------
 
 subsection velocity source
-  set type    = srf
-  set omega_z = -6.28318
+  set rotating frame type    = srf
+  set omega_z                = -6.28318
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/ribbon-gls.tpl
+++ b/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/ribbon-gls.tpl
@@ -37,8 +37,8 @@ end
 #--------------------------------------------------
 
 subsection velocity source
-  set type    = srf
-  set omega_z = -10
+  set rotating frame type    = srf
+  set omega_z                = -10
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-ribbon-mixer-srf/Re1/ribbon-gls-Re1.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-srf/Re1/ribbon-gls-Re1.prm
@@ -37,8 +37,8 @@ end
 #--------------------------------------------------
 
 subsection velocity source
-  set type    = srf
-  set omega_z = -10
+  set rotating frame type    = srf
+  set omega_z                = -10
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
@@ -46,8 +46,8 @@ end
 #--------------------------------------------------
 
 subsection velocity source
-  set type    = srf
-  set omega_z = -6.28318
+  set rotating frame type    = srf
+  set omega_z                = -6.28318
 end
 
 #---------------------------------------------------

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1265,15 +1265,15 @@ namespace Parameters
 
   struct VelocitySource
   {
-    enum class VelocitySourceType
+    enum class RotatingFrameType
     {
       none,
       srf
     };
-    VelocitySourceType type;
-    double             omega_x;
-    double             omega_y;
-    double             omega_z;
+    RotatingFrameType rotating_frame_type;
+    double            omega_x;
+    double            omega_y;
+    double            omega_z;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2605,10 +2605,10 @@ namespace Parameters
     prm.enter_subsection("velocity source");
     {
       prm.declare_entry(
-        "type",
+        "rotating frame type",
         "none",
         Patterns::Selection("none|srf"),
-        "Velocity-dependent source terms"
+        "Rotating frame velocity-dependent source terms"
         "Choices are <none|srf>. The srf stands"
         "for single rotating frame and adds"
         "the coriolis and the centrifugal force to the Navier-Stokes equations");
@@ -2639,11 +2639,11 @@ namespace Parameters
   {
     prm.enter_subsection("velocity source");
     {
-      const std::string op = prm.get("type");
+      const std::string op = prm.get("rotating frame type");
       if (op == "none")
-        type = VelocitySourceType::none;
+        rotating_frame_type = RotatingFrameType::none;
       else if (op == "srf")
-        type = VelocitySourceType::srf;
+        rotating_frame_type = RotatingFrameType::srf;
       else
         throw std::logic_error("Error, invalid velocity source type");
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -3743,8 +3743,8 @@ GLSSharpNavierStokesSolver<dim>::setup_assemblers()
         }
 
       // Velocity sources term
-      if (this->simulation_parameters.velocity_sources.type ==
-          Parameters::VelocitySource::VelocitySourceType::srf)
+      if (this->simulation_parameters.velocity_sources.rotating_frame_type ==
+          Parameters::VelocitySource::RotatingFrameType::srf)
         {
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesAssemblerSRF<dim>>(

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -126,8 +126,8 @@ GDNavierStokesSolver<dim>::setup_assemblers()
         }
 
       // Velocity sources term
-      if (this->simulation_parameters.velocity_sources.type ==
-          Parameters::VelocitySource::VelocitySourceType::srf)
+      if (this->simulation_parameters.velocity_sources.rotating_frame_type ==
+          Parameters::VelocitySource::RotatingFrameType::srf)
         {
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesAssemblerSRF<dim>>(

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -546,8 +546,8 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
         }
 
       // Velocity sources term
-      if (this->simulation_parameters.velocity_sources.type ==
-          Parameters::VelocitySource::VelocitySourceType::srf)
+      if (this->simulation_parameters.velocity_sources.rotating_frame_type ==
+          Parameters::VelocitySource::RotatingFrameType::srf)
         {
           this->assemblers.push_back(
             std::make_shared<GLSNavierStokesAssemblerSRF<dim>>(

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2083,8 +2083,8 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
                             simulation_parameters.velocity_sources.omega_y,
                             simulation_parameters.velocity_sources.omega_z);
 
-  if (simulation_parameters.velocity_sources.type ==
-      Parameters::VelocitySource::VelocitySourceType::srf)
+  if (simulation_parameters.velocity_sources.rotating_frame_type ==
+      Parameters::VelocitySource::RotatingFrameType::srf)
     data_out.add_data_vector(solution, srf);
 
   output_field_hook(data_out);


### PR DESCRIPTION
# Description of the problem

- Velocity sources are currently lumped under a single type of parameter. This is problematic since I was to add Darcy-type of source terms for phase change. Hence this needs to change

# Description of the solution

- Change the type to be rotating frame type. This will encompass all rotating frame parameters (eventually maybe MRF?)

# How Has This Been Tested?

- All current test pass. This is just a rename

# Documentation

- Documentation has been updated accordingly

