### PR TITLE
Fix the compress bug

### DIFF
--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -285,8 +285,9 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
 
   if (mapping_overconstrained_cells)
     {
+      local_dof_overconstrained.compress(VectorOperation::insert);
       dof_overconstrained = local_dof_overconstrained;
-      dof_overconstrained.compress(VectorOperation::insert);
+
 
       for (const auto &cell : cell_iterator)
         {


### PR DESCRIPTION
# Description of the problem

-new change in dealii deprecated compressing locally relevant vector.

# Description of the solution

- Compress the locally owned instead.