### PR TITLE
Change title of doxygen main page

### DIFF
--- a/doc/doxygen/doxygen-config-file
+++ b/doc/doxygen/doxygen-config-file
@@ -15,9 +15,9 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = "Developer documentation for the Lethe open-source library"
+PROJECT_NAME           = "Lethe Open-Source Library"
 PROJECT_NUMBER         =
-PROJECT_BRIEF          = 
+PROJECT_BRIEF          = "Developer Guide"
 PROJECT_LOGO           = ./logo.png
 OUTPUT_DIRECTORY       =
 CREATE_SUBDIRS         = NO


### PR DESCRIPTION
# Description of the problem

The word "documentation" was redundant in the title of the index page of the doxygen documentation. 

# Description of the solution

This avoids repetition of the word and makes it clearer.