### PR TITLE
Add stasis constraint in melting cavity example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-03-11
+
+### Added
+
+- MINOR Temperatue-dependent `stasis constraint` is now featured in the Melting Cavity heat transfer example. [#1061](https://github.com/lethe-cfd/lethe/pull/1061)
+
 ## [Master] - 2024-03-05
 
 ### Added
 
-- MINOR  The new temperature-dependent solid domain constraints for two-phase Volume of Fluid (VOF) simulations has been implemented (`constrain_stasis_with_temperature_vof()`). To select cells on which the constraints are applied, we check if the filtered phase fraction at quadrature points in the cell are within a range of accepted values. This range of accepted values is defined with the `phase fraction tolerance` parameter. This parameter defines an absolute tolerance on filtered phase fraction. Related documentation was updated and a new application test was also added. [#1048](https://github.com/lethe-cfd/lethe/pull/1048)
+- MINOR The new temperature-dependent solid domain constraints for two-phase Volume of Fluid (VOF) simulations has been implemented (`constrain_stasis_with_temperature_vof()`). To select cells on which the constraints are applied, we check if the filtered phase fraction at quadrature points in the cell are within a range of accepted values. This range of accepted values is defined with the `phase fraction tolerance` parameter. This parameter defines an absolute tolerance on filtered phase fraction. Related documentation was updated and a new application test was also added. [#1048](https://github.com/lethe-cfd/lethe/pull/1048)
 
 - MINOR Added the capability to locally refine the mesh in the vicinity of the boundary conditions as specified by a list of boundary conditions. [#1056](https://github.com/lethe-cfd/lethe/pull/1056)
 
@@ -23,7 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR In LPBF simulations, recoil pressure formulation p_rec = 0.55p_sat + [1/rho]m_dot^2 was accounting 2 times for the term [1/rho]m_dot^2 because the latter is included in the term 0.55p_sat. The formulation is now corrected and reads p_rec = 0.55p_sat.
+- MINOR In LPBF simulations, recoil pressure formulation $`p_\mathrm{rec} = 0.55p_\mathrm{sat} + [1/\rho]m_\mathrm{dot}^2`$ was accounting 2 times for the term $`[1/\rho]m_\mathrm{dot}^2`$ because the latter is included in the term $`0.55p_\mathrm{sat}`$. The formulation is now corrected and reads $`p_\mathrm{rec} = 0.55p_\mathrm{sat}`$.
 
 ## [Master] - 2024-03-02
 
@@ -107,7 +113,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR  The number of remaining particle to insert of each type is being checkpointed adequately. This means that no modification are required to the "number of particle" parameter after restarting a simulation. [#964](https://github.com/lethe-cfd/lethe/pull/964)
+- MINOR The number of remaining particle to insert of each type is being checkpointed adequately. This means that no modification are required to the "number of particle" parameter after restarting a simulation. [#964](https://github.com/lethe-cfd/lethe/pull/964)
 
 ### Fixed
 

--- a/doc/source/examples/multiphysics/melting-cavity/melting-cavity.rst
+++ b/doc/source/examples/multiphysics/melting-cavity/melting-cavity.rst
@@ -24,7 +24,7 @@ Files Used in This Example
 
 All files mentioned below are located in the example's folder (``examples/multiphysics/melting-cavity``).
 
-- Parameter files: ``melting-cavity.prm``, ``melting-cavity-darcy.prm``
+- Parameter files: ``melting-cavity.prm``, ``melting-cavity-stasis-constraint.prm``, ``melting-cavity-darcy.prm``
 - Postprocessing Python scripts: ``melting-cavity.py``, ``compare-melting-cavity.py``
 - Python script to calculate the dimensionless numbers: ``dimensionless_number_calculator.py``
 
@@ -252,17 +252,40 @@ contains the simulation results. In post-processing, the position of the solid-l
     :width: 500
 
 
+-------------------------------------------------------------
+Improving Computational Performances with Stasis Constraints
+-------------------------------------------------------------
+
+Lethe is able to :doc:`constrain temperature-dependent stasis <../../../parameters/cfd/constrain_stasis>` on fluids.
+To use this feature, the ``constrain stasis`` subsection is added to the parameter file (see ``melting-cavity-stasis-constraint.prm``):
+
+.. code-block:: text
+
+  subsection constrain stasis
+    set enable                = true
+    set number of constraints = 1
+    subsection constraint 0
+      set fluid id        = 0
+      set min temperature = 0
+      set max temperature = 28.5
+    end
+  end
+
+Employing this feature enables a more effective conditioning of the global matrix by imposing homogeneous velocity and pressure constraints on degrees of freedom (DoFs) of cells within the specified temperature range, consequently reducing computation time. For example, running the simulation with 16 CPU cores and the stasis constraint specified above only takes :math:`\sim 24 \; \mathrm{minutes}` while the solved quantities of interest remain unchanged.
+
+.. caution::
+  When using this feature, ensure that the imposed ``max temperature`` value is lower than the solidus temperature of the material. Additionally, we advise maintaining a buffer zone to prevent disruption to fluid flow resolution near the melting zone.
 
 --------------------------------------------
 Darcy Penalization: An Alternative Approach
 --------------------------------------------
 
-Lethe supports an alternative strategy to impose statis (no motion) within the solidified material using a Darcy-like penalization. This penalization adds a forcing term to the momentum equation to prohibit the motion of the solid instead of increasing its viscosity. This has the advantage of leading to a better matrix conditioning, at the expense of potentially increased motion within the solid phase. To enable this forcing term, a velocity source term must be specified:
+Lethe supports an alternative strategy to impose stasis (no motion) within the solidified material using a Darcy-like penalization. This penalization adds a forcing term to the momentum equation to prohibit the motion of the solid instead of increasing its viscosity. This has the advantage of leading to a better matrix conditioning, at the expense of potentially increased motion within the solid phase. To enable this forcing term, a velocity source term must be specified:
 
 .. code-block:: text
 
   subsection velocity source
-  set Darcy type          = phase_change
+  set Darcy type = phase_change
   end
 
 Furthermore, the ``phase change`` subsection within the physical properties but also be modified to specify the Darcy penalty of the solid and liquid phase:
@@ -270,7 +293,7 @@ Furthermore, the ``phase change`` subsection within the physical properties but 
 .. code-block:: text
 
     subsection physical properties
-      set number of fluids = 1
+      set number of fluids      = 1
       set reference temperature = 29.8
       subsection fluid 0
         set thermal conductivity model = constant
@@ -307,16 +330,16 @@ Furthermore, the ``phase change`` subsection within the physical properties but 
           set viscosity solid = 0.0007366698558439125
     
           # Thermal expansion of the liquid phase
-          set thermal expansion liquid       = 1
+          set thermal expansion liquid = 1
     
           # Thermal expansion of the solid phase
-          set thermal expansion solid        = 0
+          set thermal expansion solid = 0
     
           # Permeability of the liquid phase
-          set Darcy penalty liquid         = 0
+          set Darcy penalty liquid = 0
     
           # Permeability of the  solid phase
-          set Darcy penalty solid          = 1e4
+          set Darcy penalty solid = 1e4
         end
       end
     end

--- a/doc/source/examples/multiphysics/melting-cavity/melting-cavity.rst
+++ b/doc/source/examples/multiphysics/melting-cavity/melting-cavity.rst
@@ -14,6 +14,7 @@ Features
 - Solver: ``lethe-fluid`` 
 - Phase change (solid-liquid)
 - Buoyant force (natural convection)
+- Temperature-dependent stasis constraint
 - Unsteady problem handled by an adaptive BDF2 time-stepping scheme 
 - Usage of a python script for post-processing data
 

--- a/doc/source/parameters/cfd/constrain_stasis.rst
+++ b/doc/source/parameters/cfd/constrain_stasis.rst
@@ -3,7 +3,10 @@ Constrain Stasis
 =================
 
 This subsection is used to define temperature-dependent solid domains within a defined fluid.
-Homogenous constraints are applied on velocity and pressure degrees of freedom of cells found within the prescribed temperature range to mimic a solid.
+Homogenous constraints are applied on velocity and pressure degrees of freedom (DoFs) of cells found within the prescribed temperature range to mimic a solid.
+
+.. note::
+  Pressure DoFs of solid cells that are adjacent to fluid cells (i.e., cells with temperature values outside the specified range) are left unconstrained in order to adequately solve fluid flows.
 
 .. attention::
     In order to use this feature, the ``heat transfer`` physic must be enabled (``true``) in the :doc:`./multiphysics` subsection.

--- a/examples/multiphysics/melting-cavity/melting-cavity-stasis-constraint.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity-stasis-constraint.prm
@@ -1,0 +1,234 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method                       = bdf1
+  set time end                     = 41
+  set time step                    = 0.01
+  set adapt                        = true
+  set max cfl                      = 0.8
+  set adaptative time step scaling = 1.1
+  set output name                  = melting
+  set output control               = iteration
+  set output frequency             = 10
+  set output path                  = ./output-stasis-constraint/
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer  = true
+  set buoyancy force = true
+  set fluid dynamics = true
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+  subsection uvwp
+    set Function expression = 0; 0; 0
+  end
+  subsection temperature
+    set Function expression = 28
+  end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set Function expression = 0 ; -1 ; 0
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids      = 1
+  set reference temperature = 29.8
+  subsection fluid 0
+    set thermal conductivity model = constant
+    set thermal conductivity       = 0.040516842071415184
+
+    set thermal expansion model = phase_change
+    set thermal expansion       = 1
+
+    set rheological model   = phase_change
+    set specific heat model = phase_change
+
+    set density = 1
+
+    subsection phase change
+      # Enthalpy of the phase change
+      set latent enthalpy = 200
+
+      # Temperature of the liquidus
+      set liquidus temperature = 29.8
+
+      # Temperature of the solidus
+      set solidus temperature = 29.6
+
+      # Specific heat of the liquid phase
+      set specific heat liquid = 1
+
+      # Specific heat of the solid phase
+      set specific heat solid = 1
+
+      # Kinematic viscosity of the liquid phase
+      set viscosity liquid = 0.0007366698558439125
+
+      # Kinematic viscosity of the solid phase
+      set viscosity solid = 10
+
+      set thermal expansion liquid = 1
+      set thermal expansion solid  = 0
+    end
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 3, 2 : 0, 0 : 1, 0.714 : true
+  set initial refinement = 6
+end
+
+#---------------------------------------------------
+# Postprocessing
+#---------------------------------------------------
+
+subsection post-processing
+  set calculate liquid fraction = true
+  set verbosity                 = verbose
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 4
+  subsection bc 0
+    set id   = 0
+    set type = noslip
+  end
+  subsection bc 1
+    set id   = 1
+    set type = noslip
+  end
+  subsection bc 2
+    set id   = 2
+    set type = noslip
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noslip
+  end
+end
+
+subsection boundary conditions heat transfer
+  set number = 2
+  subsection bc 0
+    set id   = 0
+    set type = temperature
+    subsection value
+      set Function expression = 38
+    end
+  end
+  subsection bc 1
+    set id   = 1
+    set type = temperature
+    subsection value
+      set Function expression = 28
+    end
+  end
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 1
+  set pressure order = 1
+end
+
+#---------------------------------------------------
+# Constrain Solid Domain
+#---------------------------------------------------
+
+subsection constrain stasis
+  set enable                = true
+  set number of constraints = 1
+  subsection constraint 0
+    set fluid id        = 0
+    set min temperature = 0
+    set max temperature = 28.5
+  end
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set tolerance      = 1e-3
+    set max iterations = 30
+    set verbosity      = verbose
+  end
+  subsection fluid dynamics
+    set tolerance      = 1e-4
+    set max iterations = 5
+    set verbosity      = verbose
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+    set max krylov vectors                    = 1000
+  end
+  subsection heat transfer
+    set verbosity                             = verbose
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-3
+    set minimum residual                      = 1e-5
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end


### PR DESCRIPTION
# Description 

- This PR adds a small section in the melting cavity example featuring the new `constrain stasis` feature from (#1038).

# Documentation

- Parameter documentation was also updated : `doc/source/parameters/cfd/constrain_stasis.rst` 
