### PR TITLE
Minor fixes in prm files of matrix-free application tests

### DIFF
--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
@@ -156,7 +156,7 @@ subsection linear solver
     set max krylov vectors = 200
 
     #MG parameters
-    set mg verbosity       =  quiet
+    set mg verbosity       = quiet
     set mg min level       = -1
     set mg level min cells = -1
 

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
@@ -115,9 +115,9 @@ subsection linear solver
     set verbosity         = quiet
 
     #MG parameters
-    set mg verbosity           = quiet
-    set mg min level           = -1 
-    set mg level min cells     = -1 
+    set mg verbosity       = quiet
+    set mg min level       = -1
+    set mg level min cells = -1
 
     #smoother
     set mg smoother iterations = 10

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
@@ -115,9 +115,9 @@ subsection linear solver
     set verbosity         = quiet
 
     #MG parameters
-    set mg verbosity           = quiet
-    set mg min level           = -1 
-    set mg level min cells     = -1 
+    set mg verbosity       = quiet
+    set mg min level       = -1
+    set mg level min cells = -1
 
     #smoother
     set mg smoother iterations = 10

--- a/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
@@ -150,24 +150,6 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set verbosity                             = quiet
-    set method                                = gmres
-    set max iters                             = 5000
-    set relative residual                     = 1e-4
-    set minimum residual                      = 1e-9
-    set preconditioner                        = ilu
-    set ilu preconditioner fill               = 0
-    set ilu preconditioner absolute tolerance = 1e-10
-    set ilu preconditioner relative tolerance = 1.00
-  end
-end
-
-#---------------------------------------------------
-# Linear Solver Control
-#---------------------------------------------------
-
-subsection linear solver
-  subsection fluid dynamics
     set method            = gmres
     set max iters         = 5000
     set relative residual = 1e-4
@@ -181,7 +163,7 @@ subsection linear solver
     set mg level min cells = 16
 
     #smoother
-    set mg smoother iterations = 10
+    set mg smoother iterations     = 10
     set mg smoother eig estimation = true
 
     # Eigenvalue estimation parameters


### PR DESCRIPTION
Removed useless linear solver section in one test and use prmindent for all files.