### PR TITLE
Documentation errors and small change to the custom distribution

### DIFF
--- a/doc/source/parameters/dem/insertion_info.rst
+++ b/doc/source/parameters/dem/insertion_info.rst
@@ -72,7 +72,7 @@ The ``insertion method`` parameter chooses the type of insertion. Acceptable cho
 -------
 Volume
 -------
-The volume insertion method uses an insertion box where particles will be inserted. The insertion locations of particles are randomly selected if the ``random number range`` is not equal to zero, otherwise, the particles will perfectly aligns with the x, y and z directions.
+The volume insertion method uses an insertion box where particles will be inserted. The insertion locations of particles are randomly selected if the ``insertion maximum offset`` is not equal to zero, otherwise, the particles will perfectly aligns with the x, y and z directions.
 
 * The ``inserted number of particles at each time step`` defines the desired number of particles to be inserted at each insertion step. If the insertion box is not adequately large to insert ``inserted number of particles at each time step`` particles with the defined arrangement (initial distance between the inserted particles), Lethe prints a warning and inserts the maximum number of particles that fit inside the insertion box at each insertion step.
 
@@ -97,10 +97,10 @@ The distance between the inserted particles is equal to:
 .. math::
     D_i=(\epsilon + \psi)  d^{max}_p
 
-Where, :math:`{\epsilon}`, :math:`{\psi}`, and :math:`{d^{max}_p}` denote ``insertion distance threshold``, a generated random number (in the range of 0-``random number range``, and from the seed of ``insertion random number seed``), and maximum particle diameter.
+Where, :math:`{\epsilon}`, :math:`{\psi}`, and :math:`{d^{max}_p}` denote ``insertion distance threshold``, a generated random number (in the range of 0-``insertion maximum offset``, and from the seed of ``insertion prn seed``), and maximum particle diameter.
  
 .. note::
-    ``insertion distance threshold`` should also be compatible with the ``random number range``; especially if the ``random number range`` is large, a large value should be defined for ``insertion distance threshold``. Generally, we recommend users to use a value in the range of 1.3-2 (depending on the value of ``random number range``) for the ``insertion distance threshold``.
+    ``insertion distance threshold`` should also be compatible with the ``insertion maximum offset``; especially if the ``insertion maximum offset`` is large, a large value should be defined for ``insertion distance threshold``. Generally, we recommend users to use a value in the range of 1.3-2 (depending on the value of ``insertion maximum offset``) for the ``insertion distance threshold``.
 
 --------------------
 Plane

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -107,7 +107,7 @@ CustomDistribution::particle_size_sampling(const unsigned int &particle_number)
   this->particle_sizes.clear();
   this->particle_sizes.reserve(particle_number);
 
-  std::uniform_real_distribution<> dis(0.0, 1.0);
+  std::uniform_real_distribution<> dis(0.0, diameter_custom_cumu_prob.back());
 
   for (unsigned int i = 0; i < particle_number; ++i)
     {
@@ -116,7 +116,15 @@ CustomDistribution::particle_size_sampling(const unsigned int &particle_number)
                                  diameter_custom_cumu_prob.end(),
                                  dis(gen));
 
-      unsigned int index = std::distance(diameter_custom_cumu_prob.begin(), it);
+      // if dis(gen) returns exactly the maximum value of the cumulative
+      // distribution vector
+      if (it == diameter_custom_cumu_prob.end())
+        {
+          it = it - 1; // Move back to the last valid element
+        }
+
+      unsigned int index =
+        static_cast<unsigned int>(it - diameter_custom_cumu_prob.begin());
 
       this->particle_sizes.push_back(diameter_custom_values[index]);
     }


### PR DESCRIPTION
Smalls changes to the custom distribution to prevent an edge case where the random number generated is equal to or bigger than the highest value in the cumulative probability vector. 

I also find errors in the documentation. In a previous Pull request, I forgot to change the old parameter names in the text below the code example.

Bonne année!   

