### PR TITLE
Unify SUPG/PSPG and GLS matrix-free operators

### DIFF
--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -463,7 +463,7 @@ public:
     return times;
   }
 
-  Vector<double> &
+  Vector<double> const &
   get_bdf_coefficients()
   {
     return bdf_coefs;

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -463,7 +463,7 @@ public:
     return times;
   }
 
-  Vector<double> const &
+  Vector<double> &
   get_bdf_coefficients()
   {
     return bdf_coefs;

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -18,6 +18,7 @@
 
 #include <core/bdf.h>
 #include <core/simulation_control.h>
+#include <core/time_integration_utilities.h>
 
 #include <solvers/simulation_parameters.h>
 
@@ -380,7 +381,7 @@ protected:
 
 
   /**
-   * @brief Stabilization type needed to add or remove terms from operator
+   * @brief Stabilization type needed to add or remove terms from operator.
    *
    */
   StabilizationType stabilization;
@@ -464,77 +465,27 @@ protected:
 };
 
 /**
- * @brief Implements the matrix-free operator to solve the steady-state
- * Navier-Stokes equations using stabilization.
- *
- * @tparam dim An integer that denotes the number of spatial dimensions.
- * @tparam number Abstract type for number across the class (i.e., double).
- */
-template <int dim, typename number>
-class NavierStokesSteadyOperator : public NavierStokesOperatorBase<dim, number>
-{
-public:
-  using FECellIntegrator = FEEvaluation<dim, -1, 0, dim + 1, number>;
-  using VectorType       = LinearAlgebra::distributed::Vector<number>;
-
-  /**
-   * @brief Default constructor.
-   *
-   */
-  NavierStokesSteadyOperator();
-
-protected:
-  /**
-   * @brief Perform cell integral on a cell batch without gathering and scattering
-   * the values, and according to the Jacobian of the discretized Navier-Stokes
-   * equations with stabilization.
-   *
-   * @param[in] integrator FEEvaluation object that allows to evaluate functions
-   * at quadrature points and perform cell integrations.
-   */
-  void
-  do_cell_integral_local(FECellIntegrator &integrator) const override;
-
-  /**
-   * @brief Perform cell integral on a cell batch with gathering and scattering
-   * the values, and according to the residual of the discretized Navier-Stokes
-   * equations with stabilization.
-   *
-   * @param[in] matrix_free Object that contains all data.
-   * @param[in,out] dst Global vector where the final result is added.
-   * @param[in] src Input vector with all values in all cells.
-   * @param[out] range Range of the cell batch.
-   */
-  void
-  local_evaluate_residual(
-    const MatrixFree<dim, number>               &matrix_free,
-    VectorType                                  &dst,
-    const VectorType                            &src,
-    const std::pair<unsigned int, unsigned int> &range) const override;
-};
-
-/**
- * @brief Implements the matrix-free operator to solve transient Navier-Stokes equations
+ * @brief Implements the matrix-free operator to solve steady/transient Navier-Stokes equations
  * using stabilization.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions.
  * @tparam number Abstract type for number across the class (i.e., double).
  */
 template <int dim, typename number>
-class NavierStokesTransientOperator
+class NavierStokesStabilizedOperator
   : public NavierStokesOperatorBase<dim, number>
 {
 public:
   using FECellIntegrator = FEEvaluation<dim, -1, 0, dim + 1, number>;
   using VectorType       = LinearAlgebra::distributed::Vector<number>;
 
-  NavierStokesTransientOperator();
+  NavierStokesStabilizedOperator();
 
 protected:
   /**
    * @brief Perform cell integral on a cell batch without gathering and scattering
-   * the values, and according to the Jacobian of the discretized transient
-   * Navier-Stokes equations with stabilization.
+   * the values, and according to the Jacobian of the discretized
+   * steady/transient Navier-Stokes equations with stabilization.
    *
    * @param[in] integrator FEEvaluation object that allows to evaluate functions
    * at quadrature points and perform cell integrations.
@@ -544,8 +495,8 @@ protected:
 
   /**
    * @brief Perform cell integral on a cell batch with gathering and scattering
-   * the values, and according to the residual of the discretized transient
-   * Navier-Stokes equations with stabilization.
+   * the values, and according to the residual of the discretized
+   * steady/transient Navier-Stokes equations with stabilization.
    *
    * @param[in] matrix_free Object that contains all data.
    * @param[in,out] dst Global vector where the final result is added.

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -62,12 +62,8 @@ MFNavierStokesSolver<dim>::MFNavierStokesSolver(
   this->fe = std::make_shared<FESystem<dim>>(
     FE_Q<dim>(nsparam.fem_parameters.velocity_order), dim + 1);
 
-  if (is_bdf(this->simulation_control->get_assembly_method()))
-    system_operator =
-      std::make_shared<NavierStokesTransientOperator<dim, double>>();
-  else
-    system_operator =
-      std::make_shared<NavierStokesSteadyOperator<dim, double>>();
+  system_operator =
+    std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
 }
 
 template <int dim>
@@ -666,12 +662,8 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
 
       this->mg_computing_timer.enter_subsection("Set up operators");
 
-      if (is_bdf(this->simulation_control->get_assembly_method()))
-        mg_operators[level] =
-          std::make_shared<NavierStokesTransientOperator<dim, double>>();
-      else
-        mg_operators[level] =
-          std::make_shared<NavierStokesSteadyOperator<dim, double>>();
+      mg_operators[level] =
+        std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
 
       mg_operators[level]->reinit(
         *this->mapping,
@@ -1179,12 +1171,8 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
 
       this->mg_computing_timer.enter_subsection("Set up operators");
 
-      if (is_bdf(this->simulation_control->get_assembly_method()))
-        mg_operators[level] =
-          std::make_shared<NavierStokesTransientOperator<dim, double>>();
-      else
-        mg_operators[level] =
-          std::make_shared<NavierStokesSteadyOperator<dim, double>>();
+      mg_operators[level] =
+        std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
 
       mg_operators[level]->reinit(
         *this->mapping,

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -61,30 +61,13 @@ MFNavierStokesSolver<dim>::MFNavierStokesSolver(
 
   this->fe = std::make_shared<FESystem<dim>>(
     FE_Q<dim>(nsparam.fem_parameters.velocity_order), dim + 1);
-  if ((nsparam.stabilization.use_default_stabilization == true) ||
-      nsparam.stabilization.stabilization ==
-        Parameters::Stabilization::NavierStokesStabilization::pspg_supg)
-    {
-      if (is_bdf(this->simulation_control->get_assembly_method()))
-        system_operator = std::make_shared<
-          NavierStokesTransientSUPGPSPGOperator<dim, double>>();
-      else
-        system_operator =
-          std::make_shared<NavierStokesSUPGPSPGOperator<dim, double>>();
-    }
-  else if (nsparam.stabilization.stabilization ==
-           Parameters::Stabilization::NavierStokesStabilization::gls)
-    {
-      if (is_bdf(this->simulation_control->get_assembly_method()))
-        system_operator =
-          std::make_shared<NavierStokesTransientGLSOperator<dim, double>>();
-      else
-        system_operator =
-          std::make_shared<NavierStokesGLSOperator<dim, double>>();
-    }
+
+  if (is_bdf(this->simulation_control->get_assembly_method()))
+    system_operator =
+      std::make_shared<NavierStokesTransientOperator<dim, double>>();
   else
-    throw std::runtime_error(
-      "Only SUPG/PSPG and GLS stabilization is supported at the moment.");
+    system_operator =
+      std::make_shared<NavierStokesSteadyOperator<dim, double>>();
 }
 
 template <int dim>
@@ -211,6 +194,7 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
     &(*this->forcing_function),
     this->simulation_parameters.physical_properties_manager
       .get_kinematic_viscosity_scale(),
+    this->simulation_parameters.stabilization.stabilization,
     mg_level,
     this->simulation_control);
 
@@ -682,18 +666,12 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
 
       this->mg_computing_timer.enter_subsection("Set up operators");
 
-      if ((this->simulation_parameters.stabilization
-             .use_default_stabilization == true) ||
-          this->simulation_parameters.stabilization.stabilization ==
-            Parameters::Stabilization::NavierStokesStabilization::pspg_supg)
-        {
-          if (is_bdf(this->simulation_control->get_assembly_method()))
-            mg_operators[level] = std::make_shared<
-              NavierStokesTransientSUPGPSPGOperator<dim, double>>();
-          else
-            mg_operators[level] =
-              std::make_shared<NavierStokesSUPGPSPGOperator<dim, double>>();
-        }
+      if (is_bdf(this->simulation_control->get_assembly_method()))
+        mg_operators[level] =
+          std::make_shared<NavierStokesTransientOperator<dim, double>>();
+      else
+        mg_operators[level] =
+          std::make_shared<NavierStokesSteadyOperator<dim, double>>();
 
       mg_operators[level]->reinit(
         *this->mapping,
@@ -703,6 +681,7 @@ MFNavierStokesSolver<dim>::solve_with_LSMG(SolverGMRES<VectorType> &solver)
         &(*this->forcing_function),
         this->simulation_parameters.physical_properties_manager
           .get_kinematic_viscosity_scale(),
+        this->simulation_parameters.stabilization.stabilization,
         level,
         this->simulation_control);
 
@@ -1200,18 +1179,12 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
 
       this->mg_computing_timer.enter_subsection("Set up operators");
 
-      if ((this->simulation_parameters.stabilization
-             .use_default_stabilization == true) ||
-          this->simulation_parameters.stabilization.stabilization ==
-            Parameters::Stabilization::NavierStokesStabilization::pspg_supg)
-        {
-          if (is_bdf(this->simulation_control->get_assembly_method()))
-            mg_operators[level] = std::make_shared<
-              NavierStokesTransientSUPGPSPGOperator<dim, double>>();
-          else
-            mg_operators[level] =
-              std::make_shared<NavierStokesSUPGPSPGOperator<dim, double>>();
-        }
+      if (is_bdf(this->simulation_control->get_assembly_method()))
+        mg_operators[level] =
+          std::make_shared<NavierStokesTransientOperator<dim, double>>();
+      else
+        mg_operators[level] =
+          std::make_shared<NavierStokesSteadyOperator<dim, double>>();
 
       mg_operators[level]->reinit(
         *this->mapping,
@@ -1221,6 +1194,7 @@ MFNavierStokesSolver<dim>::solve_with_GCMG(SolverGMRES<VectorType> &solver)
         &(*this->forcing_function),
         this->simulation_parameters.physical_properties_manager
           .get_kinematic_viscosity_scale(),
+        this->simulation_parameters.stabilization.stabilization,
         numbers::invalid_unsigned_int,
         this->simulation_control);
 

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -576,344 +576,7 @@ template class NavierStokesOperatorBase<2, double>;
 template class NavierStokesOperatorBase<3, double>;
 
 template <int dim, typename number>
-NavierStokesSteadyOperator<dim, number>::NavierStokesSteadyOperator() = default;
-
-/**
- * The expressions calculated in this cell integral are:
- * (q,∇δu) + (v,(u·∇)δu) + (v,(δu·∇)u) - (∇·v,δp) + ν(∇v,∇δu) (Weak form
- * Jacobian),
- * plus three additional terms in the case of SUPG-PSPG stabilization:
- * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ·∇q (PSPG Jacobian)
- * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τu·∇v (SUPG Jacobian Part 1)
- * \+ ((u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2),
- * plus two additional terms in the case of full gls stabilization:
- * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ(−ν∆v) (GLS Jacobian)
- * \+ (∇·δu)τ'(∇·v) (LSIC Jacobian).
- */
-template <int dim, typename number>
-void
-NavierStokesSteadyOperator<dim, number>::do_cell_integral_local(
-  FECellIntegrator &integrator) const
-{
-  integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                      EvaluationFlags::hessians);
-
-  const unsigned int cell = integrator.get_current_cell_index();
-
-  const auto h = integrator.read_cell_data(this->get_element_size());
-
-  for (const auto q : integrator.quadrature_point_indices())
-    {
-      // Evaluate source term function
-      Tensor<1, dim + 1, VectorizedArray<number>> source_value;
-      Point<dim, VectorizedArray<number>>         point_batch =
-        integrator.quadrature_point(q);
-      source_value =
-        evaluate_function<dim, number, dim + 1>(*(this->forcing_function),
-                                                point_batch);
-
-      // Gather the original value/gradient
-      typename FECellIntegrator::value_type    value = integrator.get_value(q);
-      typename FECellIntegrator::gradient_type gradient =
-        integrator.get_gradient(q);
-      typename FECellIntegrator::gradient_type hessian_diagonal =
-        integrator.get_hessian_diagonal(q);
-
-      // Result value/gradient we will use
-      typename FECellIntegrator::value_type    value_result;
-      typename FECellIntegrator::gradient_type gradient_result;
-      typename FECellIntegrator::hessian_type  hessian_result;
-
-      // Gather previous values of the velocity and the pressure
-      auto previous_values   = this->nonlinear_previous_values(cell, q);
-      auto previous_gradient = this->nonlinear_previous_gradient(cell, q);
-      auto previous_hessian_diagonal =
-        this->nonlinear_previous_hessian_diagonal(cell, q);
-
-      // Calculate tau
-      VectorizedArray<number> u_mag_squared = 1e-12;
-      for (unsigned int k = 0; k < dim; ++k)
-        u_mag_squared += Utilities::fixed_power<2>(previous_values[k]);
-
-      const auto tau =
-        1. / std::sqrt(4. * u_mag_squared / h / h +
-                       9. * Utilities::fixed_power<2>(
-                              4. * this->kinematic_viscosity / (h * h)));
-
-      const auto tau_lsic = std::sqrt(u_mag_squared) * h * 0.5;
-
-      // Weak form Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          // ν(∇v,∇δu)
-          gradient_result[i] = this->kinematic_viscosity * gradient[i];
-          // -(∇·v,δp)
-          gradient_result[i][i] += -value[dim];
-          // +(q,∇δu)
-          value_result[dim] += gradient[i][i];
-
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // +(v,(u·∇)δu + (δu·∇)u)
-              value_result[i] += gradient[i][k] * previous_values[k] +
-                                 previous_gradient[i][k] * value[k];
-            }
-        }
-
-      // PSPG Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // (-ν∆δu + (u·∇)δu + (δu·∇)u)·τ∇q
-              gradient_result[dim][i] +=
-                tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
-                       gradient[i][k] * previous_values[k] +
-                       previous_gradient[i][k] * value[k]);
-            }
-        }
-      // (∇δp)τ·∇q
-      gradient_result[dim] += tau * gradient[dim];
-
-      // SUPG Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // Part 1
-              for (unsigned int l = 0; l < dim; ++l)
-                {
-                  // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(u·∇)v
-                  gradient_result[i][k] +=
-                    tau * previous_values[k] *
-                    (gradient[i][l] * previous_values[l] +
-                     previous_gradient[i][l] * value[l] -
-                     this->kinematic_viscosity * hessian_diagonal[i][l]);
-                }
-
-              // +(∇δp)τ(u·∇)v
-              gradient_result[i][k] +=
-                tau * previous_values[k] * gradient[dim][i];
-
-              // Part 2
-              for (unsigned int l = 0; l < dim; ++l)
-                {
-                  // +((u·∇)u -ν∆u)τ(δu·∇)v
-                  gradient_result[i][k] +=
-                    tau * value[k] *
-                    (previous_gradient[i][l] * previous_values[l] -
-                     this->kinematic_viscosity *
-                       previous_hessian_diagonal[i][l]);
-                }
-              // +(∇p - f)τ(δu·∇)v
-              gradient_result[i][k] +=
-                tau * value[k] * (previous_gradient[dim][i] - source_value[i]);
-            }
-        }
-
-      if (this->stabilization ==
-          Parameters::Stabilization::NavierStokesStabilization::gls)
-        {
-          // GLS Jacobian
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  for (unsigned int l = 0; l < dim; ++l)
-                    {
-                      // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
-                      hessian_result[i][k][k] +=
-                        tau * -this->kinematic_viscosity *
-                        (gradient[i][l] * previous_values[l] +
-                         previous_gradient[i][l] * value[l] -
-                         this->kinematic_viscosity * hessian_diagonal[i][l]);
-                    }
-
-                  // +(∇δp)τ(−ν∆v)
-                  hessian_result[i][k][k] +=
-                    tau * -this->kinematic_viscosity * gradient[dim][i];
-
-                  // LSIC term
-                  // (∇·δu)τ'(∇·v)
-                  gradient_result[i][i] += tau_lsic * gradient[k][k];
-                }
-            }
-        }
-
-
-      integrator.submit_gradient(gradient_result, q);
-      integrator.submit_value(value_result, q);
-      integrator.submit_hessian(hessian_result, q);
-    }
-
-  integrator.integrate(EvaluationFlags::values | EvaluationFlags::gradients |
-                       EvaluationFlags::hessians);
-}
-
-/**
- * The expressions calculated in this cell integral are:
- * (q, ∇·u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form),
- * plus two additional terms in the case of SUPG-PSPG stabilization:
- * \+ ((u·∇)u + ∇p - ν∆u - f)τ∇·q (PSPG term)
- * \+ ((u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term),
- * plus two additional terms in the case of full gls stabilization:
- * \+ ((u·∇)u + ∇p - ν∆u - f)τ(−ν∆v) (GLS term)
- * \+ (∇·u)τ'(∇·v) (LSIC term).
- */
-template <int dim, typename number>
-void
-NavierStokesSteadyOperator<dim, number>::local_evaluate_residual(
-  const MatrixFree<dim, number>               &matrix_free,
-  VectorType                                  &dst,
-  const VectorType                            &src,
-  const std::pair<unsigned int, unsigned int> &range) const
-{
-  FECellIntegrator integrator(matrix_free);
-
-  for (unsigned int cell = range.first; cell < range.second; ++cell)
-    {
-      integrator.reinit(cell);
-      integrator.read_dof_values_plain(src);
-      integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians);
-
-      const auto h = integrator.read_cell_data(this->get_element_size());
-
-      for (const auto q : integrator.quadrature_point_indices())
-        {
-          // Evaluate source term function
-          Tensor<1, dim + 1, VectorizedArray<number>> source_value;
-          Point<dim, VectorizedArray<number>>         point_batch =
-            integrator.quadrature_point(q);
-          source_value =
-            evaluate_function<dim, number, dim + 1>(*(this->forcing_function),
-                                                    point_batch);
-
-          // Gather the original value/gradient
-          typename FECellIntegrator::value_type value = integrator.get_value(q);
-          typename FECellIntegrator::gradient_type gradient =
-            integrator.get_gradient(q);
-          typename FECellIntegrator::gradient_type hessian_diagonal =
-            integrator.get_hessian_diagonal(q);
-
-          // Calculate tau
-          VectorizedArray<number> u_mag_squared = 1e-12;
-          for (unsigned int k = 0; k < dim; ++k)
-            u_mag_squared += Utilities::fixed_power<2>(value[k]);
-
-          const auto tau =
-            1. / std::sqrt(4. * u_mag_squared / h / h +
-                           9. * Utilities::fixed_power<2>(
-                                  4. * this->kinematic_viscosity / (h * h)));
-
-          const auto tau_lsic = std::sqrt(u_mag_squared) * h * 0.5;
-
-          // Result value/gradient we will use
-          typename FECellIntegrator::value_type    value_result;
-          typename FECellIntegrator::gradient_type gradient_result;
-          typename FECellIntegrator::hessian_type  hessian_result;
-
-          // Weak form
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              // ν(∇v,∇u)
-              gradient_result[i] = this->kinematic_viscosity * gradient[i];
-              // -(∇·v,p)
-              gradient_result[i][i] += -value[dim];
-              // -(v,f)
-              value_result[i] = -source_value[i];
-              // +(q,∇·u)
-              value_result[dim] += gradient[i][i];
-
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  // +(v,(u·∇)u)
-                  value_result[i] += gradient[i][k] * value[k];
-                }
-            }
-
-          // PSPG term
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              // (-f)·τ∇q
-              gradient_result[dim][i] += -tau * source_value[i];
-
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  //(-ν∆u + (u·∇)u)·τ∇q
-                  gradient_result[dim][i] +=
-                    tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
-                           gradient[i][k] * value[k]);
-                }
-            }
-          // +(∇p)τ∇·q
-          gradient_result[dim] += tau * gradient[dim];
-
-          // SUPG term
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  for (unsigned int l = 0; l < dim; ++l)
-                    {
-                      // (-ν∆u + (u·∇)u)τ(u·∇)v
-                      gradient_result[i][k] +=
-                        tau * value[k] *
-                        (-this->kinematic_viscosity * hessian_diagonal[i][l] +
-                         gradient[i][l] * value[l]);
-                    }
-                  // + (∇p - f)τ(u·∇)v
-                  gradient_result[i][k] +=
-                    tau * value[k] * (gradient[dim][i] - source_value[i]);
-                }
-            }
-
-          if (this->stabilization ==
-              Parameters::Stabilization::NavierStokesStabilization::gls)
-            {
-              // GLS term
-              for (unsigned int i = 0; i < dim; ++i)
-                {
-                  for (unsigned int k = 0; k < dim; ++k)
-                    {
-                      for (unsigned int l = 0; l < dim; ++l)
-                        {
-                          // (-ν∆u + (u·∇)u)τ(−ν∆v)
-                          hessian_result[i][k][k] +=
-                            tau * -this->kinematic_viscosity *
-                            (-this->kinematic_viscosity *
-                               hessian_diagonal[i][l] +
-                             gradient[i][l] * value[l]);
-                        }
-                      // + (∇p - f)τ(−ν∆v)
-                      hessian_result[i][k][k] +=
-                        tau * -this->kinematic_viscosity *
-                        (gradient[dim][i] - source_value[i]);
-
-                      // LSIC term
-                      // (∇·u)τ'(∇·v)
-                      gradient_result[i][i] += tau_lsic * gradient[k][k];
-                    }
-                }
-            }
-
-          integrator.submit_gradient(gradient_result, q);
-          integrator.submit_value(value_result, q);
-          integrator.submit_hessian(hessian_result, q);
-        }
-
-      integrator.integrate_scatter(EvaluationFlags::values |
-                                     EvaluationFlags::gradients |
-                                     EvaluationFlags::hessians,
-                                   dst);
-    }
-}
-
-template class NavierStokesSteadyOperator<2, double>;
-template class NavierStokesSteadyOperator<3, double>;
-
-template <int dim, typename number>
-NavierStokesTransientOperator<dim, number>::NavierStokesTransientOperator() =
+NavierStokesStabilizedOperator<dim, number>::NavierStokesStabilizedOperator() =
   default;
 
 /**
@@ -930,7 +593,7 @@ NavierStokesTransientOperator<dim, number>::NavierStokesTransientOperator() =
  */
 template <int dim, typename number>
 void
-NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
+NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
   FECellIntegrator &integrator) const
 {
   integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
@@ -940,14 +603,22 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
 
   const auto h = integrator.read_cell_data(this->get_element_size());
 
-  // Vector for the BDF coefficients
-  const Vector<double> &bdf_coefs =
-    this->simulation_control->get_bdf_coefficients();
-  const auto time_steps_vector =
-    this->simulation_control->get_time_steps_vector();
-  const double dt  = time_steps_vector[0];
-  const double sdt = 1. / dt;
+  // To identify whether the problem is transient or steady
+  bool transient =
+    (is_bdf(this->simulation_control->get_assembly_method())) ? true : false;
 
+  // Time step and vector for BDF coefficients
+  Vector<double> bdf_coefs;
+  double         sdt = 0.0;
+
+  if (transient)
+    {
+      bdf_coefs = this->simulation_control->get_bdf_coefficients();
+      const auto time_steps_vector =
+        this->simulation_control->get_time_steps_vector();
+      const double dt = time_steps_vector[0];
+      sdt             = 1. / dt;
+    }
 
   for (const auto q : integrator.quadrature_point_indices())
     {
@@ -977,9 +648,11 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
       auto previous_hessian_diagonal =
         this->nonlinear_previous_hessian_diagonal(cell, q);
 
-      // Time derivatives of previous solutions
-      auto previous_time_derivatives =
-        this->time_derivatives_previous_solutions(cell, q);
+      Tensor<1, dim + 1, VectorizedArray<number>> previous_time_derivatives;
+      if (transient)
+        previous_time_derivatives =
+          this->time_derivatives_previous_solutions(cell, q);
+
 
       // Calculate tau
       VectorizedArray<number> u_mag_squared = 1e-12;
@@ -1011,7 +684,8 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
                                  previous_gradient[i][k] * value[k];
             }
           // +(v,∂t δu)
-          value_result[i] += bdf_coefs[0] * value[i];
+          if (transient)
+            value_result[i] += bdf_coefs[0] * value[i];
         }
 
       // PSPG Jacobian
@@ -1026,7 +700,8 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
                        previous_gradient[i][k] * value[k]);
             }
           // +(∂t δu)·τ∇q
-          gradient_result[dim][i] += tau * bdf_coefs[0] * value[i];
+          if (transient)
+            gradient_result[dim][i] += tau * bdf_coefs[0] * value[i];
         }
       // (∇δp)τ·∇q
       gradient_result[dim] += tau * gradient[dim];
@@ -1046,10 +721,15 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
                      previous_gradient[i][l] * value[l] -
                      this->kinematic_viscosity * hessian_diagonal[i][l]);
                 }
-              // +(∇δp + ∂t δu)τ(u·∇)v
+              // +(∇δp)τ(u·∇)v
               gradient_result[i][k] +=
-                tau * previous_values[k] *
-                (gradient[dim][i] + bdf_coefs[0] * value[i]);
+                tau * previous_values[k] * (gradient[dim][i]);
+
+              // +(∂t δu)τ(u·∇)v
+              if (transient)
+                gradient_result[i][k] +=
+                  tau * previous_values[k] * (bdf_coefs[0] * value[i]);
+
 
               // Part 2
               for (unsigned int l = 0; l < dim; ++l)
@@ -1061,12 +741,15 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
                      this->kinematic_viscosity *
                        previous_hessian_diagonal[i][l]);
                 }
-              // +(∇p - f + ∂t u)τ(δu·∇)v
+              // +(∇p - f)τ(δu·∇)v
               gradient_result[i][k] +=
-                tau * value[k] *
-                (previous_gradient[dim][i] - source_value[i] +
-                 bdf_coefs[0] * previous_values[i] +
-                 previous_time_derivatives[i]);
+                tau * value[k] * (previous_gradient[dim][i] - source_value[i]);
+
+              // +(∂t u)τ(δu·∇)v
+              if (transient)
+                gradient_result[i][k] += tau * value[k] *
+                                         (bdf_coefs[0] * previous_values[i] +
+                                          previous_time_derivatives[i]);
             }
         }
 
@@ -1088,10 +771,16 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
                          this->kinematic_viscosity * hessian_diagonal[i][l]);
                     }
 
-                  // +(∇δp + ∂t δu)τ(−ν∆v)
+                  // +(∇δp)τ(−ν∆v)
                   hessian_result[i][k][k] +=
-                    tau * -this->kinematic_viscosity *
-                    (gradient[dim][i] + bdf_coefs[0] * value[i]);
+                    tau * -this->kinematic_viscosity * (gradient[dim][i]);
+
+                  // +(∂t δu)τ(−ν∆v)
+                  if (transient)
+                    hessian_result[i][k][k] += tau *
+                                               -this->kinematic_viscosity *
+                                               (bdf_coefs[0] * value[i]);
+
 
                   // LSIC term
                   // (∇·δu)τ'(∇·v)
@@ -1121,7 +810,7 @@ NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
  */
 template <int dim, typename number>
 void
-NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
+NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
   const MatrixFree<dim, number>               &matrix_free,
   VectorType                                  &dst,
   const VectorType                            &src,
@@ -1138,13 +827,23 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
 
       const auto h = integrator.read_cell_data(this->get_element_size());
 
-      // Vector for the BDF coefficients
-      const Vector<double> &bdf_coefs =
-        this->simulation_control->get_bdf_coefficients();
-      const auto time_steps_vector =
-        this->simulation_control->get_time_steps_vector();
-      const double dt  = time_steps_vector[0];
-      const double sdt = 1. / dt;
+      // To identify whether the problem is transient or steady
+      bool transient =
+        (is_bdf(this->simulation_control->get_assembly_method())) ? true :
+                                                                    false;
+
+      // Time step and vector for BDF coefficients
+      Vector<double> bdf_coefs;
+      double         sdt = 0.0;
+
+      if (transient)
+        {
+          bdf_coefs = this->simulation_control->get_bdf_coefficients();
+          const auto time_steps_vector =
+            this->simulation_control->get_time_steps_vector();
+          const double dt = time_steps_vector[0];
+          sdt             = 1. / dt;
+        }
 
       for (const auto q : integrator.quadrature_point_indices())
         {
@@ -1163,9 +862,12 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
           typename FECellIntegrator::gradient_type hessian_diagonal =
             integrator.get_hessian_diagonal(q);
 
-          // Time derivatives of previoussolutions
-          auto previous_time_derivatives =
-            this->time_derivatives_previous_solutions(cell, q);
+          // Time derivatives of previous solutions
+          Tensor<1, dim + 1, VectorizedArray<number>> previous_time_derivatives;
+          if (transient)
+            previous_time_derivatives =
+              this->time_derivatives_previous_solutions(cell, q);
+
 
           // Calculate tau
           VectorizedArray<number> u_mag_squared = 1e-12;
@@ -1192,9 +894,15 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
               gradient_result[i] = this->kinematic_viscosity * gradient[i];
               // -(∇·v,p)
               gradient_result[i][i] += -value[dim];
-              // +(v,-f + ∂t u)
-              value_result[i] = -source_value[i] + bdf_coefs[0] * value[i] +
-                                previous_time_derivatives[i];
+              // +(v,-f)
+              value_result[i] = -source_value[i];
+
+              // +(v,∂t u)
+              if (transient)
+                value_result[i] +=
+                  bdf_coefs[0] * value[i] + previous_time_derivatives[i];
+
+
               // +(q,∇·u)
               value_result[dim] += gradient[i][i];
 
@@ -1215,10 +923,13 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
                     tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
                            gradient[i][k] * value[k]);
                 }
-              // +(-f + ∂t u)·τ∇q
-              gradient_result[dim][i] +=
-                tau * (-source_value[i] + bdf_coefs[0] * value[i] +
-                       previous_time_derivatives[i]);
+              // +(-f)·τ∇q
+              gradient_result[dim][i] += tau * (-source_value[i]);
+
+              // +(∂t u)·τ∇q
+              if (transient)
+                gradient_result[dim][i] += tau * (bdf_coefs[0] * value[i] +
+                                                  previous_time_derivatives[i]);
             }
           // +(∇p)τ∇·q
           gradient_result[dim] += tau * gradient[dim];
@@ -1239,11 +950,15 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
                       gradient_result[i][k] +=
                         tau * value[k] * gradient[i][l] * value[l];
                     }
-                  // + (∇p - f + ∂t u)τ(u·∇)v
+                  // + (∇p - f)τ(u·∇)v
                   gradient_result[i][k] +=
-                    tau * value[k] *
-                    (gradient[dim][i] - source_value[i] +
-                     bdf_coefs[0] * value[i] + previous_time_derivatives[i]);
+                    tau * value[k] * (gradient[dim][i] - source_value[i]);
+
+                  // + (∂t u)τ(u·∇)v
+                  if (transient)
+                    gradient_result[i][k] +=
+                      tau * value[k] *
+                      (bdf_coefs[0] * value[i] + previous_time_derivatives[i]);
                 }
             }
 
@@ -1264,12 +979,18 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
                                hessian_diagonal[i][l] +
                              gradient[i][l] * value[l]);
                         }
-                      // + (∇p - f + ∂t u)τ(−ν∆v)
+                      // + (∇p - f)τ(−ν∆v)
                       hessian_result[i][k][k] +=
                         tau * -this->kinematic_viscosity *
-                        (gradient[dim][i] - source_value[i] +
-                         +bdf_coefs[0] * value[i] +
-                         previous_time_derivatives[i]);
+                        (gradient[dim][i] - source_value[i]);
+
+                      // + (∂t u)τ(−ν∆v)
+                      if (transient)
+                        hessian_result[i][k][k] +=
+                          tau * -this->kinematic_viscosity *
+                          (bdf_coefs[0] * value[i] +
+                           previous_time_derivatives[i]);
+
 
                       // LSIC term
                       // (∇·u)τ'(∇·v)
@@ -1290,5 +1011,5 @@ NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
     }
 }
 
-template class NavierStokesTransientOperator<2, double>;
-template class NavierStokesTransientOperator<3, double>;
+template class NavierStokesStabilizedOperator<2, double>;
+template class NavierStokesStabilizedOperator<3, double>;

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -608,12 +608,12 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
     (is_bdf(this->simulation_control->get_assembly_method())) ? true : false;
 
   // Time step and vector for BDF coefficients
-  Vector<double> bdf_coefs;
-  double         sdt = 0.0;
+  const Vector<double> *bdf_coefs;
+  double                sdt = 0.0;
 
   if (transient)
     {
-      bdf_coefs = this->simulation_control->get_bdf_coefficients();
+      bdf_coefs = &this->simulation_control->get_bdf_coefficients();
       const auto time_steps_vector =
         this->simulation_control->get_time_steps_vector();
       const double dt = time_steps_vector[0];
@@ -685,7 +685,7 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
             }
           // +(v,∂t δu)
           if (transient)
-            value_result[i] += bdf_coefs[0] * value[i];
+            value_result[i] += (*bdf_coefs)[0] * value[i];
         }
 
       // PSPG Jacobian
@@ -701,7 +701,7 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
             }
           // +(∂t δu)·τ∇q
           if (transient)
-            gradient_result[dim][i] += tau * bdf_coefs[0] * value[i];
+            gradient_result[dim][i] += tau * (*bdf_coefs)[0] * value[i];
         }
       // (∇δp)τ·∇q
       gradient_result[dim] += tau * gradient[dim];
@@ -728,7 +728,7 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
               // +(∂t δu)τ(u·∇)v
               if (transient)
                 gradient_result[i][k] +=
-                  tau * previous_values[k] * (bdf_coefs[0] * value[i]);
+                  tau * previous_values[k] * ((*bdf_coefs)[0] * value[i]);
 
 
               // Part 2
@@ -748,7 +748,7 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
               // +(∂t u)τ(δu·∇)v
               if (transient)
                 gradient_result[i][k] += tau * value[k] *
-                                         (bdf_coefs[0] * previous_values[i] +
+                                         ((*bdf_coefs)[0] * previous_values[i] +
                                           previous_time_derivatives[i]);
             }
         }
@@ -779,7 +779,7 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
                   if (transient)
                     hessian_result[i][k][k] += tau *
                                                -this->kinematic_viscosity *
-                                               (bdf_coefs[0] * value[i]);
+                                               ((*bdf_coefs)[0] * value[i]);
 
 
                   // LSIC term
@@ -833,12 +833,12 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
                                                                     false;
 
       // Time step and vector for BDF coefficients
-      Vector<double> bdf_coefs;
-      double         sdt = 0.0;
+      const Vector<double> *bdf_coefs;
+      double                sdt = 0.0;
 
       if (transient)
         {
-          bdf_coefs = this->simulation_control->get_bdf_coefficients();
+          bdf_coefs = &this->simulation_control->get_bdf_coefficients();
           const auto time_steps_vector =
             this->simulation_control->get_time_steps_vector();
           const double dt = time_steps_vector[0];
@@ -900,7 +900,7 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
               // +(v,∂t u)
               if (transient)
                 value_result[i] +=
-                  bdf_coefs[0] * value[i] + previous_time_derivatives[i];
+                  (*bdf_coefs)[0] * value[i] + previous_time_derivatives[i];
 
 
               // +(q,∇·u)
@@ -928,7 +928,7 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
 
               // +(∂t u)·τ∇q
               if (transient)
-                gradient_result[dim][i] += tau * (bdf_coefs[0] * value[i] +
+                gradient_result[dim][i] += tau * ((*bdf_coefs)[0] * value[i] +
                                                   previous_time_derivatives[i]);
             }
           // +(∇p)τ∇·q
@@ -956,9 +956,9 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
 
                   // + (∂t u)τ(u·∇)v
                   if (transient)
-                    gradient_result[i][k] +=
-                      tau * value[k] *
-                      (bdf_coefs[0] * value[i] + previous_time_derivatives[i]);
+                    gradient_result[i][k] += tau * value[k] *
+                                             ((*bdf_coefs)[0] * value[i] +
+                                              previous_time_derivatives[i]);
                 }
             }
 
@@ -988,7 +988,7 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
                       if (transient)
                         hessian_result[i][k][k] +=
                           tau * -this->kinematic_viscosity *
-                          (bdf_coefs[0] * value[i] +
+                          ((*bdf_coefs)[0] * value[i] +
                            previous_time_derivatives[i]);
 
 

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -79,6 +79,7 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
   const Quadrature<dim>             &quadrature,
   const Function<dim>               *forcing_function,
   const double                       kinematic_viscosity,
+  const StabilizationType            stabilization,
   const unsigned int                 mg_level,
   std::shared_ptr<SimulationControl> simulation_control)
 {
@@ -88,6 +89,7 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
                quadrature,
                forcing_function,
                kinematic_viscosity,
+               stabilization,
                mg_level,
                simulation_control);
 }
@@ -101,6 +103,7 @@ NavierStokesOperatorBase<dim, number>::reinit(
   const Quadrature<dim>             &quadrature,
   const Function<dim>               *forcing_function,
   const double                       kinematic_viscosity,
+  const StabilizationType            stabilization,
   const unsigned int                 mg_level,
   std::shared_ptr<SimulationControl> simulation_control)
 {
@@ -121,6 +124,17 @@ NavierStokesOperatorBase<dim, number>::reinit(
   this->forcing_function = forcing_function;
 
   this->kinematic_viscosity = kinematic_viscosity;
+
+  if (stabilization ==
+        Parameters::Stabilization::NavierStokesStabilization::pspg_supg ||
+      stabilization ==
+        Parameters::Stabilization::NavierStokesStabilization::gls)
+    {
+      this->stabilization = stabilization;
+    }
+  else
+    throw std::runtime_error(
+      "Only SUPG/PSPG and GLS stabilization is supported at the moment.");
 
   this->simulation_control = simulation_control;
 
@@ -562,584 +576,23 @@ template class NavierStokesOperatorBase<2, double>;
 template class NavierStokesOperatorBase<3, double>;
 
 template <int dim, typename number>
-NavierStokesSUPGPSPGOperator<dim, number>::NavierStokesSUPGPSPGOperator() =
-  default;
+NavierStokesSteadyOperator<dim, number>::NavierStokesSteadyOperator() = default;
 
 /**
  * The expressions calculated in this cell integral are:
  * (q,∇δu) + (v,(u·∇)δu) + (v,(δu·∇)u) - (∇·v,δp) + ν(∇v,∇δu) (Weak form
- * Jacobian)
+ * Jacobian),
+ * plus three additional terms in the case of SUPG-PSPG stabilization:
  * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ·∇q (PSPG Jacobian)
  * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τu·∇v (SUPG Jacobian Part 1)
- * \+ ((u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2).
- */
-template <int dim, typename number>
-void
-NavierStokesSUPGPSPGOperator<dim, number>::do_cell_integral_local(
-  FECellIntegrator &integrator) const
-{
-  integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                      EvaluationFlags::hessians);
-
-  const unsigned int cell = integrator.get_current_cell_index();
-
-  const auto h = integrator.read_cell_data(this->get_element_size());
-
-  for (const auto q : integrator.quadrature_point_indices())
-    {
-      // Evaluate source term function
-      Tensor<1, dim + 1, VectorizedArray<number>> source_value;
-      Point<dim, VectorizedArray<number>>         point_batch =
-        integrator.quadrature_point(q);
-      source_value =
-        evaluate_function<dim, number, dim + 1>(*(this->forcing_function),
-                                                point_batch);
-
-      // Gather the original value/gradient
-      typename FECellIntegrator::value_type    value = integrator.get_value(q);
-      typename FECellIntegrator::gradient_type gradient =
-        integrator.get_gradient(q);
-      typename FECellIntegrator::gradient_type hessian_diagonal =
-        integrator.get_hessian_diagonal(q);
-
-      // Result value/gradient we will use
-      typename FECellIntegrator::value_type    value_result;
-      typename FECellIntegrator::gradient_type gradient_result;
-
-      // Gather previous values of the velocity and the pressure
-      auto previous_values   = this->nonlinear_previous_values(cell, q);
-      auto previous_gradient = this->nonlinear_previous_gradient(cell, q);
-      auto previous_hessian_diagonal =
-        this->nonlinear_previous_hessian_diagonal(cell, q);
-
-      // Calculate tau
-      VectorizedArray<number> u_mag_squared = 1e-12;
-      for (unsigned int k = 0; k < dim; ++k)
-        u_mag_squared += Utilities::fixed_power<2>(previous_values[k]);
-
-      const auto tau =
-        1. / std::sqrt(4. * u_mag_squared / h / h +
-                       9. * Utilities::fixed_power<2>(
-                              4. * this->kinematic_viscosity / (h * h)));
-
-      // Weak form Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          // ν(∇v,∇δu)
-          gradient_result[i] = this->kinematic_viscosity * gradient[i];
-          // -(∇·v,δp)
-          gradient_result[i][i] += -value[dim];
-          // +(q,∇δu)
-          value_result[dim] += gradient[i][i];
-
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // +(v,(u·∇)δu + (δu·∇)u)
-              value_result[i] += gradient[i][k] * previous_values[k] +
-                                 previous_gradient[i][k] * value[k];
-            }
-        }
-
-      // PSPG Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // (-ν∆δu + (u·∇)δu + (δu·∇)u)·τ∇q
-              gradient_result[dim][i] +=
-                tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
-                       gradient[i][k] * previous_values[k] +
-                       previous_gradient[i][k] * value[k]);
-            }
-        }
-      // (∇δp)τ·∇q
-      gradient_result[dim] += tau * gradient[dim];
-
-      // SUPG Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // Part 1
-              for (unsigned int l = 0; l < dim; ++l)
-                {
-                  // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(u·∇)v
-                  gradient_result[i][k] +=
-                    tau * previous_values[k] *
-                    (gradient[i][l] * previous_values[l] +
-                     previous_gradient[i][l] * value[l] -
-                     this->kinematic_viscosity * hessian_diagonal[i][l]);
-                }
-
-              // +(∇δp)τ(u·∇)v
-              gradient_result[i][k] +=
-                tau * previous_values[k] * gradient[dim][i];
-
-              // Part 2
-              for (unsigned int l = 0; l < dim; ++l)
-                {
-                  // +((u·∇)u -ν∆u)τ(δu·∇)v
-                  gradient_result[i][k] +=
-                    tau * value[k] *
-                    (previous_gradient[i][l] * previous_values[l] -
-                     this->kinematic_viscosity *
-                       previous_hessian_diagonal[i][l]);
-                }
-              // +(∇p - f)τ(δu·∇)v
-              gradient_result[i][k] +=
-                tau * value[k] * (previous_gradient[dim][i] - source_value[i]);
-            }
-        }
-
-      integrator.submit_gradient(gradient_result, q);
-      integrator.submit_value(value_result, q);
-    }
-
-  integrator.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
-}
-
-/**
- * The expressions calculated in this cell integral are:
- * (q, ∇·u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form)
- * \+ ((u·∇)u + ∇p - ν∆u - f)τ∇·q (PSPG term)
- * \+ ((u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term).
- */
-template <int dim, typename number>
-void
-NavierStokesSUPGPSPGOperator<dim, number>::local_evaluate_residual(
-  const MatrixFree<dim, number>               &matrix_free,
-  VectorType                                  &dst,
-  const VectorType                            &src,
-  const std::pair<unsigned int, unsigned int> &range) const
-{
-  FECellIntegrator integrator(matrix_free);
-
-  for (unsigned int cell = range.first; cell < range.second; ++cell)
-    {
-      integrator.reinit(cell);
-      integrator.read_dof_values_plain(src);
-      integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians);
-
-      const auto h = integrator.read_cell_data(this->get_element_size());
-
-      for (const auto q : integrator.quadrature_point_indices())
-        {
-          // Evaluate source term function
-          Tensor<1, dim + 1, VectorizedArray<number>> source_value;
-          Point<dim, VectorizedArray<number>>         point_batch =
-            integrator.quadrature_point(q);
-          source_value =
-            evaluate_function<dim, number, dim + 1>(*(this->forcing_function),
-                                                    point_batch);
-
-          // Gather the original value/gradient
-          typename FECellIntegrator::value_type value = integrator.get_value(q);
-          typename FECellIntegrator::gradient_type gradient =
-            integrator.get_gradient(q);
-          typename FECellIntegrator::gradient_type hessian_diagonal =
-            integrator.get_hessian_diagonal(q);
-
-          // Calculate tau
-          VectorizedArray<number> u_mag_squared = 1e-12;
-          for (unsigned int k = 0; k < dim; ++k)
-            u_mag_squared += Utilities::fixed_power<2>(value[k]);
-
-          const auto tau =
-            1. / std::sqrt(4. * u_mag_squared / h / h +
-                           9. * Utilities::fixed_power<2>(
-                                  4. * this->kinematic_viscosity / (h * h)));
-
-          // Result value/gradient we will use
-          typename FECellIntegrator::value_type    value_result;
-          typename FECellIntegrator::gradient_type gradient_result;
-
-          // Weak form
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              // ν(∇v,∇u)
-              gradient_result[i] = this->kinematic_viscosity * gradient[i];
-              // -(∇·v,p)
-              gradient_result[i][i] += -value[dim];
-              // -(v,f)
-              value_result[i] = -source_value[i];
-              // +(q,∇·u)
-              value_result[dim] += gradient[i][i];
-
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  // +(v,(u·∇)u)
-                  value_result[i] += gradient[i][k] * value[k];
-                }
-            }
-
-          // PSPG term
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              // (-f)·τ∇q
-              gradient_result[dim][i] += -tau * source_value[i];
-
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  //(-ν∆u + (u·∇)u)·τ∇q
-                  gradient_result[dim][i] +=
-                    tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
-                           gradient[i][k] * value[k]);
-                }
-            }
-          // +(∇p)τ∇·q
-          gradient_result[dim] += tau * gradient[dim];
-
-          // SUPG term
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  for (unsigned int l = 0; l < dim; ++l)
-                    {
-                      // (-ν∆u + (u·∇)u)τ(u·∇)v
-                      gradient_result[i][k] +=
-                        tau * value[k] *
-                        (-this->kinematic_viscosity * hessian_diagonal[i][l] +
-                         gradient[i][l] * value[l]);
-                    }
-                  // + (∇p - f)τ(u·∇)v
-                  gradient_result[i][k] +=
-                    tau * value[k] * (gradient[dim][i] - source_value[i]);
-                }
-            }
-
-          integrator.submit_gradient(gradient_result, q);
-          integrator.submit_value(value_result, q);
-        }
-
-      integrator.integrate_scatter(EvaluationFlags::values |
-                                     EvaluationFlags::gradients,
-                                   dst);
-    }
-}
-
-template class NavierStokesSUPGPSPGOperator<2, double>;
-template class NavierStokesSUPGPSPGOperator<3, double>;
-
-template <int dim, typename number>
-NavierStokesTransientSUPGPSPGOperator<dim, number>::
-  NavierStokesTransientSUPGPSPGOperator() = default;
-
-/**
- * The expressions calculated in this cell integral are:
- * (q,∇δu) + (v,∂t δu) + (v,(u·∇)δu) + (v,(δu·∇)u) - (∇·v,δp) + ν(∇v,∇δu) (Weak
- * form Jacobian)
- * \+ (∂t δu +(u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ·∇q (PSPG Jacobian)
- * \+ (∂t δu +(u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τu·∇v (SUPG Jacobian Part 1)
- * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2).
- */
-template <int dim, typename number>
-void
-NavierStokesTransientSUPGPSPGOperator<dim, number>::do_cell_integral_local(
-  FECellIntegrator &integrator) const
-{
-  integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                      EvaluationFlags::hessians);
-
-  const unsigned int cell = integrator.get_current_cell_index();
-
-  const auto h = integrator.read_cell_data(this->get_element_size());
-
-  // Vector for the BDF coefficients
-  const Vector<double> &bdf_coefs =
-    this->simulation_control->get_bdf_coefficients();
-  const auto time_steps_vector =
-    this->simulation_control->get_time_steps_vector();
-  const double dt  = time_steps_vector[0];
-  const double sdt = 1. / dt;
-
-
-  for (const auto q : integrator.quadrature_point_indices())
-    {
-      // Evaluate source term function
-      Tensor<1, dim + 1, VectorizedArray<number>> source_value;
-      Point<dim, VectorizedArray<number>>         point_batch =
-        integrator.quadrature_point(q);
-      source_value =
-        evaluate_function<dim, number, dim + 1>(*(this->forcing_function),
-                                                point_batch);
-
-      // Gather the original value/gradient
-      typename FECellIntegrator::value_type    value = integrator.get_value(q);
-      typename FECellIntegrator::gradient_type gradient =
-        integrator.get_gradient(q);
-      typename FECellIntegrator::gradient_type hessian_diagonal =
-        integrator.get_hessian_diagonal(q);
-
-      // Result value/gradient we will use
-      typename FECellIntegrator::value_type    value_result;
-      typename FECellIntegrator::gradient_type gradient_result;
-
-      // Gather previous values of the velocity and the pressure
-      auto previous_values   = this->nonlinear_previous_values(cell, q);
-      auto previous_gradient = this->nonlinear_previous_gradient(cell, q);
-      auto previous_hessian_diagonal =
-        this->nonlinear_previous_hessian_diagonal(cell, q);
-
-      // Time derivatives of previous solutions
-      auto previous_time_derivatives =
-        this->time_derivatives_previous_solutions(cell, q);
-
-      // Calculate tau
-      VectorizedArray<number> u_mag_squared = 1e-12;
-      for (unsigned int k = 0; k < dim; ++k)
-        u_mag_squared += Utilities::fixed_power<2>(previous_values[k]);
-
-      const auto tau =
-        1. /
-        std::sqrt(Utilities::fixed_power<2>(sdt) + 4. * u_mag_squared / h / h +
-                  9. * Utilities::fixed_power<2>(
-                         4. * this->kinematic_viscosity / (h * h)));
-
-      // Weak form Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          // ν(∇v,∇δu)
-          gradient_result[i] = this->kinematic_viscosity * gradient[i];
-          // -(∇·v,δp)
-          gradient_result[i][i] += -value[dim];
-          // +(q,∇δu)
-          value_result[dim] += gradient[i][i];
-
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // +(v,(u·∇)δu + (δu·∇)u)
-              value_result[i] += gradient[i][k] * previous_values[k] +
-                                 previous_gradient[i][k] * value[k];
-            }
-          // +(v,∂t δu)
-          value_result[i] += bdf_coefs[0] * value[i];
-        }
-
-      // PSPG Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // (-ν∆δu + (u·∇)δu + (δu·∇)u)·τ∇q
-              gradient_result[dim][i] +=
-                tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
-                       gradient[i][k] * previous_values[k] +
-                       previous_gradient[i][k] * value[k]);
-            }
-          // +(∂t δu)·τ∇q
-          gradient_result[dim][i] += tau * bdf_coefs[0] * value[i];
-        }
-      // (∇δp)τ·∇q
-      gradient_result[dim] += tau * gradient[dim];
-
-      // SUPG Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
-        {
-          for (unsigned int k = 0; k < dim; ++k)
-            {
-              // Part 1
-              for (unsigned int l = 0; l < dim; ++l)
-                {
-                  // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(u·∇)v
-                  gradient_result[i][k] +=
-                    tau * previous_values[k] *
-                    (gradient[i][l] * previous_values[l] +
-                     previous_gradient[i][l] * value[l] -
-                     this->kinematic_viscosity * hessian_diagonal[i][l]);
-                }
-              // +(∇δp + ∂t δu)τ(u·∇)v
-              gradient_result[i][k] +=
-                tau * previous_values[k] *
-                (gradient[dim][i] + bdf_coefs[0] * value[i]);
-
-              // Part 2
-              for (unsigned int l = 0; l < dim; ++l)
-                {
-                  // +((u·∇)u - ν∆u)τ(δu·∇)v
-                  gradient_result[i][k] +=
-                    tau * value[k] *
-                    (previous_gradient[i][l] * previous_values[l] -
-                     this->kinematic_viscosity *
-                       previous_hessian_diagonal[i][l]);
-                }
-              // +(∇p - f + ∂t u)τ(δu·∇)v
-              gradient_result[i][k] +=
-                tau * value[k] *
-                (previous_gradient[dim][i] - source_value[i] +
-                 bdf_coefs[0] * previous_values[i] +
-                 previous_time_derivatives[i]);
-            }
-        }
-
-      integrator.submit_gradient(gradient_result, q);
-      integrator.submit_value(value_result, q);
-    }
-
-  integrator.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
-}
-
-/**
- * The expressions calculated in this cell integral are:
- *  (q, ∇·u) + (v,∂t u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form)
- * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f)τ∇·q (PSPG term)
- * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term).
- */
-template <int dim, typename number>
-void
-NavierStokesTransientSUPGPSPGOperator<dim, number>::local_evaluate_residual(
-  const MatrixFree<dim, number>               &matrix_free,
-  VectorType                                  &dst,
-  const VectorType                            &src,
-  const std::pair<unsigned int, unsigned int> &range) const
-{
-  FECellIntegrator integrator(matrix_free);
-
-  for (unsigned int cell = range.first; cell < range.second; ++cell)
-    {
-      integrator.reinit(cell);
-      integrator.read_dof_values_plain(src);
-      integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians);
-
-      const auto h = integrator.read_cell_data(this->get_element_size());
-
-      // Vector for the BDF coefficients
-      const Vector<double> &bdf_coefs =
-        this->simulation_control->get_bdf_coefficients();
-      const auto time_steps_vector =
-        this->simulation_control->get_time_steps_vector();
-      const double dt  = time_steps_vector[0];
-      const double sdt = 1. / dt;
-
-      for (const auto q : integrator.quadrature_point_indices())
-        {
-          // Evaluate source term function
-          Tensor<1, dim + 1, VectorizedArray<number>> source_value;
-          Point<dim, VectorizedArray<number>>         point_batch =
-            integrator.quadrature_point(q);
-          source_value =
-            evaluate_function<dim, number, dim + 1>(*(this->forcing_function),
-                                                    point_batch);
-
-          // Gather the original value/gradient
-          typename FECellIntegrator::value_type value = integrator.get_value(q);
-          typename FECellIntegrator::gradient_type gradient =
-            integrator.get_gradient(q);
-          typename FECellIntegrator::gradient_type hessian_diagonal =
-            integrator.get_hessian_diagonal(q);
-
-          // Time derivatives of previoussolutions
-          auto previous_time_derivatives =
-            this->time_derivatives_previous_solutions(cell, q);
-
-          // Calculate tau
-          VectorizedArray<number> u_mag_squared = 1e-12;
-          for (unsigned int k = 0; k < dim; ++k)
-            u_mag_squared += Utilities::fixed_power<2>(value[k]);
-
-          const auto tau =
-            1. / std::sqrt(Utilities::fixed_power<2>(sdt) +
-                           4. * u_mag_squared / h / h +
-                           9. * Utilities::fixed_power<2>(
-                                  4. * this->kinematic_viscosity / (h * h)));
-
-          // Result value/gradient we will use
-          typename FECellIntegrator::value_type    value_result;
-          typename FECellIntegrator::gradient_type gradient_result;
-
-          // Weak form
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              // ν(∇v,∇u)
-              gradient_result[i] = this->kinematic_viscosity * gradient[i];
-              // -(∇·v,p)
-              gradient_result[i][i] += -value[dim];
-              // +(v,-f + ∂t u)
-              value_result[i] = -source_value[i] + bdf_coefs[0] * value[i] +
-                                previous_time_derivatives[i];
-              // +(q,∇·u)
-              value_result[dim] += gradient[i][i];
-
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  // +(v,(u·∇)u)
-                  value_result[i] += gradient[i][k] * value[k];
-                }
-            }
-
-          // PSPG term
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  // (-ν∆u + (u·∇)u)·τ∇q
-                  gradient_result[dim][i] +=
-                    tau * (-this->kinematic_viscosity * hessian_diagonal[i][k] +
-                           gradient[i][k] * value[k]);
-                }
-              // +(-f + ∂t u)·τ∇q
-              gradient_result[dim][i] +=
-                tau * (-source_value[i] + bdf_coefs[0] * value[i] +
-                       previous_time_derivatives[i]);
-            }
-          // +(∇p)τ∇·q
-          gradient_result[dim] += tau * gradient[dim];
-
-          // SUPG term
-          for (unsigned int i = 0; i < dim; ++i)
-            {
-              for (unsigned int k = 0; k < dim; ++k)
-                {
-                  for (unsigned int l = 0; l < dim; ++l)
-                    {
-                      // (-ν∆u)τ(u·∇)v
-                      gradient_result[i][k] +=
-                        -tau * this->kinematic_viscosity * value[k] *
-                        hessian_diagonal[i][l];
-
-                      // + ((u·∇)u)τ(u·∇)v
-                      gradient_result[i][k] +=
-                        tau * value[k] * gradient[i][l] * value[l];
-                    }
-                  // + (∇p - f + ∂t u)τ(u·∇)v
-                  gradient_result[i][k] +=
-                    tau * value[k] *
-                    (gradient[dim][i] - source_value[i] +
-                     bdf_coefs[0] * value[i] + previous_time_derivatives[i]);
-                }
-            }
-
-          integrator.submit_gradient(gradient_result, q);
-          integrator.submit_value(value_result, q);
-        }
-
-      integrator.integrate_scatter(EvaluationFlags::values |
-                                     EvaluationFlags::gradients,
-                                   dst);
-    }
-}
-
-template class NavierStokesTransientSUPGPSPGOperator<2, double>;
-template class NavierStokesTransientSUPGPSPGOperator<3, double>;
-
-template <int dim, typename number>
-NavierStokesGLSOperator<dim, number>::NavierStokesGLSOperator() = default;
-
-/**
- * The expressions calculated in this cell integral are:
- * (q,∇δu) + (v,(u·∇)δu) + (v,(δu·∇)u) - (∇·v,δp) + ν(∇v,∇δu) (Weak form
- * Jacobian)
- * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ·∇q (PSPG Jacobian)
- * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τu·∇v (SUPG Jacobian Part 1)
- * \+ ((u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2)
+ * \+ ((u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2),
+ * plus two additional terms in the case of full gls stabilization:
  * \+ ((u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ(−ν∆v) (GLS Jacobian)
  * \+ (∇·δu)τ'(∇·v) (LSIC Jacobian).
  */
 template <int dim, typename number>
 void
-NavierStokesGLSOperator<dim, number>::do_cell_integral_local(
+NavierStokesSteadyOperator<dim, number>::do_cell_integral_local(
   FECellIntegrator &integrator) const
 {
   integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
@@ -1258,28 +711,32 @@ NavierStokesGLSOperator<dim, number>::do_cell_integral_local(
             }
         }
 
-      // GLS Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
+      if (this->stabilization ==
+          Parameters::Stabilization::NavierStokesStabilization::gls)
         {
-          for (unsigned int k = 0; k < dim; ++k)
+          // GLS Jacobian
+          for (unsigned int i = 0; i < dim; ++i)
             {
-              for (unsigned int l = 0; l < dim; ++l)
+              for (unsigned int k = 0; k < dim; ++k)
                 {
-                  // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
+                  for (unsigned int l = 0; l < dim; ++l)
+                    {
+                      // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
+                      hessian_result[i][k][k] +=
+                        tau * -this->kinematic_viscosity *
+                        (gradient[i][l] * previous_values[l] +
+                         previous_gradient[i][l] * value[l] -
+                         this->kinematic_viscosity * hessian_diagonal[i][l]);
+                    }
+
+                  // +(∇δp)τ(−ν∆v)
                   hessian_result[i][k][k] +=
-                    tau * -this->kinematic_viscosity *
-                    (gradient[i][l] * previous_values[l] +
-                     previous_gradient[i][l] * value[l] -
-                     this->kinematic_viscosity * hessian_diagonal[i][l]);
+                    tau * -this->kinematic_viscosity * gradient[dim][i];
+
+                  // LSIC term
+                  // (∇·δu)τ'(∇·v)
+                  gradient_result[i][i] += tau_lsic * gradient[k][k];
                 }
-
-              // +(∇δp)τ(−ν∆v)
-              hessian_result[i][k][k] +=
-                tau * -this->kinematic_viscosity * gradient[dim][i];
-
-              // LSIC term
-              // (∇·δu)τ'(∇·v)
-              gradient_result[i][i] += tau_lsic * gradient[k][k];
             }
         }
 
@@ -1295,15 +752,17 @@ NavierStokesGLSOperator<dim, number>::do_cell_integral_local(
 
 /**
  * The expressions calculated in this cell integral are:
- * (q, ∇·u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form)
+ * (q, ∇·u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form),
+ * plus two additional terms in the case of SUPG-PSPG stabilization:
  * \+ ((u·∇)u + ∇p - ν∆u - f)τ∇·q (PSPG term)
- * \+ ((u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term)
+ * \+ ((u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term),
+ * plus two additional terms in the case of full gls stabilization:
  * \+ ((u·∇)u + ∇p - ν∆u - f)τ(−ν∆v) (GLS term)
  * \+ (∇·u)τ'(∇·v) (LSIC term).
  */
 template <int dim, typename number>
 void
-NavierStokesGLSOperator<dim, number>::local_evaluate_residual(
+NavierStokesSteadyOperator<dim, number>::local_evaluate_residual(
   const MatrixFree<dim, number>               &matrix_free,
   VectorType                                  &dst,
   const VectorType                            &src,
@@ -1409,27 +868,32 @@ NavierStokesGLSOperator<dim, number>::local_evaluate_residual(
                 }
             }
 
-          // GLS term
-          for (unsigned int i = 0; i < dim; ++i)
+          if (this->stabilization ==
+              Parameters::Stabilization::NavierStokesStabilization::gls)
             {
-              for (unsigned int k = 0; k < dim; ++k)
+              // GLS term
+              for (unsigned int i = 0; i < dim; ++i)
                 {
-                  for (unsigned int l = 0; l < dim; ++l)
+                  for (unsigned int k = 0; k < dim; ++k)
                     {
-                      // (-ν∆u + (u·∇)u)τ(−ν∆v)
+                      for (unsigned int l = 0; l < dim; ++l)
+                        {
+                          // (-ν∆u + (u·∇)u)τ(−ν∆v)
+                          hessian_result[i][k][k] +=
+                            tau * -this->kinematic_viscosity *
+                            (-this->kinematic_viscosity *
+                               hessian_diagonal[i][l] +
+                             gradient[i][l] * value[l]);
+                        }
+                      // + (∇p - f)τ(−ν∆v)
                       hessian_result[i][k][k] +=
                         tau * -this->kinematic_viscosity *
-                        (-this->kinematic_viscosity * hessian_diagonal[i][l] +
-                         gradient[i][l] * value[l]);
-                    }
-                  // + (∇p - f)τ(−ν∆v)
-                  hessian_result[i][k][k] +=
-                    tau * -this->kinematic_viscosity *
-                    (gradient[dim][i] - source_value[i]);
+                        (gradient[dim][i] - source_value[i]);
 
-                  // LSIC term
-                  // (∇·u)τ'(∇·v)
-                  gradient_result[i][i] += tau_lsic * gradient[k][k];
+                      // LSIC term
+                      // (∇·u)τ'(∇·v)
+                      gradient_result[i][i] += tau_lsic * gradient[k][k];
+                    }
                 }
             }
 
@@ -1445,27 +909,28 @@ NavierStokesGLSOperator<dim, number>::local_evaluate_residual(
     }
 }
 
-template class NavierStokesGLSOperator<2, double>;
-template class NavierStokesGLSOperator<3, double>;
+template class NavierStokesSteadyOperator<2, double>;
+template class NavierStokesSteadyOperator<3, double>;
 
 template <int dim, typename number>
-NavierStokesTransientGLSOperator<dim,
-                                 number>::NavierStokesTransientGLSOperator() =
+NavierStokesTransientOperator<dim, number>::NavierStokesTransientOperator() =
   default;
 
 /**
  * The expressions calculated in this cell integral are:
  * (q,∇δu) + (v,∂t δu) + (v,(u·∇)δu) + (v,(δu·∇)u) - (∇·v,δp) + ν(∇v,∇δu) (Weak
- * form Jacobian)
+ * form Jacobian),
+ * plus three additional terms in the case of SUPG-PSPG stabilization:
  * \+ (∂t δu +(u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ·∇q (PSPG Jacobian)
  * \+ (∂t δu +(u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τu·∇v (SUPG Jacobian Part 1)
- * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2)
+ * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f )τδu·∇v (SUPG Jacobian Part 2),
+ * plus two additional terms in the case of full gls stabilization:
  * \+ (∂t δu +(u·∇)δu + (δu·∇)u + ∇δp - ν∆δu)τ(−ν∆v) (GLS Jacobian)
  * \+ (∇·δu)τ'(∇·v) (LSIC Jacobian).
  */
 template <int dim, typename number>
 void
-NavierStokesTransientGLSOperator<dim, number>::do_cell_integral_local(
+NavierStokesTransientOperator<dim, number>::do_cell_integral_local(
   FECellIntegrator &integrator) const
 {
   integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
@@ -1605,29 +1070,33 @@ NavierStokesTransientGLSOperator<dim, number>::do_cell_integral_local(
             }
         }
 
-      // GLS Jacobian
-      for (unsigned int i = 0; i < dim; ++i)
+      if (this->stabilization ==
+          Parameters::Stabilization::NavierStokesStabilization::gls)
         {
-          for (unsigned int k = 0; k < dim; ++k)
+          // GLS Jacobian
+          for (unsigned int i = 0; i < dim; ++i)
             {
-              for (unsigned int l = 0; l < dim; ++l)
+              for (unsigned int k = 0; k < dim; ++k)
                 {
-                  // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
+                  for (unsigned int l = 0; l < dim; ++l)
+                    {
+                      // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
+                      hessian_result[i][k][k] +=
+                        tau * -this->kinematic_viscosity *
+                        (gradient[i][l] * previous_values[l] +
+                         previous_gradient[i][l] * value[l] -
+                         this->kinematic_viscosity * hessian_diagonal[i][l]);
+                    }
+
+                  // +(∇δp + ∂t δu)τ(−ν∆v)
                   hessian_result[i][k][k] +=
                     tau * -this->kinematic_viscosity *
-                    (gradient[i][l] * previous_values[l] +
-                     previous_gradient[i][l] * value[l] -
-                     this->kinematic_viscosity * hessian_diagonal[i][l]);
+                    (gradient[dim][i] + bdf_coefs[0] * value[i]);
+
+                  // LSIC term
+                  // (∇·δu)τ'(∇·v)
+                  gradient_result[i][i] += tau_lsic * gradient[k][k];
                 }
-
-              // +(∇δp + ∂t δu)τ(−ν∆v)
-              hessian_result[i][k][k] +=
-                tau * -this->kinematic_viscosity *
-                (gradient[dim][i] + bdf_coefs[0] * value[i]);
-
-              // LSIC term
-              // (∇·δu)τ'(∇·v)
-              gradient_result[i][i] += tau_lsic * gradient[k][k];
             }
         }
 
@@ -1642,15 +1111,17 @@ NavierStokesTransientGLSOperator<dim, number>::do_cell_integral_local(
 
 /**
  * The expressions calculated in this cell integral are:
- *  (q, ∇·u) + (v,∂t u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form)
+ * (q, ∇·u) + (v,∂t u) + (v,(u·∇)u) - (∇·v,p) + ν(∇v,∇u) - (v,f) (Weak form),
+ * plus two additional terms in the case of SUPG-PSPG stabilization:
  * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f)τ∇·q (PSPG term)
- * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term)
+ * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f)τu·∇v (SUPG term),
+ * plus two additional terms in the case of full gls stabilization:
  * \+ (∂t u +(u·∇)u + ∇p - ν∆u - f)τ(−ν∆v) (GLS term)
  * \+ (∇·u)τ'(∇·v) (LSIC term).
  */
 template <int dim, typename number>
 void
-NavierStokesTransientGLSOperator<dim, number>::local_evaluate_residual(
+NavierStokesTransientOperator<dim, number>::local_evaluate_residual(
   const MatrixFree<dim, number>               &matrix_free,
   VectorType                                  &dst,
   const VectorType                            &src,
@@ -1776,28 +1247,34 @@ NavierStokesTransientGLSOperator<dim, number>::local_evaluate_residual(
                 }
             }
 
-          // GLS term
-          for (unsigned int i = 0; i < dim; ++i)
+          if (this->stabilization ==
+              Parameters::Stabilization::NavierStokesStabilization::gls)
             {
-              for (unsigned int k = 0; k < dim; ++k)
+              // GLS term
+              for (unsigned int i = 0; i < dim; ++i)
                 {
-                  for (unsigned int l = 0; l < dim; ++l)
+                  for (unsigned int k = 0; k < dim; ++k)
                     {
-                      // (-ν∆u + (u·∇)u)τ(−ν∆v)
+                      for (unsigned int l = 0; l < dim; ++l)
+                        {
+                          // (-ν∆u + (u·∇)u)τ(−ν∆v)
+                          hessian_result[i][k][k] +=
+                            tau * -this->kinematic_viscosity *
+                            (-this->kinematic_viscosity *
+                               hessian_diagonal[i][l] +
+                             gradient[i][l] * value[l]);
+                        }
+                      // + (∇p - f + ∂t u)τ(−ν∆v)
                       hessian_result[i][k][k] +=
                         tau * -this->kinematic_viscosity *
-                        (-this->kinematic_viscosity * hessian_diagonal[i][l] +
-                         gradient[i][l] * value[l]);
-                    }
-                  // + (∇p - f + ∂t u)τ(−ν∆v)
-                  hessian_result[i][k][k] +=
-                    tau * -this->kinematic_viscosity *
-                    (gradient[dim][i] - source_value[i] +
-                     +bdf_coefs[0] * value[i] + previous_time_derivatives[i]);
+                        (gradient[dim][i] - source_value[i] +
+                         +bdf_coefs[0] * value[i] +
+                         previous_time_derivatives[i]);
 
-                  // LSIC term
-                  // (∇·u)τ'(∇·v)
-                  gradient_result[i][i] += tau_lsic * gradient[k][k];
+                      // LSIC term
+                      // (∇·u)τ'(∇·v)
+                      gradient_result[i][i] += tau_lsic * gradient[k][k];
+                    }
                 }
             }
 
@@ -1813,5 +1290,5 @@ NavierStokesTransientGLSOperator<dim, number>::local_evaluate_residual(
     }
 }
 
-template class NavierStokesTransientGLSOperator<2, double>;
-template class NavierStokesTransientGLSOperator<3, double>;
+template class NavierStokesTransientOperator<2, double>;
+template class NavierStokesTransientOperator<3, double>;


### PR DESCRIPTION
# Description of the problem

There was a lot of code duplication introduced in #1049 since the GLS operator only adds two additional terms to the SUPG/PSPG operator.

# Description of the solution

This PR unifies the SUPG/PSPG and GLS steady operators, and the SUPG/PSPG and GLS transient operators, in only one operator that uses the stabilization type and the is_bdf function to identify what terms to take into account.

# How Has This Been Tested?

All the matrix-free application tests pass without any issue.
