### PR TITLE
Quick fix, OMP_NUM_THREADS = 1

### DIFF
--- a/doc/source/installation/digital_alliance.rst
+++ b/doc/source/installation/digital_alliance.rst
@@ -173,6 +173,7 @@ In the nano terminal, copy-paste (with ``Ctrl+Shift+V``):
 
   export DEAL_II_DIR=$HOME/dealii/inst/
   export PATH=$PATH:$HOME/lethe/inst/bin/
+  export OMP_NUM_THREADS=1  # This prevents Trilinos from using multithreading, which could lead to a drop in performance. 
 
 Exit the nano mode with ``Ctrl+x`` and save the document by hitting ``y`` on the prompt "Save modify buffer?" (in the bottom). The prompt "File Name to Write: .dealii" should then appear, hit ``Enter``.
 


### PR DESCRIPTION
# Description of the problem

- On some clusters, it is recommend to specify OMP_NUM_THREADS = 1, otherwise Trilinos can start using multithreading.

# Description of the solution

- I added a line in the .dealii file with a small comment. 

