### PR TITLE
Vof momentum monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-03-19
+
+### Added
+
+- MINOR The mass conservation feature of the VOF model now also monitors the momentum of both phases. This should be useful for some cases and to improve the sharpening mechanism. [#1073](https://github.com/lethe-cfd/lethe/pull/1073)
+
 ## [Master] - 2024-03-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR The mass conservation feature of the VOF model now also monitors the momentum of both phases. This should be useful for some cases and to improve the sharpening mechanism. [#1073](https://github.com/lethe-cfd/lethe/pull/1073)
+- MINOR The mass conservation feature of the VOF model now also monitors the momentum of both phases. This should be useful for some cases and improve the sharpening mechanism. [#1073](https://github.com/lethe-cfd/lethe/pull/1073)
 
 ## [Master] - 2024-03-16
 

--- a/applications_tests/lethe-fluid/gls_vof_1_isothermal_compressible_fluid.output
+++ b/applications_tests/lethe-fluid/gls_vof_1_isothermal_compressible_fluid.output
@@ -7,8 +7,8 @@ Running on 1 MPI rank(s)...
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      6.5778e-01              7.8933e-01      3.4222e-01              3.4222e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      6.5778e-01              7.8933e-01         0.0000e+00         0.0000e+00      3.4222e-01              3.4222e+02         0.0000e+00         0.0000e+00           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
@@ -17,8 +17,8 @@ Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.0000e-01      6.5778e-01              7.8933e-01      3.4222e-01              3.4222e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e-01      6.5778e-01              7.8933e-01        -1.0215e-02         2.4595e-02      3.4222e-01              3.4222e+02         9.4223e+00        -2.0719e+01           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.64181 
@@ -27,5 +27,5 @@ Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.64181
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.0000e-01      6.5791e-01              7.8950e-01      3.4209e-01              3.4209e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0000e-01      6.5791e-01              7.8950e-01        -2.0673e-02         4.6979e-02      3.4209e-01              3.4209e+02         1.9107e+01        -3.9475e+01           5.0000e-01 

--- a/applications_tests/lethe-fluid/gls_vof_2_isothermal_compressible_fluids.output
+++ b/applications_tests/lethe-fluid/gls_vof_2_isothermal_compressible_fluids.output
@@ -7,8 +7,8 @@ Running on 1 MPI rank(s)...
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      6.5778e-01              7.8933e-01      3.4222e-01              1.7111e+01           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      6.5778e-01              7.8933e-01         0.0000e+00         0.0000e+00      3.4222e-01              1.7111e+01         0.0000e+00         0.0000e+00           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
@@ -17,8 +17,8 @@ Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.0000e-01      6.5778e-01              7.8933e-01      3.4222e-01              1.7111e+01           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e-01      6.5778e-01              7.8933e-01        -9.3991e-03         2.3003e-02      3.4222e-01              1.7111e+01         4.2727e-01        -9.6513e-01           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.53178 
@@ -27,5 +27,5 @@ Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 1.53178
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.0000e-01      6.5796e-01              7.8955e-01      3.4204e-01              1.7102e+01           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0000e-01      6.5796e-01              7.8955e-01        -1.8829e-02         4.3885e-02      3.4204e-01              1.7102e+01         8.6422e-01        -1.8387e+00           5.0000e-01 

--- a/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.output
+++ b/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.output
@@ -7,8 +7,8 @@ Running on 1 MPI rank(s)...
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      1.8246e-02              1.8246e+00      9.8175e-01              2.9453e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      1.8246e-02              1.8246e+00         0.0000e+00        -4.1029e-02      9.8175e-01              2.9453e+02         0.0000e+00        -2.0237e-01           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.05     Time step: 0.05     CFL: 2.23662 
@@ -17,8 +17,8 @@ Transient iteration: 1        Time: 0.05     Time step: 0.05     CFL: 2.23662
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-5.0000e-02      2.0230e-02              2.0230e+00      9.7977e-01              2.9393e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+5.0000e-02      2.0230e-02              2.0230e+00        -3.9067e-03        -2.0177e+00      9.7977e-01              2.9393e+02         6.2789e-03        -2.9388e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.1      Time step: 0.05     CFL: 2.93873 
@@ -27,8 +27,8 @@ Transient iteration: 2        Time: 0.1      Time step: 0.05     CFL: 2.93873
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.0000e-01      4.0008e-02              4.0008e+00      9.5999e-01              2.8800e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e-01      4.0008e-02              4.0008e+00        -3.8830e-03        -4.0035e+00      9.5999e-01              2.8800e+02         4.4697e-03        -2.8799e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 3        Time: 0.15     Time step: 0.05     CFL: 2.87622 
@@ -37,8 +37,8 @@ Transient iteration: 3        Time: 0.15     Time step: 0.05     CFL: 2.87622
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.5000e-01      6.3657e-02              6.3657e+00      9.3634e-01              2.8090e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.5000e-01      6.3657e-02              6.3657e+00        -3.9075e-03        -6.3690e+00      9.3634e-01              2.8090e+02         4.0523e-03        -2.8089e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 4        Time: 0.2      Time step: 0.05     CFL: 2.86088 
@@ -47,8 +47,8 @@ Transient iteration: 4        Time: 0.2      Time step: 0.05     CFL: 2.86088
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.0000e-01      8.8523e-02              8.8523e+00      9.1148e-01              2.7344e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0000e-01      8.8523e-02              8.8523e+00        -3.8865e-03        -8.8559e+00      9.1148e-01              2.7344e+02         3.2708e-03        -2.7343e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 2.85365 
@@ -57,5 +57,5 @@ Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 2.85365
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.5000e-01      1.1375e-01              1.1375e+01      8.8625e-01              2.6587e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.5000e-01      1.1375e-01              1.1375e+01        -3.8482e-03        -1.1379e+01      8.8625e-01              2.6587e+02         2.2100e-03        -2.6586e+02           5.0000e-01 

--- a/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.output
+++ b/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.output
@@ -7,8 +7,8 @@ Running on 1 MPI rank(s)...
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      5.0000e-01              5.0000e+01         0.0000e+00         0.0000e+00      5.0000e-01              1.5000e+02         0.0000e+00         0.0000e+00           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.05     Time step: 0.05     CFL: 0       
@@ -17,8 +17,8 @@ Transient iteration: 1        Time: 0.05     Time step: 0.05     CFL: 0
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-5.0000e-02      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+5.0000e-02      5.0000e-01              5.0000e+01         1.2233e-09        -2.4525e+01      5.0000e-01              1.5000e+02        -3.2169e-09        -7.3575e+01           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 2        Time: 0.1      Time step: 0.05     CFL: 1.39102 
@@ -27,8 +27,8 @@ Transient iteration: 2        Time: 0.1      Time step: 0.05     CFL: 1.39102
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.0000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e-01      5.0000e-01              5.0000e+01         1.6679e-09        -4.9050e+01      5.0000e-01              1.5000e+02        -2.6982e-08        -1.4715e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 3        Time: 0.15     Time step: 0.05     CFL: 2.78204 
@@ -37,8 +37,8 @@ Transient iteration: 3        Time: 0.15     Time step: 0.05     CFL: 2.78204
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.5000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.5000e-01      5.0000e-01              5.0000e+01        -3.9391e-09        -7.3575e+01      5.0000e-01              1.5000e+02        -5.6248e-08        -2.2073e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 4        Time: 0.2      Time step: 0.05     CFL: 4.17307 
@@ -47,8 +47,8 @@ Transient iteration: 4        Time: 0.2      Time step: 0.05     CFL: 4.17307
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.0000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0000e-01      5.0000e-01              5.0000e+01         3.9061e-09        -9.8100e+01      5.0000e-01              1.5000e+02        -8.8325e-08        -2.9430e+02           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 5.56409 
@@ -57,5 +57,5 @@ Transient iteration: 5        Time: 0.25     Time step: 0.05     CFL: 5.56409
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.5000e-01      5.0000e-01              5.0000e+01      5.0000e-01              1.5000e+02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.5000e-01      5.0000e-01              5.0000e+01         2.2096e-08        -1.2262e+02      5.0000e-01              1.5000e+02        -5.5198e-08        -3.6788e+02           5.0000e-01 

--- a/applications_tests/lethe-fluid/heat_transfer_phase_change_constrain_solid_domain.output
+++ b/applications_tests/lethe-fluid/heat_transfer_phase_change_constrain_solid_domain.output
@@ -3,29 +3,90 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 867
    Volume of triangulation:      0.0625
    Number of thermal degrees of freedom: 289
+   Number of VOF degrees of freedom: 289
 Pressure drop: 0 Pa
 Total pressure drop: 0 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      3.3203e-02              3.3203e-02         0.0000e+00         0.0000e+00      2.9297e-02              2.9297e-02         0.0000e+00         0.0000e+00           5.0000e-01 
+
+---------------
+VOF Barycenter
+---------------
+  time    x_vof    y_vof    vx_vof   vy_vof  
+0.000000 0.125000 0.058681 0.000000 0.000000 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
 *******************************************************************************
-Pressure drop: -0.42844 Pa
-Total pressure drop: -0.42844 Pa
+Pressure drop: -0.367464 Pa
+Total pressure drop: -0.367464 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e-01      3.3203e-02              3.3203e-02         2.6737e-06         3.0290e-06      2.9297e-02              2.9297e-02         1.3705e-07        -6.8370e-07           5.0000e-01 
+
+---------------
+VOF Barycenter
+---------------
+  time    x_vof    y_vof    vx_vof   vy_vof   
+0.100000 0.125000 0.058681 0.000004 -0.000023 
 
 *********************************************************************************
-Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 0.00658308
+Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 0.00485702
 *********************************************************************************
-Pressure drop: -0.428532 Pa
-Total pressure drop: -0.428532 Pa
+Pressure drop: -0.367538 Pa
+Total pressure drop: -0.367538 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0000e-01      3.3203e-02              3.3203e-02         2.4166e-06         1.8421e-06      2.9297e-02              2.9297e-02         2.7621e-08         1.2799e-07           5.0000e-01 
+
+---------------
+VOF Barycenter
+---------------
+  time    x_vof    y_vof    vx_vof   vy_vof  
+0.200000 0.124998 0.058682 0.000001 0.000006 
 
 *********************************************************************************
-Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 0.00319593
+Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 0.00241665
 *********************************************************************************
-Pressure drop: -0.428499 Pa
-Total pressure drop: -0.428499 Pa
+Pressure drop: -0.367861 Pa
+Total pressure drop: -0.367861 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.0000e-01      3.3202e-02              3.3202e-02         1.9424e-06         7.4381e-07      2.9298e-02              2.9298e-02         8.4759e-08         6.1554e-07           5.0000e-01 
+
+---------------
+VOF Barycenter
+---------------
+  time    x_vof    y_vof    vx_vof   vy_vof  
+0.300000 0.124996 0.058684 0.000004 0.000023 
 
 *********************************************************************************
-Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 0.00307199
+Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 0.00157289
 *********************************************************************************
-Pressure drop: -0.42855 Pa
-Total pressure drop: -0.42855 Pa
+Pressure drop: -0.367981 Pa
+Total pressure drop: -0.367981 Pa
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+4.0000e-01      3.3201e-02              3.3201e-02         1.7114e-06         3.6318e-07      2.9299e-02              2.9299e-02         1.2070e-07         6.1979e-07           5.0000e-01 
+
+---------------
+VOF Barycenter
+---------------
+  time    x_vof    y_vof    vx_vof   vy_vof  
+0.400000 0.124992 0.058686 0.000005 0.000023 

--- a/applications_tests/lethe-fluid/heat_transfer_phase_change_constrain_solid_domain.output
+++ b/applications_tests/lethe-fluid/heat_transfer_phase_change_constrain_solid_domain.output
@@ -3,90 +3,29 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 867
    Volume of triangulation:      0.0625
    Number of thermal degrees of freedom: 289
-   Number of VOF degrees of freedom: 289
 Pressure drop: 0 Pa
 Total pressure drop: 0 Pa
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      3.3203e-02              3.3203e-02         0.0000e+00         0.0000e+00      2.9297e-02              2.9297e-02         0.0000e+00         0.0000e+00           5.0000e-01 
-
----------------
-VOF Barycenter
----------------
-  time    x_vof    y_vof    vx_vof   vy_vof  
-0.000000 0.125000 0.058681 0.000000 0.000000 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.1      Time step: 0.1      CFL: 0       
 *******************************************************************************
-Pressure drop: -0.367464 Pa
-Total pressure drop: -0.367464 Pa
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.0000e-01      3.3203e-02              3.3203e-02         2.6737e-06         3.0290e-06      2.9297e-02              2.9297e-02         1.3705e-07        -6.8370e-07           5.0000e-01 
-
----------------
-VOF Barycenter
----------------
-  time    x_vof    y_vof    vx_vof   vy_vof   
-0.100000 0.125000 0.058681 0.000004 -0.000023 
+Pressure drop: -0.42844 Pa
+Total pressure drop: -0.42844 Pa
 
 *********************************************************************************
-Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 0.00485702
+Transient iteration: 2        Time: 0.2      Time step: 0.1      CFL: 0.00658308
 *********************************************************************************
-Pressure drop: -0.367538 Pa
-Total pressure drop: -0.367538 Pa
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.0000e-01      3.3203e-02              3.3203e-02         2.4166e-06         1.8421e-06      2.9297e-02              2.9297e-02         2.7621e-08         1.2799e-07           5.0000e-01 
-
----------------
-VOF Barycenter
----------------
-  time    x_vof    y_vof    vx_vof   vy_vof  
-0.200000 0.124998 0.058682 0.000001 0.000006 
+Pressure drop: -0.428532 Pa
+Total pressure drop: -0.428532 Pa
 
 *********************************************************************************
-Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 0.00241665
+Transient iteration: 3        Time: 0.3      Time step: 0.1      CFL: 0.00319593
 *********************************************************************************
-Pressure drop: -0.367861 Pa
-Total pressure drop: -0.367861 Pa
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.0000e-01      3.3202e-02              3.3202e-02         1.9424e-06         7.4381e-07      2.9298e-02              2.9298e-02         8.4759e-08         6.1554e-07           5.0000e-01 
-
----------------
-VOF Barycenter
----------------
-  time    x_vof    y_vof    vx_vof   vy_vof  
-0.300000 0.124996 0.058684 0.000004 0.000023 
+Pressure drop: -0.428499 Pa
+Total pressure drop: -0.428499 Pa
 
 *********************************************************************************
-Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 0.00157289
+Transient iteration: 4        Time: 0.4      Time step: 0.1      CFL: 0.00307199
 *********************************************************************************
-Pressure drop: -0.367981 Pa
-Total pressure drop: -0.367981 Pa
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.0000e-01      3.3201e-02              3.3201e-02         1.7114e-06         3.6318e-07      2.9299e-02              2.9299e-02         1.2070e-07         6.1979e-07           5.0000e-01 
-
----------------
-VOF Barycenter
----------------
-  time    x_vof    y_vof    vx_vof   vy_vof  
-0.400000 0.124992 0.058686 0.000005 0.000023 
+Pressure drop: -0.42855 Pa
+Total pressure drop: -0.42855 Pa

--- a/applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.output
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_phase_change_constrain_solid_domain.output
@@ -10,8 +10,8 @@ Total pressure drop: 0 Pa
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      3.3203e-02              3.3203e-02      2.9297e-02              2.9297e-02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      3.3203e-02              3.3203e-02         0.0000e+00         0.0000e+00      2.9297e-02              2.9297e-02         0.0000e+00         0.0000e+00           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -28,8 +28,8 @@ Total pressure drop: -0.367464 Pa
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.0000e-01      3.3203e-02              3.3203e-02      2.9297e-02              2.9297e-02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e-01      3.3203e-02              3.3203e-02         2.6737e-06         3.0290e-06      2.9297e-02              2.9297e-02         1.3705e-07        -6.8370e-07           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -46,8 +46,8 @@ Total pressure drop: -0.367538 Pa
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-2.0000e-01      3.3203e-02              3.3203e-02      2.9297e-02              2.9297e-02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0000e-01      3.3203e-02              3.3203e-02         2.4166e-06         1.8421e-06      2.9297e-02              2.9297e-02         2.7621e-08         1.2799e-07           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -64,8 +64,8 @@ Total pressure drop: -0.367861 Pa
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-3.0000e-01      3.3202e-02              3.3202e-02      2.9298e-02              2.9298e-02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.0000e-01      3.3202e-02              3.3202e-02         1.9424e-06         7.4381e-07      2.9298e-02              2.9298e-02         8.4759e-08         6.1554e-07           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -82,8 +82,8 @@ Total pressure drop: -0.367981 Pa
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-4.0000e-01      3.3201e-02              3.3201e-02      2.9299e-02              2.9299e-02           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+4.0000e-01      3.3201e-02              3.3201e-02         1.7114e-06         3.6318e-07      2.9299e-02              2.9299e-02         1.2070e-07         6.1979e-07           5.0000e-01 
 
 ---------------
 VOF Barycenter

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_vof.output
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_vof.output
@@ -7,8 +7,8 @@ Running on 1 MPI rank(s)...
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-0.0000e+00      8.7500e-01              8.7500e-02      1.2500e-01              1.2500e+01           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      8.7500e-01              8.7500e-02         7.1333e-04         0.0000e+00      1.2500e-01              1.2500e+01         4.6083e-02         0.0000e+00           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -23,8 +23,8 @@ Transient iteration: 1        Time: 0.5      Time step: 0.5      CFL: 2.79578
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-5.0000e-01      8.7789e-01              8.7789e-02      1.2211e-01              1.2211e+01           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+5.0000e-01      8.7789e-01              8.7789e-02         5.6567e-03         1.2343e-03      1.2211e-01              1.2211e+01         1.3201e+00         1.9201e-01           5.0000e-01 
 
 ---------------
 VOF Barycenter
@@ -39,8 +39,8 @@ Transient iteration: 2        Time: 1        Time step: 0.5      CFL: 3.72386
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 surface_fluid_1 mass_per_length_fluid_1 sharpening_threshold 
-1.0000e+00      8.2689e-01              8.2689e-02      1.7311e-01              1.7311e+01           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0000e+00      8.2689e-01              8.2689e-02         5.7129e-03        -1.3724e-04      1.7311e-01              1.7311e+01         6.0166e+00        -3.8687e-01           5.0000e-01 
 
 ---------------
 VOF Barycenter

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -215,7 +215,7 @@ This subsection controls the post-processing other than the forces and torque on
   
 * ``barycenter name``: name of the output file containing the position and velocity of the barycenter for VOF and Cahn-Hilliard simulations. The default file name is ``barycenter_information``.
 
-* ``calculate mass conservation``: calculates the mass of both fluids for VOF simulations.
+* ``calculate mass conservation``: calculates the mass and momentum of both fluids for VOF simulations.
 
 * ``mass conservation name``: name of the output file containing the mass of both fluids for VOF simulations. The default file name is ``mass_conservation_information``.
   

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -213,8 +213,8 @@ public:
    *
    * @param[in] current_solution_fd current solution for the fluid dynamics
    *
-   * @param[in] monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding to
-   * the phase of interest.
+   * @param[in] monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding
+   * to the phase of interest.
    */
   template <typename VectorType>
   Tensor<1, dim>

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -209,11 +209,11 @@ public:
    * @brief Calculates the momentum for a given fluid phase.
    * Used for conservation monitoring.
    *
-   * @param solution VOF solution (phase fraction)
+   * @param[in] solution VOF solution (phase fraction)
    *
-   * @param current_solution_fd current solution for the fluid dynamics
+   * @param[in] current_solution_fd current solution for the fluid dynamics
    *
-   * @param monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding to
+   * @param[in] monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding to
    * the phase of interest.
    */
   template <typename VectorType>

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -206,6 +206,23 @@ public:
                             const Parameters::FluidIndicator monitored_fluid);
 
   /**
+   * @brief Calculates the momentum for a given fluid phase.
+   * Used for conservation monitoring.
+   *
+   * @param solution VOF solution (phase fraction)
+   *
+   * @param current_solution_fd current solution for the fluid dynamics
+   *
+   * @param monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding to
+   * the phase of interest.
+   */
+  template <typename VectorType>
+  Tensor<1,dim>
+  calculate_momentum(const GlobalVectorType          &solution,
+                     const VectorType                &current_solution_fd,
+                     const Parameters::FluidIndicator monitored_fluid);
+
+  /**
    * @brief Calculates the barycenter of the fluid and its velocity
    *
    * @param solution VOF solution

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -217,7 +217,7 @@ public:
    * the phase of interest.
    */
   template <typename VectorType>
-  Tensor<1,dim>
+  Tensor<1, dim>
   calculate_momentum(const GlobalVectorType          &solution,
                      const VectorType                &current_solution_fd,
                      const Parameters::FluidIndicator monitored_fluid);

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -215,6 +215,8 @@ public:
    *
    * @param[in] monitored_fluid Fluid indicator (fluid0 or fluid1) corresponding
    * to the phase of interest.
+   *
+   * @return A tensor<1,dim> corresponding to the entry_string in the prm file.
    */
   template <typename VectorType>
   Tensor<1, dim>

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1828,7 +1828,6 @@ namespace Parameters
         "mass_conservation_information",
         Patterns::FileName(),
         "Name of mass conservation output file in VOF simulations");
-
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1821,7 +1821,7 @@ namespace Parameters
         "calculate mass conservation",
         "true",
         Patterns::Bool(),
-        "Enable calculation of the mass of both fluids in VOF simulations.");
+        "Enable calculation of the mass and momentum of both fluids in VOF simulations.");
 
       prm.declare_entry(
         "mass conservation name",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1821,13 +1821,14 @@ namespace Parameters
         "calculate mass conservation",
         "true",
         Patterns::Bool(),
-        "Enable calculation of the mass of both fluids in VOF simualtions.");
+        "Enable calculation of the mass of both fluids in VOF simulations.");
 
       prm.declare_entry(
         "mass conservation name",
         "mass_conservation_information",
         Patterns::FileName(),
         "Name of mass conservation output file in VOF simulations");
+
     }
     prm.leave_subsection();
   }
@@ -2925,14 +2926,6 @@ namespace Parameters
                         "1",
                         Patterns::Double(),
                         "density of the particle ");
-      // The implementation is postponed since it makes the evaluation of the
-      // levelset more complex.
-      /*prm.declare_entry(
-        "center of mass location",
-        "0; 0; 0",
-        Patterns::Anything(),
-        "position of the center of mass relative to the frame of reference of
-        the particule");*/
       prm.declare_entry(
         "volume",
         "0",

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -881,8 +881,6 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                                                             true);
                 }
 
-              this->table_monitoring_vof.set_scientific(mass_column_name, true);
-
               if (this->simulation_parameters.post_processing.verbosity ==
                   Parameters::Verbosity::verbose)
                 {

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -835,7 +835,6 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
             {
               std::string fluid_id("");
 
-
               if (fluid_indicators[i] == Parameters::FluidIndicator::fluid1)
                 {
                   fluid_id = "fluid_1";

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -607,7 +607,7 @@ VolumeOfFluid<dim>::calculate_volume_and_mass(
 
 template <int dim>
 template <typename VectorType>
-Tensor<1,dim>
+Tensor<1, dim>
 VolumeOfFluid<dim>::calculate_momentum(
   const GlobalVectorType          &solution,
   const VectorType                &current_solution_fd,
@@ -632,14 +632,14 @@ VolumeOfFluid<dim>::calculate_momentum(
   const FEValuesExtractors::Vector velocity(0);
   const FEValuesExtractors::Scalar pressure(dim);
 
-  const unsigned int  n_q_points = this->cell_quadrature->size();
-  std::vector<double> phase_values(n_q_points);
-  std::vector<double> density_0(n_q_points);
-  std::vector<double> density_1(n_q_points);
-  std::vector<double> pressure_values(n_q_points);
-  std::vector<Tensor<1,dim>> velocity_values(n_q_points);
+  const unsigned int          n_q_points = this->cell_quadrature->size();
+  std::vector<double>         phase_values(n_q_points);
+  std::vector<double>         density_0(n_q_points);
+  std::vector<double>         density_1(n_q_points);
+  std::vector<double>         pressure_values(n_q_points);
+  std::vector<Tensor<1, dim>> velocity_values(n_q_points);
 
-  Tensor<1,dim> total_momentum;
+  Tensor<1, dim> total_momentum;
 
   // Physical properties
   const auto density_models =
@@ -687,15 +687,15 @@ VolumeOfFluid<dim>::calculate_momentum(
                 {
                   case Parameters::FluidIndicator::fluid0:
                     {
-                      total_momentum +=fe_values_vof.JxW(q) *
-                                        (1 - phase_values[q]) * velocity_values[q] *
-                                        density_0[q];
+                      total_momentum += fe_values_vof.JxW(q) *
+                                        (1 - phase_values[q]) *
+                                        velocity_values[q] * density_0[q];
                       break;
                     }
                   case Parameters::FluidIndicator::fluid1:
                     {
-                      total_momentum +=
-                        fe_values_vof.JxW(q) * phase_values[q] * velocity_values[q]*density_1[q];
+                      total_momentum += fe_values_vof.JxW(q) * phase_values[q] *
+                                        velocity_values[q] * density_1[q];
                       break;
                     }
                   default:
@@ -706,8 +706,7 @@ VolumeOfFluid<dim>::calculate_momentum(
         }
     }
 
-  total_momentum =
-    Utilities::MPI::sum(total_momentum, mpi_communicator);
+  total_momentum = Utilities::MPI::sum(total_momentum, mpi_communicator);
 
   return total_momentum;
 }
@@ -797,7 +796,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
       std::vector<std::string> dependent_column_names;
       dependent_column_names.reserve(n_fluids * 2 + 1);
       std::vector<double> volumes_masses_momentum_and_sharpening_threshold;
-      volumes_masses_momentum_and_sharpening_threshold.reserve(n_fluids * 2 + 1);
+      volumes_masses_momentum_and_sharpening_threshold.reserve(n_fluids * 2 +
+                                                               1);
 
       if (this_mpi_process == 0)
         {
@@ -825,10 +825,11 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                                     fluid_indicators[i]);
 
           // Calculate momentum
-          const Tensor<1,dim> momentum = calculate_momentum(this->present_solution,
-                             *multiphysics->get_solution(
-                               PhysicsID::fluid_dynamics),
-                             fluid_indicators[i]);
+          const Tensor<1, dim> momentum =
+            calculate_momentum(this->present_solution,
+                               *multiphysics->get_solution(
+                                 PhysicsID::fluid_dynamics),
+                               fluid_indicators[i]);
 
           if (this_mpi_process == 0)
             {
@@ -845,8 +846,10 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                   fluid_id = "fluid_0";
                 }
 
-              std::vector<std::string> momentum_names ({ "momentum-x_" + fluid_id, "momentum-y_" + fluid_id});
-              if constexpr(dim==3) momentum_names.push_back( "momentum-z_" + fluid_id);
+              std::vector<std::string> momentum_names(
+                {"momentum-x_" + fluid_id, "momentum-y_" + fluid_id});
+              if constexpr (dim == 3)
+                momentum_names.push_back("momentum-z_" + fluid_id);
 
               if constexpr (dim == 2)
                 {
@@ -871,10 +874,12 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
               this->table_monitoring_vof.set_scientific(mass_column_name, true);
 
               // Add "momentum" columns
-              for (unsigned int d = 0 ; d <dim ; ++d)
+              for (unsigned int d = 0; d < dim; ++d)
                 {
-                  this->table_monitoring_vof.add_value(momentum_names[d], momentum[d]);
-                  this->table_monitoring_vof.set_scientific(momentum_names[d], true);
+                  this->table_monitoring_vof.add_value(momentum_names[d],
+                                                       momentum[d]);
+                  this->table_monitoring_vof.set_scientific(momentum_names[d],
+                                                            true);
                 }
 
               this->table_monitoring_vof.set_scientific(mass_column_name, true);
@@ -892,10 +897,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                     {
                       dependent_column_names.push_back(momentum_names[d]);
                       volumes_masses_momentum_and_sharpening_threshold
-                        .push_back(
-                        momentum[d]);
+                        .push_back(momentum[d]);
                     }
-
                 }
             }
         }

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -606,6 +606,113 @@ VolumeOfFluid<dim>::calculate_volume_and_mass(
 }
 
 template <int dim>
+template <typename VectorType>
+Tensor<1,dim>
+VolumeOfFluid<dim>::calculate_momentum(
+  const GlobalVectorType          &solution,
+  const VectorType                &current_solution_fd,
+  const Parameters::FluidIndicator monitored_fluid)
+{
+  const MPI_Comm mpi_communicator = this->triangulation->get_communicator();
+
+  FEValues<dim> fe_values_vof(*this->mapping,
+                              *this->fe,
+                              *this->cell_quadrature,
+                              update_values | update_JxW_values);
+
+  QGauss<dim>            quadrature_formula(this->cell_quadrature->size());
+  const DoFHandler<dim> *dof_handler_fd =
+    multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
+
+  FEValues<dim> fe_values_fd(*this->mapping,
+                             dof_handler_fd->get_fe(),
+                             quadrature_formula,
+                             update_values);
+
+  const FEValuesExtractors::Vector velocity(0);
+  const FEValuesExtractors::Scalar pressure(dim);
+
+  const unsigned int  n_q_points = this->cell_quadrature->size();
+  std::vector<double> phase_values(n_q_points);
+  std::vector<double> density_0(n_q_points);
+  std::vector<double> density_1(n_q_points);
+  std::vector<double> pressure_values(n_q_points);
+  std::vector<Tensor<1,dim>> velocity_values(n_q_points);
+
+  Tensor<1,dim> total_momentum;
+
+  // Physical properties
+  const auto density_models =
+    this->simulation_parameters.physical_properties_manager
+      .get_density_vector();
+  std::map<field, std::vector<double>> fields;
+  fields.insert(
+    std::pair<field, std::vector<double>>(field::pressure, n_q_points));
+
+  for (const auto &cell_vof : this->dof_handler.active_cell_iterators())
+    {
+      if (cell_vof->is_locally_owned())
+        {
+          fe_values_vof.reinit(cell_vof);
+          fe_values_vof.get_function_values(solution, phase_values);
+
+          // Get fluid dynamics active cell iterator
+          typename DoFHandler<dim>::active_cell_iterator cell_fd(
+            &(*(this->triangulation)),
+            cell_vof->level(),
+            cell_vof->index(),
+            dof_handler_fd);
+          fe_values_fd.reinit(cell_fd);
+
+          fe_values_fd[velocity].get_function_values(current_solution_fd,
+                                                     velocity_values);
+
+          if (this->simulation_parameters.physical_properties_manager
+                .field_is_required(field::pressure))
+            {
+              fe_values_fd[pressure].get_function_values(current_solution_fd,
+                                                         pressure_values);
+              set_field_vector(field::pressure, pressure_values, fields);
+            }
+
+
+
+          // Calculate physical properties for the cell
+          density_models[0]->vector_value(fields, density_0);
+          density_models[1]->vector_value(fields, density_1);
+
+          for (unsigned int q = 0; q < n_q_points; q++)
+            {
+              switch (monitored_fluid)
+                {
+                  case Parameters::FluidIndicator::fluid0:
+                    {
+                      total_momentum +=fe_values_vof.JxW(q) *
+                                        (1 - phase_values[q]) * velocity_values[q] *
+                                        density_0[q];
+                      break;
+                    }
+                  case Parameters::FluidIndicator::fluid1:
+                    {
+                      total_momentum +=
+                        fe_values_vof.JxW(q) * phase_values[q] * velocity_values[q]*density_1[q];
+                      break;
+                    }
+                  default:
+                    throw std::runtime_error(
+                      "Unsupported number of fluids (>2)");
+                }
+            }
+        }
+    }
+
+  total_momentum =
+    Utilities::MPI::sum(total_momentum, mpi_communicator);
+
+  return total_momentum;
+}
+
+template <int dim>
 void
 VolumeOfFluid<dim>::finish_simulation()
 {
@@ -689,8 +796,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
       // To display when verbose
       std::vector<std::string> dependent_column_names;
       dependent_column_names.reserve(n_fluids * 2 + 1);
-      std::vector<double> volumes_masses_and_sharpening_threshold;
-      volumes_masses_and_sharpening_threshold.reserve(n_fluids * 2 + 1);
+      std::vector<double> volumes_masses_momentum_and_sharpening_threshold;
+      volumes_masses_momentum_and_sharpening_threshold.reserve(n_fluids * 2 + 1);
 
       if (this_mpi_process == 0)
         {
@@ -717,9 +824,16 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                                       PhysicsID::fluid_dynamics),
                                     fluid_indicators[i]);
 
+          // Calculate momentum
+          const Tensor<1,dim> momentum = calculate_momentum(this->present_solution,
+                             *multiphysics->get_solution(
+                               PhysicsID::fluid_dynamics),
+                             fluid_indicators[i]);
+
           if (this_mpi_process == 0)
             {
               std::string fluid_id("");
+
 
               if (fluid_indicators[i] == Parameters::FluidIndicator::fluid1)
                 {
@@ -730,6 +844,9 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                 {
                   fluid_id = "fluid_0";
                 }
+
+              std::vector<std::string> momentum_names ({ "momentum-x_" + fluid_id, "momentum-y_" + fluid_id});
+              if constexpr(dim==3) momentum_names.push_back( "momentum-z_" + fluid_id);
 
               if constexpr (dim == 2)
                 {
@@ -753,15 +870,32 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                                                    this->mass_monitored);
               this->table_monitoring_vof.set_scientific(mass_column_name, true);
 
+              // Add "momentum" columns
+              for (unsigned int d = 0 ; d <dim ; ++d)
+                {
+                  this->table_monitoring_vof.add_value(momentum_names[d], momentum[d]);
+                  this->table_monitoring_vof.set_scientific(momentum_names[d], true);
+                }
+
+              this->table_monitoring_vof.set_scientific(mass_column_name, true);
+
               if (this->simulation_parameters.post_processing.verbosity ==
                   Parameters::Verbosity::verbose)
                 {
                   dependent_column_names.push_back(volume_column_name);
                   dependent_column_names.push_back(mass_column_name);
-                  volumes_masses_and_sharpening_threshold.push_back(
+                  volumes_masses_momentum_and_sharpening_threshold.push_back(
                     this->volume_monitored);
-                  volumes_masses_and_sharpening_threshold.push_back(
+                  volumes_masses_momentum_and_sharpening_threshold.push_back(
                     this->mass_monitored);
+                  for (unsigned int d = 0; d < dim; ++d)
+                    {
+                      dependent_column_names.push_back(momentum_names[d]);
+                      volumes_masses_momentum_and_sharpening_threshold
+                        .push_back(
+                        momentum[d]);
+                    }
+
                 }
             }
         }
@@ -790,7 +924,7 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
           if (this->simulation_parameters.post_processing.verbosity ==
               Parameters::Verbosity::verbose)
             {
-              volumes_masses_and_sharpening_threshold.push_back(
+              volumes_masses_momentum_and_sharpening_threshold.push_back(
                 this->sharpening_threshold);
               dependent_column_names.push_back("sharpening_threshold");
 
@@ -799,7 +933,7 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
               std::vector<std::vector<double>>
                 volumes_masses_and_sharpening_thresholds;
               volumes_masses_and_sharpening_thresholds.push_back(
-                volumes_masses_and_sharpening_threshold);
+                volumes_masses_momentum_and_sharpening_threshold);
 
               // Time column
               std::string         independent_column_name = "time";
@@ -820,7 +954,6 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
             }
         }
     }
-
 
   if (this->simulation_parameters.post_processing.calculate_barycenter)
     {


### PR DESCRIPTION
# Description of the problem

- For some cases we are running, it is relevant to monitor both the mass and the momentum in VOF simulations

# Description of the solution

- Add momentum monitoring to the mass monitoring. I don't think it's worth it to make multiple files, instead I appended the information to the existing file.

# How Has This Been Tested?

- Tested on some of our regular benchmark and the results make sense.

# Documentation

- Updated documentation accordingly

# Future changes

- The parameter monitor mass conservation is maybe not the most appropriate right now, but I don't want to break the prm file in this PR. We could have a parameter called monitor conservation instead, of maybe monitoring mass and momentum, but i 'd rather postpone this change because it's only esthetics 
