### PR TITLE
Remove expansion term from recoil pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR The parameter subsection `constrain solid domain` was renamed to `constrain stasis`. Related documentation was also updated. [#1048](https://github.com/lethe-cfd/lethe/pull/1048)
 
+### Fixed
+
+- MINOR In LPBF simulations, recoil pressure formulation p_rec = 0.55p_sat + [1/rho]m_dot^2 was accounting 2 times for the term [1/rho]m_dot^2 because the latter is included in the term 0.55p_sat. The formulation is now corrected and reads p_rec = 0.55p_sat.
+
 ## [Master] - 2024-03-02
 
 ### Fixed
@@ -197,5 +201,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - MAJOR/MINOR/PATCH Description (#PR).
-
-


### PR DESCRIPTION
# Description of the problem

- Recoil pressure formulation 0.55p_sat + [1/rho]m_dot^2 was accounting 2 time the [1/rho]m_dot^2 because the latter is included in the term  0.55p_sat.

# Description of the solution

- Remove it, the formulation is now 0.55*p_sat

# How Has This Been Tested?

- no test has changed

# Documentation

- no documentation has changed

# Future changes

- Add test and doc for evaporation model
