### PR TITLE
Remove brief description

### DIFF
--- a/doc/doxygen/doxygen-config-file
+++ b/doc/doxygen/doxygen-config-file
@@ -24,7 +24,7 @@ CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 OUTPUT_TEXT_DIRECTION  = None
-BRIEF_MEMBER_DESC      = YES
+BRIEF_MEMBER_DESC      = NO
 REPEAT_BRIEF           = YES
 ABBREVIATE_BRIEF       = "The $name class" \
                          "The $name widget" \


### PR DESCRIPTION
# Description of the problem

In the current doxygen documentation we see the brief description of each function in the "Public Member Functions" tab.

# Description of the solution

The corresponding option in the doxygen tab is fixed, so that we only see the list and if more recommendation required one can go to the "Member Function Documentation" section.  Just like in deal.ii. 

