### PR TITLE
Add temperature extrapolation

### DIFF
--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -64,8 +64,10 @@ public:
    * necessary memory for all member variables. However, it does not do any
    * evaluation, since this needs to be done at the cell level.
    *
-   * @param properties_manager The physical properties Manager (see
-   * physical_properties_manager.h)
+   * @param simulation_control The SimulationControl object that holds
+   * information related to the control of the steady-state or transient
+   * simulation. This is used to extrapolate velocity solutions in time
+   * for transient simulation.
    *
    * @param fe_vof The FESystem used to solve the VOF equations
    *
@@ -103,7 +105,7 @@ public:
    * definition of the WorkStream mechanism it is assumed that the content of
    * the scratch will be reset on a cell basis.
    *
-   * @param sd The scratch data
+   * @param sd The scratch data to be copied
    */
   VOFScratchData(const VOFScratchData<dim> &sd)
     : simulation_control(sd.simulation_control)
@@ -203,7 +205,13 @@ public:
    * @param cell The cell for which the velocity is reinitialized
    * This cell must be compatible with the Fluid Dynamics FE
    *
-   * @param current_solution The present value of the solution for [u,p]
+   * @param current_solution The present value of the solution for \f$[u,p]\f$
+   *
+   * @param previous_solutions Vector of \f$n\f$ @p VectorType containers of
+   * previous fluid dynamic solutions (\f$[u,p]\f$). \f$n\f$ depends on the BDF
+   * scheme selected for time-stepping.
+   *
+   * @param ale ALE parameters
    *
    */
 
@@ -259,8 +267,8 @@ public:
           }
       }
 
-    // Extrapolate velocity to t+dt using the BDF scheme if a BDF method is
-    // selected
+    // Extrapolate velocity to t+dt using the BDF scheme if the simulation is
+    // transient
     const auto method = this->simulation_control->get_assembly_method();
     if (is_bdf(method))
       {

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1552,6 +1552,7 @@ GLSVANSSolver<dim>::assemble_system_matrix()
     setup_assemblers();
 
     auto scratch_data = NavierStokesScratchData<dim>(
+      this->simulation_control,
       this->simulation_parameters.physical_properties_manager,
       *this->fe,
       *this->cell_quadrature,
@@ -1657,6 +1658,7 @@ GLSVANSSolver<dim>::assemble_system_rhs()
   setup_assemblers();
 
   auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_control,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -156,7 +156,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
       if (this->simulation_parameters.physical_properties_manager
             .is_non_newtonian())
         {
-          // Core assembler with Non newtonian viscosity
+          // Core assembler with non-Newtonian viscosity
           this->assemblers.push_back(
             std::make_shared<GDNavierStokesAssemblerNonNewtonianCore<dim>>(
               this->simulation_control, gamma));

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -203,6 +203,7 @@ GDNavierStokesSolver<dim>::assemble_system_matrix()
   setup_assemblers();
 
   auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_control,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
@@ -332,6 +333,7 @@ GDNavierStokesSolver<dim>::assemble_system_rhs()
   setup_assemblers();
 
   auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_control,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
@@ -423,9 +425,10 @@ GDNavierStokesSolver<dim>::assemble_local_system_rhs(
         cell->index(),
         dof_handler_ht);
 
-      scratch_data.reinit_heat_transfer(temperature_cell,
-                                        *this->multiphysics->get_solution(
-                                          PhysicsID::heat_transfer));
+      scratch_data.reinit_heat_transfer(
+        temperature_cell,
+        *this->multiphysics->get_solution(PhysicsID::heat_transfer),
+        *this->multiphysics->get_previous_solutions(PhysicsID::heat_transfer));
     }
 
   scratch_data.calculate_physical_properties();

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1577,11 +1577,11 @@ GLSNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
   current_preconditioner_fill_level = initial_preconditioner_fill_level;
 }
 
-// The solver starts from the initial fill levle provided in the parameter file.
+// The solver starts from the initial fill level provided in the parameter file.
 // If for any reason the linear solver crashes, it will restart with a fill
 // level increased by 1. This restart happens up to a maximum of 20 times, after
-// which it will let the solver cras. If a change happened on the fill level, it
-// will go back to its original value at the end of the restart process.
+// which it will let the solver crash. If a change happened on the fill level,
+// it will go back to its original value at the end of the restart process.
 template <int dim>
 void
 GLSNavierStokesSolver<dim>::solve_system_BiCGStab(

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -656,6 +656,7 @@ GLSNavierStokesSolver<dim>::assemble_system_matrix_without_preconditioner()
   setup_assemblers();
 
   auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_control,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
@@ -813,9 +814,10 @@ GLSNavierStokesSolver<dim>::assemble_local_system_matrix(
         cell->index(),
         dof_handler_ht);
 
-      scratch_data.reinit_heat_transfer(temperature_cell,
-                                        *this->multiphysics->get_solution(
-                                          PhysicsID::heat_transfer));
+      scratch_data.reinit_heat_transfer(
+        temperature_cell,
+        *this->multiphysics->get_solution(PhysicsID::heat_transfer),
+        *this->multiphysics->get_previous_solutions(PhysicsID::heat_transfer));
     }
 
   scratch_data.calculate_physical_properties();
@@ -860,6 +862,7 @@ GLSNavierStokesSolver<dim>::assemble_system_rhs()
   setup_assemblers();
 
   auto scratch_data = NavierStokesScratchData<dim>(
+    this->simulation_control,
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
@@ -1020,9 +1023,10 @@ GLSNavierStokesSolver<dim>::assemble_local_system_rhs(
         cell->index(),
         dof_handler_ht);
 
-      scratch_data.reinit_heat_transfer(temperature_cell,
-                                        *this->multiphysics->get_solution(
-                                          PhysicsID::heat_transfer));
+      scratch_data.reinit_heat_transfer(
+        temperature_cell,
+        *this->multiphysics->get_solution(PhysicsID::heat_transfer),
+        *this->multiphysics->get_previous_solutions(PhysicsID::heat_transfer));
     }
 
   scratch_data.calculate_physical_properties();

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -291,8 +291,14 @@ NavierStokesScratchData<dim>::enable_heat_transfer(
   fe_values_temperature = std::make_shared<FEValues<dim>>(
     mapping, fe, quadrature, update_values | update_gradients);
 
-  temperature_values    = std::vector<double>(this->n_q_points);
+  temperature_values = std::vector<double>(this->n_q_points);
+  previous_temperature_values =
+    std::vector<std::vector<double>>(maximum_number_of_previous_solutions(),
+                                     std::vector<double>(this->n_q_points));
   temperature_gradients = std::vector<Tensor<1, dim>>(this->n_q_points);
+  previous_temperature_gradients = std::vector<std::vector<Tensor<1, dim>>>(
+    maximum_number_of_previous_solutions(),
+    std::vector<Tensor<1, dim>>(this->n_q_points));
   fields.insert(
     std::pair<field, std::vector<double>>(field::temperature, n_q_points));
 }

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -75,7 +75,8 @@ VolumeOfFluid<dim>::assemble_system_matrix()
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   auto scratch_data =
-    VOFScratchData<dim>(this->simulation_parameters.physical_properties_manager,
+    VOFScratchData<dim>(this->simulation_control,
+                        this->simulation_parameters.physical_properties_manager,
                         *this->fe,
                         *this->cell_quadrature,
                         *this->mapping,
@@ -199,7 +200,8 @@ VolumeOfFluid<dim>::assemble_system_rhs()
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
   auto scratch_data =
-    VOFScratchData<dim>(this->simulation_parameters.physical_properties_manager,
+    VOFScratchData<dim>(this->simulation_control,
+                        this->simulation_parameters.physical_properties_manager,
                         *this->fe,
                         *this->cell_quadrature,
                         *this->mapping,

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -311,13 +311,6 @@ VOFAssemblerBDF<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
   Vector<double>      bdf_coefs = bdf_coefficients(method, time_steps_vector);
   std::vector<double> phase_value(1 + number_of_previous_solutions(method));
 
-  // Extrapolate velocity to t+dt using the BDF scheme
-  std::vector<double> time_vector = simulation_control->get_simulation_times();
-  bdf_extrapolate(time_vector,
-                  scratch_data.previous_velocity_values,
-                  number_of_previous_solutions(method),
-                  scratch_data.velocity_values);
-
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
@@ -375,13 +368,6 @@ VOFAssemblerBDF<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
   // Vector for the BDF coefficients
   Vector<double>      bdf_coefs = bdf_coefficients(method, time_steps_vector);
   std::vector<double> phase_value(1 + number_of_previous_solutions(method));
-
-  // Extrapolate velocity to t+dt using the BDF scheme
-  std::vector<double> time_vector = simulation_control->get_simulation_times();
-  bdf_extrapolate(time_vector,
-                  scratch_data.previous_velocity_values,
-                  number_of_previous_solutions(method),
-                  scratch_data.velocity_values);
 
   // Loop over the quadrature points
   for (unsigned int q = 0; q < n_q_points; ++q)


### PR DESCRIPTION
# Description 
- This PR adds the extrapolation in time of temperature and temperature gradient value for source terms in the Navier-Stokes equations requiring them (Marangoni and evaporation recoil force terms). 

# How Has This Been Tested?
- All tests have passed

# Comment
- Velocity extrapolation has been moved to `include/solvers/vof_scratch_data.h`. Solution extrapolations are now located in `ScratchData` to avoid constraint on assemblers order. 