### PR TITLE
Add compressibility to heat transfer

### DIFF
--- a/applications_tests/lethe-fluid/heat_transfer_vof_weakly_compressible_flow.output
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_weakly_compressible_flow.output
@@ -1,0 +1,32 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       256
+   Number of degrees of freedom: 867
+   Volume of triangulation:      0.0625
+   Number of thermal degrees of freedom: 289
+   Number of VOF degrees of freedom: 289
+Pressure drop: 0 Pa
+Total pressure drop: 0 Pa
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
+*******************************************************************************
+Pressure drop: -156.575 Pa
+Total pressure drop: -156.575 Pa
+
+*******************************************************************************
+Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 0.317772
+*******************************************************************************
+Pressure drop: -161.604 Pa
+Total pressure drop: -161.604 Pa
+
+*******************************************************************************
+Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 0.363124
+*******************************************************************************
+Pressure drop: -162.235 Pa
+Total pressure drop: -162.235 Pa
+
+*******************************************************************************
+Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 0.380725
+*******************************************************************************
+Pressure drop: -162.369 Pa
+Total pressure drop: -162.369 Pa

--- a/applications_tests/lethe-fluid/heat_transfer_vof_weakly_compressible_flow.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_weakly_compressible_flow.prm
@@ -1,0 +1,205 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = bdf1
+  set time end         = 0.4
+  set time step        = 0.1
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer = true
+  set VOF           = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  subsection temperature
+    set Function expression = (40-25)*(0.25-x)*4+25
+  end
+  subsection VOF
+    set Function expression = if(y>=0.125, 0, 1)
+  end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set Function expression = 5 ; 0 ; 0
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 0
+    set thermal conductivity = 0.5
+    set kinematic viscosity  = 0.01
+    set thermal expansion    = 0.0001
+    set specific heat        = 100
+    set density model        = isothermal_ideal_gas
+    subsection isothermal_ideal_gas
+      set density_ref = 10
+      set R           = 287.05
+      set T           = 298.15
+    end
+  end
+  subsection fluid 0
+    set thermal conductivity = 0.5
+    set kinematic viscosity  = 0.01
+    set thermal expansion    = 0.0001
+    set specific heat        = 200
+    set density model        = isothermal_ideal_gas
+    subsection isothermal_ideal_gas
+      set density_ref = 15
+      set R           = 287.05
+      set T           = 298.15
+    end
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_cube
+  set grid arguments     = 0 : 0.25 : true
+  set initial refinement = 4
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 4
+  subsection bc 0
+    set id   = 0
+    set type = noslip
+  end
+  subsection bc 1
+    set id   = 1
+    set type = noslip
+  end
+  subsection bc 2
+    set id   = 2
+    set type = noslip
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noslip
+  end
+end
+
+subsection boundary conditions heat transfer
+  set number = 2
+  subsection bc 0
+    set id   = 0
+    set type = temperature
+    subsection value
+      set Function expression = 40
+    end
+  end
+  subsection bc 1
+    set id   = 1
+    set type = temperature
+    subsection value
+      set Function expression = 25
+    end
+  end
+end
+
+#---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity                   = verbose
+  set calculate pressure drop     = true
+  set calculate mass conservation = false
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set tolerance      = 1e-3
+    set max iterations = 20
+    set verbosity      = quiet
+  end
+  subsection fluid dynamics
+    set tolerance      = 1e-4
+    set max iterations = 5
+    set verbosity      = quiet
+  end
+  subsection VOF
+    set tolerance      = 1e-9
+    set max iterations = 20
+    set verbosity      = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 1000
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection VOF
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-10
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end

--- a/applications_tests/lethe-fluid/heat_transfer_weakly_compressible_flow.output
+++ b/applications_tests/lethe-fluid/heat_transfer_weakly_compressible_flow.output
@@ -1,0 +1,31 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       256
+   Number of degrees of freedom: 867
+   Volume of triangulation:      0.0625
+   Number of thermal degrees of freedom: 289
+Pressure drop: 0 Pa
+Total pressure drop: 0 Pa
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
+*******************************************************************************
+Pressure drop: -123.246 Pa
+Total pressure drop: -123.246 Pa
+
+**********************************************************************************
+Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 6.88457e-05
+**********************************************************************************
+Pressure drop: -123.485 Pa
+Total pressure drop: -123.485 Pa
+
+**********************************************************************************
+Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 4.78548e-05
+**********************************************************************************
+Pressure drop: -123.636 Pa
+Total pressure drop: -123.636 Pa
+
+**********************************************************************************
+Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 3.46342e-05
+**********************************************************************************
+Pressure drop: -123.757 Pa
+Total pressure drop: -123.757 Pa

--- a/applications_tests/lethe-fluid/heat_transfer_weakly_compressible_flow.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_weakly_compressible_flow.prm
@@ -1,0 +1,172 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = bdf1
+  set time end         = 0.4
+  set time step        = 0.1
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  subsection temperature
+    set Function expression = (40-25)*(0.25-x)*4+25
+  end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set Function expression = 5 ; 0 ; 0
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set thermal conductivity = 0.5
+    set kinematic viscosity  = 0.01
+    set thermal expansion    = 0.0001
+    set specific heat        = 100
+    set density model        = isothermal_ideal_gas
+    subsection isothermal_ideal_gas
+      set density_ref = 100
+      set R           = 287.05
+      set T           = 298.15
+    end
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_cube
+  set grid arguments     = 0 : 0.25 : true
+  set initial refinement = 4
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 4
+  subsection bc 0
+    set id   = 0
+    set type = noslip
+  end
+  subsection bc 1
+    set id   = 1
+    set type = noslip
+  end
+  subsection bc 2
+    set id   = 2
+    set type = noslip
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noslip
+  end
+end
+
+subsection boundary conditions heat transfer
+  set number = 2
+  subsection bc 0
+    set id   = 0
+    set type = temperature
+    subsection value
+      set Function expression = 40
+    end
+  end
+  subsection bc 1
+    set id   = 1
+    set type = temperature
+    subsection value
+      set Function expression = 25
+    end
+  end
+end
+
+#---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity               = verbose
+  set calculate pressure drop = true
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set tolerance      = 1e-3
+    set max iterations = 20
+    set verbosity      = quiet
+  end
+  subsection fluid dynamics
+    set tolerance      = 1e-4
+    set max iterations = 5
+    set verbosity      = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 1000
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -284,29 +284,39 @@ public:
       }
   }
 
-  /** @brief Reinitialize the velocity, calculated by the fluid dynamics while also taking into account ALE
+  /**
+   * @brief Reinitialize cell's velocity and pressure values with values
+   * calculated in the Fluid Dynamics (FD) physic while also taking into account
+   * ALE for the velocity.
    *
-   * @tparam VectorType The Vector type used for the solvers
+   * @tparam VectorType Type of vector used for storing fluid dynamics
+   * solutions.
    *
-   * @param cell The cell for which the velocity is reinitialized
-   * This cell must be compatible with the Fluid Dynamics FE
+   * @param[in] cell Pointer to an active cell for which the velocity and
+   * pressure are reinitialized.This cell must be compatible with the FD
+   * FiniteElement.
    *
-   * @param current_solution The present value of the solution for [u,p]
+   * @param[in] current_solution Solution vector from FD containing velocity
+   * components and pressure values.
    *
-   * @param ale The ALE parameters which include the ALE function
+   * @param[in] ale The ALE parameters which include the ALE function
    *
    */
 
   template <typename VectorType>
   void
-  reinit_velocity(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                  const VectorType           &current_solution,
-                  const Parameters::ALE<dim> &ale)
+  reinit_fluid_dynamics(
+    const typename DoFHandler<dim>::active_cell_iterator &cell,
+    const VectorType                                     &current_solution,
+    const Parameters::ALE<dim>                           &ale)
   {
     this->fe_values_fd.reinit(cell);
 
     this->fe_values_fd[velocities].get_function_values(current_solution,
                                                        velocity_values);
+    if (!this->properties_manager.density_is_constant())
+      this->fe_values_fd[pressure].get_function_values(current_solution,
+                                                       pressure_values);
 
     if (!ale.enabled())
       return;
@@ -344,30 +354,6 @@ public:
     this->fe_values_fd[velocities].get_function_gradients(
       current_solution, velocity_gradient_values);
   }
-
-  /**
-   *@brief Reinitialize cell's pressure value with value calculated in the Fluid
-   * Dynamics (FD) physic.
-   *
-   * @tparam VectorType Type of vector used for storing fluid dynamics
-   * solutions.
-   *
-   * @param[in] cell The cell for which the pressure is reinitialized
-   * This cell must be compatible with the FD FiniteElement.
-   *
-   * @param[in] current_solution Solution vector from FD containing velocity
-   * components and pressure values.
-   */
-  template <typename VectorType>
-  void
-  reinit_pressure(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                  const VectorType &current_solution)
-  {
-    this->fe_values_fd.reinit(cell);
-    this->fe_values_fd[pressure].get_function_values(current_solution,
-                                                     pressure_values);
-  }
-
 
   /**
    * @brief enable_vof Enables the collection of the VOF data by the scratch.

--- a/include/solvers/heat_transfer_scratch_data.h
+++ b/include/solvers/heat_transfer_scratch_data.h
@@ -54,10 +54,10 @@ using namespace dealii;
  * for a heat transfer advection-diffusion equation. Consequently, this class
  * calculates the heat transfer (values, gradients, laplacians) and the shape
  * function (values, gradients, laplacians) at all the gauss points for all
- * degrees of freedom and stores it into arrays. Additionnaly, the user can
+ * degrees of freedom and stores it into arrays. Additionally, the user can
  * request that this class gathers additional fields for physics which are
  * coupled to the heat transfer equation, such as the velocity which is
- * required. This class serves as a seperation between the evaluation at the
+ * required. This class serves as a separation between the evaluation at the
  * gauss point of the variables of interest and their use in the assembly, which
  * is carried out by the assembler methods. For more information on this
  * design, the reader can consult deal.II step-9
@@ -79,7 +79,7 @@ public:
    * @brief Constructor. The constructor creates the fe_values that will be used
    * to fill the member variables of the scratch. It also allocated the
    * necessary memory for all member variables. However, it does not do any
-   * evalution, since this needs to be done at the cell level.
+   * evaluation, since this needs to be done at the cell level.
    *
    * @param properties_manager The physical properties Manager (see physical_properties_manager.h)
    *
@@ -106,6 +106,8 @@ public:
                   quadrature,
                   update_values | update_quadrature_points | update_JxW_values |
                     update_gradients | update_hessians)
+    , velocities(0)
+    , pressure(dim)
     , fe_values_fd(mapping, fe_fd, quadrature, update_values | update_gradients)
     , fe_face_values_ht(mapping,
                         fe_ht,
@@ -134,6 +136,8 @@ public:
                   sd.fe_values_T.get_quadrature(),
                   update_values | update_quadrature_points | update_JxW_values |
                     update_gradients | update_hessians)
+    , velocities(0)
+    , pressure(dim)
     , fe_values_fd(sd.fe_values_fd.get_mapping(),
                    sd.fe_values_fd.get_fe(),
                    sd.fe_values_fd.get_quadrature(),
@@ -341,6 +345,29 @@ public:
       current_solution, velocity_gradient_values);
   }
 
+  /**
+   *@brief Reinitialize cell's pressure value with value calculated in the Fluid
+   * Dynamics (FD) physic.
+   *
+   * @tparam VectorType Type of vector used for storing fluid dynamics
+   * solutions.
+   *
+   * @param[in] cell The cell for which the pressure is reinitialized
+   * This cell must be compatible with the FD FiniteElement.
+   *
+   * @param[in] current_solution Solution vector from FD containing velocity
+   * components and pressure values.
+   */
+  template <typename VectorType>
+  void
+  reinit_pressure(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                  const VectorType &current_solution)
+  {
+    this->fe_values_fd.reinit(cell);
+    this->fe_values_fd[pressure].get_function_values(current_solution,
+                                                     pressure_values);
+  }
+
 
   /**
    * @brief enable_vof Enables the collection of the VOF data by the scratch.
@@ -482,14 +509,17 @@ public:
   std::shared_ptr<VolumeOfFluidFilterBase> filter; // Phase fraction filter
 
   /**
-   * Scratch component for the Navier-Stokes component
+   * Scratch component for the Navier-Stokes components
    */
-  FEValuesExtractors::Vector velocities;
-  // This FEValues must mandatorily be instantiated for the velocity
+  const FEValuesExtractors::Vector velocities;
+  const FEValuesExtractors::Scalar pressure;
+  // This FEValues must be instantiated for the velocity
   FEValues<dim>               fe_values_fd;
   std::vector<Tensor<1, dim>> velocity_values;
   std::vector<Tensor<2, dim>> velocity_gradient_values;
   std::vector<double>         shear_rate_values;
+  /// Pressure field for physical property models requiring them
+  std::vector<double> pressure_values;
 
   // Scratch for the face boundary condition
   FEFaceValues<dim>                fe_face_values_ht;

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -466,7 +466,7 @@ HeatTransfer<dim>::assemble_local_system_matrix(
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing.initial_time)
         {
-          scratch_data.reinit_velocity(
+          scratch_data.reinit_fluid_dynamics(
             fd_cell,
             *multiphysics->get_block_time_average_solution(
               PhysicsID::fluid_dynamics),
@@ -475,10 +475,10 @@ HeatTransfer<dim>::assemble_local_system_matrix(
       else
         {
           if (!this->simulation_parameters.ale.enabled())
-            scratch_data.reinit_velocity(fd_cell,
-                                         *multiphysics->get_block_solution(
-                                           PhysicsID::fluid_dynamics),
-                                         this->simulation_parameters.ale);
+            scratch_data.reinit_fluid_dynamics(
+              fd_cell,
+              *multiphysics->get_block_solution(PhysicsID::fluid_dynamics),
+              this->simulation_parameters.ale);
         }
     }
   else
@@ -488,30 +488,18 @@ HeatTransfer<dim>::assemble_local_system_matrix(
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing.initial_time)
         {
-          scratch_data.reinit_velocity(fd_cell,
-                                       *multiphysics->get_time_average_solution(
-                                         PhysicsID::fluid_dynamics),
-                                       this->simulation_parameters.ale);
+          scratch_data.reinit_fluid_dynamics(
+            fd_cell,
+            *multiphysics->get_time_average_solution(PhysicsID::fluid_dynamics),
+            this->simulation_parameters.ale);
         }
       else
         {
-          scratch_data.reinit_velocity(fd_cell,
-                                       *multiphysics->get_solution(
-                                         PhysicsID::fluid_dynamics),
-                                       this->simulation_parameters.ale);
+          scratch_data.reinit_fluid_dynamics(fd_cell,
+                                             *multiphysics->get_solution(
+                                               PhysicsID::fluid_dynamics),
+                                             this->simulation_parameters.ale);
         }
-    }
-
-  if (!this->simulation_parameters.physical_properties_manager
-         .density_is_constant())
-    {
-      if (!multiphysics->fluid_dynamics_is_block())
-        scratch_data.reinit_pressure(
-          fd_cell, *multiphysics->get_solution(PhysicsID::fluid_dynamics));
-      else
-        scratch_data.reinit_pressure(fd_cell,
-                                     *multiphysics->get_block_solution(
-                                       PhysicsID::fluid_dynamics));
     }
 
   if (this->simulation_parameters.multiphysics.VOF)
@@ -636,7 +624,7 @@ HeatTransfer<dim>::assemble_local_system_rhs(
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing.initial_time)
         {
-          scratch_data.reinit_velocity(
+          scratch_data.reinit_fluid_dynamics(
             fd_cell,
             *multiphysics->get_block_time_average_solution(
               PhysicsID::fluid_dynamics),
@@ -644,10 +632,10 @@ HeatTransfer<dim>::assemble_local_system_rhs(
         }
       else
         {
-          scratch_data.reinit_velocity(fd_cell,
-                                       *multiphysics->get_block_solution(
-                                         PhysicsID::fluid_dynamics),
-                                       this->simulation_parameters.ale);
+          scratch_data.reinit_fluid_dynamics(fd_cell,
+                                             *multiphysics->get_block_solution(
+                                               PhysicsID::fluid_dynamics),
+                                             this->simulation_parameters.ale);
         }
       scratch_data.reinit_velocity_gradient(
         *multiphysics->get_block_solution(PhysicsID::fluid_dynamics));
@@ -659,17 +647,17 @@ HeatTransfer<dim>::assemble_local_system_rhs(
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing.initial_time)
         {
-          scratch_data.reinit_velocity(fd_cell,
-                                       *multiphysics->get_time_average_solution(
-                                         PhysicsID::fluid_dynamics),
-                                       this->simulation_parameters.ale);
+          scratch_data.reinit_fluid_dynamics(
+            fd_cell,
+            *multiphysics->get_time_average_solution(PhysicsID::fluid_dynamics),
+            this->simulation_parameters.ale);
         }
       else
         {
-          scratch_data.reinit_velocity(fd_cell,
-                                       *multiphysics->get_solution(
-                                         PhysicsID::fluid_dynamics),
-                                       this->simulation_parameters.ale);
+          scratch_data.reinit_fluid_dynamics(fd_cell,
+                                             *multiphysics->get_solution(
+                                               PhysicsID::fluid_dynamics),
+                                             this->simulation_parameters.ale);
         }
 
       scratch_data.reinit_velocity_gradient(

--- a/source/solvers/heat_transfer_scratch_data.cc
+++ b/source/solvers/heat_transfer_scratch_data.cc
@@ -19,12 +19,12 @@ HeatTransferScratchData<dim>::allocate()
   this->source = std::vector<double>(n_q_points);
 
   // Initialize arrays related to velocity and pressure
-  this->velocities.first_vector_component = 0;
   // Velocity
   this->velocity_values          = std::vector<Tensor<1, dim>>(n_q_points);
   this->velocity_gradient_values = std::vector<Tensor<2, dim>>(n_q_points);
   this->shear_rate_values        = std::vector<double>(n_q_points);
-
+  // Pressure
+  this->pressure_values = std::vector<double>(n_q_points);
 
   // Initialize arrays related to temperature
   this->present_temperature_values = std::vector<double>(n_q_points);
@@ -67,6 +67,8 @@ HeatTransferScratchData<dim>::allocate()
     std::pair<field, std::vector<double>>(field::temperature_p2, n_q_points));
   fields.insert(
     std::pair<field, std::vector<double>>(field::shear_rate, n_q_points));
+  fields.insert(
+    std::pair<field, std::vector<double>>(field::pressure, n_q_points));
 }
 
 template <int dim>
@@ -170,6 +172,11 @@ HeatTransferScratchData<dim>::calculate_physical_properties()
         }
 
       set_field_vector(field::shear_rate, shear_rate_values, this->fields);
+    }
+
+  if (properties_manager.field_is_required(field::pressure))
+    {
+      set_field_vector(field::pressure, this->pressure_values, this->fields);
     }
 
   if (material_id < 1 || properties_manager.get_number_of_solids() < 1)


### PR DESCRIPTION
# Description of the problem

- The previously implemented weak compressibility () was not working with heat transfer physic.

# Description of the solution

- Missing pressure field was added to scratch data.

# How Has This Been Tested?

- The new feature has been tested on an impinging jet case.
- Two application tests were added to test this feature : 
  - `applications_tests/lethe-fluid/heat_transfer_weakly_compressible_flow.prm` (`.output`)
  - `applications_tests/lethe-fluid/heat_transfer_vof_weakly_compressible_flow.prm` (`.output`)

# Future changes

- Pressure field should be added to other scratch data using the density. To generalize, all `fields` should be checked if required in all scratch data that calculates physical properties.

# Comments

- Other small typo corrections were made.
