### PR TITLE
Add doxygen biref to ale.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ cmake-build-release/*
 
 # Doc
 doc/build/*
+doc/doxygen/html/
+doc/doxygen/DoxygenWarningLog.txt
 contrib/utilities/programs/*
 contrib/postprocessing/build
 contrib/postprocessing/dist

--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,6 @@ cmake-build-release/*
 
 # Doc
 doc/build/*
-doc/doxygen/html/
-doc/doxygen/DoxygenWarningLog.txt
 contrib/utilities/programs/*
 contrib/postprocessing/build
 contrib/postprocessing/dist

--- a/include/core/ale.h
+++ b/include/core/ale.h
@@ -46,16 +46,16 @@ namespace Parameters
       velocity = std::make_shared<Functions::ParsedFunction<dim>>(dim);
     }
 
-    
-    /** 
+
+    /**
      * @brief Declare the parameters.
      *
      * @param[in,out] prm The ParameterHandler.
      */
     virtual void
     declare_parameters(ParameterHandler &prm);
-    
-    /** 
+
+    /**
      * @brief Parse the parameters.
      *
      * @param[in,out] prm The ParameterHandler.
@@ -66,9 +66,9 @@ namespace Parameters
 
     /**
      * @brief ALE velocity function
-     */ 
+     */
     std::shared_ptr<Functions::ParsedFunction<dim>> velocity;
-    
+
     /**
      * @brief Return if the ALE module is enabled.
      *

--- a/include/core/ale.h
+++ b/include/core/ale.h
@@ -23,32 +23,57 @@
 #include <deal.II/lac/vector.h>
 
 using namespace dealii;
-/**
- * The ALE class provides an interface for all common
- * element required for the introduction of the required terms for a moving
- *referential in the governing equations.
- **/
 
 namespace Parameters
 {
+  /**
+   * @brief An interface for all the common parameters required to consider
+   * a moving frame of reference in a simplified Arbitrary Lagrangian Eulerian
+   * (ALE) module.
+   *
+   * @tparam dim An integer that denotes the dimension of the space in which
+   * the problem is solved.
+   */
   template <int dim>
   class ALE
   {
   public:
+    /**
+     * @brief Construct a new ALE object.
+     */
     ALE()
     {
       velocity = std::make_shared<Functions::ParsedFunction<dim>>(dim);
     }
 
+    
+    /** 
+     * @brief Declare the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     */
     virtual void
     declare_parameters(ParameterHandler &prm);
+    
+    /** 
+     * @brief Parse the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     */
     virtual void
     parse_parameters(ParameterHandler &prm);
 
 
-    // ALE-Velocity function
+    /**
+     * @brief ALE velocity function
+     */ 
     std::shared_ptr<Functions::ParsedFunction<dim>> velocity;
-
+    
+    /**
+     * @brief Return if the ALE module is enabled.
+     *
+     * @return enable A boolean that indicates if the ALE module is enabled.
+     */
     bool
     enabled() const
     {
@@ -56,6 +81,9 @@ namespace Parameters
     }
 
   private:
+    /**
+     * @brief Boolean indicating if the ALE module is enabled.
+     */
     bool enable;
   };
 


### PR DESCRIPTION
# Description of the problem

- Doxygen missing in ale.h

# Description of the solution

- Add the required description.

# How Has This Been Tested?

- compile and inspect the doxygen output.

# Future changes

- parameters.h is next.

# Comments

- Since it is in the parameters namespace, the same description will be use in the parameters.h for declare and parse. I wanted to avoid the repetition of the description for declare and parse, but sometimes they differ a little bit, so I guess we should add the description everywher.

