### PR TITLE
Update CI to run on external PRs

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,6 @@
 name: Check_indent
 
-on: [pull_request_target, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,6 @@
 name: Check_indent
 
-on: [push, pull_request]
+on: [pull_request_target, pull_request]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -1,6 +1,6 @@
 name: Publish doc to GitHub Pages
 
-on: push
+on: [push, pull_request]
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -1,6 +1,6 @@
 name: Publish doc to GitHub Pages
 
-on: [push, pull_request]
+on: [pull_request_target, pull_request]
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -1,6 +1,6 @@
 name: Publish doc to GitHub Pages
 
-on: [pull_request_target, pull_request]
+on: [pull_request]
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -2,9 +2,6 @@ name: CI-Debug
 
 on:
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  pull_request_target:
-    paths-ignore:
-      - 'doc/**'
   pull_request:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -2,7 +2,7 @@ name: CI-Debug
 
 on:
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  push:
+  pull_request_target:
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'doc/**'
 

--- a/.github/workflows/main_parameter_files.yml
+++ b/.github/workflows/main_parameter_files.yml
@@ -2,7 +2,7 @@ name: CI-Parameter-files-examples
 
 on: 
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  push:
+  pull_request_target:
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/main_parameter_files.yml
+++ b/.github/workflows/main_parameter_files.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'doc/**'
 

--- a/.github/workflows/main_parameter_files.yml
+++ b/.github/workflows/main_parameter_files.yml
@@ -2,9 +2,6 @@ name: CI-Parameter-files-examples
 
 on: 
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  pull_request_target:
-    paths-ignore:
-      - 'doc/**'
   pull_request:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -2,9 +2,6 @@ name: CI-Release
 
 on:
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  pull_request_target:
-    paths-ignore:
-      - 'doc/**'
   pull_request:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -2,7 +2,7 @@ name: CI-Release
 
 on:
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  push:
+  pull_request_target:
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'doc/**'
 

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -2,7 +2,7 @@ name: CI-Warnings
 
 on: 
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  push:
+  pull_request_target:
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'doc/**'
 

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -2,9 +2,6 @@ name: CI-Warnings
 
 on: 
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
-  pull_request_target:
-    paths-ignore:
-      - 'doc/**'
   pull_request:
     paths-ignore:
       - 'doc/**'


### PR DESCRIPTION
# Description of the problem

- Right now the CI cannot run on Pull requests that are opened from a fork. 

# Description of the solution

- Modify the target of the CI (On) to enable running on pull_request and not just pull_request_target. Ideally this should fix the issue.


# How Has This Been Tested?
- This PR is a test for for this in a way.
