### PR TITLE
fix lid driven cavity postprocessing

### DIFF
--- a/doc/source/first_simulation.rst
+++ b/doc/source/first_simulation.rst
@@ -28,7 +28,7 @@ The source folder of lethe contains an examples folder. This folder contains rea
 
 .. code-block:: text
 
- cp -r $SOURCE_FOLDER/examples/incompressible_flow/2d_lid_driven_cavity destination/first_simulation
+ cp -r $SOURCE_FOLDER/examples/incompressible-flow/2d-lid-driven-cavity destination/first_simulation
 
 Step 2: Launching the Example
 -----------------------------

--- a/examples/incompressible-flow/2d-lid-driven-cavity/post_process_Reynolds_400.py
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/post_process_Reynolds_400.py
@@ -26,7 +26,7 @@ y_ghia=raw_ghia[:,0]
 u_ghia=raw_ghia[:,2]
 
 # Load VTU file
-vtu_file="out.0001.0000.vtu"
+vtu_file="out.00001.00000.vtu"
 sim = pv.read(vtu_file)
 sim.set_active_vectors("velocity")
 


### PR DESCRIPTION
# Description of the problem

- The postprocessing for the 2d-lid-driven-cavity example was outdated

# Description of the solution

- Quick fix on the corresponding line of the postprocessing script.

# How Has This Been Tested?

- Running and postprocessing the example results.

# Comments

- Documentation related to launching the first simulation was also updated
