### PR TITLE
replace reduced pressure with kinematic pressure

### DIFF
--- a/doc/source/theory/fluid_dynamics/navier-stokes.rst
+++ b/doc/source/theory/fluid_dynamics/navier-stokes.rst
@@ -32,10 +32,10 @@ In `Einstein notation <https://en.wikipedia.org/wiki/Einstein_notation>`_, they 
     \partial_t u_k + u_l \partial_l u_k &= -\frac{1}{\rho} \partial_k p^* + \nu \partial_l \partial_l u_k + f_k
 
 
-In Lethe, instead of solving for pressure directly, we solve for a reduced pressure :math:`p=\frac{p^*}{\rho}`. This has two advantages, first the scaling of the pressure is more adequate with respect to that of the velocity and, secondly, for single phase simulations, this means that we require a single physical property: the kinematic viscosity. Consequently, unless specified otherwise, you should assume that pressure actually refers to the reduced pressure :math:`p`. Although it may seem confusing at first, this is standard in incompressible fluid dynamics.
+In Lethe, instead of solving for pressure directly, we solve for a kinematic pressure :math:`p=\frac{p^*}{\rho}`. This has two advantages, first the scaling of the pressure is more adequate with respect to that of the velocity and, secondly, for single phase simulations, this means that we require a single physical property: the kinematic viscosity. Consequently, unless specified otherwise, you should assume that pressure actually refers to the kinematic pressure :math:`p`. Although it may seem confusing at first, this is standard in incompressible fluid dynamics.
 
 .. note::
-    The choice to use :math:`p^*` for the pressure and :math:`p` for the reduced pressure was made to lighten the writing throughout the documentation.
+    The choice to use :math:`p^*` for the pressure and :math:`p` for the kinematic pressure was made to lighten the writing throughout the documentation.
 
 By default, Lethe does not use any units for Length (:math:`L`), Time (:math:`T`), Mass (:math:`M`) and Temperature (:math:`\Theta`). Although this may seem confusing at first, this is relatively easy to work with. By default, most cases can be formulated using SI units (meters, seconds, kilograms and Celsius or Kelvin). However, in some cases, this may lead to a large imbalance in the scaling of different variables (e.g. the numerical value of pressure being 1000x that of the velocity). In these cases, the user must manually rescale the problem to a better balanced set of units (i.e. by using centimeter units instead of meters).
 


### PR DESCRIPTION
# Documentation

- kinematic pressure: pressure/reference_state_density
- reduced pressure: pressure/critical_pressure

The "kinematic pressure" in the documentation on incompressible Navier-Stokes equations was referred to as "reduced pressure"; this has been replaced. 