### PR TITLE
Fix broken tests due to #1007

### DIFF
--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2340,7 +2340,15 @@ NavierStokesBase<dim, VectorType, DofsType>::init_temporary_vector()
 {
   VectorType tmp;
 
-  tmp.reinit(locally_owned_dofs, locally_relevant_dofs, this->mpi_communicator);
+  if constexpr (std::is_same_v<VectorType, GlobalVectorType> ||
+                std::is_same_v<VectorType, GlobalBlockVectorType>)
+    tmp.reinit(locally_owned_dofs, this->mpi_communicator);
+
+  else if constexpr (std::is_same_v<VectorType,
+                                    LinearAlgebra::distributed::Vector<double>>)
+    tmp.reinit(locally_owned_dofs,
+               locally_relevant_dofs,
+               this->mpi_communicator);
 
   return tmp;
 }


### PR DESCRIPTION
# Description of the problem
Eight tests were failing in debug mode due to the different behavior of the interpolate function of the solution transfer for different types of vectors. 

# Description of the solution
Revert change made in #1007 for the `init_temporary_vector()` function.