### PR TITLE
Dem output solid object option

### DIFF
--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -14,10 +14,10 @@ This subsection explains the solid objects (floating meshes) information. First 
 
 .. code-block:: text
 
- subsection floating walls
+ subsection solid objects
   # Total number of floating walls
     set number of solids  = 1
-      subsection  solid object 0
+      subsection solid object 0
         subsection mesh
             set type                   = gmsh
             set file name              = none
@@ -45,6 +45,10 @@ This subsection explains the solid objects (floating meshes) information. First 
             # Z COR
             set z = 0
         end
+
+        subsection output
+            set output solid object = true
+        end
     end
  end
 
@@ -57,4 +61,6 @@ This subsection explains the solid objects (floating meshes) information. First 
 * In the subsection ``angular velocity``, we define the angular velocity of the floating mesh.
 
 * In the subsection ``center of rotation``, we define the center of rotation of the solid object (in the case of rotational motion).
+
+* In the subsection ``output``, we define if we want an output file to be generated for the solid object at every output time step.
 

--- a/doc/source/parameters/dem/floating_mesh.rst
+++ b/doc/source/parameters/dem/floating_mesh.rst
@@ -46,9 +46,8 @@ This subsection explains the solid objects (floating meshes) information. First 
             set z = 0
         end
 
-        subsection output
-            set output solid object = true
-        end
+        set output solid object = true
+
     end
  end
 
@@ -62,5 +61,5 @@ This subsection explains the solid objects (floating meshes) information. First 
 
 * In the subsection ``center of rotation``, we define the center of rotation of the solid object (in the case of rotational motion).
 
-* In the subsection ``output``, we define if we want an output file to be generated for the solid object at every output time step.
+* The ``output solid object`` defines if we want an output file to be generated for the solid object at every output time step.
 

--- a/doc/source/parameters/dem/simulation_control.rst
+++ b/doc/source/parameters/dem/simulation_control.rst
@@ -27,19 +27,22 @@ where :math:`{d_p}`, :math:`{\rho_p}`, :math:`{G}`, :math:`{\nu}` denote particl
 
     subsection simulation control
       # DEM time-step
-      set time step        = 1e-5
+      set time step         = 1e-5
 
       # Simulation end time
-      set time end         = 0.2
+      set time end          = 0.2
 
       # File output prefix
-      set output path      = ./
+      set output path       = ./
 
       # Log frequency
-      set log frequency    = 1000
+      set log frequency     = 1000
 
       # Output frequency
-      set output frequency = 10000
+      set output frequency  = 10000
+
+      # Output boundary
+      set output boundaries = true
     end
 
 

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -291,8 +291,8 @@ private:
   Vector<double>                                displacement_since_mapped;
 
   // Output management
-  PVDHandler  pvdhandler;
-  const bool *output_bool;
+  PVDHandler pvdhandler;
+  const bool output_bool;
 
   // Elements used to store the velocity of the solid object
   Function<spacedim> *translational_velocity;

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -291,7 +291,8 @@ private:
   Vector<double>                                displacement_since_mapped;
 
   // Output management
-  PVDHandler pvdhandler;
+  PVDHandler  pvdhandler;
+  const bool *output_bool;
 
   // Elements used to store the velocity of the solid object
   Function<spacedim> *translational_velocity;

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -71,8 +71,7 @@ namespace Parameters
     std::string force_output_name;
     std::string torque_output_name;
   };
-
-
+  
   template <int dim>
   void
   NitscheObject<dim>::declare_parameters(ParameterHandler &prm, unsigned int id)
@@ -267,6 +266,7 @@ namespace Parameters
     prm.leave_subsection();
   }
 
+
   template <int dim>
   class RigidSolidObject
   {
@@ -283,6 +283,9 @@ namespace Parameters
 
     // Solid mesh
     Parameters::Mesh solid_mesh;
+
+    // Output management
+    bool output_bool;
 
     // Solid velocity
     Functions::ParsedFunction<dim> translational_velocity;
@@ -316,6 +319,13 @@ namespace Parameters
       prm.declare_entry("y", "0", Patterns::Double(), "Y COR");
       prm.declare_entry("z", "0", Patterns::Double(), "Z COR");
       prm.leave_subsection();
+
+      prm.enter_subsection("output");
+      prm.declare_entry("output solid object",
+                        "true",
+                        Patterns::Bool(),
+                        "Controls the generation of output files");
+      prm.leave_subsection();
     }
     prm.leave_subsection();
   }
@@ -341,6 +351,10 @@ namespace Parameters
       center_of_rotation[1] = prm.get_double("y");
       if (dim == 3)
         center_of_rotation[2] = prm.get_double("z");
+      prm.leave_subsection();
+
+      prm.enter_subsection("output");
+      output_bool = prm.get_bool("output solid object");
       prm.leave_subsection();
     }
     prm.leave_subsection();

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -71,7 +71,7 @@ namespace Parameters
     std::string force_output_name;
     std::string torque_output_name;
   };
-  
+
   template <int dim>
   void
   NitscheObject<dim>::declare_parameters(ParameterHandler &prm, unsigned int id)
@@ -419,7 +419,6 @@ namespace Parameters
     }
     prm.leave_subsection();
   }
-
 } // namespace Parameters
 
 #endif

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -320,12 +320,10 @@ namespace Parameters
       prm.declare_entry("z", "0", Patterns::Double(), "Z COR");
       prm.leave_subsection();
 
-      prm.enter_subsection("output");
       prm.declare_entry("output solid object",
                         "true",
                         Patterns::Bool(),
                         "Controls the generation of output files");
-      prm.leave_subsection();
     }
     prm.leave_subsection();
   }
@@ -353,9 +351,7 @@ namespace Parameters
         center_of_rotation[2] = prm.get_double("z");
       prm.leave_subsection();
 
-      prm.enter_subsection("output");
       output_bool = prm.get_bool("output solid object");
-      prm.leave_subsection();
     }
     prm.leave_subsection();
   }

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -14,7 +14,6 @@
  * ---------------------------------------------------------------------
  */
 
-
 #include <core/lethe_grid_tools.h>
 #include <core/serial_solid.h>
 #include <core/solutions_output.h>
@@ -37,8 +36,6 @@
 
 #include <fstream>
 
-
-
 template <int dim, int spacedim>
 SerialSolid<dim, spacedim>::SerialSolid(
   std::shared_ptr<Parameters::RigidSolidObject<spacedim>> &param,
@@ -48,6 +45,7 @@ SerialSolid<dim, spacedim>::SerialSolid(
   , this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator))
   , param(param)
   , id(id)
+  , output_bool(&param->output_bool)
   , translational_velocity(&param->translational_velocity)
   , angular_velocity(&param->angular_velocity)
   , center_of_rotation(param->center_of_rotation)
@@ -469,52 +467,55 @@ void
 SerialSolid<dim, spacedim>::write_output_results(
   std::shared_ptr<SimulationControl> simulation_control)
 {
-  DataOut<dim, spacedim> data_out;
-  data_out.attach_dof_handler(displacement_dh);
+  if (*output_bool)
+    {
+      DataOut<dim, spacedim> data_out;
+      data_out.attach_dof_handler(displacement_dh);
 
-  {
-    std::vector<std::string> displacement_names(spacedim, "displacement");
-    std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      data_component_interpretation(
-        spacedim, DataComponentInterpretation::component_is_part_of_vector);
+      {
+        std::vector<std::string> displacement_names(spacedim, "displacement");
+        std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          data_component_interpretation(
+            spacedim, DataComponentInterpretation::component_is_part_of_vector);
 
-    data_out.add_data_vector(displacement,
-                             displacement_names,
-                             DataOut<dim, spacedim>::type_dof_data,
-                             data_component_interpretation);
-  }
+        data_out.add_data_vector(displacement,
+                                 displacement_names,
+                                 DataOut<dim, spacedim>::type_dof_data,
+                                 data_component_interpretation);
+      }
 
-  {
-    std::vector<std::string> displacement_names(spacedim,
-                                                "displacement_since_mapped");
-    std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      data_component_interpretation(
-        spacedim, DataComponentInterpretation::component_is_part_of_vector);
+      {
+        std::vector<std::string> displacement_names(
+          spacedim, "displacement_since_mapped");
+        std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          data_component_interpretation(
+            spacedim, DataComponentInterpretation::component_is_part_of_vector);
 
-    data_out.add_data_vector(displacement_since_mapped,
-                             displacement_names,
-                             DataOut<dim, spacedim>::type_dof_data,
-                             data_component_interpretation);
-  }
+        data_out.add_data_vector(displacement_since_mapped,
+                                 displacement_names,
+                                 DataOut<dim, spacedim>::type_dof_data,
+                                 data_component_interpretation);
+      }
 
-  data_out.build_patches();
+      data_out.build_patches();
 
-  const std::string folder        = simulation_control->get_output_path();
-  const std::string solution_name = simulation_control->get_output_name() +
-                                    ".solid_object." +
-                                    Utilities::int_to_string(id, 2);
-  const unsigned int iter        = simulation_control->get_step_number();
-  const double       time        = simulation_control->get_current_time();
-  const unsigned int group_files = simulation_control->get_group_files();
+      const std::string folder        = simulation_control->get_output_path();
+      const std::string solution_name = simulation_control->get_output_name() +
+                                        ".solid_object." +
+                                        Utilities::int_to_string(id, 2);
+      const unsigned int iter        = simulation_control->get_step_number();
+      const double       time        = simulation_control->get_current_time();
+      const unsigned int group_files = simulation_control->get_group_files();
 
-  write_vtu_and_pvd<dim, spacedim>(pvdhandler,
-                                   data_out,
-                                   folder,
-                                   solution_name,
-                                   time,
-                                   iter,
-                                   group_files,
-                                   this->mpi_communicator);
+      write_vtu_and_pvd<dim, spacedim>(pvdhandler,
+                                       data_out,
+                                       folder,
+                                       solution_name,
+                                       time,
+                                       iter,
+                                       group_files,
+                                       this->mpi_communicator);
+    }
 }
 
 template <int dim, int spacedim>

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -15,6 +15,7 @@
  */
 
 #include <core/lethe_grid_tools.h>
+#include <core/serial_solid.h>
 #include <core/solutions_output.h>
 
 #include <deal.II/base/point.h>


### PR DESCRIPTION
# Description of the problem

- Solid object output files were always being outputted at every output time step. When using a large amount of solid object, the amount of output files can become astronomical pretty quickly. 

# Description of the solution

- I have added a new parameter to solid object. We can now specify if we want output files to be generated or not. By default, this parameter is at true, which keep compatibility with the previous parameter files (like the examples). 

# How Has This Been Tested?

- I used one of my prm file for my LPBF simulation and put solid object 0 and 2 to false. Ran the simulation with zero particle and no output file were generated for those two solid objects. 

# Documentation

- Small correction to the solid object documentation.
- Added the parameter to the doc.

# Future changes

- We could replace this new bool to a function like for the "translational velocity", so that vtus would be outputted during a certain period.
