### PR TITLE
Remove global vector type from prototypes

### DIFF
--- a/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
+++ b/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
@@ -59,8 +59,6 @@
 #include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <core/vector.h>
-
 #include <fstream>
 #include <iostream>
 
@@ -457,7 +455,7 @@ private:
   void
   output_results(const unsigned int cycle) const;
 
-  using VectorType = GlobalVectorType;
+  using VectorType = TrilinosWrappers::MPI::Vector;
   using MatrixType = TrilinosWrappers::SparseMatrix;
 
   parallel::distributed::Triangulation<dim> triangulation;
@@ -1353,7 +1351,7 @@ MatrixBasedAdvectionDiffusion<dim, fe_degree>::compute_update()
 {
   TimerOutput::Scope t(computing_timer, "compute update");
 
-  GlobalVectorType completely_distributed_solution(
+  TrilinosWrappers::MPI::Vector completely_distributed_solution(
     locally_owned_dofs, mpi_communicator);
 
   SolverControl solver_control(200, 1.e-8 * system_rhs.l2_norm(), true, true);

--- a/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
+++ b/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
@@ -59,8 +59,6 @@
 #include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <core/vector.h>
-
 #include <fstream>
 #include <iostream>
 
@@ -350,7 +348,7 @@ private:
   void
   output_results(const unsigned int cycle) const;
 
-  using VectorType = GlobalVectorType;
+  using VectorType = TrilinosWrappers::MPI::Vector;
   using MatrixType = TrilinosWrappers::SparseMatrix;
 
   parallel::distributed::Triangulation<dim> triangulation;
@@ -996,7 +994,7 @@ MatrixBasedPoissonProblem<dim, fe_degree>::compute_update()
 {
   TimerOutput::Scope t(computing_timer, "compute update");
 
-  GlobalVectorType completely_distributed_solution(
+  TrilinosWrappers::MPI::Vector completely_distributed_solution(
     locally_owned_dofs, mpi_communicator);
 
   SolverControl              solver_control(100, 1.e-12);


### PR DESCRIPTION
# Description of the problem

The `GlobalVectorType` was introduced in two prototypes in PR #1001.

# Description of the solution

This change was reverted as this is just a prototype and we do not need it to work with Trilinos and L::d::V vectors.