### PR TITLE
Fix vof mass monitoring print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-03-13
+
+### Changed
+
+- MINOR In a similar way to "VOF Barycenter", the output of the "VOF Mass Conservation" is now displayed at every time iteration on the terminal when `calculate mass conservation` in the `post-processing` is enabled (default) and the `verbosity` is set to `verbose`. [#1062](https://github.com/lethe-cfd/lethe/pull/1062)
+
+- MINOR A new boolean argument in `make_table` functions has been added, namely `display_scientific_notation` to decide if the display of table values is displayed at a fixed decimal or in scientific notation. [#1062](https://github.com/lethe-cfd/lethe/pull/1062)
+
+### Added
+
+- MINOR A new `make_table_scalars_vectors` function has been added in `utilities.h`(`.cc`). [#1062](https://github.com/lethe-cfd/lethe/pull/1062)
+
 ## [Master] - 2024-03-11
 
 ### Added

--- a/applications_tests/lethe-fluid/gls_vof_1_isothermal_compressible_fluid.output
+++ b/applications_tests/lethe-fluid/gls_vof_1_isothermal_compressible_fluid.output
@@ -4,17 +4,28 @@ Running on 1 MPI rank(s)...
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 4225
 
-*******************************************************************************
-Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
-*******************************************************************************
-
-*******************************************************************************
-Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.64181 
-*******************************************************************************
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      6.5778e-01              7.8933e-01      3.4222e-01              3.4222e+02               0.5000 
-1.0000e-01      6.5778e-01              7.8933e-01      3.4222e-01              3.4222e+02               0.5000 
-2.0000e-01      6.5791e-01              7.8950e-01      3.4209e-01              3.4209e+02               0.5000 
+0.0000e+00      6.5778e-01              7.8933e-01      3.4222e-01              3.4222e+02           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.0000e-01      6.5778e-01              7.8933e-01      3.4222e-01              3.4222e+02           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.64181 
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+2.0000e-01      6.5791e-01              7.8950e-01      3.4209e-01              3.4209e+02           5.0000e-01 

--- a/applications_tests/lethe-fluid/gls_vof_2_isothermal_compressible_fluids.output
+++ b/applications_tests/lethe-fluid/gls_vof_2_isothermal_compressible_fluids.output
@@ -4,17 +4,28 @@ Running on 1 MPI rank(s)...
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 4225
 
-*******************************************************************************
-Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
-*******************************************************************************
-
-*******************************************************************************
-Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.53178 
-*******************************************************************************
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      6.5778e-01              7.8933e-01      3.4222e-01              1.7111e+01               0.5000 
-1.0000e-01      6.5778e-01              7.8933e-01      3.4222e-01              1.7111e+01               0.5000 
-2.0000e-01      6.5796e-01              7.8955e-01      3.4204e-01              1.7102e+01               0.5000 
+0.0000e+00      6.5778e-01              7.8933e-01      3.4222e-01              1.7111e+01           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.0000e-01      6.5778e-01              7.8933e-01      3.4222e-01              1.7111e+01           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.53178 
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+2.0000e-01      6.5796e-01              7.8955e-01      3.4204e-01              1.7102e+01           5.0000e-01 

--- a/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.output
+++ b/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.output
@@ -4,32 +4,58 @@ Running on 1 MPI rank(s)...
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 4225
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+0.0000e+00      1.8246e-02              1.8246e+00      9.8175e-01              2.9453e+02           5.0000e-01 
+
 *******************************************************************************
 Transient iteration: 1        Time: 0.05     Time step: 0.05     CFL: 2.23662 
 *******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+5.0000e-02      2.0230e-02              2.0230e+00      9.7977e-01              2.9393e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.1      Time step: 0.05     CFL: 2.93873 
 *******************************************************************************
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.0000e-01      4.0008e-02              4.0008e+00      9.5999e-01              2.8800e+02           5.0000e-01 
+
 *******************************************************************************
 Transient iteration: 3        Time: 0.15     Time step: 0.05     CFL: 2.87622 
 *******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.5000e-01      6.3657e-02              6.3657e+00      9.3634e-01              2.8090e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 4        Time: 0.2      Time step: 0.05     CFL: 2.86088 
 *******************************************************************************
 
-*******************************************************************************
-Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 2.85365 
-*******************************************************************************
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      1.8246e-02              1.8246e+00      9.8175e-01              2.9453e+02               0.5000 
-5.0000e-02      2.0230e-02              2.0230e+00      9.7977e-01              2.9393e+02               0.5000 
-1.0000e-01      4.0008e-02              4.0008e+00      9.5999e-01              2.8800e+02               0.5000 
-1.5000e-01      6.3657e-02              6.3657e+00      9.3634e-01              2.8090e+02               0.5000 
-2.0000e-01      8.8523e-02              8.8523e+00      9.1148e-01              2.7344e+02               0.5000 
-2.5000e-01      1.1375e-01              1.1375e+01      8.8625e-01              2.6587e+02               0.5000 
+2.0000e-01      8.8523e-02              8.8523e+00      9.1148e-01              2.7344e+02           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 2.85365 
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+2.5000e-01      1.1375e-01              1.1375e+01      8.8625e-01              2.6587e+02           5.0000e-01 

--- a/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.output
+++ b/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.output
@@ -4,32 +4,58 @@ Running on 1 MPI rank(s)...
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 4225
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+0.0000e+00      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+
 *******************************************************************************
 Transient iteration: 1        Time: 0.05     Time step: 0.05     CFL: 0       
 *******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+5.0000e-02      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.1      Time step: 0.05     CFL: 1.39102 
 *******************************************************************************
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.0000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+
 *******************************************************************************
 Transient iteration: 3        Time: 0.15     Time step: 0.05     CFL: 2.78204 
 *******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.5000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 4        Time: 0.2      Time step: 0.05     CFL: 4.17307 
 *******************************************************************************
 
-*******************************************************************************
-Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 5.56409 
-*******************************************************************************
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02               0.5000 
-5.0000e-02      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02               0.5000 
-1.0000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02               0.5000 
-1.5000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02               0.5000 
-2.0000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02               0.5000 
-2.5000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02               0.5000 
+2.0000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 5.56409 
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+2.5000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 

--- a/applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.output
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.output
@@ -7,6 +7,12 @@ Running on 1 MPI rank(s)...
 Pressure drop: 0 Pa
 Total pressure drop: 0 Pa
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+0.0000e+00      3.3203e-02              3.3203e-02      2.9297e-02              2.9297e-02           5.0000e-01 
+
 ---------------
 VOF Barycenter
 ---------------
@@ -18,6 +24,12 @@ Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0
 *******************************************************************************
 Pressure drop: -0.367464 Pa
 Total pressure drop: -0.367464 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.0000e-01      3.3203e-02              3.3203e-02      2.9297e-02              2.9297e-02           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -31,6 +43,12 @@ Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 0.00485702
 Pressure drop: -0.367538 Pa
 Total pressure drop: -0.367538 Pa
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+2.0000e-01      3.3203e-02              3.3203e-02      2.9297e-02              2.9297e-02           5.0000e-01 
+
 ---------------
 VOF Barycenter
 ---------------
@@ -43,6 +61,12 @@ Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 0.00241665
 Pressure drop: -0.367861 Pa
 Total pressure drop: -0.367861 Pa
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+3.0000e-01      3.3202e-02              3.3202e-02      2.9298e-02              2.9298e-02           5.0000e-01 
+
 ---------------
 VOF Barycenter
 ---------------
@@ -54,6 +78,12 @@ Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 0.00157289
 *********************************************************************************
 Pressure drop: -0.367981 Pa
 Total pressure drop: -0.367981 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+4.0000e-01      3.3201e-02              3.3201e-02      2.9299e-02              2.9299e-02           5.0000e-01 
 
 ---------------
 VOF Barycenter

--- a/applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.prm
@@ -163,7 +163,7 @@ end
 subsection post-processing
   set verbosity                   = verbose
   set calculate pressure drop     = true
-  set calculate mass conservation = false
+  set calculate mass conservation = true
   set calculate barycenter        = true
 end
 

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_vof.output
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_vof.output
@@ -4,6 +4,12 @@ Running on 1 MPI rank(s)...
    Volume of triangulation:      1
    Number of VOF degrees of freedom: 81
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+0.0000e+00      8.7500e-01              8.7500e-02      1.2500e-01              1.2500e+01           5.0000e-01 
+
 ---------------
 VOF Barycenter
 ---------------
@@ -13,6 +19,12 @@ VOF Barycenter
 *******************************************************************************
 Transient iteration: 1        Time: 0.5      Time step: 0.5      CFL: 2.79578 
 *******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+5.0000e-01      8.7789e-01              8.7789e-02      1.2211e-01              1.2211e+01           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -24,15 +36,14 @@ VOF Barycenter
 Transient iteration: 2        Time: 1        Time step: 0.5      CFL: 3.72386 
 *******************************************************************************
 
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
+1.0000e+00      8.2689e-01              8.2689e-02      1.7311e-01              1.7311e+01           5.0000e-01 
+
 ---------------
 VOF Barycenter
 ---------------
   time    x_vof    y_vof    vx_vof   vy_vof   
 1.000000 0.513560 0.638656 0.449731 -0.013803 
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      8.7500e-01              8.7500e-02      1.2500e-01              1.2500e+01               0.5000 
-5.0000e-01      8.7789e-01              8.7789e-02      1.2211e-01              1.2211e+01               0.5000 
-1.0000e+00      8.2689e-01              8.2689e-02      1.7311e-01              1.7311e+01               0.5000 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -75,57 +75,69 @@ add_statistics_to_table_handler(const std::string variable,
 }
 
 /**
- * @brief Generate a table from two vector of scalars.
+ * @brief Generate a table from a vector of scalars (independent variable) and
+ * a vector of vectors of scalars (dependent variables).
  *
- * @tparam T1 Scalar type of independent variables.
- *
- * @tparam T2 Scalar type of dependent variables.
+ * @tparam T Scalar type of independent variables.
  *
  * @param[in] independent_values Vector of scalar values that serve as the
- * independent variable. For example, time.
+ * independent variable (e.g., time).
  *
- * @param[in] independent_column_name Vector of strings representing the labels
- * of independent scalar values.
+ * @param[in] independent_column_name Label of the independent variable.
  *
  * @param[in] dependent_vector Vector of vectors of scalar values containing
- * dependant values.
+ * dependant variables values.
  *
  * @param[in] dependent_column_name Vector of strings representing the labels of
- * dependent scalar values.
+ * dependent variables.
  *
- * @param[in] display_precision Integer indicating the precision at which
- * the table is written.
+ * @param[in] display_precision Integer indicating the precision at which the
+ * table is written.
  *
  * @param[in] display_scientific_notation Boolean indicating if the values
  * should be displayed in scientific notation (true) or not (false).
  *
- * @return A table with the independent values followed by the dependent values.
+ * @return Table with the independent variable values followed by the dependent
+ * variables values.
  */
-template <typename T1, typename T2>
+template <typename T>
 TableHandler
 make_table_scalars_vectors(
-  const std::vector<T1>              &independent_values,
-  const std::string                  &independent_column_name,
-  const std::vector<std::vector<T2>> &dependent_vector,
-  const std::vector<std::string>     &dependent_column_name,
-  const unsigned int                  display_precision,
-  const bool                          display_scientific_notation = false);
+  const std::vector<T>                   &independent_values,
+  const std::string                      &independent_column_name,
+  const std::vector<std::vector<double>> &dependent_vector,
+  const std::vector<std::string>         &dependent_column_name,
+  const unsigned int                      display_precision,
+  const bool                              display_scientific_notation = false);
 
 
 /**
- * @brief Generate a table from a vector of scalar and a vector of tensor<1,dim>
+ * @brief Generate a table from a vector of scalars (independent variable) and
+ * a vector of Tensor<1,dim> (dependent variables).
  *
- * @param independent_values A vector of scalar values that serve as the independent
- * variable. For example time.
+ * @tparam T Scalar type of independent variables.
  *
- * @param independent_column_name The name of the independent variable
+ * @tparam dim Integer that denotes the number of spatial dimensions.
  *
- * @param dependent_vector. A vector of Tensor<1,dim> which are the dependent variable. For example force.
+ * @param[in] independent_values Vector of scalar values that serve as the
+ * independent variable (e.g., time).
  *
- * @param dependent_column_names. A vector of string which are the label of dependent tensor
+ * @param[in] independent_column_name Label of the independent variable.
  *
- * @param display_precision. An integer which indicate the precision at which the tables are written
+ * @param[in] dependent_vector Vector of Tensor<1,dim> containing dependent
+ * variables values (e.g., force).
  *
+ * @param[in] dependent_column_names Vector of strings representing the labels
+ * of dependent variables.
+ *
+ * @param[in] display_precision Integer indicating the precision at which the
+ * table is written.
+ *
+ * @param[in] display_scientific_notation Boolean indicating if the values
+ * should be displayed in scientific notation (true) or not (false).
+ *
+ * @return Table with the independent variable values followed by the dependent
+ * variables values.
  */
 template <int dim, typename T>
 TableHandler
@@ -134,9 +146,37 @@ make_table_scalars_tensors(
   const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
   const std::vector<std::string>    &dependent_column_name,
-  const unsigned int                 display_precision);
+  const unsigned int                 display_precision,
+  const bool                         display_scientific_notation = false);
 
-
+/**
+ * @brief Generate a table from a vector of scalar (independent variable) and a
+ * vector of vectors of Tensor<1,dim> (dependent variables).
+ *
+ * @tparam T Scalar type of independent variables.
+ *
+ * @tparam dim Integer that denotes the number of spatial dimensions.
+ *
+ * @param[in] independent_values Vector of scalar values that serve as the
+ * independent variable (e.g., time).
+ *
+ * @param[in] independent_column_name Label of the independent variable.
+ *
+ * @param[in] dependent_vector Vector of vectors of Tensor<1,dim> containing
+ * dependent variables values (e.g., force).
+ *
+ * @param[in] dependent_column_names Vector of strings representing the labels
+ * of dependent variables.
+ *
+ * @param[in] display_precision Integer indicating the precision at which the
+ * table is written.
+ *
+ * @param[in] display_scientific_notation Boolean indicating if the values
+ * should be displayed in scientific notation (true) or not (false).
+ *
+ * @return Table with the independent variable values followed by the dependent
+ * variables values.
+ */
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
@@ -144,25 +184,36 @@ make_table_scalars_tensors(
   const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vector,
   const std::vector<std::string>                 &dependent_column_name,
-  const unsigned int                              display_precision);
+  const unsigned int                              display_precision,
+  const bool display_scientific_notation = false);
 
 /**
- * @brief Generate a table from a vector of tensor<1,dim> and a vector of tensor<1,dim>
+ * @brief Generate a table from a vector of Tensor<1,dim> (independent
+ * variables) and a vector of Tensor<1,dim> (dependent variables).
  *
- * @param independent_values A vector of Tensor<1,dim> that serve as the independent
- * variable. For example position.
+ * @tparam dim Integer that denotes the number of spatial dimensions.
  *
- * @param independent_column_name A vector of string which are the label of the independent tensor.
+ * @param[in] independent_values Vector of Tensor<1,dim> that serves as the
+ * independent variable (e.g., position).
  *
- * @param dependent_vector. A vector of Tensor<1,dim> which are the dependent variable. For example force.
+ * @param[in] independent_column_name Vector of strings representing labels of
+ * the independent tensor.
  *
- * @param dependent_column_names. A vector of string which are the label of dependent tensor.
+ * @param[in] dependent_vector Vector of vectors of Tensor<1,dim> containing
+ * dependent variables values (e.g., force).
  *
- * @param display_precision. An integer which indicate the precision at which the tables are written.
+ * @param[in] dependent_column_names Vector of strings representing the labels
+ * of dependent variables.
  *
+ * @param[in] display_precision Integer indicating the precision at which the
+ * table is written.
+ *
+ * @param[in] display_scientific_notation Boolean indicating if the values
+ * should be displayed in scientific notation (true) or not (false).
+ *
+ * @return Table with the independent variables values followed by the dependent
+ * variables values.
  */
-
-
 template <int dim>
 TableHandler
 make_table_tensors_tensors(
@@ -170,23 +221,32 @@ make_table_tensors_tensors(
   const std::vector<std::string>    &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
   const std::vector<std::string>    &dependent_column_name,
-  const unsigned int                 display_precision);
+  const unsigned int                 display_precision,
+  const bool                         display_scientific_notation = false);
 
 
 /**
- * @brief Generate a table from a vector of tensor<1,dim> and a vector of tensor<1,dim>.
+ * @brief Generate a table from a vector of Tensor<1,dim> (independent
+ * variables) and a vector of scalars (dependent variable).
  *
- * @param independent_values A vector of Tensor<1,dim> that serve as the independent
- * variable. For example position.
+ * @tparam dim Integer that denotes the number of spatial dimensions.
  *
- * @param independent_column_name The name of the independent variable.
+ * @param[in] independent_values Vector of Tensor<1,dim> that serves as the
+ * independent variable (e.g., position).
  *
- * @param dependent_vector. A vector of scalar which are the dependent variable. For example energy.
+ * @param[in] independent_column_name Vector of strings representing labels of
+ * the independent tensor.
  *
- * @param dependent_column_names. The label of the dependent scalar.
+ * @param[in] dependent_vector Vector of scalar that serves as the dependent
+ * variable (e.g., energy).
  *
- * @param display_precision. An integer which indicate the precision at which the tables are written.
+ * @param[in] dependent_column_names Label of the dependent variable.
  *
+ * @param[in] display_scientific_notation Boolean indicating if the values
+ * should be displayed in scientific notation (true) or not (false).
+ *
+ * @return Table with the independent variables values followed by the dependent
+ * variable values.
  */
 template <int dim>
 TableHandler
@@ -195,12 +255,13 @@ make_table_tensors_scalars(
   const std::vector<std::string>    &independent_column_name,
   const std::vector<double>         &dependent_values,
   const std::string                 &dependent_column_name,
-  const unsigned int                 display_precision);
-
+  const unsigned int                 display_precision,
+  const bool                         display_scientific_notation = false);
 
 
 /**
- * @brief Used in multiphasic simulations to calculates the equivalent properties for a given phase. Method called in quadrature points loop
+ * @brief Calculate the equivalent properties for a given phase. Method called
+ * in quadrature points loops in VOF simulations.
  *
  * @param phase Phase value for the given quadrature point
  *
@@ -262,7 +323,8 @@ clip(const T &n, const T &lower, const T &upper)
 }
 
 /**
- * @brief Used in multiphasic simulations to calculates the equivalent properties for a given phase given by the Cahn-Hilliard equations. Method called in quadrature points loop
+ * @brief Calculate the equivalent properties for a given phase. Method called
+ * in quadrature points loops in Cahn-Hilliard simulations.
  *
  * @param phase Phase value for the given quadrature point
  *

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -88,8 +88,8 @@ add_statistics_to_table_handler(const std::string variable,
  * @param[in] dependent_vector Vector of vectors of scalar values containing
  * dependant variables values.
  *
- * @param[in] dependent_column_name Vector of strings representing the labels of
- * dependent variables.
+ * @param[in] dependent_column_names Vector of strings representing the labels
+ * of dependent variables.
  *
  * @param[in] display_precision Integer indicating the precision at which the
  * table is written.
@@ -106,7 +106,7 @@ make_table_scalars_vectors(
   const std::vector<T>                   &independent_values,
   const std::string                      &independent_column_name,
   const std::vector<std::vector<double>> &dependent_vector,
-  const std::vector<std::string>         &dependent_column_name,
+  const std::vector<std::string>         &dependent_column_names,
   const unsigned int                      display_precision,
   const bool                              display_scientific_notation = false);
 
@@ -145,7 +145,7 @@ make_table_scalars_tensors(
   const std::vector<T>              &independent_values,
   const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string>    &dependent_column_name,
+  const std::vector<std::string>    &dependent_column_names,
   const unsigned int                 display_precision,
   const bool                         display_scientific_notation = false);
 
@@ -183,7 +183,7 @@ make_table_scalars_tensors(
   const std::vector<T>                           &independent_values,
   const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vector,
-  const std::vector<std::string>                 &dependent_column_name,
+  const std::vector<std::string>                 &dependent_column_names,
   const unsigned int                              display_precision,
   const bool display_scientific_notation = false);
 
@@ -196,7 +196,7 @@ make_table_scalars_tensors(
  * @param[in] independent_values Vector of Tensor<1,dim> that serves as the
  * independent variable (e.g., position).
  *
- * @param[in] independent_column_name Vector of strings representing labels of
+ * @param[in] independent_column_names Vector of strings representing labels of
  * the independent tensor.
  *
  * @param[in] dependent_vector Vector of vectors of Tensor<1,dim> containing
@@ -218,9 +218,9 @@ template <int dim>
 TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string>    &independent_column_name,
+  const std::vector<std::string>    &independent_column_names,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string>    &dependent_column_name,
+  const std::vector<std::string>    &dependent_column_names,
   const unsigned int                 display_precision,
   const bool                         display_scientific_notation = false);
 
@@ -234,13 +234,13 @@ make_table_tensors_tensors(
  * @param[in] independent_values Vector of Tensor<1,dim> that serves as the
  * independent variable (e.g., position).
  *
- * @param[in] independent_column_name Vector of strings representing labels of
+ * @param[in] independent_column_names Vector of strings representing labels of
  * the independent tensor.
  *
  * @param[in] dependent_vector Vector of scalar that serves as the dependent
  * variable (e.g., energy).
  *
- * @param[in] dependent_column_names Label of the dependent variable.
+ * @param[in] dependent_column_name Label of the dependent variable.
  *
  * @param[in] display_scientific_notation Boolean indicating if the values
  * should be displayed in scientific notation (true) or not (false).
@@ -252,7 +252,7 @@ template <int dim>
 TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string>    &independent_column_name,
+  const std::vector<std::string>    &independent_column_names,
   const std::vector<double>         &dependent_values,
   const std::string                 &dependent_column_name,
   const unsigned int                 display_precision,

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -75,6 +75,44 @@ add_statistics_to_table_handler(const std::string variable,
 }
 
 /**
+ * @brief Generate a table from two vector of scalars.
+ *
+ * @tparam T1 Scalar type of independent variables.
+ *
+ * @tparam T2 Scalar type of dependent variables.
+ *
+ * @param[in] independent_values Vector of scalar values that serve as the
+ * independent variable. For example, time.
+ *
+ * @param[in] independent_column_name Vector of strings representing the labels
+ * of independent scalar values.
+ *
+ * @param[in] dependent_vector Vector of vectors of scalar values containing
+ * dependant values.
+ *
+ * @param[in] dependent_column_name Vector of strings representing the labels of
+ * dependent scalar values.
+ *
+ * @param[in] display_precision Integer indicating the precision at which
+ * the table is written.
+ *
+ * @param[in] display_scientific_notation Boolean indicating if the values
+ * should be displayed in scientific notation (true) or not (false).
+ *
+ * @return A table with the independent values followed by the dependent values.
+ */
+template <typename T1, typename T2>
+TableHandler
+make_table_scalars_vectors(
+  const std::vector<T1>              &independent_values,
+  const std::string                  &independent_column_name,
+  const std::vector<std::vector<T2>> &dependent_vector,
+  const std::vector<std::string>     &dependent_column_name,
+  const unsigned int                  display_precision,
+  const bool                          display_scientific_notation = false);
+
+
+/**
  * @brief Generate a table from a vector of scalar and a vector of tensor<1,dim>
  *
  * @param independent_values A vector of scalar values that serve as the independent

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -5,15 +5,15 @@
 #  include <filesystem>
 #endif
 
-template <typename T1, typename T2>
+template <typename T>
 TableHandler
 make_table_scalars_vectors(
-  const std::vector<T1>              &independent_values,
-  const std::string                  &independent_column_name,
-  const std::vector<std::vector<T2>> &dependent_vector,
-  const std::vector<std::string>     &dependent_column_name,
-  const unsigned int                  display_precision,
-  const bool                          display_scientific_notation)
+  const std::vector<T>                   &independent_values,
+  const std::string                      &independent_column_name,
+  const std::vector<std::vector<double>> &dependent_vector,
+  const std::vector<std::string>         &dependent_column_name,
+  const unsigned int                      display_precision,
+  const bool                              display_scientific_notation)
 {
   AssertDimension(independent_values.size(), dependent_vector.size());
 
@@ -49,11 +49,11 @@ make_table_scalars_tensors(
   const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
   const std::vector<std::string>    &dependent_column_name,
-  const unsigned int                 display_precision)
+  const unsigned int                 display_precision,
+  const bool                         display_scientific_notation)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
   AssertDimension(dependent_column_name.size(), dim);
-
 
   TableHandler table;
 
@@ -64,9 +64,18 @@ make_table_scalars_tensors(
         table.add_value(dependent_column_name[d], dependent_vector[i][d]);
     }
 
-  table.set_precision(independent_column_name, display_precision);
-  for (unsigned int d = 0; d < dim; ++d)
-    table.set_precision(dependent_column_name[d], display_precision);
+  if (display_scientific_notation)
+    {
+      table.set_scientific(independent_column_name, true);
+      for (unsigned int d = 0; d < dim; ++d)
+        table.set_scientific(dependent_column_name[d], true);
+    }
+  else
+    {
+      table.set_precision(independent_column_name, display_precision);
+      for (unsigned int d = 0; d < dim; ++d)
+        table.set_precision(dependent_column_name[d], display_precision);
+    }
 
   return table;
 }
@@ -78,7 +87,8 @@ make_table_scalars_tensors(
   const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vectors,
   const std::vector<std::string>                 &dependent_column_name,
-  const unsigned int                              display_precision)
+  const unsigned int                              display_precision,
+  const bool                                      display_scientific_notation)
 {
   AssertDimension(dependent_column_name.size(), dependent_vectors.size() * dim);
 
@@ -97,14 +107,24 @@ make_table_scalars_tensors(
             {
               table.add_value(dependent_column_name[d + vect_index],
                               vect[i][d]);
-              table.set_precision(dependent_column_name[d + vect_index],
-                                  display_precision);
+              if (display_scientific_notation)
+                {
+                  table.set_scientific(dependent_column_name[d + vect_index],
+                                       display_precision);
+                }
+              else
+                {
+                  table.set_precision(dependent_column_name[d + vect_index],
+                                      display_precision);
+                }
             }
         }
       vect_index += dim;
     }
-
-  table.set_precision(independent_column_name, display_precision);
+  if (display_scientific_notation)
+    table.set_scientific(independent_column_name, display_precision);
+  else
+    table.set_precision(independent_column_name, display_precision);
 
   return table;
 }
@@ -117,7 +137,8 @@ make_table_tensors_tensors(
   const std::vector<std::string>    &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
   const std::vector<std::string>    &dependent_column_name,
-  const unsigned int                 display_precision)
+  const unsigned int                 display_precision,
+  const bool                         display_scientific_notation)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
   AssertDimension(independent_column_name.size(), dim);
@@ -133,12 +154,18 @@ make_table_tensors_tensors(
           table.add_value(dependent_column_name[d], dependent_vector[i][d]);
         }
     }
-
-  for (unsigned int d = 0; d < dim; ++d)
-    {
-      table.set_precision(independent_column_name[d], display_precision);
-      table.set_precision(dependent_column_name[d], display_precision);
-    }
+  if (display_scientific_notation)
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        table.set_scientific(independent_column_name[d], display_precision);
+        table.set_scientific(dependent_column_name[d], display_precision);
+      }
+  else
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        table.set_precision(independent_column_name[d], display_precision);
+        table.set_precision(dependent_column_name[d], display_precision);
+      }
 
   return table;
 }
@@ -150,7 +177,8 @@ make_table_tensors_scalars(
   const std::vector<std::string>    &independent_column_name,
   const std::vector<double>         &dependent_vector,
   const std::string                 &dependent_column_name,
-  const unsigned int                 display_precision)
+  const unsigned int                 display_precision,
+  const bool                         display_scientific_notation)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
   AssertDimension(independent_column_name.size(), dim);
@@ -165,9 +193,18 @@ make_table_tensors_scalars(
         table.add_value(independent_column_name[d], independent_vector[i][d]);
     }
 
-  table.set_precision(dependent_column_name, display_precision);
-  for (unsigned int d = 0; d < dim; ++d)
-    table.set_precision(independent_column_name[d], display_precision);
+  if (display_scientific_notation)
+    {
+      table.set_scientific(dependent_column_name, display_precision);
+      for (unsigned int d = 0; d < dim; ++d)
+        table.set_scientific(independent_column_name[d], display_precision);
+    }
+  else
+    {
+      table.set_precision(dependent_column_name, display_precision);
+      for (unsigned int d = 0; d < dim; ++d)
+        table.set_precision(independent_column_name[d], display_precision);
+    }
 
   return table;
 }
@@ -378,7 +415,8 @@ make_table_scalars_tensors(
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -386,7 +424,8 @@ make_table_scalars_tensors(
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -394,7 +433,8 @@ make_table_scalars_tensors(
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
   const std::vector<std::string>               &dependent_column_name,
-  const unsigned int                            display_precision);
+  const unsigned int                            display_precision,
+  const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -402,7 +442,8 @@ make_table_scalars_tensors(
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
   const std::vector<std::string>               &dependent_column_name,
-  const unsigned int                            display_precision);
+  const unsigned int                            display_precision,
+  const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -410,7 +451,8 @@ make_table_scalars_tensors(
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -418,7 +460,8 @@ make_table_scalars_tensors(
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -426,7 +469,8 @@ make_table_scalars_tensors(
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
   const std::vector<std::string>               &dependent_column_name,
-  const unsigned int                            display_precision);
+  const unsigned int                            display_precision,
+  const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -434,7 +478,8 @@ make_table_scalars_tensors(
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
   const std::vector<std::string>               &dependent_column_name,
-  const unsigned int                            display_precision);
+  const unsigned int                            display_precision,
+  const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -442,7 +487,8 @@ make_table_scalars_tensors(
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -450,7 +496,8 @@ make_table_scalars_tensors(
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -458,7 +505,8 @@ make_table_scalars_tensors(
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
   const std::vector<std::string>               &dependent_column_name,
-  const unsigned int                            display_precision);
+  const unsigned int                            display_precision,
+  const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(
@@ -466,7 +514,8 @@ make_table_scalars_tensors(
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
   const std::vector<std::string>               &dependent_column_name,
-  const unsigned int                            display_precision);
+  const unsigned int                            display_precision,
+  const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_tensors_tensors(
@@ -474,7 +523,8 @@ make_table_tensors_tensors(
   const std::vector<std::string>  &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_tensors_tensors(
@@ -482,7 +532,8 @@ make_table_tensors_tensors(
   const std::vector<std::string>  &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
   const std::vector<std::string>  &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_tensors_scalars(
@@ -490,7 +541,8 @@ make_table_tensors_scalars(
   const std::vector<std::string>  &independent_column_name,
   const std::vector<double>       &dependent_values,
   const std::string               &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_tensors_scalars(
@@ -498,7 +550,8 @@ make_table_tensors_scalars(
   const std::vector<std::string>  &independent_column_name,
   const std::vector<double>       &dependent_values,
   const std::string               &dependent_column_name,
-  const unsigned int               display_precision);
+  const unsigned int               display_precision,
+  const bool                       display_scientific_notation);
 
 
 std::string

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -11,7 +11,7 @@ make_table_scalars_vectors(
   const std::vector<T>                   &independent_values,
   const std::string                      &independent_column_name,
   const std::vector<std::vector<double>> &dependent_vector,
-  const std::vector<std::string>         &dependent_column_name,
+  const std::vector<std::string>         &dependent_column_names,
   const unsigned int                      display_precision,
   const bool                              display_scientific_notation)
 {
@@ -22,21 +22,21 @@ make_table_scalars_vectors(
   for (unsigned int i = 0; i < independent_values.size(); ++i)
     {
       table.add_value(independent_column_name, independent_values[i]);
-      for (unsigned int d = 0; d < dependent_column_name.size(); ++d)
-        table.add_value(dependent_column_name[d], dependent_vector[i][d]);
+      for (unsigned int d = 0; d < dependent_column_names.size(); ++d)
+        table.add_value(dependent_column_names[d], dependent_vector[i][d]);
     }
 
   if (display_scientific_notation)
     {
       table.set_scientific(independent_column_name, true);
-      for (unsigned int d = 0; d < dependent_column_name.size(); ++d)
-        table.set_scientific(dependent_column_name[d], true);
+      for (unsigned int d = 0; d < dependent_column_names.size(); ++d)
+        table.set_scientific(dependent_column_names[d], true);
     }
   else
     {
       table.set_precision(independent_column_name, display_precision);
-      for (unsigned int d = 0; d < dependent_column_name.size(); ++d)
-        table.set_precision(dependent_column_name[d], display_precision);
+      for (unsigned int d = 0; d < dependent_column_names.size(); ++d)
+        table.set_precision(dependent_column_names[d], display_precision);
     }
 
   return table;
@@ -48,12 +48,12 @@ make_table_scalars_tensors(
   const std::vector<T>              &independent_vector,
   const std::string                 &independent_column_name,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string>    &dependent_column_name,
+  const std::vector<std::string>    &dependent_column_names,
   const unsigned int                 display_precision,
   const bool                         display_scientific_notation)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
-  AssertDimension(dependent_column_name.size(), dim);
+  AssertDimension(dependent_column_names.size(), dim);
 
   TableHandler table;
 
@@ -61,20 +61,20 @@ make_table_scalars_tensors(
     {
       table.add_value(independent_column_name, independent_vector[i]);
       for (unsigned int d = 0; d < dim; ++d)
-        table.add_value(dependent_column_name[d], dependent_vector[i][d]);
+        table.add_value(dependent_column_names[d], dependent_vector[i][d]);
     }
 
   if (display_scientific_notation)
     {
       table.set_scientific(independent_column_name, true);
       for (unsigned int d = 0; d < dim; ++d)
-        table.set_scientific(dependent_column_name[d], true);
+        table.set_scientific(dependent_column_names[d], true);
     }
   else
     {
       table.set_precision(independent_column_name, display_precision);
       for (unsigned int d = 0; d < dim; ++d)
-        table.set_precision(dependent_column_name[d], display_precision);
+        table.set_precision(dependent_column_names[d], display_precision);
     }
 
   return table;
@@ -86,11 +86,12 @@ make_table_scalars_tensors(
   const std::vector<T>                           &independent_vector,
   const std::string                              &independent_column_name,
   const std::vector<std::vector<Tensor<1, dim>>> &dependent_vectors,
-  const std::vector<std::string>                 &dependent_column_name,
+  const std::vector<std::string>                 &dependent_column_names,
   const unsigned int                              display_precision,
   const bool                                      display_scientific_notation)
 {
-  AssertDimension(dependent_column_name.size(), dependent_vectors.size() * dim);
+  AssertDimension(dependent_column_names.size(),
+                  dependent_vectors.size() * dim);
 
   TableHandler table;
   unsigned int vect_index = 0;
@@ -105,16 +106,16 @@ make_table_scalars_tensors(
         {
           for (unsigned int d = 0; d < dim; ++d)
             {
-              table.add_value(dependent_column_name[d + vect_index],
+              table.add_value(dependent_column_names[d + vect_index],
                               vect[i][d]);
               if (display_scientific_notation)
                 {
-                  table.set_scientific(dependent_column_name[d + vect_index],
+                  table.set_scientific(dependent_column_names[d + vect_index],
                                        display_precision);
                 }
               else
                 {
-                  table.set_precision(dependent_column_name[d + vect_index],
+                  table.set_precision(dependent_column_names[d + vect_index],
                                       display_precision);
                 }
             }
@@ -134,15 +135,15 @@ template <int dim>
 TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string>    &independent_column_name,
+  const std::vector<std::string>    &independent_column_names,
   const std::vector<Tensor<1, dim>> &dependent_vector,
-  const std::vector<std::string>    &dependent_column_name,
+  const std::vector<std::string>    &dependent_column_names,
   const unsigned int                 display_precision,
   const bool                         display_scientific_notation)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
-  AssertDimension(independent_column_name.size(), dim);
-  AssertDimension(dependent_column_name.size(), dim);
+  AssertDimension(independent_column_names.size(), dim);
+  AssertDimension(dependent_column_names.size(), dim);
 
   TableHandler table;
 
@@ -150,21 +151,22 @@ make_table_tensors_tensors(
     {
       for (unsigned int d = 0; d < dim; ++d)
         {
-          table.add_value(independent_column_name[d], independent_vector[i][d]);
-          table.add_value(dependent_column_name[d], dependent_vector[i][d]);
+          table.add_value(independent_column_names[d],
+                          independent_vector[i][d]);
+          table.add_value(dependent_column_names[d], dependent_vector[i][d]);
         }
     }
   if (display_scientific_notation)
     for (unsigned int d = 0; d < dim; ++d)
       {
-        table.set_scientific(independent_column_name[d], display_precision);
-        table.set_scientific(dependent_column_name[d], display_precision);
+        table.set_scientific(independent_column_names[d], display_precision);
+        table.set_scientific(dependent_column_names[d], display_precision);
       }
   else
     for (unsigned int d = 0; d < dim; ++d)
       {
-        table.set_precision(independent_column_name[d], display_precision);
-        table.set_precision(dependent_column_name[d], display_precision);
+        table.set_precision(independent_column_names[d], display_precision);
+        table.set_precision(dependent_column_names[d], display_precision);
       }
 
   return table;
@@ -174,14 +176,14 @@ template <int dim>
 TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, dim>> &independent_vector,
-  const std::vector<std::string>    &independent_column_name,
+  const std::vector<std::string>    &independent_column_names,
   const std::vector<double>         &dependent_vector,
   const std::string                 &dependent_column_name,
   const unsigned int                 display_precision,
   const bool                         display_scientific_notation)
 {
   AssertDimension(independent_vector.size(), dependent_vector.size());
-  AssertDimension(independent_column_name.size(), dim);
+  AssertDimension(independent_column_names.size(), dim);
 
 
   TableHandler table;
@@ -190,20 +192,20 @@ make_table_tensors_scalars(
     {
       table.add_value(dependent_column_name, dependent_vector[i]);
       for (unsigned int d = 0; d < dim; ++d)
-        table.add_value(independent_column_name[d], independent_vector[i][d]);
+        table.add_value(independent_column_names[d], independent_vector[i][d]);
     }
 
   if (display_scientific_notation)
     {
       table.set_scientific(dependent_column_name, display_precision);
       for (unsigned int d = 0; d < dim; ++d)
-        table.set_scientific(independent_column_name[d], display_precision);
+        table.set_scientific(independent_column_names[d], display_precision);
     }
   else
     {
       table.set_precision(dependent_column_name, display_precision);
       for (unsigned int d = 0; d < dim; ++d)
-        table.set_precision(independent_column_name[d], display_precision);
+        table.set_precision(independent_column_names[d], display_precision);
     }
 
   return table;
@@ -387,7 +389,7 @@ make_table_scalars_vectors(
   const std::vector<double>              &independent_values,
   const std::string                      &independent_column_name,
   const std::vector<std::vector<double>> &dependent_vector,
-  const std::vector<std::string>         &dependent_column_name,
+  const std::vector<std::string>         &dependent_column_names,
   const unsigned int                      display_precision,
   const bool                              display_scientific_notation);
 
@@ -396,7 +398,7 @@ make_table_scalars_vectors(
   const std::vector<unsigned int>        &independent_values,
   const std::string                      &independent_column_name,
   const std::vector<std::vector<double>> &dependent_vector,
-  const std::vector<std::string>         &dependent_column_name,
+  const std::vector<std::string>         &dependent_column_names,
   const unsigned int                      display_precision,
   const bool                              display_scientific_notation);
 
@@ -405,7 +407,7 @@ make_table_scalars_vectors(
   const std::vector<int>                 &independent_values,
   const std::string                      &independent_column_name,
   const std::vector<std::vector<double>> &dependent_vector,
-  const std::vector<std::string>         &dependent_column_name,
+  const std::vector<std::string>         &dependent_column_names,
   const unsigned int                      display_precision,
   const bool                              display_scientific_notation);
 
@@ -414,7 +416,7 @@ make_table_scalars_tensors(
   const std::vector<double>       &independent_values,
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
@@ -423,7 +425,7 @@ make_table_scalars_tensors(
   const std::vector<double>       &independent_values,
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
@@ -432,7 +434,7 @@ make_table_scalars_tensors(
   const std::vector<double>                    &independent_values,
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
-  const std::vector<std::string>               &dependent_column_name,
+  const std::vector<std::string>               &dependent_column_names,
   const unsigned int                            display_precision,
   const bool                                    display_scientific_notation);
 
@@ -441,7 +443,7 @@ make_table_scalars_tensors(
   const std::vector<double>                    &independent_values,
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
-  const std::vector<std::string>               &dependent_column_name,
+  const std::vector<std::string>               &dependent_column_names,
   const unsigned int                            display_precision,
   const bool                                    display_scientific_notation);
 
@@ -450,7 +452,7 @@ make_table_scalars_tensors(
   const std::vector<unsigned int> &independent_values,
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
@@ -459,7 +461,7 @@ make_table_scalars_tensors(
   const std::vector<unsigned int> &independent_values,
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
@@ -468,7 +470,7 @@ make_table_scalars_tensors(
   const std::vector<unsigned int>              &independent_values,
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
-  const std::vector<std::string>               &dependent_column_name,
+  const std::vector<std::string>               &dependent_column_names,
   const unsigned int                            display_precision,
   const bool                                    display_scientific_notation);
 
@@ -477,7 +479,7 @@ make_table_scalars_tensors(
   const std::vector<unsigned int>              &independent_values,
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
-  const std::vector<std::string>               &dependent_column_name,
+  const std::vector<std::string>               &dependent_column_names,
   const unsigned int                            display_precision,
   const bool                                    display_scientific_notation);
 
@@ -486,7 +488,7 @@ make_table_scalars_tensors(
   const std::vector<int>          &independent_values,
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
@@ -495,7 +497,7 @@ make_table_scalars_tensors(
   const std::vector<int>          &independent_values,
   const std::string               &independent_column_name,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
@@ -504,7 +506,7 @@ make_table_scalars_tensors(
   const std::vector<int>                       &independent_values,
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 2>>> &dependent_vector,
-  const std::vector<std::string>               &dependent_column_name,
+  const std::vector<std::string>               &dependent_column_names,
   const unsigned int                            display_precision,
   const bool                                    display_scientific_notation);
 
@@ -513,32 +515,32 @@ make_table_scalars_tensors(
   const std::vector<int>                       &independent_values,
   const std::string                            &independent_column_name,
   const std::vector<std::vector<Tensor<1, 3>>> &dependent_vector,
-  const std::vector<std::string>               &dependent_column_name,
+  const std::vector<std::string>               &dependent_column_names,
   const unsigned int                            display_precision,
   const bool                                    display_scientific_notation);
 
 template TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, 2>> &independent_values,
-  const std::vector<std::string>  &independent_column_name,
+  const std::vector<std::string>  &independent_column_names,
   const std::vector<Tensor<1, 2>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_tensors_tensors(
   const std::vector<Tensor<1, 3>> &independent_values,
-  const std::vector<std::string>  &independent_column_name,
+  const std::vector<std::string>  &independent_column_names,
   const std::vector<Tensor<1, 3>> &dependent_vector,
-  const std::vector<std::string>  &dependent_column_name,
+  const std::vector<std::string>  &dependent_column_names,
   const unsigned int               display_precision,
   const bool                       display_scientific_notation);
 
 template TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, 2>> &independent_vector,
-  const std::vector<std::string>  &independent_column_name,
+  const std::vector<std::string>  &independent_column_names,
   const std::vector<double>       &dependent_values,
   const std::string               &dependent_column_name,
   const unsigned int               display_precision,
@@ -547,7 +549,7 @@ make_table_tensors_scalars(
 template TableHandler
 make_table_tensors_scalars(
   const std::vector<Tensor<1, 3>> &independent_vector,
-  const std::vector<std::string>  &independent_column_name,
+  const std::vector<std::string>  &independent_column_names,
   const std::vector<double>       &dependent_values,
   const std::string               &dependent_column_name,
   const unsigned int               display_precision,

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -5,6 +5,43 @@
 #  include <filesystem>
 #endif
 
+template <typename T1, typename T2>
+TableHandler
+make_table_scalars_vectors(
+  const std::vector<T1>              &independent_values,
+  const std::string                  &independent_column_name,
+  const std::vector<std::vector<T2>> &dependent_vector,
+  const std::vector<std::string>     &dependent_column_name,
+  const unsigned int                  display_precision,
+  const bool                          display_scientific_notation)
+{
+  AssertDimension(independent_values.size(), dependent_vector.size());
+
+  TableHandler table;
+
+  for (unsigned int i = 0; i < independent_values.size(); ++i)
+    {
+      table.add_value(independent_column_name, independent_values[i]);
+      for (unsigned int d = 0; d < dependent_column_name.size(); ++d)
+        table.add_value(dependent_column_name[d], dependent_vector[i][d]);
+    }
+
+  if (display_scientific_notation)
+    {
+      table.set_scientific(independent_column_name, true);
+      for (unsigned int d = 0; d < dependent_column_name.size(); ++d)
+        table.set_scientific(dependent_column_name[d], true);
+    }
+  else
+    {
+      table.set_precision(independent_column_name, display_precision);
+      for (unsigned int d = 0; d < dependent_column_name.size(); ++d)
+        table.set_precision(dependent_column_name[d], display_precision);
+    }
+
+  return table;
+}
+
 template <int dim, typename T>
 TableHandler
 make_table_scalars_tensors(
@@ -307,6 +344,33 @@ create_output_folder(const std::string &dirname)
   // mkdir(dirname.c_str(), 0755);
 #endif
 }
+
+template TableHandler
+make_table_scalars_vectors(
+  const std::vector<double>              &independent_values,
+  const std::string                      &independent_column_name,
+  const std::vector<std::vector<double>> &dependent_vector,
+  const std::vector<std::string>         &dependent_column_name,
+  const unsigned int                      display_precision,
+  const bool                              display_scientific_notation);
+
+template TableHandler
+make_table_scalars_vectors(
+  const std::vector<unsigned int>        &independent_values,
+  const std::string                      &independent_column_name,
+  const std::vector<std::vector<double>> &dependent_vector,
+  const std::vector<std::string>         &dependent_column_name,
+  const unsigned int                      display_precision,
+  const bool                              display_scientific_notation);
+
+template TableHandler
+make_table_scalars_vectors(
+  const std::vector<int>                 &independent_values,
+  const std::string                      &independent_column_name,
+  const std::vector<std::vector<double>> &dependent_vector,
+  const std::vector<std::string>         &dependent_column_name,
+  const unsigned int                      display_precision,
+  const bool                              display_scientific_notation);
 
 template TableHandler
 make_table_scalars_tensors(


### PR DESCRIPTION
# Description of the problem

- When `calculate mass conservation` in the `post-processing` was enabled (default) and the `verbosity` was set to `verbose`, the mass conservation table was displayed on terminal at the end of the simulation. If a lot of time iterations were made, this could cover a significant chunk of the terminal window and might not be pertinent to have it their when `.dat` files is also outputted by the simulation.

# Description of the solution

- In a similar way to "VOF Barycenter", the output of the "VOF Mass Conservation" is now displayed at every time iteration on the terminal.

# How Has This Been Tested?

- Expected tests have been updated output :
  - `applications_tests/lethe-fluid/gls_vof_1_isothermal_compressible_fluid.output`
  - `applications_tests/lethe-fluid/gls_vof_2_isothermal_compressible_fluids.output`
  - `applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.output`
  - `applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.output`
  - `applications_tests/lethe-fluid/time_dependent_boundaries_vof.output`
  
- Mass monitoring has been added to the following test to improve robustness:
  - `applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.prm` (`.output`)

# Future changes

- Change all `set_precision` in the `make_table` functions to `set_scientific` as default.

# Comments

- A new `make_table_scalars_vectors` function has been added in utilities.h/.cc.
- A new boolean argument in `make_table` functions has been added, namely `display_scientific_notation` to decide if the display of table values is displayed at a fixed decimal or in scientific notation.
