### PR TITLE
Initial refinement at boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR  The new temperature-dependent solid domain constraints for two-phase Volume of Fluid (VOF) simulations has been implemented (`constrain_stasis_with_temperature_vof()`). To select cells on which the constraints are applied, we check if the filtered phase fraction at quadrature points in the cell are within a range of accepted values. This range of accepted values is defined with the `phase fraction tolerance` parameter. This parameter defines an absolute tolerance on filtered phase fraction. Related documentation was updated and a new application test was also added. [#1048](https://github.com/lethe-cfd/lethe/pull/1048)
 
+- MINOR Added the capability to locally refine the mesh in the vicinity of the boundary conditions as specified by a list of boundary conditions. [#1056](https://github.com/lethe-cfd/lethe/pull/1056)
+
 ### Changed
 
 - MINOR Previously implemented temperature-dependant solid domain constraints for one-fluid simulations (`constrain_solid_domain()`) was renamed to `constrain_stasis_with_temperature()` and its content changed a bit to avoid copied lines in `constrain_stasis_with_temperature_vof()`. [#1048](https://github.com/lethe-cfd/lethe/pull/1048)

--- a/applications_tests/lethe-fluid/taylorcouette_boundary_ref.output
+++ b/applications_tests/lethe-fluid/taylorcouette_boundary_ref.output
@@ -1,0 +1,47 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       160
+   Number of degrees of freedom: 2304
+   Volume of triangulation:      2.95
+
+*****************************
+Steady iteration:        1/3
+*****************************
+
++------------------------------------------+
+|  Torque summary                          |
++------------------------------------------+
+Boundary ID  T_x   T_y   T_z   
+          0 0.000 0.000 -0.819 
+          1 0.000 0.000  0.836 
+
+*****************************
+Steady iteration:        2/3
+*****************************
+   Number of active cells:       640
+   Number of degrees of freedom: 8448
+   Volume of triangulation:      2.95
+
++------------------------------------------+
+|  Torque summary                          |
++------------------------------------------+
+Boundary ID  T_x   T_y   T_z   
+          0 0.000 0.000 -0.832 
+          1 0.000 0.000  0.837 
+
+*****************************
+Steady iteration:        3/3
+*****************************
+   Number of active cells:       2560
+   Number of degrees of freedom: 32256
+   Volume of triangulation:      2.95
+
++------------------------------------------+
+|  Torque summary                          |
++------------------------------------------+
+Boundary ID  T_x   T_y   T_z   
+          0 0.000 0.000 -0.836 
+          1 0.000 0.000  0.838 
+cells error_velocity error_pressure 
+  160 1.678e-04    - 9.108e-05    - 
+  640 2.242e-05 2.90 1.414e-05 2.69 
+ 2560 2.857e-06 2.97 2.331e-06 2.60 

--- a/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
@@ -1,0 +1,146 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method            = steady
+  set output name       = couette
+  set output frequency  = 0
+  set number mesh adapt = 2 # If steady, nb mesh adaptation
+  set log precision     = 3 # Log precision
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 2
+  set pressure order = 2
+  set qmapping all   = true
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set kinematic viscosity = 1.0000
+  end
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable = true
+  subsection uvwp
+    # A= -(eta_ * eta_) / (1. - eta_ * eta_);
+    # B= ri_ * ri_ / (1. - eta_ * eta_);
+    set Function constants  = eta=0.25, ri=0.25, A=-0.06666666666666667, B=0.06666666666666666667
+    set Function expression = -sin(atan2(y,x))*(-(eta*eta) / (1-eta*eta)* sqrt(x*x+y*y)+ ri*ri/(1-eta*eta)/sqrt(x*x+y*y)); cos(atan2(y,x))*(-(eta*eta) / (1-eta*eta)* sqrt(x*x+y*y)+ ri*ri/(1-eta*eta)/sqrt(x*x+y*y)) ; A*A*(x^2+y^2)/2 + 2 *A*B *ln(sqrt(x^2+y^2)) - 0.5*B*B/(x^2+y^2)
+  end
+end
+
+#---------------------------------------------------
+# Forces
+#---------------------------------------------------
+
+subsection forces
+  set verbosity             = verbose # Output force and torques in log <quiet|verbose>
+  set calculate force       = false   # Enable force calculation
+  set calculate torque      = true    # Enable torque calculation
+  set force name            = force   # Name prefix of force files
+  set torque name           = torque  # Name prefix of torque files
+  set output precision      = 10      # Output precision
+  set calculation frequency = 1       # Frequency of the force calculation
+  set output frequency      = 1       # Frequency of file update
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_shell
+  set grid arguments     = 0, 0 : 0.25 : 1 : 4:  true
+  set initial refinement = 2
+  set initial boundary refinement = 1
+  set boundaries refined = 0, 1
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 2
+  subsection bc 1
+    set type = noslip
+  end
+  subsection bc 0
+    set type = function
+    subsection u
+      set Function expression = -y
+    end
+    subsection v
+      set Function expression = x
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+end
+
+#---------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+
+subsection mesh adaptation
+  set type = uniform
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set tolerance          = 1e-10
+    set max iterations     = 10
+    set residual precision = 2
+    set verbosity          = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-11
+    set preconditioner                            = amg
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
+end

--- a/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
@@ -70,12 +70,12 @@ end
 #---------------------------------------------------
 
 subsection mesh
-  set type               = dealii
-  set grid type          = hyper_shell
-  set grid arguments     = 0, 0 : 0.25 : 1 : 4:  true
-  set initial refinement = 2
+  set type                        = dealii
+  set grid type                   = hyper_shell
+  set grid arguments              = 0, 0 : 0.25 : 1 : 4:  true
+  set initial refinement          = 2
   set initial boundary refinement = 1
-  set boundaries refined = 0, 1
+  set boundaries refined          = 0, 1
 end
 
 #---------------------------------------------------

--- a/doc/source/parameters/cfd/mesh.rst
+++ b/doc/source/parameters/cfd/mesh.rst
@@ -22,8 +22,8 @@ This subsection provides information of the simulation geometry and its mesh. Th
     # Initial refinement of the mesh near user-specified boundaries
     set initial boundary refinement = 0
 
-    # Lists of boundaries next to which the mesh should be refined. The list must contain integers seperated by commas.
-    set boundaries refined = 0 , 1
+    # Lists of boundaries next to which the mesh should be refined. The list must contain integers separated by commas.
+    set boundaries refined = 0, 1
 
     # Indicates that the mesh is a simplex mesh
     set simplex            = false
@@ -47,6 +47,6 @@ This subsection provides information of the simulation geometry and its mesh. Th
 
 * The initial refinement number determines the number of refinements the grid will undergo in the simulation before the simulation is run. This allows one to refine a coarse grid automatically. By default, most deal.II grids will be as coarse as possible and need to be refined. This is a desirable behavior for parallel simulations, since for quad/hex meshes, the coarsest level of the grid is shared amongst all cores. Consequently, using a coarse grid with too many cells will lead to a prohibitive memory consumption.
 
-* The initial boundary refinement determines the number of refinement the grid will undergo in the simulation in the vicinities of the boundary specified by the ``boundaries refined`` parameter.
+* The initial boundary refinement determines the number of refinements the grid will undergo in the simulation in the vicinities of the boundary specified by the ``boundaries refined`` parameter.
 
 * `simplex`. If simplex is set to true, it indicates that the mesh being read is made of only simplex elements. If the mesh is of ``type = dealii`` it will be converted from a quad/hex mesh to a simplex mesh. If the mesh is of ``type = gsmh``, it will be read from a file as long as it is only made of simplices.

--- a/doc/source/parameters/cfd/mesh.rst
+++ b/doc/source/parameters/cfd/mesh.rst
@@ -19,6 +19,12 @@ This subsection provides information of the simulation geometry and its mesh. Th
     # Initial refinement of the mesh
     set initial refinement = 0
 
+    # Initial refinement of the mesh near user-specified boundaries
+    set initial boundary refinement = 0
+
+    # Lists of boundaries next to which the mesh should be refined. The list must contain integers seperated by commas.
+    set boundaries refined = 0 , 1
+
     # Indicates that the mesh is a simplex mesh
     set simplex            = false
   end
@@ -40,5 +46,7 @@ This subsection provides information of the simulation geometry and its mesh. Th
     :align: center
 
 * The initial refinement number determines the number of refinements the grid will undergo in the simulation before the simulation is run. This allows one to refine a coarse grid automatically. By default, most deal.II grids will be as coarse as possible and need to be refined. This is a desirable behavior for parallel simulations, since for quad/hex meshes, the coarsest level of the grid is shared amongst all cores. Consequently, using a coarse grid with too many cells will lead to a prohibitive memory consumption.
+
+* The initial boundary refinement determines the number of refinement the grid will undergo in the simulation in the vicinities of the boundary specified by the ``boundaries refined`` parameter.
 
 * `simplex`. If simplex is set to true, it indicates that the mesh being read is made of only simplex elements. If the mesh is of ``type = dealii`` it will be converted from a quad/hex mesh to a simplex mesh. If the mesh is of ``type = gsmh``, it will be read from a file as long as it is only made of simplices.

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -84,9 +84,11 @@ read_mesh_and_manifolds(
  *
  * @param[in] n_refinement The number of times the boundary should be refined
  *
- * @param[in] boundary_ids The boundary ids for which the cells should be refined
+ * @param[in] boundary_ids The boundary ids for which the cells should be
+ * refined
  *
- * @param[in, out] triangulation The triangulation on which refinement must be carried out
+ * @param[in, out] triangulation The triangulation on which refinement must be
+ * carried out
  *
  */
 template <int dim, int spacedim = dim>

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -82,11 +82,11 @@ read_mesh_and_manifolds(
 /**
  * @brief Refine a mesh around specific boundary ids
  *
- * @param n_refinement The number of times the boundary should be refined
+ * @param[in] n_refinement The number of times the boundary should be refined
  *
- * @param boundary_ids The boundary ids for which the cells should be refined
+ * @param[in] boundary_ids The boundary ids for which the cells should be refined
  *
- * @param triangulation The triangulation on which refinement must be carried out
+ * @param[in, out] triangulation The triangulation on which refinement must be carried out
  *
  */
 template <int dim, int spacedim = dim>
@@ -96,7 +96,7 @@ refine_triangulation_at_boundaries(
   const unsigned int                                     n_refinement,
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation)
 {
-  // For the amount of refinement required
+  // For the amount of refinements required
   for (unsigned int r = 0; r < n_refinement; ++r)
     {
       // Loop over the cells and flag all cells which are within the list of

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -103,18 +103,22 @@ refine_triangulation_at_boundaries(
     {
       // Loop over the cells and flag all cells which are within the list of
       // boundary ids
-      for (const auto &cell : triangulation.cell_iterators())
+      for (const auto &cell : triangulation.active_cell_iterators())
         {
-          for (const auto f : cell->face_indices())
+          if (cell->is_locally_owned())
             {
-              if (cell->face(f)->at_boundary())
+              for (const auto f : cell->face_indices())
+
                 {
-                  if (std::find(boundary_ids.begin(),
-                                boundary_ids.end(),
-                                cell->face(f)->boundary_id()) !=
-                      boundary_ids.end())
+                  if (cell->face(f)->at_boundary())
                     {
-                      cell->set_refine_flag();
+                      if (std::find(boundary_ids.begin(),
+                                    boundary_ids.end(),
+                                    cell->face(f)->boundary_id()) !=
+                          boundary_ids.end())
+                        {
+                          cell->set_refine_flag();
+                        }
                     }
                 }
             }

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -79,4 +79,46 @@ read_mesh_and_manifolds(
   const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
 
 
+/**
+ * @brief Refine a mesh around specific boundary ids
+ *
+ * @param n_refinement The number of times the boundary should be refined
+ *
+ * @param boundary_ids The boundary ids for which the cells should be refined
+ *
+ * @param triangulation The triangulation on which refinement must be carried out
+ *
+ */
+template <int dim, int spacedim = dim>
+void
+refine_triangulation_at_boundaries(
+  const std::vector<int>                                 boundary_ids,
+  const unsigned int                                     n_refinement,
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation)
+{
+  // For the amount of refinement required
+  for (unsigned int r = 0; r < n_refinement; ++r)
+    {
+      // Loop over the cells and flag all cells which are within the list of
+      // boundary ids
+      for (const auto &cell : triangulation.cell_iterators())
+        {
+          for (const auto f : cell->face_indices())
+            {
+              if (cell->face(f)->at_boundary())
+                {
+                  if (std::find(boundary_ids.begin(),
+                                boundary_ids.end(),
+                                cell->face(f)->boundary_id()) !=
+                      boundary_ids.end())
+                    {
+                      cell->set_refine_flag();
+                    }
+                }
+            }
+        }
+      triangulation.execute_coarsening_and_refinement();
+    }
+}
+
 #endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1190,16 +1190,16 @@ namespace Parameters
     /// List of boundary ids to refine
     std::vector<int> boundaries_to_refine;
 
-    /// Enabling fixing initial refinement from a target size
+    /// Enable fixing initial refinement from a target size
     bool refine_until_target_size;
 
-    /// Allowing the use of a simplex mesh
+    /// Allow the use of a simplex mesh
     bool simplex;
 
     /// Target size when automatically refining initial mesh
     double target_size;
 
-    /// Enables checking the input grid for diamond-shaped cells
+    /// Enable checking the input grid for diamond-shaped cells
     bool check_for_diamond_cells;
 
     /* A boolean parameter which enables adding the neighbor boundary cells of

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1171,36 +1171,42 @@ namespace Parameters
     };
     Type type;
 
-    // File name of the mesh
+    /// File name of the mesh
     std::string file_name;
 
-    // Name of the grid in GridTools
+    /// Name of the grid in GridTools
     std::string grid_type;
 
-    // Arguments of the GridTools
+    /// Arguments of the GridTools
     std::string grid_arguments;
 
-    // Initial refinement level of primitive mesh
+    /// Initial refinement level of primitive mesh
     unsigned int initial_refinement;
 
-    // Enabling fixing initial refinement from a target size
+    /// Initial refinement level of primitive mesh near user-defined boundary conditions
+    unsigned int initial_refinement_at_boundaries;
+
+    /// List of boundary ids to refine
+    std::vector<int> boundaries_to_refine;
+
+    /// Enabling fixing initial refinement from a target size
     bool refine_until_target_size;
 
-    // Allowing the use of a simplex mesh
+    /// Allowing the use of a simplex mesh
     bool simplex;
 
-    // Target size when automatically refining initial mesh
+    /// Target size when automatically refining initial mesh
     double target_size;
 
-    // Enables checking the input grid for diamond-shaped cells
+    /// Enables checking the input grid for diamond-shaped cells
     bool check_for_diamond_cells;
 
-    // A boolean parameter which enables adding the neighbor boundary cells of
-    // boundary cells in DEM simulations. This parameter should only be enabled
-    // for simulations with concave geometries (for instance particles inside a
-    // drum). In simulations with convex geometries, it must not be enabled.
-    // This is also reported to users in a warning in
-    // find_boundary_cells_information.
+    /* A boolean parameter which enables adding the neighbor boundary cells of
+    * boundary cells in DEM simulations. This parameter should only be enabled
+    * for simulations with concave geometries (for instance particles inside a
+    * drum). In simulations with convex geometries, it must not be enabled.
+    * This is also reported to users in a warning in
+     find_boundary_cells_information.*/
     bool expand_particle_wall_contact_search;
 
     // Grid displacement at initiation
@@ -1582,14 +1588,34 @@ namespace Parameters
    * the default value is returned. If the entry is not equivalent to a vector,
    * an error will be thrown.
    *
+   * @tparam T The type of vector (int, unsigned int or double)
    * @param prm A parameter handler which is currently used to parse the simulation
    * information.
    * @param entry_string A declare string in the parameter file.
    *
    * @return A std::vector<double> corresponding to the entry_string in the prm file.
    */
-  std::vector<double>
+  template <typename T>
+  std::vector<T>
   convert_string_to_vector(ParameterHandler  &prm,
-                           const std::string &entry_string);
+                           const std::string &entry_string)
+  {
+    std::string              full_str = prm.get(entry_string);
+    std::vector<std::string> vector_of_string(
+      Utilities::split_string_list(full_str));
+    if constexpr (std::is_same<T, int>::value )
+      {
+        std::vector<T> vector =
+          Utilities::string_to_int(vector_of_string);
+        return vector;
+      }
+    if  constexpr (std::is_same<T, double>::value )
+      {
+        std::vector<T> vector =
+          Utilities::string_to_double(vector_of_string);
+        return vector;
+      }
+  }
+
 } // namespace Parameters
 #endif

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1183,7 +1183,8 @@ namespace Parameters
     /// Initial refinement level of primitive mesh
     unsigned int initial_refinement;
 
-    /// Initial refinement level of primitive mesh near user-defined boundary conditions
+    /// Initial refinement level of primitive mesh near user-defined boundary
+    /// conditions
     unsigned int initial_refinement_at_boundaries;
 
     /// List of boundary ids to refine
@@ -1603,16 +1604,14 @@ namespace Parameters
     std::string              full_str = prm.get(entry_string);
     std::vector<std::string> vector_of_string(
       Utilities::split_string_list(full_str));
-    if constexpr (std::is_same<T, int>::value )
+    if constexpr (std::is_same<T, int>::value)
       {
-        std::vector<T> vector =
-          Utilities::string_to_int(vector_of_string);
+        std::vector<T> vector = Utilities::string_to_int(vector_of_string);
         return vector;
       }
-    if  constexpr (std::is_same<T, double>::value )
+    if constexpr (std::is_same<T, double>::value)
       {
-        std::vector<T> vector =
-          Utilities::string_to_double(vector_of_string);
+        std::vector<T> vector = Utilities::string_to_double(vector_of_string);
         return vector;
       }
   }

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -478,6 +478,10 @@ read_mesh_and_manifolds(
         {
           const int initial_refinement = mesh_parameters.initial_refinement;
           triangulation.refine_global(initial_refinement);
+          refine_triangulation_at_boundaries(
+            mesh_parameters.boundaries_to_refine,
+            mesh_parameters.initial_refinement_at_boundaries,
+            triangulation);
         }
     }
 }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2061,6 +2061,16 @@ namespace Parameters
                         Patterns::Integer(),
                         "Initial refinement of the mesh");
 
+      prm.declare_entry("initial boundary refinement",
+                        "0",
+                        Patterns::Integer(),
+                        "Initial refinement of the mesh at the boundaries specified by the user");
+
+      prm.declare_entry("boundaries refined",
+                        "",
+                        Patterns::List(Patterns::Integer()),
+                        "Boundary ids of the boundaries to be initially refined");
+
       if (prm.get("type") == "periodic_hills")
         {
           prm.declare_entry("grid arguments", "1 ; 1 ; 1 ; 1 ; 1");
@@ -2153,6 +2163,9 @@ namespace Parameters
       file_name = prm.get("file name");
 
       initial_refinement = prm.get_integer("initial refinement");
+      initial_refinement_at_boundaries = prm.get_integer("initial boundary refinement");
+
+      boundaries_to_refine =  convert_string_to_vector<int>(prm, "boundaries refined");
 
       grid_type      = prm.get("grid type");
       grid_arguments = prm.get("grid arguments");
@@ -3647,20 +3660,6 @@ namespace Parameters
       output_tensor[i] = vector_of_double[i];
 
     return output_tensor;
-  }
-
-  std::vector<double>
-  convert_string_to_vector(ParameterHandler  &prm,
-                           const std::string &entry_string)
-  {
-    std::string              full_str = prm.get(entry_string);
-    std::vector<std::string> vector_of_string(
-      Utilities::split_string_list(full_str));
-
-    std::vector<double> vector_of_double =
-      Utilities::string_to_double(vector_of_string);
-
-    return vector_of_double;
   }
 
   template class Laser<2>;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2061,15 +2061,17 @@ namespace Parameters
                         Patterns::Integer(),
                         "Initial refinement of the mesh");
 
-      prm.declare_entry("initial boundary refinement",
-                        "0",
-                        Patterns::Integer(),
-                        "Initial refinement of the mesh at the boundaries specified by the user");
+      prm.declare_entry(
+        "initial boundary refinement",
+        "0",
+        Patterns::Integer(),
+        "Initial refinement of the mesh at the boundaries specified by the user");
 
-      prm.declare_entry("boundaries refined",
-                        "",
-                        Patterns::List(Patterns::Integer()),
-                        "Boundary ids of the boundaries to be initially refined");
+      prm.declare_entry(
+        "boundaries refined",
+        "",
+        Patterns::List(Patterns::Integer()),
+        "Boundary ids of the boundaries to be initially refined");
 
       if (prm.get("type") == "periodic_hills")
         {
@@ -2163,9 +2165,11 @@ namespace Parameters
       file_name = prm.get("file name");
 
       initial_refinement = prm.get_integer("initial refinement");
-      initial_refinement_at_boundaries = prm.get_integer("initial boundary refinement");
+      initial_refinement_at_boundaries =
+        prm.get_integer("initial boundary refinement");
 
-      boundaries_to_refine =  convert_string_to_vector<int>(prm, "boundaries refined");
+      boundaries_to_refine =
+        convert_string_to_vector<int>(prm, "boundaries refined");
 
       grid_type      = prm.get("grid type");
       grid_arguments = prm.get("grid arguments");

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -79,9 +79,9 @@ namespace Parameters
       particle_size_std.at(particle_type) =
         prm.get_double("standard deviation");
       particle_custom_diameter.at(particle_type) =
-        convert_string_to_vector(prm, "custom diameters");
+        convert_string_to_vector<double>(prm, "custom diameters");
       particle_custom_probability.at(particle_type) =
-        convert_string_to_vector(prm, "custom volume fractions");
+        convert_string_to_vector<double>(prm, "custom volume fractions");
       seed_for_distributions.push_back(
         prm.get_integer("random seed distribution"));
 


### PR DESCRIPTION
# Description of the problem

- Currently, it is not possible to refine the mesh initially in the vicinity of the boundaries. However, this could be very desirable in some cases to have a coarse boundary layer mesh

# Description of the solution

- Add the capability to refine the mesh in the vicinity of a list of boundary IDs specified by the user

# How Has This Been Tested?

- Added a taylor-couette case that uses this principle as a test. It works just fine
-

# Documentation

- Documentation has been added to the RST file



# Comments

- This does not seem to work well with the matrix-free solver right now, but most likely because the MF solver still faces challenges with respect to the constraints.

