### PR TITLE
Add time step limit for adaptive time stepping scheme

### DIFF
--- a/doc/source/parameters/cfd/simulation_control.rst
+++ b/doc/source/parameters/cfd/simulation_control.rst
@@ -48,6 +48,9 @@ This subsection contains the general information of the simulation, including th
 
     # Maximum CFL value
     set max cfl                      = 1
+		
+		# Maximum time step value
+    set max time step                = 1e6
 
     # Adaptative time step scaling
     set adaptative time step scaling = 1.1
@@ -117,6 +120,8 @@ This subsection contains the general information of the simulation, including th
 
 * ``max cfl``: maximal value of the :math:`\text{CFL}` condition that can be reached during the simulation. This parameter is only used when ``set adapt = true``.
 
+* ``max time step``: maximal value of the time step that can be reached during the simulation. This parameter is only used when ``set adapt = true``. It is useful when the problem of interest has an additional time step constraint such as the capillary time step limit described in :doc:`../../examples/multiphysics/capillary-wave/capillary-wave`.
+
 * ``adaptative time step scaling``: rate of increase of the time step value. The new time step value is fixed by ``adaptative time step scaling`` * ``previous value of the time step``
 
 * ``log frequency``: frequency at which information is written in terminal
@@ -166,4 +171,3 @@ This subsection contains the general information of the simulation, including th
 
 .. tip::
 	Generally, we advise to use a subdivision level of :math:`(n)` for interpolation order of :math:`n`. For example, a Q2-Q1 interpolation could be visualized with ``set subdivision = 2``.
-

--- a/doc/source/parameters/cfd/simulation_control.rst
+++ b/doc/source/parameters/cfd/simulation_control.rst
@@ -82,7 +82,7 @@ This subsection contains the general information of the simulation, including th
     # Output time
     set output time                  = 1
 
-    # Maximal number of vtu output files
+    # Maximum number of vtu output files
     set group files                  = 1
 
     # Output the boundaries of the domain along with their ID
@@ -118,9 +118,9 @@ This subsection contains the general information of the simulation, including th
 
 * ``adapt``: controls if adaptive time-stepping is enabled. If set to ``true``, the time-step will evolve to ensure that the ``max cfl`` value is reached.
 
-* ``max cfl``: maximal value of the :math:`\text{CFL}` condition that can be reached during the simulation. This parameter is only used when ``set adapt = true``.
+* ``max cfl``: maximum value of the :math:`\text{CFL}` condition that can be reached during the simulation. This parameter is only used when ``set adapt = true``.
 
-* ``max time step``: maximal value of the time step that can be reached during the simulation. This parameter is only used when ``set adapt = true``. It is useful when the problem of interest has an additional time step constraint such as the capillary time step limit described in :doc:`../../examples/multiphysics/capillary-wave/capillary-wave`.
+* ``max time step``: maximum time step value that can be reached during the simulation. This parameter is only used when ``set adapt = true``. It is useful when the problem of interest has an additional time step constraint such as the capillary time step limit described in :doc:`../../examples/multiphysics/capillary-wave/capillary-wave`.
 
 * ``adaptative time step scaling``: rate of increase of the time step value. The new time step value is fixed by ``adaptative time step scaling`` * ``previous value of the time step``
 

--- a/doc/source/parameters/cfd/simulation_control.rst
+++ b/doc/source/parameters/cfd/simulation_control.rst
@@ -49,7 +49,7 @@ This subsection contains the general information of the simulation, including th
     # Maximum CFL value
     set max cfl                      = 1
 		
-		# Maximum time step value
+    # Maximum time step value
     set max time step                = 1e6
 
     # Adaptative time step scaling

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -114,11 +114,14 @@ namespace Parameters
 
     // Max CFL
     double maxCFL;
+    
+    // Max dt
+    double max_dt;
 
     // Aimed tolerance at which simulation is stopped
     double stop_tolerance;
 
-    // Max CFL
+    // Rate of increase of the time step value
     double adaptative_time_step_scaling;
 
     // BDF startup time scaling

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -115,7 +115,7 @@ namespace Parameters
     // Max CFL
     double maxCFL;
 
-    // Max dt
+    // Max time step
     double max_dt;
 
     // Aimed tolerance at which simulation is stopped

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -114,7 +114,7 @@ namespace Parameters
 
     // Max CFL
     double maxCFL;
-    
+
     // Max dt
     double max_dt;
 

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -452,7 +452,7 @@ protected:
 
   // Time step scaling for adaptative time stepping
   double adaptative_time_step_scaling;
-  
+
   // Max time step
   double max_dt;
 

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -452,6 +452,9 @@ protected:
 
   // Time step scaling for adaptative time stepping
   double adaptative_time_step_scaling;
+  
+  // Max time step
+  double max_dt;
 
   /**
    * @brief Calculates the next value of the time step. If adaptation

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -109,6 +109,10 @@ namespace Parameters
                         "1",
                         Patterns::Double(),
                         "Maximum CFL value");
+      prm.declare_entry("max time step",
+                        "1e6",
+                        Patterns::Double(),
+                        "Maximum time step value");
       prm.declare_entry("stop tolerance",
                         "1e-10",
                         Patterns::Double(),
@@ -216,6 +220,7 @@ namespace Parameters
       timeEnd        = prm.get_double("time end");
       adapt          = prm.get_bool("adapt");
       maxCFL         = prm.get_double("max cfl");
+      max_dt         = prm.get_double("max time step");
       stop_tolerance = prm.get_double("stop tolerance");
       adaptative_time_step_scaling =
         prm.get_double("adaptative time step scaling");

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -288,7 +288,7 @@ SimulationControlTransientDynamicOutput::calculate_time_step()
       new_time_step = time_step * adaptative_time_step_scaling;
       if (CFL > 0 && max_CFL / CFL < adaptative_time_step_scaling)
         new_time_step = time_step * max_CFL / CFL;
-        
+
       new_time_step = std::min(new_time_step, max_dt);
     }
 
@@ -403,7 +403,7 @@ SimulationControlAdjointSteady::calculate_time_step()
       new_time_step = time_step * adaptative_time_step_scaling;
       if (CFL > 0 && max_CFL / CFL < adaptative_time_step_scaling)
         new_time_step = time_step * max_CFL / CFL;
-      
+
       new_time_step = std::min(new_time_step, max_dt);
     }
 

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -232,6 +232,8 @@ SimulationControlTransient::calculate_time_step()
       new_time_step = time_step * adaptative_time_step_scaling;
       if (CFL > 0 && max_CFL / CFL < adaptative_time_step_scaling)
         new_time_step = time_step * max_CFL / CFL;
+      
+      new_time_step = std::min(new_time_step, max_dt);
     }
   if (current_time + new_time_step > end_time)
     new_time_step = end_time - current_time;

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -288,6 +288,8 @@ SimulationControlTransientDynamicOutput::calculate_time_step()
       new_time_step = time_step * adaptative_time_step_scaling;
       if (CFL > 0 && max_CFL / CFL < adaptative_time_step_scaling)
         new_time_step = time_step * max_CFL / CFL;
+        
+      new_time_step = std::min(new_time_step, max_dt);
     }
 
   if (current_time + new_time_step > end_time)
@@ -401,6 +403,8 @@ SimulationControlAdjointSteady::calculate_time_step()
       new_time_step = time_step * adaptative_time_step_scaling;
       if (CFL > 0 && max_CFL / CFL < adaptative_time_step_scaling)
         new_time_step = time_step * max_CFL / CFL;
+      
+      new_time_step = std::min(new_time_step, max_dt);
     }
 
   return new_time_step;

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -172,6 +172,7 @@ SimulationControlTransient::SimulationControlTransient(
   : SimulationControl(param)
   , adapt(param.adapt)
   , adaptative_time_step_scaling(param.adaptative_time_step_scaling)
+  , max_dt(param.max_dt)
 {}
 
 void

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -232,7 +232,7 @@ SimulationControlTransient::calculate_time_step()
       new_time_step = time_step * adaptative_time_step_scaling;
       if (CFL > 0 && max_CFL / CFL < adaptative_time_step_scaling)
         new_time_step = time_step * max_CFL / CFL;
-      
+
       new_time_step = std::min(new_time_step, max_dt);
     }
   if (current_time + new_time_step > end_time)

--- a/tests/core/simulation_control_03.cc
+++ b/tests/core/simulation_control_03.cc
@@ -84,7 +84,7 @@ test()
     simulation_control_parameters.dt                           = 1;
     simulation_control_parameters.adaptative_time_step_scaling = 1.2;
     simulation_control_parameters.maxCFL                       = 2;
-
+    simulation_control_parameters.max_dt                       = 1e6;
 
 
     SimulationControlTransient simulation_control(
@@ -126,7 +126,7 @@ test()
     simulation_control_parameters.output_time                  = 7.5;
     simulation_control_parameters.output_control =
       Parameters::SimulationControl::OutputControl::time;
-
+    simulation_control_parameters.max_dt                       = 1e6;
 
 
     SimulationControlTransientDynamicOutput simulation_control(

--- a/tests/core/simulation_control_03.cc
+++ b/tests/core/simulation_control_03.cc
@@ -126,7 +126,7 @@ test()
     simulation_control_parameters.output_time                  = 7.5;
     simulation_control_parameters.output_control =
       Parameters::SimulationControl::OutputControl::time;
-    simulation_control_parameters.max_dt                       = 1e6;
+    simulation_control_parameters.max_dt = 1e6;
 
 
     SimulationControlTransientDynamicOutput simulation_control(

--- a/tests/solvers/average_velocities_02.cc
+++ b/tests/solvers/average_velocities_02.cc
@@ -59,6 +59,7 @@ test()
   simulation_control_parameters.output_frequency             = 1;
   simulation_control_parameters.adapt                        = true;
   simulation_control_parameters.adaptative_time_step_scaling = 0.95;
+  simulation_control_parameters.max_dt                       = 1e6;
 
   Parameters::PostProcessing postprocessing_parameters;
   postprocessing_parameters.calculate_average_velocities = true;

--- a/tests/solvers/reynolds_stress_02.cc
+++ b/tests/solvers/reynolds_stress_02.cc
@@ -58,6 +58,7 @@ test()
   simulation_control_parameters.timeEnd                      = 1.0;
   simulation_control_parameters.adapt                        = true;
   simulation_control_parameters.adaptative_time_step_scaling = 0.99;
+  simulation_control_parameters.max_dt                       = 1e6;
 
   Parameters::PostProcessing postprocessing_parameters;
   postprocessing_parameters.calculate_average_velocities = true;


### PR DESCRIPTION
# Description of the problem

- Adaptive time stepping was only based on the CFL, meaning that for problems with another time step limit (i.e. surface tension problems(, the latter could be not respected.

# Description of the solution

- A max_dt was added

# How Has This Been Tested?

- Default value of max_dt was added to unit test so they don't fail
- [x] core/simulation_control_03.cc
- [x] solvers/average_velocities_02.cc
- [x] solvers/reynolds_stress_02.cc

# Documentation
- Update simulation control doc
- [x] simulation_control.rst


