### PR TITLE
Update installation instructions 

### DIFF
--- a/doc/source/installation/digital_alliance.rst
+++ b/doc/source/installation/digital_alliance.rst
@@ -46,7 +46,7 @@ Load ``Trilinos``, ``Parmetis`` and ``P4est``, and their prerequisite modules:
   module load cmake/3.23.1
   module load gcc/9.3.0
   module load openmpi/4.0.3
-  module load trilinos/13.0.1
+  module load trilinos/13.4.1
   module load parmetis/4.0.3
   module load p4est/2.2
   module load opencascade/7.5.2


### PR DESCRIPTION
# Description of the problem

Deal.II was not compiling in the Research Alliance clusters due to the version of Trilinos.

# Description of the solution

Use a more recent version and update instructions in doc.