### PR TITLE
Lethe pyvista padding

### DIFF
--- a/contrib/postprocessing/lethe_pyvista_tools/_write_df_to_vtu.py
+++ b/contrib/postprocessing/lethe_pyvista_tools/_write_df_to_vtu.py
@@ -1,5 +1,7 @@
 from tqdm import tqdm
 
+# Hard coded string :
+padding_string = ".00000.vtu"
 
 # Write modifications on each df to VTU files
 def write_df_to_vtu(self, prefix = "mod_"):
@@ -29,7 +31,7 @@ def write_df_to_vtu(self, prefix = "mod_"):
 
                         # If line matches one of the files
                         if path in line:
-                            line = line.replace(".pvtu", "."+self.padding+".vtu")
+                            line = line.replace('.pvtu', padding_string)
                             
                             # If vtu is in list_vtu
                             if line.split('file="')[1].split('"/>')[0] in self.list_vtu:

--- a/include/core/solutions_output.h
+++ b/include/core/solutions_output.h
@@ -65,6 +65,8 @@ write_vtu_and_pvd(PVDHandler                            &pvd_handler,
                   const unsigned int                     group_files,
                   const MPI_Comm                        &mpi_communicator,
                   const unsigned int                     digits = 5);
+//  By changing the default digit value, you need to change the hard
+//  coded strings in Lethe_pyvista (__init__.py and write_df_to_vtu.py)
 
 /**
  * @brief Output the Data Out Faces to a single vtu file


### PR DESCRIPTION
# Description of the problem

- We had problem with the padding used in lethe and in lethe_pyvista.  

# Description of the solution

- I went back to the old implementation. The hard coded string is written at the top of the __init__.py and wrtie_df_to_vtu.py files so it's easier to change if needed. I've also added a comment right next to the default value saying to change the hard coded string if the value needed to be change in lethe.   

# How Has This Been Tested?

- Ran the oblique_wall_impact_postprocessing.py with the new implementation and everything seem to be working. 
- Also ran a CFD example with Amishga. 

# Future changes

- We should be reading the .pvd instead.
