### PR TITLE
Dem insertion naming refactor

### DIFF
--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -168,10 +168,10 @@ namespace Parameters
       // Insertion method
       enum class InsertionMethod
       {
-        volume,
-        list,
         file,
-        plane
+        list,
+        plane,
+        volume
       } insertion_method;
 
       // Inserted number of particles at each time step

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -25,7 +25,6 @@
 #include <dem/find_boundary_cells_information.h>
 #include <dem/grid_motion.h>
 #include <dem/insertion.h>
-#include <dem/insertion_volume.h>
 #include <dem/integrator.h>
 #include <dem/lagrangian_post_processing.h>
 #include <dem/output_force_torque_calculation.h>

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -25,6 +25,7 @@
 #include <dem/find_boundary_cells_information.h>
 #include <dem/grid_motion.h>
 #include <dem/insertion.h>
+#include <dem/insertion_volume.h>
 #include <dem/integrator.h>
 #include <dem/lagrangian_post_processing.h>
 #include <dem/output_force_torque_calculation.h>
@@ -33,7 +34,6 @@
 #include <dem/particle_wall_contact_force.h>
 #include <dem/periodic_boundaries_manipulator.h>
 #include <dem/visualization.h>
-#include <dem/volume_insertion.h>
 
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/timer.h>

--- a/include/dem/insertion_file.h
+++ b/include/dem/insertion_file.h
@@ -24,19 +24,19 @@
 
 #include <deal.II/particles/particle_handler.h>
 
-#ifndef lethe_file_insertion_h
-#  define lethe_file_insertion_h
+#ifndef lethe_insertion_file_h
+#  define lethe_insertion_file_h
 
 template <int dim>
-class FileInsertion : public Insertion<dim>
+class InsertionFile : public Insertion<dim>
 {
 public:
-  FileInsertion(const DEMSolverParameters<dim> &dem_parameters,
+  InsertionFile(const DEMSolverParameters<dim> &dem_parameters,
                 const std::vector<std::shared_ptr<Distribution>>
                   &distribution_object_container);
 
   /**
-   * @brief The FileInsertion class inserts particles using data stored in a file.
+   * @brief The InsertionFile class inserts particles using data stored in a file.
    * This allows the insertion of any number of particles at a well-controlled
    * location with any diameter value, translation and angular velocity.
    *
@@ -108,4 +108,4 @@ public:
   std::string file_name;
 };
 
-#endif /* file_insertion_h */
+#endif /* lethe_insertion_file_h */

--- a/include/dem/insertion_list.h
+++ b/include/dem/insertion_list.h
@@ -24,19 +24,19 @@
 
 #include <deal.II/particles/particle_handler.h>
 
-#ifndef lethe_list_insertion_h
-#  define lethe_list_insertion_h
+#ifndef lethe_insertion_list_h
+#  define lethe_insertion_list_h
 
 template <int dim>
-class ListInsertion : public Insertion<dim>
+class InsertionList : public Insertion<dim>
 {
 public:
-  ListInsertion(const DEMSolverParameters<dim> &dem_parameters,
+  InsertionList(const DEMSolverParameters<dim> &dem_parameters,
                 const std::vector<std::shared_ptr<Distribution>>
                   &distribution_object_container);
 
   /**
-   * @brief The ListInsertion class inserts particles using a list specific position.
+   * @brief The InsertionList class inserts particles using a list specific position.
    * This allows the insertion of any number of particles at a well-controled
    * location which is especially useful from a testing perspective. The code
    * ensures that the number of positions provided in the x,y (and possibly z)
@@ -115,4 +115,4 @@ public:
   std::vector<double>       diameters;
 };
 
-#endif /* list_insertion_h */
+#endif /* lethe_insertion_list_h */

--- a/include/dem/insertion_plane.h
+++ b/include/dem/insertion_plane.h
@@ -24,8 +24,8 @@
 #include <deal.II/particles/particle_handler.h>
 
 
-#ifndef plane_insertion_h
-#  define plane_insertion_h
+#ifndef insertion_plane_h
+#  define insertion_plane_h
 
 /**
  * Insertion of particles using cells cut by a plane
@@ -40,7 +40,7 @@
  */
 
 template <int dim>
-class PlaneInsertion : public Insertion<dim>
+class InsertionPlane : public Insertion<dim>
 {
 public:
   /**
@@ -54,7 +54,7 @@ public:
    * @param dem_parameters DEM parameters declared in the .prm file
    * @param triangulation Triangulation object used in the simulation.
    */
-  PlaneInsertion(const DEMSolverParameters<dim> &dem_parameters,
+  InsertionPlane(const DEMSolverParameters<dim> &dem_parameters,
                  const parallel::distributed::Triangulation<dim> &triangulation,
                  const std::vector<std::shared_ptr<Distribution>>
                    &distribution_object_container);
@@ -130,4 +130,4 @@ private:
 };
 
 
-#endif /* plane_insertion_h */
+#endif /* insertion_plane_h */

--- a/include/dem/insertion_volume.h
+++ b/include/dem/insertion_volume.h
@@ -22,11 +22,11 @@
 
 #include <deal.II/particles/particle_handler.h>
 
-#ifndef volume_insertion_h
-#  define volume_insertion_h
+#ifndef insertion_volume_h
+#  define insertion_volume_h
 
 template <int dim>
-class VolumeInsertion : public Insertion<dim>
+class InsertionVolume : public Insertion<dim>
 {
 public:
   /**
@@ -41,7 +41,7 @@ public:
    * @param maximum_particle_diameter Maximum particle diameter based on values
    * defined in the parameter handler
    */
-  VolumeInsertion(const DEMSolverParameters<dim> &dem_parameters,
+  InsertionVolume(const DEMSolverParameters<dim> &dem_parameters,
                   const double                    maximum_particle_diameter,
                   const std::vector<std::shared_ptr<Distribution>>
                     &distribution_object_container);
@@ -125,4 +125,4 @@ private:
   // upcoming insertion steps
   unsigned int particles_of_each_type_remaining;
 };
-#endif /* volume_insertion_h */
+#endif /* insertion_volume_h */

--- a/source/dem/CMakeLists.txt
+++ b/source/dem/CMakeLists.txt
@@ -10,14 +10,16 @@ add_library(lethe-dem
   find_boundary_cells_information.cc
   find_cell_neighbors.cc
   find_contact_detection_step.cc
-  file_insertion.cc
   gear3_integrator.cc
   grid_motion.cc
   input_parameter_inspection.cc
   insertion.cc
+  insertion_file.cc
+  insertion_list.cc
+  insertion_plane.cc
+  insertion_volume.cc
   integrator.cc
   lagrangian_post_processing.cc
-  list_insertion.cc
   output_force_torque_calculation.cc
   particle_particle_broad_search.cc
   particle_particle_contact_force.cc
@@ -33,7 +35,6 @@ add_library(lethe-dem
   particle_wall_linear_force.cc
   particle_wall_nonlinear_force.cc
   periodic_boundaries_manipulator.cc
-  plane_insertion.cc
   post_processing.cc
   read_checkpoint.cc
   read_mesh.cc
@@ -43,7 +44,6 @@ add_library(lethe-dem
   update_local_particle_containers.cc
   velocity_verlet_integrator.cc
   visualization.cc
-  volume_insertion.cc
   write_checkpoint.cc
   # Headers
   ../../include/dem/boundary_cells_info_struct.h
@@ -57,14 +57,16 @@ add_library(lethe-dem
   ../../include/dem/find_boundary_cells_information.h
   ../../include/dem/find_cell_neighbors.h
   ../../include/dem/find_contact_detection_step.h
-        ../../include/dem/file_insertion.h
   ../../include/dem/gear3_integrator.h
   ../../include/dem/grid_motion.h
   ../../include/dem/input_parameter_inspection.h
   ../../include/dem/insertion.h
+  ../../include/dem/insertion_file.h
+  ../../include/dem/insertion_list.h
+  ../../include/dem/insertion_plane.h
+  ../../include/dem/insertion_volume.h
   ../../include/dem/integrator.h
   ../../include/dem/lagrangian_post_processing.h
-  ../../include/dem/list_insertion.h
   ../../include/dem/output_force_torque_calculation.h
   ../../include/dem/particle_particle_broad_search.h
   ../../include/dem/particle_particle_contact_force.h
@@ -83,7 +85,6 @@ add_library(lethe-dem
   ../../include/dem/particle_wall_linear_force.h
   ../../include/dem/particle_wall_nonlinear_force.h
   ../../include/dem/periodic_boundaries_manipulator.h
-  ../../include/dem/plane_insertion.h
   ../../include/dem/post_processing.h
   ../../include/dem/read_checkpoint.h
   ../../include/dem/read_mesh.h
@@ -94,7 +95,6 @@ add_library(lethe-dem
   ../../include/dem/update_local_particle_containers.h
   ../../include/dem/velocity_verlet_integrator.h
   ../../include/dem/visualization.h
-  ../../include/dem/volume_insertion.h
   ../../include/dem/write_checkpoint.h)
 
 deal_ii_setup_target(lethe-dem)

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -21,20 +21,20 @@
 #include <dem/dem.h>
 #include <dem/distributions.h>
 #include <dem/explicit_euler_integrator.h>
-#include <dem/file_insertion.h>
 #include <dem/find_contact_detection_step.h>
 #include <dem/gear3_integrator.h>
 #include <dem/input_parameter_inspection.h>
-#include <dem/list_insertion.h>
+#include <dem/insertion_file.h>
+#include <dem/insertion_list.h>
+#include <dem/insertion_plane.h>
+#include <dem/insertion_volume.h>
 #include <dem/particle_wall_nonlinear_force.h>
-#include <dem/plane_insertion.h>
 #include <dem/post_processing.h>
 #include <dem/read_checkpoint.h>
 #include <dem/read_mesh.h>
 #include <dem/set_particle_particle_contact_force_model.h>
 #include <dem/set_particle_wall_contact_force_model.h>
 #include <dem/velocity_verlet_integrator.h>
-#include <dem/volume_insertion.h>
 #include <dem/write_checkpoint.h>
 
 #include <deal.II/base/table_handler.h>
@@ -934,7 +934,7 @@ DEMSolver<dim>::set_insertion_type(const DEMSolverParameters<dim> &parameters)
       Parameters::Lagrangian::InsertionInfo::InsertionMethod::volume)
     {
       insertion_object =
-        std::make_shared<VolumeInsertion<dim>>(parameters,
+        std::make_shared<InsertionVolume<dim>>(parameters,
                                                maximum_particle_diameter,
                                                distribution_object_container);
     }
@@ -942,21 +942,21 @@ DEMSolver<dim>::set_insertion_type(const DEMSolverParameters<dim> &parameters)
            Parameters::Lagrangian::InsertionInfo::InsertionMethod::list)
     {
       insertion_object =
-        std::make_shared<ListInsertion<dim>>(parameters,
+        std::make_shared<InsertionList<dim>>(parameters,
                                              distribution_object_container);
     }
   else if (parameters.insertion_info.insertion_method ==
            Parameters::Lagrangian::InsertionInfo::InsertionMethod::file)
     {
       insertion_object =
-        std::make_shared<FileInsertion<dim>>(parameters,
+        std::make_shared<InsertionFile<dim>>(parameters,
                                              distribution_object_container);
     }
   else if (parameters.insertion_info.insertion_method ==
            Parameters::Lagrangian::InsertionInfo::InsertionMethod::plane)
     {
       insertion_object =
-        std::make_shared<PlaneInsertion<dim>>(parameters,
+        std::make_shared<InsertionPlane<dim>>(parameters,
                                               triangulation,
                                               distribution_object_container);
     }

--- a/source/dem/insertion_file.cc
+++ b/source/dem/insertion_file.cc
@@ -1,12 +1,12 @@
 #include <core/utilities.h>
 
-#include <dem/file_insertion.h>
+#include <dem/insertion_file.h>
 
 
 using namespace DEM;
 
 template <int dim>
-FileInsertion<dim>::FileInsertion(
+InsertionFile<dim>::InsertionFile(
   const DEMSolverParameters<dim> &dem_parameters,
   const std::vector<std::shared_ptr<Distribution>>
     &distribution_object_container)
@@ -22,7 +22,7 @@ FileInsertion<dim>::FileInsertion(
 
 template <int dim>
 void
-FileInsertion<dim>::insert(
+InsertionFile<dim>::insert(
   Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const DEMSolverParameters<dim>                  &dem_parameters)
@@ -120,7 +120,7 @@ FileInsertion<dim>::insert(
 
 template <int dim>
 void
-FileInsertion<dim>::assign_particle_properties_for_file_insertion(
+InsertionFile<dim>::assign_particle_properties_for_file_insertion(
   const DEMSolverParameters<dim>             &dem_parameters,
   const unsigned int                         &inserted_this_step_this_proc,
   std::map<std::string, std::vector<double>> &particles_data,
@@ -181,5 +181,5 @@ FileInsertion<dim>::assign_particle_properties_for_file_insertion(
     }
 }
 
-template class FileInsertion<2>;
-template class FileInsertion<3>;
+template class InsertionFile<2>;
+template class InsertionFile<3>;

--- a/source/dem/insertion_list.cc
+++ b/source/dem/insertion_list.cc
@@ -1,4 +1,4 @@
-#include <dem/list_insertion.h>
+#include <dem/insertion_list.h>
 
 using namespace DEM;
 
@@ -13,7 +13,7 @@ DeclException2(DiameterSizeCoherence,
  * create the insertion_points member
  */
 template <int dim>
-ListInsertion<dim>::ListInsertion(
+InsertionList<dim>::InsertionList(
   const DEMSolverParameters<dim> &dem_parameters,
   const std::vector<std::shared_ptr<Distribution>>
     &distribution_object_container)
@@ -77,7 +77,7 @@ ListInsertion<dim>::ListInsertion(
 // particles
 template <int dim>
 void
-ListInsertion<dim>::insert(
+InsertionList<dim>::insert(
   Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const DEMSolverParameters<dim>                  &dem_parameters)
@@ -158,7 +158,7 @@ ListInsertion<dim>::insert(
 
 template <int dim>
 void
-ListInsertion<dim>::assign_particle_properties_for_list_insertion(
+InsertionList<dim>::assign_particle_properties_for_list_insertion(
   const DEMSolverParameters<dim>   &dem_parameters,
   const unsigned int               &inserted_this_step_this_proc,
   const unsigned int               &current_inserting_particle_type,
@@ -220,5 +220,5 @@ ListInsertion<dim>::assign_particle_properties_for_list_insertion(
 }
 
 
-template class ListInsertion<2>;
-template class ListInsertion<3>;
+template class InsertionList<2>;
+template class InsertionList<3>;

--- a/source/dem/insertion_plane.cc
+++ b/source/dem/insertion_plane.cc
@@ -1,6 +1,6 @@
 #include <core/tensors_and_points_dimension_manipulation.h>
 
-#include <dem/plane_insertion.h>
+#include <dem/insertion_plane.h>
 
 using namespace DEM;
 
@@ -8,7 +8,7 @@ using namespace DEM;
 // cells are going to be use for the insertion and we also find the centers of
 // those cells.
 template <int dim>
-PlaneInsertion<dim>::PlaneInsertion(
+InsertionPlane<dim>::InsertionPlane(
   const DEMSolverParameters<dim>                  &dem_parameters,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const std::vector<std::shared_ptr<Distribution>>
@@ -42,7 +42,7 @@ PlaneInsertion<dim>::PlaneInsertion(
 
 template <int dim>
 void
-PlaneInsertion<dim>::find_inplane_cells(
+InsertionPlane<dim>::find_inplane_cells(
   const parallel::distributed::Triangulation<dim> &triangulation,
   Point<3>                                         plane_point,
   Tensor<1, 3>                                     plane_normal_vector)
@@ -92,7 +92,7 @@ PlaneInsertion<dim>::find_inplane_cells(
 
 template <int dim>
 void
-PlaneInsertion<dim>::find_centers_of_inplane_cells()
+InsertionPlane<dim>::find_centers_of_inplane_cells()
 {
   cells_centers.clear();
   for (const auto &cell : plane_cells_for_insertion)
@@ -105,7 +105,7 @@ PlaneInsertion<dim>::find_centers_of_inplane_cells()
 // particle at the cell center with a random shifts particles
 template <int dim>
 void
-PlaneInsertion<dim>::insert(
+InsertionPlane<dim>::insert(
   Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const DEMSolverParameters<dim>                  &dem_parameters)
@@ -305,5 +305,5 @@ PlaneInsertion<dim>::insert(
     }
 }
 
-template class PlaneInsertion<2>;
-template class PlaneInsertion<3>;
+template class InsertionPlane<2>;
+template class InsertionPlane<3>;

--- a/source/dem/insertion_volume.cc
+++ b/source/dem/insertion_volume.cc
@@ -1,4 +1,4 @@
-#include <dem/volume_insertion.h>
+#include <dem/insertion_volume.h>
 
 using namespace DEM;
 
@@ -8,7 +8,7 @@ using namespace DEM;
 // direction (number_of_particles_x_direction, number_of_particles_y_direction
 // and number_of_particles_z_direction) are also obtained
 template <int dim>
-VolumeInsertion<dim>::VolumeInsertion(
+InsertionVolume<dim>::InsertionVolume(
   const DEMSolverParameters<dim> &dem_parameters,
   const double                    maximum_particle_diameter,
   const std::vector<std::shared_ptr<Distribution>>
@@ -27,7 +27,7 @@ VolumeInsertion<dim>::VolumeInsertion(
 // the particles
 template <int dim>
 void
-VolumeInsertion<dim>::insert(
+InsertionVolume<dim>::insert(
   Particles::ParticleHandler<dim>                 &particle_handler,
   const parallel::distributed::Triangulation<dim> &triangulation,
   const DEMSolverParameters<dim>                  &dem_parameters)
@@ -147,7 +147,7 @@ VolumeInsertion<dim>::insert(
 // in the parameter handler
 template <int dim>
 void
-VolumeInsertion<dim>::create_random_number_container(
+InsertionVolume<dim>::create_random_number_container(
   std::vector<double> &random_container,
   const double         maximum_range,
   const int            seed_for_insertion)
@@ -163,7 +163,7 @@ VolumeInsertion<dim>::create_random_number_container(
 // This function assigns the insertion points of the inserted particles
 template <>
 void
-VolumeInsertion<2>::find_insertion_location_volume(
+InsertionVolume<2>::find_insertion_location_volume(
   Point<2>                                    &insertion_location,
   const unsigned int                           id,
   const double                                 random_number1,
@@ -198,7 +198,7 @@ VolumeInsertion<2>::find_insertion_location_volume(
 
 template <>
 void
-VolumeInsertion<3>::find_insertion_location_volume(
+InsertionVolume<3>::find_insertion_location_volume(
   Point<3>                                    &insertion_location,
   const unsigned int                           id,
   const double                                 random_number1,
@@ -243,5 +243,5 @@ VolumeInsertion<3>::find_insertion_location_volume(
                               random_number1) *
                                this->maximum_diameter;
 }
-template class VolumeInsertion<2>;
-template class VolumeInsertion<3>;
+template class InsertionVolume<2>;
+template class InsertionVolume<3>;

--- a/tests/dem/distribution_custom.cc
+++ b/tests/dem/distribution_custom.cc
@@ -27,7 +27,7 @@
 
 // Lethe
 #include <dem/dem_solver_parameters.h>
-#include <dem/volume_insertion.h>
+#include <dem/insertion_volume.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>
@@ -84,7 +84,7 @@ test()
     dem_parameters.lagrangian_physical_properties.seed_for_distributions[0]));
 
   // Calling volume insertion
-  VolumeInsertion<dim> insertion_object(
+  InsertionVolume<dim> insertion_object(
     dem_parameters,
     distribution_object_container[0]->find_max_diameter(),
     distribution_object_container);

--- a/tests/dem/distribution_normal.cc
+++ b/tests/dem/distribution_normal.cc
@@ -27,7 +27,7 @@
 
 // Lethe
 #include <dem/dem_solver_parameters.h>
-#include <dem/volume_insertion.h>
+#include <dem/insertion_volume.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>
@@ -82,7 +82,7 @@ test()
     dem_parameters.lagrangian_physical_properties.seed_for_distributions[0]));
 
   // Calling volume insertion
-  VolumeInsertion<dim> insertion_object(
+  InsertionVolume<dim> insertion_object(
     dem_parameters,
     distribution_object_container[0]->find_max_diameter(),
     distribution_object_container);

--- a/tests/dem/insertion_plane.cc
+++ b/tests/dem/insertion_plane.cc
@@ -29,7 +29,7 @@
 
 // Lethe
 #include <dem/dem_solver_parameters.h>
-#include <dem/plane_insertion.h>
+#include <dem/insertion_plane.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>
@@ -77,7 +77,7 @@ test()
       .particle_average_diameter[0]));
 
   // Calling plane insertion
-  PlaneInsertion<dim> insertion_object(dem_parameters,
+  InsertionPlane<dim> insertion_object(dem_parameters,
                                        tr,
                                        distribution_object_container);
 

--- a/tests/dem/insertion_volume_1.cc
+++ b/tests/dem/insertion_volume_1.cc
@@ -28,7 +28,7 @@
 
 // Lethe
 #include <dem/dem_solver_parameters.h>
-#include <dem/volume_insertion.h>
+#include <dem/insertion_volume.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>
@@ -79,7 +79,7 @@ test()
       .particle_average_diameter[0]));
 
   // Calling volume insertion
-  VolumeInsertion<dim> insertion_object(
+  InsertionVolume<dim> insertion_object(
     dem_parameters,
     distribution_object_container[0]->find_max_diameter(),
     distribution_object_container);

--- a/tests/dem/insertion_volume_2.cc
+++ b/tests/dem/insertion_volume_2.cc
@@ -27,7 +27,7 @@
 
 // Lethe
 #include <dem/dem_solver_parameters.h>
-#include <dem/volume_insertion.h>
+#include <dem/insertion_volume.h>
 
 // Tests (with common definitions)
 #include <../tests/tests.h>
@@ -78,7 +78,7 @@ test()
       .particle_average_diameter[0]));
 
   // Calling volume insertion
-  VolumeInsertion<dim> insertion_object(
+  InsertionVolume<dim> insertion_object(
     dem_parameters,
     distribution_object_container[0]->find_max_diameter(),
     distribution_object_container);


### PR DESCRIPTION
# Description of the problem

- The naming scheme for the insertion files were not coherent with the rest of the code. (i.e., `integrator_...` , `particle_wall_...` , etc.). This was annoying when trying to find a specific insertion file. Now they are next to each other.  

# Description of the solution

- The files are now named like this: `insertion_method.cc` or `insertion_method.h`

# How Has This Been Tested?

- Tests are running on my machine with these changes. 

# Comments

- Anything that you want to add up that didn't fit in any other category can be written here
