### PR TITLE
Add doxygen build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ contrib/postprocessing/dist
 contrib/postprocessing/lethe_pyvista_tools.egg-info
 *__pycache__
 /.github/
+doc/doxygen/html/
+doc/doxygen/DoxygenWarningLog.txt


### PR DESCRIPTION
# Description of the problem

The doxygen build files were not in the .gitignore.

# Description of the solution

Added the paths to the .gitignore to prevent people from pushing build files.