### PR TITLE
Add darcy penalization in vof

### DIFF
--- a/applications_tests/lethe-fluid/vof_phase_change_darcy.output
+++ b/applications_tests/lethe-fluid/vof_phase_change_darcy.output
@@ -1,0 +1,83 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       200
+   Number of degrees of freedom: 765
+   Volume of triangulation:      0.1
+   Number of thermal degrees of freedom: 255
+   Number of VOF degrees of freedom: 255
+
+*******************************************************************************
+Transient iteration: 1        Time: 2        Time step: 2        CFL: 62.5156 
+*******************************************************************************
+----
+VOF
+----
+Newton iteration: 0  - Residual:  0.00954761
+  -Tolerance of iterative solver is : 9.54761e-06
+  -Iterative solver took : 1 steps 
+	alpha =      1 res = 1.465e-06	L^2(dx) =  1.937	L^infty(dx) = 1.858
+Newton iteration: 1  - Residual:  1.465e-06
+  -Tolerance of iterative solver is : 1.465e-09
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 4.739e-10	L^2(dx) = 0.0105	L^infty(dx) = 0.008732
+
+*******************************************************************************
+Transient iteration: 2        Time: 4        Time step: 2        CFL: 63.6716 
+*******************************************************************************
+----
+VOF
+----
+Newton iteration: 0  - Residual:  0.02127
+  -Tolerance of iterative solver is : 2.127e-05
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 7.169e-07	L^2(dx) =  2.119	L^infty(dx) = 1.465
+
+*******************************************************************************
+Transient iteration: 3        Time: 6        Time step: 2        CFL: 78.5226 
+*******************************************************************************
+----
+VOF
+----
+Newton iteration: 0  - Residual:  0.1358
+  -Tolerance of iterative solver is : 0.0001358
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 2.107e-05	L^2(dx) =  4.648	L^infty(dx) = 1.182
+Newton iteration: 1  - Residual:  2.107e-05
+  -Tolerance of iterative solver is : 2.107e-08
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 2.693e-09	L^2(dx) = 0.0005704	L^infty(dx) = 0.0003765
+
+*******************************************************************************
+Transient iteration: 4        Time: 8        Time step: 2        CFL: 78.606  
+*******************************************************************************
+----
+VOF
+----
+Newton iteration: 0  - Residual:  0.01584
+  -Tolerance of iterative solver is : 1.584e-05
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 2.71e-06	L^2(dx) =  1.488	L^infty(dx) = 0.8036
+Newton iteration: 1  - Residual:  2.71e-06
+  -Tolerance of iterative solver is : 2.71e-09
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 1.382e-10	L^2(dx) = 0.0002117	L^infty(dx) = 0.0001389
+
+*******************************************************************************
+Transient iteration: 5        Time: 10       Time step: 2        CFL: 78.5993 
+*******************************************************************************
+----
+VOF
+----
+Newton iteration: 0  - Residual:  0.0193
+  -Tolerance of iterative solver is : 1.93e-05
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 3.695e-06	L^2(dx) = 0.7697	L^infty(dx) = 0.5295
+Newton iteration: 1  - Residual:  3.695e-06
+  -Tolerance of iterative solver is : 3.695e-09
+  -Iterative solver took : 2 steps 
+	alpha =      1 res = 1.122e-09	L^2(dx) = 0.0002465	L^infty(dx) = 0.00018
+ time   error_velocity error_pressure 
+ 2.0000   1.232504e-01         0.0000 
+ 4.0000   9.762791e-03         0.0000 
+ 6.0000   1.287210e-03         0.0000 
+ 8.0000   5.294252e-04         0.0000 
+10.0000   5.288528e-04         0.0000 

--- a/applications_tests/lethe-fluid/vof_phase_change_darcy.output
+++ b/applications_tests/lethe-fluid/vof_phase_change_darcy.output
@@ -8,73 +8,22 @@ Running on 1 MPI rank(s)...
 *******************************************************************************
 Transient iteration: 1        Time: 2        Time step: 2        CFL: 62.5156 
 *******************************************************************************
-----
-VOF
-----
-Newton iteration: 0  - Residual:  0.00954761
-  -Tolerance of iterative solver is : 9.54761e-06
-  -Iterative solver took : 1 steps 
-	alpha =      1 res = 1.465e-06	L^2(dx) =  1.937	L^infty(dx) = 1.858
-Newton iteration: 1  - Residual:  1.465e-06
-  -Tolerance of iterative solver is : 1.465e-09
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 4.739e-10	L^2(dx) = 0.0105	L^infty(dx) = 0.008732
 
 *******************************************************************************
 Transient iteration: 2        Time: 4        Time step: 2        CFL: 63.6716 
 *******************************************************************************
-----
-VOF
-----
-Newton iteration: 0  - Residual:  0.02127
-  -Tolerance of iterative solver is : 2.127e-05
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 7.169e-07	L^2(dx) =  2.119	L^infty(dx) = 1.465
 
 *******************************************************************************
 Transient iteration: 3        Time: 6        Time step: 2        CFL: 78.5226 
 *******************************************************************************
-----
-VOF
-----
-Newton iteration: 0  - Residual:  0.1358
-  -Tolerance of iterative solver is : 0.0001358
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 2.107e-05	L^2(dx) =  4.648	L^infty(dx) = 1.182
-Newton iteration: 1  - Residual:  2.107e-05
-  -Tolerance of iterative solver is : 2.107e-08
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 2.693e-09	L^2(dx) = 0.0005704	L^infty(dx) = 0.0003765
 
 *******************************************************************************
 Transient iteration: 4        Time: 8        Time step: 2        CFL: 78.606  
 *******************************************************************************
-----
-VOF
-----
-Newton iteration: 0  - Residual:  0.01584
-  -Tolerance of iterative solver is : 1.584e-05
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 2.71e-06	L^2(dx) =  1.488	L^infty(dx) = 0.8036
-Newton iteration: 1  - Residual:  2.71e-06
-  -Tolerance of iterative solver is : 2.71e-09
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 1.382e-10	L^2(dx) = 0.0002117	L^infty(dx) = 0.0001389
 
 *******************************************************************************
 Transient iteration: 5        Time: 10       Time step: 2        CFL: 78.5993 
 *******************************************************************************
-----
-VOF
-----
-Newton iteration: 0  - Residual:  0.0193
-  -Tolerance of iterative solver is : 1.93e-05
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 3.695e-06	L^2(dx) = 0.7697	L^infty(dx) = 0.5295
-Newton iteration: 1  - Residual:  3.695e-06
-  -Tolerance of iterative solver is : 3.695e-09
-  -Iterative solver took : 2 steps 
-	alpha =      1 res = 1.122e-09	L^2(dx) = 0.0002465	L^infty(dx) = 0.00018
  time   error_velocity error_pressure 
  2.0000   1.232504e-01         0.0000 
  4.0000   9.762791e-03         0.0000 

--- a/applications_tests/lethe-fluid/vof_phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/vof_phase_change_darcy.prm
@@ -256,6 +256,11 @@ subsection non-linear solver
     set tolerance      = 1e-8
     set max iterations = 5
   end
+  subsection VOF
+    set verbosity      = quiet
+    set tolerance      = 1e-8
+    set max iterations = 5
+  end
 end
 
 #---------------------------------------------------
@@ -275,6 +280,17 @@ subsection linear solver
     set ilu preconditioner relative tolerance = 1.00
   end
   subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
     set verbosity                             = quiet
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid/vof_phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/vof_phase_change_darcy.prm
@@ -1,0 +1,288 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method            = bdf1
+  set number mesh adapt = 0
+  set output frequency  = 0
+  set time end          = 10
+  set time step         = 2
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 1
+  set pressure order = 1
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+  subsection uvwp
+    set Function expression = 0; 0; 0;
+  end
+  subsection VOF
+    set Function expression = if(x*x<=0.000625, 1, 0)
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 0
+    set thermal conductivity model = constant
+    set thermal conductivity       = 1
+    set rheological model          = phase_change
+
+    set specific heat model = phase_change
+    subsection phase change
+      # Enthalpy of the phase change
+      set latent enthalpy = 0
+
+      # Temperature of the liquidus
+      set liquidus temperature = 0.51
+
+      # Temperature of the solidus
+      set solidus temperature = 0.49
+
+      # Specific heat of the liquid phase
+      set specific heat liquid = 1
+
+      # Specific heat of the solid phase
+      set specific heat solid = 1
+
+      # Permeability of the liquid phase
+      set Darcy penalty liquid = 0
+
+      # Permeability of the solid phase
+      set Darcy penalty solid = 1e5
+    end
+  end
+  subsection fluid 1
+    set thermal conductivity model = constant
+    set thermal conductivity       = 1
+    set rheological model          = phase_change
+
+    set specific heat model = phase_change
+    subsection phase change
+      # Enthalpy of the phase change
+      set latent enthalpy = 0
+
+      # Temperature of the liquidus
+      set liquidus temperature = 0.51
+
+      # Temperature of the solidus
+      set solidus temperature = 0.49
+
+      # Specific heat of the liquid phase
+      set specific heat liquid = 1
+
+      # Specific heat of the solid phase
+      set specific heat solid = 1
+
+      # Permeability of the liquid phase
+      set Darcy penalty liquid = 0
+
+      # Permeability of the solid phase
+      set Darcy penalty solid = 1e5
+    end
+  end
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable = true
+  subsection uvwp
+    set Function constants  = H=1, G=1, mu=1
+    set Function expression = if(y>=0.5,0,2*(0.5-y)) ; 0 ; 0
+  end
+end
+
+#---------------------------------------------------
+# Velocity Source
+#---------------------------------------------------
+
+subsection velocity source
+  # Darcy-like permeability term. Choices are <none|phase_change>.
+  set Darcy type = phase_change
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 4, 50 : -0.05, 0 : 0.05, 1 : true
+  set initial refinement = 0
+end
+
+#---------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+
+subsection mesh adaptation
+  set type                 = none
+  set max number elements  = 20000
+  set max refinement level = 3
+  set min refinement level = 0
+  set frequency            = 1
+  set fraction refinement  = 0.1
+  set fraction coarsening  = 0.1
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 3
+  subsection bc 0
+    set type               = periodic
+    set id                 = 0
+    set periodic_id        = 1
+    set periodic_direction = 0
+  end
+  subsection bc 2
+    set type = noslip
+    set id   = 3
+  end
+  subsection bc 1
+    set id   = 2
+    set type = function
+    subsection u
+      set Function expression = 1
+    end
+    subsection v
+      set Function expression = 0
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+end
+
+subsection boundary conditions heat transfer
+  set number = 2
+  subsection bc 0
+    set type = temperature
+    set id   = 2
+    subsection value
+      set Function expression = 1
+    end
+  end
+  subsection bc 1
+    set type = temperature
+    set id   = 3
+    subsection value
+      set Function expression = 0
+    end
+  end
+end
+
+subsection boundary conditions VOF
+  set number         = 4
+  set time dependent = false
+  subsection bc 0
+    set id   = 0
+    set type = dirichlet
+    subsection dirichlet
+      set Function expression = 0
+    end
+  end
+  subsection bc 1
+    set id   = 1
+    set type = dirichlet
+    subsection dirichlet
+      set Function expression = 0
+    end
+  end
+  subsection bc 2
+    set id   = 2
+    set type = dirichlet
+    subsection dirichlet
+      set Function expression = if(x*x<=0.000625, 1, 0)
+    end
+  end
+  subsection bc 3
+    set id   = 3
+    set type = dirichlet
+    subsection dirichlet
+      set Function expression = if(x*x<=0.000625, 1, 0)
+    end
+  end
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer = true
+  set VOF           = true
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set verbosity      = quiet
+    set tolerance      = 1e-8
+    set max iterations = 5
+  end
+  subsection fluid dynamics
+    set verbosity      = quiet
+    set tolerance      = 1e-8
+    set max iterations = 5
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-11
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end

--- a/doc/source/parameters/cfd/laser_heat_source.rst
+++ b/doc/source/parameters/cfd/laser_heat_source.rst
@@ -63,7 +63,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
   .. math::
       q_\text{rad} = \epsilon \sigma (T^4 - T_\text{inf}^4)
 
-  * ``enable``: controls if the radiation cooling is enabled. The radiation sink is modulated by the filtered phase fraction gradient norm, :math:`|\nabla \phi'|`, in such way that the flux is applied at the interface between the fluids.
+  * ``enable``: controls if the radiation cooling is enabled. The radiation sink is modulated by the filtered phase fraction gradient norm, :math:`|\nabla \psi|`, in such way that the flux is applied at the interface between the fluids.
 
     .. warning::
         To apply this radiation cooling, the ``VOF`` parameter must be set to ``true`` in the :doc:`multiphysics` subsection.
@@ -85,9 +85,9 @@ Laser types
   When the ``exponential_decay`` is used in conjunction with the :doc:`VOF auxiliary physic <./volume_of_fluid>` the equation takes the following form:
 
   .. math::
-      q(x,y,z) = \frac{\phi' \eta \alpha P}{\pi r^2 \mu} \exp{\left(-\eta \frac{r^2}{R^2}\right)} \exp{\left(- \frac{|z|}{\mu}\right)}
+      q(x,y,z) = \frac{\psi \eta \alpha P}{\pi r^2 \mu} \exp{\left(-\eta \frac{r^2}{R^2}\right)} \exp{\left(- \frac{|z|}{\mu}\right)}
 
-  where :math:`\phi'` is the filtered phase fraction.
+  where :math:`\psi` is the filtered phase fraction.
 
   .. attention::
     In this case, the heat affects the fluid initialized as ``fluid 1``.
@@ -95,9 +95,9 @@ Laser types
 * When ``type`` is set to ``heat_flux_vof_interface``, it **must be used in conjunction with the** :doc:`VOF auxiliary physic <./volume_of_fluid>`. This model is used to apply the heat flux, given by the expression below, only at the interface.
 
   .. math::
-      q(x,y,z) = \frac{|\nabla \phi'| \eta \alpha P}{\pi r^2} \exp{\left(-\eta \frac{r^2}{R^2}\right)}
+      q(x,y,z) = \frac{|\nabla \psi| \eta \alpha P}{\pi r^2} \exp{\left(-\eta \frac{r^2}{R^2}\right)}
 
-  where :math:`r` is the radial distance from the laser's axis and :math:`|\nabla \phi'|` is the :math:`L^2` norm of the filtered phase fraction gradient.
+  where :math:`r` is the radial distance from the laser's axis and :math:`|\nabla \psi|` is the :math:`L^2` norm of the filtered phase fraction gradient.
 
 
 -----------

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -542,7 +542,7 @@ Thermal Expansion Models
 Lethe supports two types of thermal expansion heat models. Setting ``thermal expansion model=constant`` sets a constant thermal expansion. Lethe also supports a ``phase_change`` thermal expansion model. This model can simulate the melting and solidification of a material with natural convection. It works by defining a different value of the thermal expansion coefficient depending on the value of the temperature:
 
 .. math::
-  \beta =   c^{*}_\text{p}  = \begin{cases} \beta_\text{s} & \text{if}\;T \leq T_\text{l}\\
+  \beta = \begin{cases} \beta_\text{s} & \text{if}\;T \leq T_\text{l}\\
               \beta_\text{l} & \text{if}\;T > T_\text{l}
               \end{cases}
 

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -339,6 +339,8 @@ The parameters for the Carreau model are defined by the ``carreau`` subsection. 
 .. note::
     The Carreau model is only suitable for Newtonian and shear-thinning flows.
 
+.. _rheological phase change model:
+
 Phase-Change Model
 ^^^^^^^^^^^^^^^^^^^ 
 
@@ -351,7 +353,7 @@ The phase change model is a simple rheological model in which the viscosity depe
               \nu_\text{l} & \text{if} \; T>T_\text{l}
               \end{cases}
 
-where :math:`T_\text{l}` and :math:`T_\text{s}` are the liquidus and solidus temperature. The underlying hypothesis of this model is that the melting and the solidification occurs over a phase change interval. Melting will occur between :math:`T_\text{s}` and :math:`T_\text{l}` and solidification will occur between :math:`T_\text{l}` and :math:`T_\text{s}`.
+where :math:`T_\text{l}` and :math:`T_\text{s}` are the liquidus and solidus temperature. The underlying hypothesis of this model is that the melting and the solidification occur over a phase change interval. Melting will occur between :math:`T_\text{s}` and :math:`T_\text{l}` and solidification will occur between :math:`T_\text{l}` and :math:`T_\text{s}`.
 
 This model is parameterized using the ``phase change`` subsection
 
@@ -364,10 +366,10 @@ This model is parameterized using the ``phase change`` subsection
     # Temperature of the solidus
     set solidus temperature  = 0
 
-    # Specific heat of the liquid phase
+    # Viscosity of the liquid phase
     set viscosity liquid     = 1
   
-    # viscosity of the solid phase
+    # Viscosity of the solid phase
     set viscosity solid      = 1
   end
 
@@ -436,6 +438,8 @@ Constant, linear and phase_change thermal conductivities are supported in Lethe.
 
 where :math:`k_{A,0}` and :math:`k_{A,1}` are constants and :math:`T` is the temperature. This enables a linear variation of the thermal conductivity as a function of the temperature.
 
+.. _thermal conductivity phase change model:
+
 In the ``phase_change`` thermal conductivity model, two different values (``thermal conductivity liquid``, and ``thermal conductivity solid``) are required for calculating the thermal conductivities of the liquid and solid phases, respectively. For the liquid phase (:math:`T>T_\text{liquidus}`), the ``thermal conductivity liquid`` is applied, while for the solid phase (:math:`T<T_\text{solidus}`), the model uses the ``thermal conductivity solid``. In the mushy zone between :math:`T_\text{solidus}` and :math:`T_\text{liquidus}`, the thermal conductivity is equal to:
 
 .. math::
@@ -444,6 +448,35 @@ In the ``phase_change`` thermal conductivity model, two different values (``ther
 
 
 where :math:`k_\text{l}`, :math:`k_\text{s}` and  :math:`\alpha_\text{l}` denote thermal conductivities of the liquid and solid phases and the liquid fraction.
+
+This model is parameterized using the following section:
+
+.. code-block:: text
+
+  subsection phase change
+    # Temperature of the liquidus
+    set liquidus temperature = 1
+
+    # Temperature of the solidus
+    set solidus temperature  = 0
+
+    # Thermal conductivity of the liquid phase
+    set thermal conductivity liquid = 1
+
+    # Thermal conductivity of the solid phase
+    set thermal conductivity solid  = 1
+  end
+
+* The ``liquidus temperature`` is :math:`T_\text{l}`
+
+* The ``solidus temperature`` is :math:`T_\text{s}`
+
+* The ``thermal conductivity liquid`` is :math:`k_\text{l}`
+
+* The ``thermal conductivity solid`` is :math:`k_\text{s}`
+
+
+.. _specific heat phase change model:
 
 Specific Heat Models
 ~~~~~~~~~~~~~~~~~~~~~
@@ -502,6 +535,7 @@ This model is parameterized using the following section:
 
 * The ``specific heat solid`` is :math:`C_\text{p,s}`
 
+.. _thermal expansion phase change model:
 
 Thermal Expansion Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -538,6 +572,69 @@ This model is parameterized using the following section:
 * The ``thermal expansion liquid`` is :math:`\beta_\text{l}`
 
 * The ``thermal expansion solid`` is :math:`\beta_\text{s}`
+
+Phase Change
+~~~~~~~~~~~~~
+
+The current section recapitulates the `phase change` subsection.
+Snippets of this subsection can be found across the different physical property models' descriptions.
+
+.. code-block:: text
+
+  subsection phase change
+    set liquidus temperature = 1
+    set solidus temperature  = 0
+
+    # Rheology
+    set viscosity liquid = 1
+    set viscosity solid  = 1
+
+    # Specific heat
+    set latent enthalpy      = 1
+    set specific heat liquid = 1
+    set specific heat solid  = 1
+
+    # Thermal conductivity
+    set thermal conductivity liquid = 1
+    set thermal conductivity solid  = 1
+
+    # Thermal expansion
+    set thermal expansion liquid = 1
+    set thermal expansion solid  = 0
+
+    # Darcy penalization
+    set Darcy penalty liquid = 0
+    set Darcy penalty solid  = 0
+  end
+
+The phase change is modelled with the underlying hypothesis that melting and solidification occur over a phase change interval. Melting occurs between :math:`T_\text{s}` and :math:`T_\text{l}`, respectively the ``solidus temperature`` and the ``liquidus temperature``. Analogously, solidification occurs between :math:`T_\text{l}` and :math:`T_\text{s}`.
+
+* Rheology (see `rheological phase change model`_):
+
+  * ``viscosity liquid``: kinematic viscosity of the liquid phase :math:`(\nu_\text{l})`
+  * ``viscosity solid``: kinematic viscosity of the solid phase :math:`(\nu_\text{s})`
+
+* Specific heat (see `specific heat phase change model`_):
+
+  * ``latent enthalpy``: latent enthalpy of the phase change :math:`(h_\text{l})`
+  * ``specific heat liquid``: specific heat of the liquid phase :math:`(C_\text{p,l})`
+  * ``specific heat solid``: specific heat of the solid phase :math:`(C_\text{p,s})`
+
+* Thermal conductivity (see `thermal conductivity phase change model`_):
+
+  * ``thermal conductivity liquid``: thermal conductivity of the liquid phase :math:`(k_\text{l})`
+  * ``thermal conductivity solid``: thermal conductivity of the solid phase :math:`(k_\text{s})`
+
+
+* Thermal expansion (see `thermal expansion phase change model`_):
+
+  * ``thermal expansion liquid``: thermal expansion of the liquid phase :math:`(\beta_\text{l})`
+  * ``thermal expansion solid``: thermal expansion of the solid phase :math:`(\beta_\text{s})`
+
+* Darcy penalization (see `Darcy penalization <https://lethe-cfd.github.io/lethe/documentation/parameters/cfd/velocity_source.html#darcy-penalization>`_):
+
+  * ``Darcy penalty liquid``: Darcy penalty coefficient for the liquid phase
+  * ``Darcy penalty solid``: Darcy penalty coefficient for the solid phase
 
 Interface Physical Property Models
 ***********************************

--- a/doc/source/parameters/cfd/physical_properties.rst
+++ b/doc/source/parameters/cfd/physical_properties.rst
@@ -100,9 +100,9 @@ Physical Properties
 
     .. math::
 
-      {\bf{F_{B}}} = -\beta {\bf{g}} (T-T_{ref})
+      {\bf{F_{B}}} = -\beta {\bf{g}} (T-T_\text{ref})
 
-    where :math:`F_B` denotes the buoyant force source term, :math:`\beta` is the thermal expansion coefficient, :math:`T` is temperature, and :math:`T_{ref}` is the reference temperature. This is only used when a constant thermal expansion model is used.
+    where :math:`F_B` denotes the buoyant force source term, :math:`\beta` is the thermal expansion coefficient, :math:`T` is temperature, and :math:`T_\text{ref}` is the reference temperature. This is only used when a constant thermal expansion model is used.
 
   * The ``tracer diffusivity model`` specifies the model used to calculate the tracer diffusivity. At the moment, only a constant tracer diffusivity is supported.
 
@@ -346,12 +346,12 @@ The phase change model is a simple rheological model in which the viscosity depe
 
 .. math::
 
-  \nu =   c^{*}_p  = \begin{cases} \nu_s \; \text{if} \; T<T_{s} \\
-              \frac{T-T_s}{T_l-T_s} \nu_l + (1-\frac{T-T_s}{T_l-T_s}) \nu_s \; \text{if} \; T_{l}>T>T_{s}\\
-              \nu_l \; \text{if} \; T>T_{l}
+  \nu =   c^{*}_\text{p}  = \begin{cases} \nu_\text{s} & \text{if} \; T<T_\text{s} \\
+              \frac{T-T_\text{s}}{T_\text{l}-T_\text{s}} \nu_\text{l} + \left(1-\frac{T-T_\text{s}}{T_\text{l}-T_\text{s}}\right) \nu_\text{s} & \text{if} \; T_\text{l}>T>T_\text{s}\\
+              \nu_\text{l} & \text{if} \; T>T_\text{l}
               \end{cases}
 
-where :math:`T_l` and :math:`T_s` are the liquidus and solidus temperature. The underlying hypothesis of this model is that the melting and the solidification occurs over a phase change interval. Melting will occur between :math:`T_s` and :math:`T_l` and solidification will occur between :math:`T_l` and :math:`T_s`.
+where :math:`T_\text{l}` and :math:`T_\text{s}` are the liquidus and solidus temperature. The underlying hypothesis of this model is that the melting and the solidification occurs over a phase change interval. Melting will occur between :math:`T_\text{s}` and :math:`T_\text{l}` and solidification will occur between :math:`T_\text{l}` and :math:`T_\text{s}`.
 
 This model is parameterized using the ``phase change`` subsection
 
@@ -372,13 +372,13 @@ This model is parameterized using the ``phase change`` subsection
   end
 
 
-* The ``liquidus temperature`` is :math:`T_l`
+* The ``liquidus temperature`` is :math:`T_\text{l}`
 
-* The ``solidus temperature`` is :math:`T_s`
+* The ``solidus temperature`` is :math:`T_\text{s}`
 
-* The ``viscosity liquid`` is :math:`\nu_{l}`
+* The ``viscosity liquid`` is :math:`\nu_\text{l}`
 
-* The ``viscosity solid`` is :math:`\nu_{s}`
+* The ``viscosity solid`` is :math:`\nu_\text{s}`
 
 .. note::
   The phase change subsection is used to parametrize *both* ``rheological model = phase_change`` *and* ``specific heat model = phase_change``. This prevents parameter duplication.
@@ -391,9 +391,9 @@ Density Models
 Lethe supports both ``constant`` and ``isothermal_ideal_gas`` density models. Constant density assumes a constant density value. Isothermal ideal gas density assumes that the fluid's density varies according the following state equation:
 
 .. math::
-  \rho = \rho_{ref} + \psi p = \rho_{ref} + \frac{1}{R T} \ p
+  \rho = \rho_\text{ref} + \psi p = \rho_\text{ref} + \frac{1}{R T} \ p
 
-where :math:`\rho_{ref}` is the density of the fluid at the reference state, :math:`\psi = \frac{1}{R T}` is the compressibility factor derived from the ideal gas law with :math:`R= \frac{R_u}{M}` the specific gas constant (universal gas constant (:math:`R_u`) divided by the molar mass of the gas (:math:`M`)) and :math:`T` the temperature of the gas, finally, :math:`p` is the differential pressure between the reference state and the current state. This model is used for weakly compressible flows when temperature fluctuations' influence on density can be neglected.
+where :math:`\rho_\text{ref}` is the density of the fluid at the reference state, :math:`\psi = \frac{1}{R T}` is the compressibility factor derived from the ideal gas law with :math:`R= \frac{R_u}{M}` the specific gas constant (universal gas constant (:math:`R_u`) divided by the molar mass of the gas (:math:`M`)) and :math:`T` the temperature of the gas, finally, :math:`p` is the differential pressure between the reference state and the current state. This model is used for weakly compressible flows when temperature fluctuations' influence on density can be neglected.
 
 This model is parametrized using the ``isothermal_ideal_gas`` subsection:
 
@@ -413,7 +413,7 @@ This model is parametrized using the ``isothermal_ideal_gas`` subsection:
 
 where:
 
-* ``density_ref`` corresponds to :math:`\rho_{ref}`
+* ``density_ref`` corresponds to :math:`\rho_\text{ref}`
 
 * ``R`` corresponds to :math:`R`
 
@@ -436,40 +436,40 @@ Constant, linear and phase_change thermal conductivities are supported in Lethe.
 
 where :math:`k_{A,0}` and :math:`k_{A,1}` are constants and :math:`T` is the temperature. This enables a linear variation of the thermal conductivity as a function of the temperature.
 
-In the ``phase_change`` thermal conductivity model, two different values (``thermal conductivity liquid``, and ``thermal conductivity solid``) are required for calculating the thermal conductivities of the liquid and solid phases, respectively. For the liquid phase (T>T_liquidus), the ``thermal conductivity liquid`` is applied, while for the solid phase (T<T_solidus), the model uses the ``thermal conductivity solid``. In the mushy zone between T_solidus and T_liquidus, the thermal conductivity is equal to:
+In the ``phase_change`` thermal conductivity model, two different values (``thermal conductivity liquid``, and ``thermal conductivity solid``) are required for calculating the thermal conductivities of the liquid and solid phases, respectively. For the liquid phase (:math:`T>T_\text{liquidus}`), the ``thermal conductivity liquid`` is applied, while for the solid phase (:math:`T<T_\text{solidus}`), the model uses the ``thermal conductivity solid``. In the mushy zone between :math:`T_\text{solidus}` and :math:`T_\text{liquidus}`, the thermal conductivity is equal to:
 
 .. math::
 
-  k = \alpha_l k_l + (1 - \alpha_l) k_s
+  k = \alpha_\text{l} k_\text{l} + (1 - \alpha_\text{l}) k_\text{s}
 
 
-where :math:`k_l`, :math:`k_s` and  :math:`\alpha_l` denote thermal conductivities of the liquid and solid phases and the liquid fraction.
+where :math:`k_\text{l}`, :math:`k_\text{s}` and  :math:`\alpha_\text{l}` denote thermal conductivities of the liquid and solid phases and the liquid fraction.
 
 Specific Heat Models
 ~~~~~~~~~~~~~~~~~~~~~
 
-Lethe supports two types of specific heat models. Setting ``specific heat=constant`` sets a constant specific heat. Lethe also supports a ``phase_change`` specific heat model. This model can simulate the melting and solidification of a material. The model follows the work of Blais & Ilinca `[1] <https://doi.org/10.1016/j.compfluid.2018.03.037>`_. This approach defines the specific heat :math:`C_p` as:
+Lethe supports two types of specific heat models. Setting ``specific heat=constant`` sets a constant specific heat. Lethe also supports a ``phase_change`` specific heat model. This model can simulate the melting and solidification of a material. The model follows the work of Blais & Ilinca `[1] <https://doi.org/10.1016/j.compfluid.2018.03.037>`_. This approach defines the specific heat :math:`C_\text{p}` as:
 
 .. math::
 
-  C_p = \frac{H(T)-H(T_0)}{T-T_0}
+  C_\text{p} = \frac{H(T)-H(T_0)}{T-T_0}
 
 
 where :math:`T` is the temperature, :math:`T_0` is the temperature at the previous time and :math:`H(T)` is the enthalpy, as a function of the temperature, to be:
 
 .. math::
-  H(T) = H_0 + \int_{T_0}^{T} c^{*}_p (T^*) dT
+  H(T) = H_0 + \int_{T_0}^{T} c^{*}_\text{p} (T^*) dT
 
 
-where :math:`H_0` is a reference enthalpy, taken to be 0, and :math:`c^{*}_p` is:
+where :math:`H_0` is a reference enthalpy, taken to be 0, and :math:`c^{*}_\text{p}` is:
 
 .. math::
-  c^{*}_p  = \begin{cases} C_{p,s} \text{if}\;T<T_s\\
-              \frac{C_{p,s}+C_{p,l}}{2}+\frac{h_l}{T_l-T_s} \text{if}\;T\in[T_s,T_l]\\
-              C_{p,l} \text{if} T>T_l
+  c^{*}_\text{p}  = \begin{cases} C_\text{p,s} & \text{if} \; T<T_\text{s}\\
+              \frac{C_\text{p,s}+C_\text{p,l}}{2}+\frac{h_\text{l}}{T_\text{l}-T_\text{s}} & \text{if} \; T\in[T_\text{s},T_\text{l}]\\
+              C_\text{p,l} & \text{if} \; T>T_\text{l}
               \end{cases}
 
-where :math:`C_{p,s}` and :math:`C_{p,l}` are the solid and liquid specific heat, respectively. :math:`h_l` is the latent enthalpy (enthalpy related to the phase change), :math:`T_l` and :math:`T_s` are the liquidus and solidus temperature. The underlying hypothesis of this model is that the melting and the solidification occurs over a phase change interval. Melting will occur between :math:`T_s` and :math:`T_l` and solidification will occur between :math:`T_l` and :math:`T_s`.
+where :math:`C_\text{p,s}` and :math:`C_\text{p,l}` are the solid and liquid specific heat, respectively. :math:`h_\text{l}` is the latent enthalpy (enthalpy related to the phase change), :math:`T_\text{l}` and :math:`T_\text{s}` are the liquidus and solidus temperature. The underlying hypothesis of this model is that the melting and the solidification occurs over a phase change interval. Melting will occur between :math:`T_\text{s}` and :math:`T_\text{l}` and solidification will occur between :math:`T_\text{l}` and :math:`T_\text{s}`.
 
 This model is parameterized using the following section:
 
@@ -492,15 +492,15 @@ This model is parameterized using the following section:
     set specific heat solid  = 1
   end
 
-* The ``latent enthalpy`` is the latent enthalpy of the phase change: :math:`h_l`
+* The ``latent enthalpy`` is the latent enthalpy of the phase change: :math:`h_\text{l}`
 
-* The ``liquidus temperature`` is :math:`T_l`
+* The ``liquidus temperature`` is :math:`T_\text{l}`
 
-* The ``solidus temperature`` is :math:`T_s`
+* The ``solidus temperature`` is :math:`T_\text{s}`
 
-* The ``specific heat liquid`` is :math:`C_{p,l}`
+* The ``specific heat liquid`` is :math:`C_\text{p,l}`
 
-* The ``specific heat solid`` is :math:`C_{p,s}`
+* The ``specific heat solid`` is :math:`C_\text{p,s}`
 
 
 Thermal Expansion Models
@@ -508,8 +508,8 @@ Thermal Expansion Models
 Lethe supports two types of thermal expansion heat models. Setting ``thermal expansion model=constant`` sets a constant thermal expansion. Lethe also supports a ``phase_change`` thermal expansion model. This model can simulate the melting and solidification of a material with natural convection. It works by defining a different value of the thermal expansion coefficient depending on the value of the temperature:
 
 .. math::
-  \beta =   c^{*}_p  = \begin{cases} \beta_s, \text{if}\;T \leq T_l\\
-              \beta_l, \text{if}\;T > T_l
+  \beta =   c^{*}_\text{p}  = \begin{cases} \beta_\text{s} & \text{if}\;T \leq T_\text{l}\\
+              \beta_\text{l} & \text{if}\;T > T_\text{l}
               \end{cases}
 
 
@@ -531,13 +531,13 @@ This model is parameterized using the following section:
     set thermal expansion solid  = 0
   end
 
-* The ``liquidus temperature`` is :math:`T_l`
+* The ``liquidus temperature`` is :math:`T_\text{l}`
 
-* The ``solidus temperature`` is :math:`T_s`
+* The ``solidus temperature`` is :math:`T_\text{s}`
 
-* The ``thermal expansion liquid`` is :math:`\beta_{l}`
+* The ``thermal expansion liquid`` is :math:`\beta_\text{l}`
 
-* The ``thermal expansion solid`` is :math:`\beta_{s}`
+* The ``thermal expansion solid`` is :math:`\beta_\text{s}`
 
 Interface Physical Property Models
 ***********************************
@@ -570,7 +570,7 @@ where :math:`T_\mathrm{s}` and :math:`T_\mathrm{l}` correspond to the ``solidus 
   \alpha_{\mathrm{l}} = 
     \begin{cases}
         0 &\quad\text{if}\; T<T_\mathrm{s}\\
-        \dfrac{T-T_\mathrm{s}}{T_\mathrm{L}-T_\mathrm{s}} &\quad\text{if}\; T_\mathrm{l}\le T \le T_\mathrm{s}\\
+        \dfrac{T-T_\mathrm{s}}{T_\mathrm{l}-T_\mathrm{s}} &\quad\text{if}\; T_\mathrm{l}\le T \le T_\mathrm{s}\\
         1 &\quad\text{if}\; T_\mathrm{l} <T
     \end{cases}
 

--- a/doc/source/parameters/cfd/velocity_source.rst
+++ b/doc/source/parameters/cfd/velocity_source.rst
@@ -31,7 +31,7 @@ Rotating frame simulations use the following parameters:
 Darcy Penalization
 ~~~~~~~~~~~~~~~~~~
 
-A Darcy-like source term can be added to the simulation using the following parmeters:
+A Darcy-like source term can be added to the simulation using the following parameters:
 
 .. code-block:: text
 
@@ -40,3 +40,6 @@ A Darcy-like source term can be added to the simulation using the following parm
   end
 
 * The ``Darcy type`` parameter specifies the type of Darcy penalization term to be applied to the Navier-Stokes equations. The options are ``none`` or ``phase_change``. The ``phase_change`` model uses the values of the ``Darcy penalty liquid``  and ``Darcy penalty solid`` set-up within the ``phase change`` subsection of the :doc:`physical_properties`.
+
+.. caution::
+  The phase change Darcy model does not currently have a Cahn-Hilliard implementation.

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -35,10 +35,6 @@ DeclExceptionMsg(
   "Using the phase change Darcy model requires to run a multiphysics simulation with the heat transfer solver enabled.");
 
 DeclExceptionMsg(
-  PhaseChangeDarcyModelDoesNotSupportVOF,
-  "The phase change Darcy model does not currently have a VOF implementation.");
-
-DeclExceptionMsg(
   PhaseChangeDarcyModelDoesNotSupportCHN,
   "The phase change Darcy model does not currently have a Cahn-Hilliard implementation.");
 
@@ -717,13 +713,13 @@ private:
 };
 
 /**
- * @brief Class that assembles a phase change Darcy forcing term. This term adds \f$-\beta_D  \mathbf{u} \f$ to the
- * right hand-side of the Navier-Stokes equations to prohibit the motion of a
- * material. In the phase change model, the value of the \f$ \beta_D \f$
- * coefficient depends on the temperature field. Generally, this is used to
- * prohibit fluid motion in the solid phase within phase change problem. This
- * generally leads to a better conditioning of the linear system than increasing
- * the viscosity of the solid phase.
+ * @brief Class that assembles a phase change Darcy forcing term. This term adds
+ * \f$-\beta_D  \mathbf{u} \f$ to the right hand-side of the Navier-Stokes
+ * equations to prohibit the motion of a material. In the phase change model,
+ * the value of the \f$ \beta_D \f$ coefficient depends on the temperature
+ * field. Generally, this is used to prohibit fluid motion in the solid phase
+ * within phase change problem. This generally leads to a better conditioning of
+ * the linear system than increasing the viscosity of the solid phase.
  *
  *
  * @tparam dim An integer that denotes the number of spatial dimensions

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -121,7 +121,7 @@ public:
  * material. In the phase change model, the value of the \f$ \beta_D \f$
  * coefficient depends on the temperature field and the material (fluid)
  * properties. Generally, this is used to impose the stasis in the solid
- * phase. This generally leads to a better conditioning of the linear 
+ * phase. This generally leads to a better conditioning of the linear
  * system than increasing the viscosity of the solid phase.
  *
  *

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -116,14 +116,13 @@ public:
 
 /**
  * @brief Assembles a phase change Darcy forcing term for a VOF two-fluid
- * simulation. This term adds \f$-\phi \beta_D  \mathbf{u} \f$ to the right
+ * simulation. The term  \f$-\phi \beta_D  \mathbf{u} \f$ is added to the right
  * hand-side of the Navier-Stokes equations to prohibit the motion of a
  * material. In the phase change model, the value of the \f$ \beta_D \f$
  * coefficient depends on the temperature field and the material (fluid)
- * properties. Generally, this is used to prohibit fluid motion in the solid
- * phase within phase change problems. This generally leads to a better
- * conditioning of the linear system than increasing the viscosity of the solid
- * phase.
+ * properties. Generally, this is used to impose the stasis in the solid
+ * phase. This generally leads to a better conditioning of the linear 
+ * system than increasing the viscosity of the solid phase.
  *
  *
  * @tparam dim An integer that denotes the number of spatial dimensions

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -121,7 +121,7 @@ public:
  * material. In the phase change model, the value of the \f$ \beta_D \f$
  * coefficient depends on the temperature field and the material (fluid)
  * properties. Generally, this is used to prohibit fluid motion in the solid
- * phase within phase change problem. This generally leads to a better
+ * phase within phase change problems. This generally leads to a better
  * conditioning of the linear system than increasing the viscosity of the solid
  * phase.
  *

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -26,7 +26,7 @@
 
 
 /**
- * @brief Class that assembles the core of the Navier-Stokes equation with
+ * @brief Assembles the core of the Navier-Stokes equation with
  * free surface using VOF modeling.
  * According to the following weak form:
  * \f$ \nabla \cdot \mathbf{u} + \rho \mathbf{u} \cdot \nabla
@@ -73,7 +73,7 @@ public:
 };
 
 /**
- * @brief Class that assembles the transient time arising from BDF time
+ * @brief Assembles the transient time arising from BDF time
  * integration for the Navier-Stokes equation with
  * free surface using VOF modeling. For example, if a BDF1 scheme is
  * chosen, the following is assembled
@@ -115,7 +115,61 @@ public:
 };
 
 /**
- * @brief Class that assembles the Surface Tension Force (STF) for the
+ * @brief Assembles a phase change Darcy forcing term for a VOF two-fluid
+ * simulation. This term adds \f$-\phi \beta_D  \mathbf{u} \f$ to the right
+ * hand-side of the Navier-Stokes equations to prohibit the motion of a
+ * material. In the phase change model, the value of the \f$ \beta_D \f$
+ * coefficient depends on the temperature field and the material (fluid)
+ * properties. Generally, this is used to prohibit fluid motion in the solid
+ * phase within phase change problem. This generally leads to a better
+ * conditioning of the linear system than increasing the viscosity of the solid
+ * phase.
+ *
+ *
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+
+template <int dim>
+class PhaseChangeDarcyVOFAssembler : public NavierStokesAssemblerBase<dim>
+{
+public:
+  PhaseChangeDarcyVOFAssembler(
+    const std::vector<Parameters::PhaseChange> &phase_change_parameters_vector)
+    : phase_change_parameters_vector(phase_change_parameters_vector)
+  {}
+
+  /**
+   * @brief assemble_matrix Assembles the matrix of: \f$-\beta_D  \mathbf{u}\f$.
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_matrix(NavierStokesScratchData<dim>         &scratch_data,
+                  StabilizedMethodsTensorCopyData<dim> &copy_data) override;
+
+
+  /**
+   * @brief assemble_rhs Assembles the weak form of: \f$-\beta_D  \mathbf{u} \f$
+   * @param scratch_data (see base class)
+   * @param copy_data (see base class)
+   */
+  virtual void
+  assemble_rhs(NavierStokesScratchData<dim>         &scratch_data,
+               StabilizedMethodsTensorCopyData<dim> &copy_data) override;
+
+private:
+  /*
+   * Phase change parameters are kept within the assembler and are used to
+   * calculate, on the fly, the inverse permeability (\f$ \beta_D \f$).
+   */
+  const std::vector<Parameters::PhaseChange> phase_change_parameters_vector;
+};
+
+
+/**
+ * @brief Assembles the Surface Tension Force (STF) for the
  * Navier-Stokes equations according to the following equation:
  *
  * \f$\mathbf{F_{CSV}}=\sigma k \nabla \phi \frac{2 \rho}{\rho_0 + \rho_1} \f$
@@ -161,7 +215,7 @@ public:
 
 
 /**
- * @brief Class that assembles the marangoni effect for the
+ * @brief Assembles the Marangoni effect for the
  * Navier-Stokes equations according to the following equation:
  *
  * \f$\mathbf{F_{Ma}}= \frac{\partial \sigma}{\partial T} \left[ \nabla T
@@ -210,7 +264,7 @@ public:
 };
 
 /**
- * @brief Class that assembles the momentum source due to evaporation for the
+ * @brief Assembles the momentum source due to evaporation for the
  * Navier-Stokes equations.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
@@ -261,7 +315,7 @@ private:
 };
 
 /**
- * @brief Class that assembles the core of the Navier-Stokes equation
+ * @brief Assembles the core of the Navier-Stokes equation
  * using a Rheological model to predict non-Newtonian behaviors
  *
  * @tparam dim An integer that denotes the number of spatial dimensions

--- a/include/solvers/physical_properties_manager.h
+++ b/include/solvers/physical_properties_manager.h
@@ -212,6 +212,12 @@ public:
     return thermal_expansion;
   }
 
+  std::vector<Parameters::PhaseChange>
+  get_phase_change_parameters_vector() const
+  {
+    return phase_change_parameters;
+  }
+
   std::vector<std::shared_ptr<TracerDiffusivityModel>>
   get_tracer_diffusivity_vector() const
   {
@@ -358,7 +364,8 @@ private:
   std::vector<std::shared_ptr<TracerDiffusivityModel>>   tracer_diffusivity;
   std::vector<std::shared_ptr<SurfaceTensionModel>>      surface_tension;
   std::vector<std::shared_ptr<MobilityCahnHilliardModel>>
-    mobility_cahn_hilliard;
+                                       mobility_cahn_hilliard;
+  std::vector<Parameters::PhaseChange> phase_change_parameters;
 
   std::map<field, bool> required_fields;
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -586,7 +586,7 @@ namespace Parameters
       // thermal_expansion_l is in theta^-1
       thermal_expansion_s *= dimensions.thermal_expansion_scaling;
 
-      // Darcy permeability terms
+      // Darcy penalty terms
       penalty_l = prm.get_double("Darcy penalty liquid");
       penalty_s = prm.get_double("Darcy penalty solid");
     }

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -100,9 +100,17 @@ GDNavierStokesSolver<dim>::setup_assemblers()
               this->simulation_control));
         }
 
-      AssertThrow(this->simulation_parameters.velocity_sources.darcy_type !=
-                    Parameters::VelocitySource::DarcySourceType::phase_change,
-                  PhaseChangeDarcyModelDoesNotSupportVOF());
+      // Darcy force for phase change simulations
+      if (this->simulation_parameters.velocity_sources.darcy_type ==
+          Parameters::VelocitySource::DarcySourceType::phase_change)
+        {
+          AssertThrow(this->simulation_parameters.multiphysics.heat_transfer,
+                      PhaseChangeDarcyModelRequiresTemperature());
+          this->assemblers.push_back(
+            std::make_shared<PhaseChangeDarcyVOFAssembler<dim>>(
+              this->simulation_parameters.physical_properties_manager
+                .get_phase_change_parameters_vector()));
+        }
 
       if (!this->simulation_parameters.physical_properties_manager
              .density_is_constant())

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -502,9 +502,17 @@ GLSNavierStokesSolver<dim>::setup_assemblers()
               this->simulation_parameters.evaporation));
         }
 
-      AssertThrow(this->simulation_parameters.velocity_sources.darcy_type !=
-                    Parameters::VelocitySource::DarcySourceType::phase_change,
-                  PhaseChangeDarcyModelDoesNotSupportVOF());
+      // Darcy force for phase change simulations
+      if (this->simulation_parameters.velocity_sources.darcy_type ==
+          Parameters::VelocitySource::DarcySourceType::phase_change)
+        {
+          AssertThrow(this->simulation_parameters.multiphysics.heat_transfer,
+                      PhaseChangeDarcyModelRequiresTemperature());
+          this->assemblers.push_back(
+            std::make_shared<PhaseChangeDarcyVOFAssembler<dim>>(
+              this->simulation_parameters.physical_properties_manager
+                .get_phase_change_parameters_vector()));
+        }
 
       if (this->simulation_parameters.physical_properties_manager
             .is_non_newtonian())

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -482,7 +482,7 @@ PhaseChangeDarcyVOFAssembler<dim>::assemble_matrix(
               phase_change_parameters_vector[p].penalty_s);
         }
 
-      // For a VOF two-fluid system, the global Darcy permeability coefficient
+      // For a VOF two-fluid system, the global Darcy penalty coefficient
       // takes into account the phase change parameters in both fluids
       const double darcy_penalty =
         ((1 - filtered_phase[q]) * darcy_penalties[0] +
@@ -540,7 +540,7 @@ PhaseChangeDarcyVOFAssembler<dim>::assemble_rhs(
       // Current temperature values
       double current_temperature = temperatures[q];
       // Loop to calculate the liquid fraction and Darcy permeability of each
-      // fluid. Calculated Darcy permeability coefficients depend on the
+      // fluid. Calculated Darcy penalty coefficients depend on the
       // temperature and material (fluid) properties. A min(max) approach is
       // used to calculate the liquid fractions avoiding if conditions.
       for (unsigned int p = 0; p < number_of_fluids; p++)

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -122,8 +122,6 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
           velocity_gradient_x_phi_u_j[j] = velocity_gradient * phi_u_j;
         }
 
-
-
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
           const auto &phi_u_i      = scratch_data.phi_u[q][i];
@@ -309,10 +307,9 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
     }
 }
 
-
-
 template class GLSNavierStokesVOFAssemblerCore<2>;
 template class GLSNavierStokesVOFAssemblerCore<3>;
+
 
 template <int dim>
 void
@@ -433,6 +430,155 @@ GLSNavierStokesVOFAssemblerBDF<dim>::assemble_rhs(
 
 template class GLSNavierStokesVOFAssemblerBDF<2>;
 template class GLSNavierStokesVOFAssemblerBDF<3>;
+
+
+template <int dim>
+void
+PhaseChangeDarcyVOFAssembler<dim>::assemble_matrix(
+  NavierStokesScratchData<dim>         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &copy_data)
+{
+  // Loop and quadrature information
+  const auto        &JxW_vec        = scratch_data.JxW;
+  const unsigned int n_q_points     = scratch_data.n_q_points;
+  const unsigned int n_dofs         = scratch_data.n_dofs;
+  const auto        &velocities     = scratch_data.velocity_values;
+  const auto        &temperatures   = scratch_data.temperature_values;
+  const auto        &filtered_phase = scratch_data.filtered_phase_values;
+
+  auto &local_matrix    = copy_data.local_matrix;
+  auto &strong_residual = copy_data.strong_residual;
+  auto &strong_jacobian = copy_data.strong_jacobian;
+
+  const unsigned int  number_of_fluids = phase_change_parameters_vector.size();
+  std::vector<double> liquid_fractions;
+  std::vector<double> darcy_penalties;
+  liquid_fractions.reserve(number_of_fluids);
+  darcy_penalties.reserve(number_of_fluids);
+
+  // Loop over the quadrature points
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      // Store JxW in local variable for faster access;
+      const double JxW = JxW_vec[q];
+      // Current temperature values
+      double current_temperature = temperatures[q];
+      // Loop to calculate the liquid fraction and Darcy permeability of each
+      // fluid. Calculated Darcy permeability coefficients depend on the
+      // temperature and material (fluid) properties. A min(max) approach is
+      // used to calculate the liquid fractions avoiding if conditions.
+      for (unsigned int p = 0; p < number_of_fluids; p++)
+        {
+          liquid_fractions.emplace_back(
+            (std::min(1.,
+                      std::max((current_temperature -
+                                phase_change_parameters_vector[p].T_solidus) /
+                                 (phase_change_parameters_vector[p].T_liquidus -
+                                  phase_change_parameters_vector[p].T_solidus),
+                               0.))));
+          darcy_penalties.emplace_back(
+            phase_change_parameters_vector[p].penalty_l * liquid_fractions[p] +
+            (1. - liquid_fractions[p]) *
+              phase_change_parameters_vector[p].penalty_s);
+        }
+
+      // For a VOF two-fluid system, the global Darcy permeability coefficient
+      // takes into account the phase change parameters in both fluids
+      const double darcy_penalty =
+        ((1 - filtered_phase[q]) * darcy_penalties[0] +
+         filtered_phase[q] * darcy_penalties[1]);
+
+      strong_residual[q] += darcy_penalty * velocities[q];
+
+      for (unsigned int j = 0; j < n_dofs; ++j)
+        {
+          strong_jacobian[q][j] += darcy_penalty * scratch_data.phi_u[q][j];
+        }
+
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto &phi_u_i = scratch_data.phi_u[q][i];
+          for (unsigned int j = 0; j < n_dofs; ++j)
+            {
+              const auto &phi_u_j = scratch_data.phi_u[q][j];
+              local_matrix(i, j) += darcy_penalty * phi_u_i * phi_u_j * JxW;
+            }
+        }
+      liquid_fractions.clear();
+      darcy_penalties.clear();
+    }
+}
+
+template <int dim>
+void
+PhaseChangeDarcyVOFAssembler<dim>::assemble_rhs(
+  NavierStokesScratchData<dim>         &scratch_data,
+  StabilizedMethodsTensorCopyData<dim> &copy_data)
+{
+  // Loop and quadrature information
+  const auto        &JxW_vec        = scratch_data.JxW;
+  const unsigned int n_q_points     = scratch_data.n_q_points;
+  const unsigned int n_dofs         = scratch_data.n_dofs;
+  const auto        &velocities     = scratch_data.velocity_values;
+  const auto        &temperatures   = scratch_data.temperature_values;
+  const auto        &filtered_phase = scratch_data.filtered_phase_values;
+
+  auto &local_rhs       = copy_data.local_rhs;
+  auto &strong_residual = copy_data.strong_residual;
+
+  const double        number_of_fluids = phase_change_parameters_vector.size();
+  std::vector<double> liquid_fractions;
+  std::vector<double> darcy_penalties;
+  liquid_fractions.reserve(number_of_fluids);
+  darcy_penalties.reserve(number_of_fluids);
+
+  // Loop over the quadrature points
+  for (unsigned int q = 0; q < n_q_points; ++q)
+    {
+      // Store JxW in local variable for faster access;
+      const double JxW = JxW_vec[q];
+      // Current temperature values
+      double current_temperature = temperatures[q];
+      // Loop to calculate the liquid fraction and Darcy permeability of each
+      // fluid. Calculated Darcy permeability coefficients depend on the
+      // temperature and material (fluid) properties. A min(max) approach is
+      // used to calculate the liquid fractions avoiding if conditions.
+      for (unsigned int p = 0; p < number_of_fluids; p++)
+        {
+          liquid_fractions.emplace_back(
+            (std::min(1.,
+                      std::max((current_temperature -
+                                phase_change_parameters_vector[p].T_solidus) /
+                                 (phase_change_parameters_vector[p].T_liquidus -
+                                  phase_change_parameters_vector[p].T_solidus),
+                               0.))));
+          darcy_penalties.emplace_back(
+            phase_change_parameters_vector[p].penalty_l * liquid_fractions[p] +
+            (1. - liquid_fractions[p]) *
+              phase_change_parameters_vector[p].penalty_s);
+        }
+
+      // For a VOF two-fluid system, the global Darcy permeability coefficient
+      // takes into account the phase change parameters in both fluids
+      const double darcy_penalty =
+        ((1 - filtered_phase[q]) * darcy_penalties[0] +
+         filtered_phase[q] * darcy_penalties[1]);
+
+      strong_residual[q] += darcy_penalty * velocities[q];
+
+      // Assembly of the right-hand side
+      for (unsigned int i = 0; i < n_dofs; ++i)
+        {
+          const auto phi_u_i = scratch_data.phi_u[q][i];
+
+          // Laplacian on the velocity terms
+          local_rhs(i) -= darcy_penalty * velocities[q] * phi_u_i * JxW;
+        }
+    }
+}
+
+template class PhaseChangeDarcyVOFAssembler<2>;
+template class PhaseChangeDarcyVOFAssembler<3>;
 
 
 template <int dim>
@@ -572,6 +718,7 @@ GLSNavierStokesVOFAssemblerMarangoni<dim>::assemble_rhs(
 template class GLSNavierStokesVOFAssemblerMarangoni<2>;
 template class GLSNavierStokesVOFAssemblerMarangoni<3>;
 
+
 template <int dim>
 void
 NavierStokesVOFAssemblerEvaporation<dim>::assemble_matrix(
@@ -633,6 +780,7 @@ NavierStokesVOFAssemblerEvaporation<dim>::assemble_rhs(
 
 template class NavierStokesVOFAssemblerEvaporation<2>;
 template class NavierStokesVOFAssemblerEvaporation<3>;
+
 
 template <int dim>
 void

--- a/source/solvers/physical_properties_manager.cc
+++ b/source/solvers/physical_properties_manager.cc
@@ -111,6 +111,9 @@ PhysicalPropertiesManager::initialize(
         ThermalExpansionModel::model_cast(physical_properties.fluids[f]));
       establish_fields_required_by_model(*thermal_expansion[f]);
 
+      phase_change_parameters.push_back(
+        physical_properties.fluids[f].phase_change_parameters);
+
       if (rheology.back()->is_non_newtonian_rheological_model())
         non_newtonian_flow = true;
     }
@@ -131,7 +134,6 @@ PhysicalPropertiesManager::initialize(
       specific_heat.push_back(
         SpecificHeatModel::model_cast(physical_properties.solids[s]));
       establish_fields_required_by_model(*specific_heat[s]);
-
 
       thermal_conductivity.push_back(
         ThermalConductivityModel::model_cast(physical_properties.solids[s]));
@@ -160,6 +162,7 @@ PhysicalPropertiesManager::initialize(
       establish_fields_required_by_model(*surface_tension[i]);
       if (!surface_tension.back()->is_constant_surface_tension_model())
         constant_surface_tension = false;
+
       mobility_cahn_hilliard.push_back(MobilityCahnHilliardModel::model_cast(
         physical_properties.material_interactions[i]));
       establish_fields_required_by_model(*mobility_cahn_hilliard[i]);


### PR DESCRIPTION
# Description of the problem

- As an alternative to viscous penalization for solid phase modelling in phase change simulation, a Darcy-like penalization as implemented for single fluid flows. However, laser powder bed fusion (LPBF) simulations are two-fluid simulations.

# Description of the solution

- This Darcy-like penalization is now extended to two-fluid VOF simulations with the `PhaseChangeDarcyVOFAssembler` assembler class.

# How Has This Been Tested?

- All tests have passed.
- A new application test has been added: `applications_tests/lethe-fluid/vof_phase_change_darcy.prm` (`.output`)

# Documentation

- Documentation related to this feature was updated (`doc/source/parameters/cfd/velocity_source.rst`)

# Comments

- Other minor changes and corrections were brought to the documentation.
