### PR TITLE
Fix heat flux postprocessor material_id processing

### DIFF
--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -696,6 +696,10 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
   const unsigned int n_solids =
     this->simulation_parameters.physical_properties_manager
       .get_number_of_solids();
+  unsigned int mesh_m_id = 0;
+
+  // Check if there are solids
+  const bool solid_phase_present = (n_solids > 0);
 
   // Postprocess heat fluxes
   heat_flux_postprocessors.clear();
@@ -703,8 +707,12 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
   // Heat fluxes in fluids
   for (unsigned int f_id = 0; f_id < n_fluids; ++f_id)
     {
-      heat_flux_postprocessors.push_back(HeatFluxPostprocessor<dim>(
-        thermal_conductivity_models[f_id], "f", f_id, f_id));
+      heat_flux_postprocessors.push_back(
+        HeatFluxPostprocessor<dim>(thermal_conductivity_models[f_id],
+                                   "f",
+                                   f_id,
+                                   mesh_m_id,
+                                   solid_phase_present));
       data_out.add_data_vector(this->dof_handler,
                                this->present_solution,
                                heat_flux_postprocessors[f_id]);
@@ -712,8 +720,13 @@ HeatTransfer<dim>::attach_solution_to_output(DataOut<dim> &data_out)
   // Heat fluxes in solids
   for (unsigned int m_id = n_fluids; m_id < n_fluids + n_solids; ++m_id)
     {
-      heat_flux_postprocessors.push_back(HeatFluxPostprocessor<dim>(
-        thermal_conductivity_models[m_id], "s", m_id - n_fluids, m_id));
+      mesh_m_id += 1;
+      heat_flux_postprocessors.push_back(
+        HeatFluxPostprocessor<dim>(thermal_conductivity_models[m_id],
+                                   "s",
+                                   m_id - n_fluids,
+                                   mesh_m_id,
+                                   solid_phase_present));
       data_out.add_data_vector(this->dof_handler,
                                this->present_solution,
                                heat_flux_postprocessors[m_id]);


### PR DESCRIPTION
# Description of the problem

- In the previous implementation of the heat flux postprocessor, there was a confusion related to the `material_id` of a cell. As a cell's `material_id` is defined in the mesh, fluids moving from a cell to another did not have the right `material_id` when outputted. Futhermore, some dealii meshs have an intrinc way of numbering `material_ids` (e.g. colorized subdivided_hyper_rectangle) that were leading to inadequate comparison of the `material_ids`.

# Description of the solution

- As of this PR, in the heat flux postprocessor, the `material_id` is only used to indentify cell material when solids are present. When simulating with fluids and solids, cells of the mesh in which the fluids lie should have a `material_id` of `0`.
- For _fluids-only_ simulations, at the moment, their heat fluxes will be output on the entire domain, as the current `DataPostprocessor` can only hold 1 `dof_handler`. During postprocessing, the user could clip the domain of interest of each fluid using the `phase` or `filtered_phase` fields outputted.

# How Has This Been Tested?

- Visual inspection of outputted results for a:

- [x] single fluid simulation,
- [x] 1 fluid + 1 solid simulation, and
- [x] 2 fluids simulaiton.

# Future changes

- For multiple-fluids simulations, a `DataPostprocessor` handling multiple `dof_handlers` to allow postprocessing of quantities of interest of fluids in their respective subdomains will have to be added to the code.
