### PR TITLE
Add fields check to physical property models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- MINOR Assertion on fields required for physical property models were added to the code. This is done to ensure that if a physical property model necessitating a certain field is employed and the field is not defined, the exception thrown is comprehensible. [#add_PR_number](add_PR_link)
+
 - MINOR A new `make_table_scalars_vectors` function has been added in `utilities.h`(`.cc`). [#1062](https://github.com/lethe-cfd/lethe/pull/1062)
 
 ## [Master] - 2024-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Assertion on fields required for physical property models were added to the code. This is done to ensure that if a physical property model necessitating a certain field is employed and the field is not defined, the exception thrown is comprehensible. [#add_PR_number](add_PR_link)
+- MINOR Assertion on fields required for physical property models were added to the code. This is done to ensure that if a physical property model necessitating a certain field is employed and that field is not defined, an exception thrown is comprehensible. [#add_PR_number](add_PR_link)
 
 - MINOR A new `make_table_scalars_vectors` function has been added in `utilities.h`(`.cc`). [#1062](https://github.com/lethe-cfd/lethe/pull/1062)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Assertion on fields required for physical property models were added to the code. This is done to ensure that if a physical property model necessitating a certain field is employed and that field is not defined, an exception thrown is comprehensible. [#add_PR_number](add_PR_link)
+- MINOR Assertion on fields required for physical property models were added to the code. This is done to ensure that if a physical property model necessitating a certain field is employed and that field is not defined, the exception message thrown is comprehensible. [#1065](https://github.com/lethe-cfd/lethe/pull/1065)
 
 - MINOR A new `make_table_scalars_vectors` function has been added in `utilities.h`(`.cc`). [#1062](https://github.com/lethe-cfd/lethe/pull/1062)
 

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -94,18 +94,18 @@ public:
   /**
    * @brief Compute density value.
    *
-   * @param[in] fields_value Value of the various fields on which the property
-   * may depend.
+   * @param[in] field_values Value of the various fields on which the property
+   * may depend. The map stores a single value per field.
    *
-   * @note Here, the @p fields_value parameter is ignored since the density
+   * @note Here, the @p field_values parameter is ignored since the density
    * remains constant.
    *
    * @return Density value.
    */
   double
-  value(const std::map<field, double> &fields_value) override
+  value(const std::map<field, double> &field_values) override
   {
-    (void)fields_value;
+    (void)field_values;
     return density;
   }
 
@@ -113,7 +113,7 @@ public:
    * @brief Compute a vector of density values.
    *
    * @param[in] field_vectors Vectors of the fields on which the density may
-   * depend.
+   * depend. The map stores a vector of values per field.
    *
    * @param[out] property_vector Vector of computed density values.
    *
@@ -133,7 +133,7 @@ public:
    * respect to a specified field.
    *
    * @param[in] field_values Values of the various fields on which the density
-   * may depend.
+   * may depend. The map stores a single value per field.
    *
    * @param[in] id Indicator of the field with respect to which the jacobian
    * should be computed.
@@ -158,7 +158,7 @@ public:
    * fields.
    *
    * @param[in] field_vectors Vector of values of the fields used to evaluate
-   * the density.
+   * the density. The map stores a vector of values per field.
    *
    * @param[in] id Identifier of the field with respect to which a derivative
    * should be computed.
@@ -167,7 +167,7 @@ public:
    * with respect to the field of the specified @p id. In this case, it returns
    * a vector of zeros since the density remains constant.
    *
-   * @note Here, the @p field_values and @p id parameters are ignored since the
+   * @note Here, the @p field_vectors and @p id parameters are ignored since the
    * density remains constant.
    *
    */
@@ -256,18 +256,19 @@ public:
   /**
    * @brief Compute the density of the isothermal ideal gas.
    *
-   * @param[in] fields_value Value of the various fields on which the property
-   * may depend. In this case, the density depends on pressure.
+   * @param[in] field_values Values of the various fields on which the property
+   * may depend. In this case, the density depends on pressure. The map stores a
+   * single value per field.
    *
-   * @return Value of the density computed with the @p fields_value.
+   * @return Value of the density computed with the @p field_values.
    */
   double
-  value(const std::map<field, double> &fields_value) override
+  value(const std::map<field, double> &field_values) override
   {
-    AssertThrow(fields_value.find(field::pressure) != fields_value.end(),
+    AssertThrow(field_values.find(field::pressure) != field_values.end(),
                 PhysicialPropertyModelFieldUndefined(
                   "DensityIsothermalIdealGas", "pressure"));
-    const double pressure = fields_value.at(field::pressure);
+    const double pressure = field_values.at(field::pressure);
     return density_ref + psi * pressure;
   }
 
@@ -275,7 +276,8 @@ public:
    * @brief Compute a vector of density values for an isothermal ideal gas.
    *
    * @param[in] field_vectors Vectors of the fields on which the density may
-   * depend. In this case, the density depends on pressure.
+   * depend. In this case, the density depends on pressure. The map stores a
+   * vector of values per field.
    *
    * @param[out] property_vector Vectors of computed density values.
    */
@@ -296,7 +298,7 @@ public:
    * respect to a specified field.
    *
    * @param[in] field_values Values of the various fields on which the density
-   * may depend.
+   * may depend. The map stores a single value per field.
    *
    * @param[in] id Indicator of the field with respect to which the jacobian
    * should be computed.
@@ -319,7 +321,7 @@ public:
    * an isothermal ideal gas.
    *
    * @param[in] field_vectors Vector of values of the fields used to evaluate
-   * the density.
+   * the density. The map stores a vector of values per field.
    *
    * @param[in] id Identifier of the field with respect to which a derivative
    * should be computed.

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -264,6 +264,9 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::pressure) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "DensityIsothermalIdealGas", "pressure"));
     const double pressure = fields_value.at(field::pressure);
     return density_ref + psi * pressure;
   }
@@ -280,6 +283,9 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::pressure) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "DensityIsothermalIdealGas", "pressure"));
     const std::vector<double> &pressure = field_vectors.at(field::pressure);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
       property_vector[i] = density_ref + psi * pressure[i];

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -215,7 +215,7 @@ public:
     , ambient_gas_density_inv(1.0 / p_evaporation.ambient_gas_density)
     , liquid_density_inv(1.0 / p_evaporation.liquid_density)
   {
-    model_depends_on[temperature] = false;
+    model_depends_on[field::temperature] = false;
   }
 
 
@@ -413,7 +413,7 @@ public:
     , liquid_density_inv(1.0 / p_evaporation.liquid_density)
     , universal_gas_constant(p_evaporation.universal_gas_constant)
   {
-    model_depends_on[temperature] = true;
+    model_depends_on[field::temperature] = true;
   }
 
   /**
@@ -425,6 +425,9 @@ public:
   double
   saturation_pressure(const std::map<field, double> &field_values)
   {
+    AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "EvaporationModelTemperature", "temperature"));
     const double temperature_inv =
       1.0 / (field_values.at(field::temperature) + 1e-16);
 
@@ -450,6 +453,9 @@ public:
   saturation_pressure(const std::map<field, std::vector<double>> &field_vectors,
                       std::vector<double> &saturation_pressure_vector)
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "EvaporationModelTemperature", "temperature"));
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
 
@@ -506,6 +512,9 @@ public:
   mass_flux(const std::map<field, std::vector<double>> &field_vectors,
             std::vector<double> &mass_flux_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "EvaporationModelTemperature", "temperature"));
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
 
@@ -578,6 +587,9 @@ public:
   heat_flux_jacobian(const std::map<field, double> &field_values,
                      const field                    id) override
   {
+    AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "EvaporationModelTemperature", "temperature"));
     const double temperature_inv =
       1.0 / (field_values.at(field::temperature) + 1e-16);
 
@@ -620,6 +632,10 @@ public:
 
     if (id == field::temperature)
       {
+        AssertThrow(
+          field_vectors.find(field::temperature) != field_vectors.end(),
+          PhysicialPropertyModelFieldUndefined("EvaporationModelTemperature",
+                                               "temperature"));
         const std::vector<double> &temperature =
           field_vectors.at(field::temperature);
 

--- a/include/core/mobility_cahn_hilliard_model.h
+++ b/include/core/mobility_cahn_hilliard_model.h
@@ -199,6 +199,10 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(
+      fields_value.find(field::phase_order_cahn_hilliard) != fields_value.end(),
+      PhysicialPropertyModelFieldUndefined("MobilityCahnHilliardModelQuartic",
+                                           "phase_order_cahn_hilliard"));
     const double &phase_order_cahn_hilliard =
       fields_value.at(field::phase_order_cahn_hilliard);
 
@@ -221,6 +225,11 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(
+      field_vectors.find(field::phase_order_cahn_hilliard) !=
+        field_vectors.end(),
+      PhysicialPropertyModelFieldUndefined("MobilityCahnHilliardModelQuartic",
+                                           "phase_order_cahn_hilliard"));
     const std::vector<double> &phase_order_cahn_hilliard =
       field_vectors.at(field::phase_order_cahn_hilliard);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
@@ -248,6 +257,10 @@ public:
   double
   jacobian(const std::map<field, double> &fields_value, field /*id*/) override
   {
+    AssertThrow(
+      fields_value.find(field::phase_order_cahn_hilliard) != fields_value.end(),
+      PhysicialPropertyModelFieldUndefined("MobilityCahnHilliardModelQuartic",
+                                           "phase_order_cahn_hilliard"));
     const double &phase_order_cahn_hilliard =
       fields_value.at(field::phase_order_cahn_hilliard);
 
@@ -275,6 +288,11 @@ public:
                   const field /*id*/,
                   std::vector<double> &jacobian_vector) override
   {
+    AssertThrow(
+      field_vectors.find(field::phase_order_cahn_hilliard) !=
+        field_vectors.end(),
+      PhysicialPropertyModelFieldUndefined("MobilityCahnHilliardModelQuartic",
+                                           "phase_order_cahn_hilliard"));
     const std::vector<double> &phase_order_cahn_hilliard =
       field_vectors.at(field::phase_order_cahn_hilliard);
     for (unsigned int i = 0; i < jacobian_vector.size(); ++i)

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -254,7 +254,7 @@ namespace Parameters
   };
 
   /**
-   * @brief Carreau rheological model to solve for non Newtonian
+   * @brief Carreau model to solve for non Newtonian
    * flows.
    */
   struct CarreauParameters

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -33,6 +33,13 @@ DeclException2(SizeOfFields,
                << " is not equal to the number of values for another field "
                << arg2);
 
+DeclException2(PhysicialPropertyModelFieldUndefined,
+               std::string,
+               std::string,
+               << "Error in '" << arg1 << "' model. \n "
+               << "The " << arg2
+               << " field required by the model is not defined.");
+
 /*
  * Fields on which physical property can depend. All fields are assumed
  * to be at time t+dt other than those for which a _p suffix is explicitly

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -37,8 +37,8 @@ DeclException2(PhysicialPropertyModelFieldUndefined,
                std::string,
                std::string,
                << "Error in '" << arg1 << "' model. \n "
-               << "The " << arg2
-               << " field required by the model is not defined.");
+               << "The '" << arg2
+               << "' field required by the model is not defined.");
 
 /*
  * Fields on which physical property can depend. All fields are assumed

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -300,8 +300,8 @@ public:
     , n(n)
     , shear_rate_min(shear_rate_min)
   {
-    this->model_depends_on[shear_rate]    = true;
-    this->non_newtonian_rheological_model = true;
+    this->model_depends_on[field::shear_rate] = true;
+    this->non_newtonian_rheological_model     = true;
   }
 
   /**
@@ -404,6 +404,9 @@ public:
     const double                  &p_density_ref,
     const std::map<field, double> &field_values) const override
   {
+    AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
+                PhysicialPropertyModelFieldUndefined("PowerLaw rheological",
+                                                     "shear_rate"));
     const double shear_rate_magnitude = field_values.at(field::shear_rate);
     return calculate_kinematic_viscosity(shear_rate_magnitude) * p_density_ref;
   }
@@ -420,6 +423,9 @@ public:
     const std::map<field, std::vector<double>> &field_vectors,
     std::vector<double>                        &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("PowerLaw rheological",
+                                                     "shear_rate"));
     const std::vector<double> &shear_rate_magnitude =
       field_vectors.at(field::shear_rate);
 
@@ -469,8 +475,8 @@ public:
     , a(p_a)
     , n(p_n)
   {
-    this->model_depends_on[shear_rate]    = true;
-    this->non_newtonian_rheological_model = true;
+    this->model_depends_on[field::shear_rate] = true;
+    this->non_newtonian_rheological_model     = true;
   }
 
   /**
@@ -564,6 +570,9 @@ public:
     const double                  &p_density_ref,
     const std::map<field, double> &field_values) const override
   {
+    AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
+                PhysicialPropertyModelFieldUndefined("Carreau rheological",
+                                                     "shear_rate"));
     const double shear_rate_magnitude = field_values.at(field::shear_rate);
     return calculate_kinematic_viscosity(shear_rate_magnitude) * p_density_ref;
   }
@@ -580,6 +589,9 @@ public:
     const std::map<field, std::vector<double>> &field_vectors,
     std::vector<double>                        &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("Carreau rheological",
+                                                     "shear_rate"));
     const std::vector<double> &shear_rate_magnitude =
       field_vectors.at(field::shear_rate);
 
@@ -639,7 +651,7 @@ public:
   PhaseChangeRheology(const Parameters::PhaseChange p_phase_change_parameters)
     : param(p_phase_change_parameters)
   {
-    this->model_depends_on[temperature] = true;
+    this->model_depends_on[field::temperature] = true;
   }
 
   /**
@@ -700,6 +712,9 @@ public:
     const double                  &p_density_ref,
     const std::map<field, double> &field_values) const override
   {
+    AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeRheology",
+                                                     "temperature"));
     const double temperature = field_values.at(field::temperature);
     return kinematic_viscosity(temperature) * p_density_ref;
   }
@@ -716,6 +731,9 @@ public:
     const std::map<field, std::vector<double>> &field_vectors,
     std::vector<double>                        &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeRheology",
+                                                     "temperature"));
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
 

--- a/include/core/rheological_model.h
+++ b/include/core/rheological_model.h
@@ -405,8 +405,7 @@ public:
     const std::map<field, double> &field_values) const override
   {
     AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
-                PhysicialPropertyModelFieldUndefined("PowerLaw rheological",
-                                                     "shear_rate"));
+                PhysicialPropertyModelFieldUndefined("PowerLaw", "shear_rate"));
     const double shear_rate_magnitude = field_values.at(field::shear_rate);
     return calculate_kinematic_viscosity(shear_rate_magnitude) * p_density_ref;
   }
@@ -424,8 +423,7 @@ public:
     std::vector<double>                        &property_vector) override
   {
     AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
-                PhysicialPropertyModelFieldUndefined("PowerLaw rheological",
-                                                     "shear_rate"));
+                PhysicialPropertyModelFieldUndefined("PowerLaw", "shear_rate"));
     const std::vector<double> &shear_rate_magnitude =
       field_vectors.at(field::shear_rate);
 
@@ -571,8 +569,7 @@ public:
     const std::map<field, double> &field_values) const override
   {
     AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
-                PhysicialPropertyModelFieldUndefined("Carreau rheological",
-                                                     "shear_rate"));
+                PhysicialPropertyModelFieldUndefined("Carreau", "shear_rate"));
     const double shear_rate_magnitude = field_values.at(field::shear_rate);
     return calculate_kinematic_viscosity(shear_rate_magnitude) * p_density_ref;
   }
@@ -590,8 +587,7 @@ public:
     std::vector<double>                        &property_vector) override
   {
     AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
-                PhysicialPropertyModelFieldUndefined("Carreau rheological",
-                                                     "shear_rate"));
+                PhysicialPropertyModelFieldUndefined("Carreau", "shear_rate"));
     const std::vector<double> &shear_rate_magnitude =
       field_vectors.at(field::shear_rate);
 

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -143,6 +143,15 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::temperature) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeSpecificHeat",
+                                                     "temperature"));
+    AssertThrow(fields_value.find(field::temperature_p1) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeSpecificHeat",
+                                                     "temperature_p1"));
+    AssertThrow(fields_value.find(field::temperature_p2) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeSpecificHeat",
+                                                     "temperature_p2"));
     double temperature    = fields_value.at(field::temperature);
     double temperature_p1 = fields_value.at(field::temperature_p1);
     double temperature_p2 = fields_value.at(field::temperature_p2);
@@ -217,6 +226,17 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeSpecificHeat",
+                                                     "temperature"));
+    AssertThrow(field_vectors.find(field::temperature_p1) !=
+                  field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeSpecificHeat",
+                                                     "temperature_p1"));
+    AssertThrow(field_vectors.find(field::temperature_p2) !=
+                  field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("PhaseChangeSpecificHeat",
+                                                     "temperature_p2"));
     const std::vector<double> &temperature_vec =
       field_vectors.at(field::temperature);
     const std::vector<double> &p1_temperature_vec =
@@ -310,7 +330,12 @@ public:
   jacobian(const std::map<field, double> &field_values, field id) override
   {
     if (id == field::temperature)
-      return numerical_jacobian(field_values, field::temperature);
+      {
+        AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                    PhysicialPropertyModelFieldUndefined(
+                      "EvaporationModelTemperature", "temperature"));
+        return numerical_jacobian(field_values, field::temperature);
+      }
     else
       return 0;
   };
@@ -326,6 +351,9 @@ public:
                   const field                                 id,
                   std::vector<double> &jacobian_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "EvaporationModelTemperature", "temperature"));
     vector_numerical_jacobian(field_vectors, id, jacobian_vector);
   };
 

--- a/include/core/surface_tension_model.h
+++ b/include/core/surface_tension_model.h
@@ -170,6 +170,9 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::temperature) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined("SurfaceTensionLinear",
+                                                     "temperature"));
     const double temperature = fields_value.at(field::temperature);
     return surface_tension_coefficient +
            surface_tension_gradient * (temperature - T_0);
@@ -185,6 +188,9 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined("SurfaceTensionLinear",
+                                                     "temperature"));
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
@@ -273,6 +279,9 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::temperature) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "SurfaceTensionPhaseChange", "temperature"));
     const double temperature = fields_value.at(field::temperature);
 
     double surface_tension;
@@ -304,6 +313,9 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "SurfaceTensionPhaseChange", "temperature"));
     const std::vector<double> &temperature =
       field_vectors.at(field::temperature);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
@@ -339,6 +351,9 @@ public:
   {
     if (id == field::temperature)
       {
+        AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                    PhysicialPropertyModelFieldUndefined(
+                      "SurfaceTensionPhaseChange", "temperature"));
         const double temperature = field_values.at(field::temperature);
         if (temperature < T_solidus)
           return 0;
@@ -372,6 +387,10 @@ public:
   {
     if (id == field::temperature)
       {
+        AssertThrow(
+          field_vectors.find(field::temperature) != field_vectors.end(),
+          PhysicialPropertyModelFieldUndefined("SurfaceTensionPhaseChange",
+                                               "temperature"));
         const std::vector<double> &temperature =
           field_vectors.at(field::temperature);
         for (unsigned int i = 0; i < jacobian_vector.size(); ++i)

--- a/include/core/thermal_conductivity_model.h
+++ b/include/core/thermal_conductivity_model.h
@@ -136,6 +136,9 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::temperature) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalConductivityLinear", "temperature"));
     return A + B * fields_value.at(field::temperature);
   };
 
@@ -148,6 +151,9 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalConductivityLinear", "temperature"));
     const std::vector<double> &T = field_vectors.at(field::temperature);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
       property_vector[i] = A + B * T[i];
@@ -217,6 +223,9 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::temperature) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalConductivityPhaseChange", "temperature"));
     double thermal_conductivity;
     // Thermal conductivity of solid phase
     if (fields_value.at(field::temperature) < T_solidus)
@@ -247,6 +256,9 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalConductivityPhaseChange", "temperature"));
     const std::vector<double> &T = field_vectors.at(field::temperature);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
       {
@@ -279,7 +291,12 @@ public:
   jacobian(const std::map<field, double> &field_values, field id) override
   {
     if (id == field::temperature)
-      return this->numerical_jacobian(field_values, field::temperature);
+      {
+        AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                    PhysicialPropertyModelFieldUndefined(
+                      "ThermalConductivityPhaseChange", "temperature"));
+        return this->numerical_jacobian(field_values, field::temperature);
+      }
     else
       return 0;
   };
@@ -296,6 +313,9 @@ public:
                   const field                                 id,
                   std::vector<double> &jacobian_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalConductivityPhaseChange", "temperature"));
     vector_numerical_jacobian(field_vectors, id, jacobian_vector);
   };
 

--- a/include/core/thermal_expansion_model.h
+++ b/include/core/thermal_expansion_model.h
@@ -134,6 +134,9 @@ public:
   double
   value(const std::map<field, double> &fields_value) override
   {
+    AssertThrow(fields_value.find(field::temperature) != fields_value.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalExpansionPhaseChange", "temperature"));
     if (fields_value.at(field::temperature) > p_phase_change_params.T_liquidus)
       return p_phase_change_params.thermal_expansion_l;
     else
@@ -149,6 +152,9 @@ public:
   vector_value(const std::map<field, std::vector<double>> &field_vectors,
                std::vector<double> &property_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalExpansionPhaseChange", "temperature"));
     const std::vector<double> &T = field_vectors.at(field::temperature);
     for (unsigned int i = 0; i < property_vector.size(); ++i)
       {
@@ -173,7 +179,12 @@ public:
   jacobian(const std::map<field, double> &field_values, field id) override
   {
     if (id == field::temperature)
-      return this->numerical_jacobian(field_values, field::temperature);
+      {
+        AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                    PhysicialPropertyModelFieldUndefined(
+                      "ThermalExpansionPhaseChange", "temperature"));
+        return this->numerical_jacobian(field_values, field::temperature);
+      }
     else
       return 0;
   };
@@ -190,6 +201,9 @@ public:
                   const field                                 id,
                   std::vector<double> &jacobian_vector) override
   {
+    AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+                PhysicialPropertyModelFieldUndefined(
+                  "ThermalExpansionPhaseChange", "temperature"));
     vector_numerical_jacobian(field_vectors, id, jacobian_vector);
   };
 

--- a/source/core/rheological_model.cc
+++ b/source/core/rheological_model.cc
@@ -39,6 +39,8 @@ Newtonian::value(const std::map<field, double> & /*field_values*/)
 double
 PowerLaw::value(const std::map<field, double> &field_values)
 {
+  AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
+              PhysicialPropertyModelFieldUndefined("PowerLaw", "shear_rate"));
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
   return calculate_kinematic_viscosity(shear_rate_magnitude);
@@ -49,6 +51,8 @@ PowerLaw::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
   std::vector<double>                        &property_vector)
 {
+  AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
+              PhysicialPropertyModelFieldUndefined("PowerLaw", "shear_rate"));
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
@@ -60,7 +64,12 @@ PowerLaw::jacobian(const std::map<field, double> &field_values, const field id)
 {
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
   if (id == field::shear_rate)
-    return calculate_derivative(shear_rate_magnitude);
+    {
+      AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
+                  PhysicialPropertyModelFieldUndefined("PowerLaw",
+                                                       "shear_rate"));
+      return calculate_derivative(shear_rate_magnitude);
+    }
   else
     return 0;
 }
@@ -71,6 +80,8 @@ PowerLaw::vector_jacobian(
   const field                                 id,
   std::vector<double>                        &jacobian_vector)
 {
+  AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
+              PhysicialPropertyModelFieldUndefined("PowerLaw", "shear_rate"));
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
   if (id == field::shear_rate)
@@ -83,6 +94,8 @@ PowerLaw::vector_jacobian(
 double
 Carreau::value(const std::map<field, double> &field_values)
 {
+  AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
+              PhysicialPropertyModelFieldUndefined("Carreau", "shear_rate"));
   const double shear_rate_magnitude = field_values.at(field::shear_rate);
 
   return calculate_kinematic_viscosity(shear_rate_magnitude);
@@ -92,6 +105,8 @@ void
 Carreau::vector_value(const std::map<field, std::vector<double>> &field_vectors,
                       std::vector<double> &property_vector)
 {
+  AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
+              PhysicialPropertyModelFieldUndefined("Carreau", "shear_rate"));
   const auto shear_rate_magnitude = field_vectors.at(field::shear_rate);
 
   for (unsigned int i = 0; i < shear_rate_magnitude.size(); ++i)
@@ -105,7 +120,12 @@ double
 Carreau::jacobian(const std::map<field, double> &field_values, const field id)
 {
   if (id == field::shear_rate)
-    return this->numerical_jacobian(field_values, field::shear_rate);
+    {
+      AssertThrow(field_values.find(field::shear_rate) != field_values.end(),
+                  PhysicialPropertyModelFieldUndefined("Carreau",
+                                                       "shear_rate"));
+      return this->numerical_jacobian(field_values, field::shear_rate);
+    }
   else
     return 0;
 }
@@ -117,9 +137,14 @@ Carreau::vector_jacobian(
   std::vector<double>                        &jacobian_vector)
 {
   if (id == field::shear_rate)
-    this->vector_numerical_jacobian(field_vectors,
-                                    field::shear_rate,
-                                    jacobian_vector);
+    {
+      AssertThrow(field_vectors.find(field::shear_rate) != field_vectors.end(),
+                  PhysicialPropertyModelFieldUndefined("Carreau",
+                                                       "shear_rate"));
+      this->vector_numerical_jacobian(field_vectors,
+                                      field::shear_rate,
+                                      jacobian_vector);
+    }
   else
     std::fill(jacobian_vector.begin(), jacobian_vector.end(), 0);
 }
@@ -129,6 +154,9 @@ Carreau::vector_jacobian(
 double
 PhaseChangeRheology::value(const std::map<field, double> &field_values)
 {
+  AssertThrow(field_values.find(field::temperature) != field_values.end(),
+              PhysicialPropertyModelFieldUndefined("PhaseChangeRheology",
+                                                   "temperature"));
   const double temperature = field_values.at(field::temperature);
 
   return kinematic_viscosity(temperature);
@@ -139,6 +167,9 @@ PhaseChangeRheology::vector_value(
   const std::map<field, std::vector<double>> &field_vectors,
   std::vector<double>                        &property_vector)
 {
+  AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+              PhysicialPropertyModelFieldUndefined("PhaseChangeRheology",
+                                                   "temperature"));
   const std::vector<double> &temperature_vec =
     field_vectors.at(field::temperature);
 
@@ -153,7 +184,12 @@ PhaseChangeRheology::jacobian(const std::map<field, double> &field_values,
                               const field                    id)
 {
   if (id == field::temperature)
-    return this->numerical_jacobian(field_values, field::temperature);
+    {
+      AssertThrow(field_values.find(field::temperature) != field_values.end(),
+                  PhysicialPropertyModelFieldUndefined("PhaseChangeRheology",
+                                                       "temperature"));
+      return this->numerical_jacobian(field_values, field::temperature);
+    }
   else
     return 0;
 }
@@ -164,5 +200,8 @@ PhaseChangeRheology::vector_jacobian(
   const field                                 id,
   std::vector<double>                        &jacobian_vector)
 {
+  AssertThrow(field_vectors.find(field::temperature) != field_vectors.end(),
+              PhysicialPropertyModelFieldUndefined("PhaseChangeRheology",
+                                                   "temperature"));
   vector_numerical_jacobian(field_vectors, id, jacobian_vector);
 }


### PR DESCRIPTION
# Description of the problem

- Some physical and interface property models require certain fields to compute property values and partial derivatives. When these fields were not defined a not so debug-friendly message was printed out.

# Description of the solution

- To help the debugging process, if an error were to occur, assertions were added to the property models in functions where the fields were required.

# How Has This Been Tested?

- By commenting lines in unit tests and code, the throw of the exception was verified in DEBUG mode.

# Comments

- Doxygen descriptions were also added to `specific_heat_model.h`.
