### PR TITLE
Add scaling factor for 2D gaussian laser model

### DIFF
--- a/applications_tests/lethe-fluid/heat_transfer_vof_interface_gaussian_laser.output
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_interface_gaussian_laser.output
@@ -14,16 +14,16 @@ Temperature statistics on fluid :
 Transient iteration: 1        Time: 0.005    Time step: 0.005    CFL: 0       
 *******************************************************************************
 Temperature statistics on fluid : 
-	     Min : 47.3726
-	     Max : 153.328
-	 Average : 89.2813
-	 Std-Dev : 20.3699
+	     Min : 41.8451
+	     Max : 126.386
+	 Average : 75.2838
+	 Std-Dev : 16.2531
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.01     Time step: 0.005    CFL: 0       
 *******************************************************************************
 Temperature statistics on fluid : 
-	     Min : 83.2004
-	     Max : 229.986
-	 Average : 155.921
-	 Std-Dev : 31.9188
+	     Min : 70.4877
+	     Max : 187.61
+	 Average : 128.516
+	 Std-Dev : 25.4705

--- a/doc/source/parameters/cfd/laser_heat_source.rst
+++ b/doc/source/parameters/cfd/laser_heat_source.rst
@@ -8,7 +8,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
 
   subsection laser parameters
     set enable               = false
-    set type                 = exponential_decay
+    set type                 = gaussian_heat_flux_vof_interface
     set concentration factor = 2.0
     set power                = 0.0
     set absorptivity         = 0.5
@@ -33,7 +33,7 @@ If a laser heat source is present in a simulation, it can be added in this secti
 
 * The ``enable`` parameter is set to ``true`` if the problem has a laser heat source term and enables its calculation.
 
-* The ``type`` parameter is set to ``exponential_decay`` (default) if we assume that the laser behaves as a volumetric source.  If the laser is assumed to be a surface flux, the ``type`` can be set at ``gaussian_heat_flux_vof_interface`` or ``uniform_heat_flux_vof_interface`` and used in conjunction with the :doc:`VOF auxiliary physic <./volume_of_fluid>`. The different models are detailed :ref:`below <LaserTypes>`.
+* The ``type`` parameter is set to ``gaussian_heat_flux_vof_interface`` (default) if we assume that the laser behaves as a surface heat flux with a normal irradiation distribution.  If the laser is assumed to have a uniform surface heat flux, the ``type`` can be set at ``uniform_heat_flux_vof_interface``. In both cases, the laser model must be used in conjunction with the :doc:`VOF auxiliary physic <./volume_of_fluid>`. The third available laser model is the  ``exponential_decay`` and considers that the laser behaves as a volumetric source. The different models are detailed :ref:`below <LaserTypes>`.
 
 * Laser ``concentration factor`` parameter indicates the definition of the beam radius. In almost all the articles, it is assumed equal to :math:`2.0`.
 
@@ -75,6 +75,28 @@ If a laser heat source is present in a simulation, it can be added in this secti
 Laser types
 ^^^^^^^^^^^^^
 
+* When the ``type`` is set to ``gaussian_heat_flux_vof_interface`` or ``uniform_heat_flux_vof_interface``, it **must be used in conjunction with the** :doc:`VOF auxiliary physic <./volume_of_fluid>`.
+
+  * The ``gaussian_heat_flux_vof_interface`` model is used to apply a gaussian heat flux only at the interface. In 3D, this heat flux is given by:
+  
+    .. math::
+      
+        q(x,y,z) = \frac{|\nabla \psi| \eta \alpha P}{\pi R^2} \exp{\left(-\eta \frac{r^2}{R^2}\right)}
+        
+    where :math:`r` is the radial distance from the laser's axis and :math:`|\nabla \psi|` is the :math:`L^2` norm of the filtered phase fraction gradient. In 2D, the pre-exponential factor accounts for the change in the receiving area (going from a disk of radius :math:`R` in 3D to a line segment of length :math:`2R` in 2D): 
+    
+    .. math::
+
+        q(x,y,z) = \frac{2|\nabla \psi| \sqrt{\eta\;} \alpha P}{\sqrt{\pi^3} R^2} \exp{\left(-\eta \frac{r^2}{R^2}\right)}
+        
+    
+  * The ``uniform_heat_flux_vof_interface`` model is used to apply a uniform heat flux, given by the expression below, only at the interface.
+  
+    .. math::
+      
+        q(x,y,z) = \frac{|\nabla \psi| \alpha P}{\pi R^2}
+
+
 * When the ``type`` parameter is set to ``exponential_decay``, the exponential model from Zhang *et al.* `[2] <https://doi.org/10.1016/j.matdes.2018.01.022>`_ is used to simulate the laser heat source:
 
   .. math::
@@ -91,23 +113,7 @@ Laser types
 
   .. attention::
     In this case, the heat affects the fluid initialized as ``fluid 1``.
-
-* When ``type`` is set to ``gaussian_heat_flux_vof_interface`` or ``uniform_heat_flux_vof_interface``, it **must be used in conjunction with the** :doc:`VOF auxiliary physic <./volume_of_fluid>`.
-
-  * The ``gaussian_heat_flux_vof_interface`` model is used to apply a gaussian heat flux, given by the expression below, only at the interface.
-  
-    .. math::
-      
-        q(x,y,z) = \frac{|\nabla \psi| \eta \alpha P}{\pi R^2} \exp{\left(-\eta \frac{r^2}{R^2}\right)}
-        
-    where :math:`r` is the radial distance from the laser's axis and :math:`|\nabla \psi|` is the :math:`L^2` norm of the filtered phase fraction gradient.
     
-  * The ``uniform_heat_flux_vof_interface`` model is used to apply a uniform heat flux, given by the expression below, only at the interface.
-  
-    .. math::
-      
-        q(x,y,z) = \frac{|\nabla \psi| \alpha P}{\pi R^2}
-
 -----------
 References
 -----------

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1371,7 +1371,7 @@ namespace Parameters
       prm.declare_entry("enable", "false", Patterns::Bool(), "Activate laser");
       prm.declare_entry(
         "type",
-        "exponential_decay",
+        "gaussian_heat_flux_vof_interface",
         Patterns::Selection(
           "exponential_decay|gaussian_heat_flux_vof_interface|uniform_heat_flux_vof_interface"),
         "Type of laser model used."

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -895,7 +895,7 @@ HeatTransferAssemblerLaserGaussianHeatFluxVOFInterface<dim>::assemble_rhs(
                 2 * sqrt(concentration_factor) /
                 (sqrt(std::pow(M_PI, 3)) * beam_radius * beam_radius);
             }
-          else
+          if constexpr (dim == 3)
             {
               laser_heat_source *=
                 concentration_factor / (M_PI * beam_radius * beam_radius);

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -881,14 +881,23 @@ HeatTransferAssemblerLaserGaussianHeatFluxVOFInterface<dim>::assemble_rhs(
             scratch_data.filtered_phase_gradient_values[q].norm();
 
           // Calculate the strong residual for GLS stabilization
-          const double laser_heat_source =
-            (concentration_factor * absorptivity * laser_power /
-             (M_PI * beam_radius * beam_radius)) *
+          double laser_heat_source =
+             absorptivity * laser_power *
             exp(-1.0 * concentration_factor *
                 std::pow(laser_location_on_surface.distance(
                            quadrature_point_on_surface),
                          2.0) /
                 (beam_radius * beam_radius));
+                
+          if constexpr (dim == 2)
+          {
+            laser_heat_source *= 2*sqrt(concentration_factor)/(sqrt(std::pow(M_PI,3))*beam_radius*beam_radius);
+          }
+          else
+          {
+            laser_heat_source *= concentration_factor / (M_PI * beam_radius * beam_radius);
+          }
+                
           strong_residual[q] -=
             filtered_phase_gradient_value_q_norm * laser_heat_source;
 

--- a/source/solvers/heat_transfer_assemblers.cc
+++ b/source/solvers/heat_transfer_assemblers.cc
@@ -882,22 +882,25 @@ HeatTransferAssemblerLaserGaussianHeatFluxVOFInterface<dim>::assemble_rhs(
 
           // Calculate the strong residual for GLS stabilization
           double laser_heat_source =
-             absorptivity * laser_power *
+            absorptivity * laser_power *
             exp(-1.0 * concentration_factor *
                 std::pow(laser_location_on_surface.distance(
                            quadrature_point_on_surface),
                          2.0) /
                 (beam_radius * beam_radius));
-                
+
           if constexpr (dim == 2)
-          {
-            laser_heat_source *= 2*sqrt(concentration_factor)/(sqrt(std::pow(M_PI,3))*beam_radius*beam_radius);
-          }
+            {
+              laser_heat_source *=
+                2 * sqrt(concentration_factor) /
+                (sqrt(std::pow(M_PI, 3)) * beam_radius * beam_radius);
+            }
           else
-          {
-            laser_heat_source *= concentration_factor / (M_PI * beam_radius * beam_radius);
-          }
-                
+            {
+              laser_heat_source *=
+                concentration_factor / (M_PI * beam_radius * beam_radius);
+            }
+
           strong_residual[q] -=
             filtered_phase_gradient_value_q_norm * laser_heat_source;
 


### PR DESCRIPTION
# Description of the problem

- The gaussian laser model in 2D was not consistent with the 3D one (energy-wise)
- The default laser model was the exponential decy, while we are now using much more the gaussian_heat_flux_vof_interface.

# Description of the solution

- Add a scaling factor in 2D so that the average heat flux is the same in 2D and 3D.
- Switch the default laser model for gaussian_heat_flux_vof_interface.

# How Has This Been Tested?

The test for the gaussian laser was updated.

- [x] heat_transfer_vof_interface_gaussian_laser.prm 

# Documentation

The doc was updated

- [x] laser_heat_source.rst

