### PR TITLE
Modularization of the GMG preconditioners

### DIFF
--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -84,6 +84,9 @@ public:
   void
   vmult(VectorType &dst, const VectorType &src) const;
 
+  void
+  clear() const;
+
 private:
   // onlt GC
   mutable MGLevelObject<DoFHandler<dim>>                     dof_handlers;

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -187,24 +187,14 @@ private:
                      const double relative_residual);
 
   /**
-   * @brief  Setup the local smoothing multigrid preconditioner and call the solve
+   * @brief  Setup the geometric multigrid preconditioner and call the solve
    * function of the linear solver.
    *
    * @param[in] solver Linear solver object that needs the multigrid
    * preconditioner.
    */
   void
-  solve_with_LSMG(SolverGMRES<VectorType> &solver);
-
-  /**
-   * @brief Setup the global coarsening multigrid preconditioner and call the solve
-   * function of the linear solver.
-   *
-   * @param[in] solver Linear solver object that needs the multigrid
-   * preconditioner.
-   */
-  void
-  solve_with_GCMG(SolverGMRES<VectorType> &solver);
+  solve_with_GMG(SolverGMRES<VectorType> &solver);
 
   /**
    * @brief Setup the implicit LU preconditioner and call the solve function of the

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -84,9 +84,6 @@ public:
   void
   vmult(VectorType &dst, const VectorType &src) const;
 
-  void
-  clear() const;
-
 private:
   // onlt GC
   mutable MGLevelObject<DoFHandler<dim>>                     dof_handlers;

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -76,19 +76,18 @@ public:
    * @param[in] simulation_control Required to get the time stepping method.
    */
   void
-  initialize_ls(
-    TimerOutput                             &computing_timer,
-    const DoFHandler<dim>                   &dof_handler,
-    const SimulationParameters<dim>         &simulation_parameters,
-    const std::shared_ptr<Mapping<dim>>     &mapping,
-    const std::shared_ptr<FESystem<dim>>     fe,
-    TimerOutput                             &mg_computing_timer,
-    const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
-    const std::shared_ptr<Function<dim>>     forcing_function,
-    const VectorType                        &present_solution,
-    const VectorType                        &time_derivative_previous_solutions,
-    const ConditionalOStream                &pcout,
-    const std::shared_ptr<SimulationControl> simulation_control) const;
+  initialize_ls(TimerOutput                            &computing_timer,
+                const DoFHandler<dim>                  &dof_handler,
+                const SimulationParameters<dim>        &simulation_parameters,
+                const std::shared_ptr<Mapping<dim>>    &mapping,
+                const std::shared_ptr<FESystem<dim>>    fe,
+                TimerOutput                            &mg_computing_timer,
+                const std::shared_ptr<Quadrature<dim>> &cell_quadrature,
+                const std::shared_ptr<Function<dim>>    forcing_function,
+                const VectorType                       &present_solution,
+                const VectorType         &time_derivative_previous_solutions,
+                const ConditionalOStream &pcout,
+                const std::shared_ptr<SimulationControl> simulation_control);
 
   /**
    * @brief Initialize all relevant objects needed for the local smoothing
@@ -112,19 +111,18 @@ public:
    * @param[in] simulation_control Required to get the time stepping method.
    */
   void
-  initialize_gc(
-    TimerOutput                             &computing_timer,
-    const DoFHandler<dim>                   &dof_handler,
-    const SimulationParameters<dim>         &simulation_parameters,
-    const std::shared_ptr<Mapping<dim>>     &mapping,
-    const std::shared_ptr<FESystem<dim>>     fe,
-    TimerOutput                             &mg_computing_timer,
-    const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
-    const std::shared_ptr<Function<dim>>     forcing_function,
-    const VectorType                        &present_solution,
-    const VectorType                        &time_derivative_previous_solutions,
-    const ConditionalOStream                &pcout,
-    const std::shared_ptr<SimulationControl> simulation_control) const;
+  initialize_gc(TimerOutput                            &computing_timer,
+                const DoFHandler<dim>                  &dof_handler,
+                const SimulationParameters<dim>        &simulation_parameters,
+                const std::shared_ptr<Mapping<dim>>    &mapping,
+                const std::shared_ptr<FESystem<dim>>    fe,
+                TimerOutput                            &mg_computing_timer,
+                const std::shared_ptr<Quadrature<dim>> &cell_quadrature,
+                const std::shared_ptr<Function<dim>>    forcing_function,
+                const VectorType                       &present_solution,
+                const VectorType         &time_derivative_previous_solutions,
+                const ConditionalOStream &pcout,
+                const std::shared_ptr<SimulationControl> simulation_control);
 
   /**
    * @brief Calls the v cycle function of the multigrid object.
@@ -137,64 +135,63 @@ public:
 
 private:
   /// DoF handlers for each of the levels of the global coarsening algorithm
-  mutable MGLevelObject<DoFHandler<dim>> dof_handlers;
+  MGLevelObject<DoFHandler<dim>> dof_handlers;
 
   /// Transfers for each of the levels of the global coarsening algorithm
-  mutable MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers;
+  MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers;
 
   /// Level operators for the geometric multigrid
-  mutable MGLevelObject<std::shared_ptr<OperatorType>>
-    mg_operators; // TODO: reuse
+  MGLevelObject<std::shared_ptr<OperatorType>> mg_operators; // TODO: reuse
 
   /// Multigrid level object storing all operators
-  mutable std::shared_ptr<mg::Matrix<VectorType>> mg_matrix;
+  std::shared_ptr<mg::Matrix<VectorType>> mg_matrix;
 
   /// Interface edge matrix needed only for local smoothing
-  mutable std::shared_ptr<mg::Matrix<VectorType>> mg_interface_matrix_in;
-  mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
+  std::shared_ptr<mg::Matrix<VectorType>> mg_interface_matrix_in;
+  MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
     ls_mg_operators;
-  mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
+  MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
     ls_mg_interface_in;
 
   /// Smoother object
-  mutable std::shared_ptr<
+  std::shared_ptr<
     MGSmootherPrecondition<OperatorType, SmootherType, VectorType>>
     mg_smoother;
 
   /// Collection of boundary constraints and refinement edge constrations for
   /// the different levels in the local smoothing approach.
-  mutable MGConstrainedDoFs mg_constrained_dofs;
+  MGConstrainedDoFs mg_constrained_dofs;
 
   /// Transfer operator for local smoothing
-  mutable std::shared_ptr<LSTransferType> mg_transfer_ls; // TODO: reuse
+  std::shared_ptr<LSTransferType> mg_transfer_ls; // TODO: reuse
 
   /// Transfer operator for global coarsening
-  mutable std::shared_ptr<GCTransferType> mg_transfer_gc; // TODO: reuse
+  std::shared_ptr<GCTransferType> mg_transfer_gc; // TODO: reuse
 
   /// Algebraic multigrid as coarse grid solver
-  mutable TrilinosWrappers::PreconditionAMG precondition_amg;
+  TrilinosWrappers::PreconditionAMG precondition_amg;
 
   /// Incomplete LU as coarse grid solver
-  mutable TrilinosWrappers::PreconditionILU precondition_ilu;
+  TrilinosWrappers::PreconditionILU precondition_ilu;
 
   /// Solver control for the coarse grid solver
-  mutable std::shared_ptr<ReductionControl> coarse_grid_solver_control;
+  std::shared_ptr<ReductionControl> coarse_grid_solver_control;
 
   /// GMRES as coarse grid solver
-  mutable std::shared_ptr<SolverGMRES<VectorType>> coarse_grid_solver;
+  std::shared_ptr<SolverGMRES<VectorType>> coarse_grid_solver;
 
   /// Multigrid wrapper for the coarse grid solver
-  mutable std::shared_ptr<MGCoarseGridBase<VectorType>> mg_coarse;
+  std::shared_ptr<MGCoarseGridBase<VectorType>> mg_coarse;
 
   /// Multigrid method
-  mutable std::shared_ptr<Multigrid<VectorType>> mg;
+  std::shared_ptr<Multigrid<VectorType>> mg;
 
   /// Local smoothing multigrid preconditioner object
-  mutable std::shared_ptr<PreconditionMG<dim, VectorType, LSTransferType>>
+  std::shared_ptr<PreconditionMG<dim, VectorType, LSTransferType>>
     ls_multigrid_preconditioner;
 
   /// Global coarsening multigrid preconiditoner object
-  mutable std::shared_ptr<PreconditionMG<dim, VectorType, GCTransferType>>
+  std::shared_ptr<PreconditionMG<dim, VectorType, GCTransferType>>
     gc_multigrid_preconditioner;
 };
 

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -99,15 +99,10 @@ private:
 
   // edge matrices (only LS)
   mutable std::shared_ptr<mg::Matrix<VectorType>> mg_interface_matrix_in;
-  mutable std::shared_ptr<mg::Matrix<VectorType>> mg_interface_matrix_out;
   mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
     ls_mg_operators;
   mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
     ls_mg_interface_in;
-  mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
-                                                       ls_mg_interface_out;
-  mutable MGLevelObject<std::shared_ptr<OperatorType>> mg_interface_in;
-  mutable MGLevelObject<std::shared_ptr<OperatorType>> mg_interface_out;
 
   // smoother
   mutable std::shared_ptr<

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -154,9 +154,7 @@ class MFNavierStokesSolver
                             LinearAlgebra::distributed::Vector<double>,
                             IndexSet>
 {
-  using VectorType     = LinearAlgebra::distributed::Vector<double>;
-  using LSTransferType = MGTransferMatrixFree<dim, double>;
-  using GCTransferType = MGTransferGlobalCoarsening<dim, VectorType>;
+  using VectorType = LinearAlgebra::distributed::Vector<double>;
 
 public:
   /**
@@ -251,6 +249,13 @@ protected:
   define_zero_constraints();
 
   /**
+   * @brief Set up appropriate preconditioner.
+   *
+   */
+  void
+  setup_preconditioner();
+
+  /**
    * @brief Solve the linear system of equations using the method specified in
    * the simulation parameters.
    *
@@ -293,12 +298,9 @@ private:
   /**
    * @brief  Setup the geometric multigrid preconditioner and call the solve
    * function of the linear solver.
-   *
-   * @param[in] solver Linear solver object that needs the multigrid
-   * preconditioner.
    */
   void
-  solve_with_GMG(SolverGMRES<VectorType> &solver);
+  setup_GMG();
 
   /**
    * @brief Setup the implicit LU preconditioner and call the solve function of the
@@ -306,7 +308,7 @@ private:
    * the matrix-free operator.
    */
   void
-  solve_with_ILU(SolverGMRES<VectorType> &solver);
+  setup_ILU();
 
 protected:
   /**
@@ -316,18 +318,10 @@ protected:
   std::shared_ptr<NavierStokesOperatorBase<dim, double>> system_operator;
 
   /**
-   * @brief Geometric local smoothing multigrid preconditioner.
+   * @brief Geometric multigrid preconditioner.
    *
    */
-  std::shared_ptr<PreconditionMG<dim, VectorType, LSTransferType>>
-    ls_multigrid_preconditioner;
-
-  /**
-   * @brief Geometric global coarsening multigrid preconditioner.
-   *
-   */
-  std::shared_ptr<PreconditionMG<dim, VectorType, GCTransferType>>
-    gc_multigrid_preconditioner;
+  std::shared_ptr<MFNavierStokesPreconditionGMG<dim>> gmg_preconditioner;
 
   /**
    * @brief Implicit LU preconditioner.

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -44,1072 +44,1012 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
+
 template <int dim>
-class PreconditionGMG
+void
+MFNavierStokesPreconditionGMG<dim>::initialize_ls(
+  TimerOutput                             &computing_timer,
+  const DoFHandler<dim>                   &dof_handler,
+  const SimulationParameters<dim>         &simulation_parameters,
+  const std::shared_ptr<Mapping<dim>>     &mapping,
+  const std::shared_ptr<FESystem<dim>>     fe,
+  TimerOutput                             &mg_computing_timer,
+  const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
+  const std::shared_ptr<Function<dim>>     forcing_function,
+  const VectorType                        &present_solution,
+  const VectorType                        &time_derivative_previous_solutions,
+  const ConditionalOStream                &pcout,
+  const std::shared_ptr<SimulationControl> simulation_control) const
 {
-  using VectorType     = LinearAlgebra::distributed::Vector<double>;
-  using LSTransferType = MGTransferMatrixFree<dim, double>;
-  using GCTransferType = MGTransferGlobalCoarsening<dim, VectorType>;
-  using OperatorType   = NavierStokesOperatorBase<dim, double>;
-  using SmootherPreconditionerType = DiagonalMatrix<VectorType>;
-  using SmootherType =
-    PreconditionRelaxation<OperatorType, SmootherPreconditionerType>;
-  using PreconditionerTypeLS = PreconditionMG<dim, VectorType, LSTransferType>;
-  using PreconditionerTypeGC = PreconditionMG<dim, VectorType, GCTransferType>;
+  computing_timer.enter_subsection("Setup LSMG");
 
+  // Create level objects
+  MGLevelObject<VectorType> mg_solution;
+  MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
+  MGLevelObject<AffineConstraints<double>> level_constraints;
+  mg_constrained_dofs.clear();
+  std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>> partitioners(
+    dof_handler.get_triangulation().n_global_levels());
 
-public:
-  void
-  initialize_ls(
-    TimerOutput                             &computing_timer,
-    const DoFHandler<dim>                   &dof_handler,
-    const SimulationParameters<dim>         &simulation_parameters,
-    const std::shared_ptr<Mapping<dim>>     &mapping,
-    const std::shared_ptr<FESystem<dim>>     fe,
-    TimerOutput                             &mg_computing_timer,
-    const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
-    const std::shared_ptr<Function<dim>>     forcing_function,
-    const VectorType                        &present_solution,
-    const VectorType                        &time_derivative_previous_solutions,
-    const ConditionalOStream                &pcout,
-    const std::shared_ptr<SimulationControl> simulation_control) const
-  {
-    computing_timer.enter_subsection("Setup LSMG");
+  // Extract min and max levels and resize mg level objects accordingly
+  const unsigned int n_h_levels =
+    dof_handler.get_triangulation().n_global_levels();
 
-    // Create level objects
-    MGLevelObject<VectorType> mg_solution;
-    MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
-    MGLevelObject<AffineConstraints<double>> level_constraints;
-    mg_constrained_dofs.clear();
-    std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>>
-      partitioners(dof_handler.get_triangulation().n_global_levels());
+  unsigned int minlevel = 0;
+  unsigned int maxlevel = n_h_levels - 1;
 
-    // Extract min and max levels and resize mg level objects accordingly
-    const unsigned int n_h_levels =
-      dof_handler.get_triangulation().n_global_levels();
+  this->mg_operators.resize(0, n_h_levels - 1);
+  mg_solution.resize(0, n_h_levels - 1);
+  mg_time_derivative_previous_solutions.resize(0, n_h_levels - 1);
+  level_constraints.resize(0, n_h_levels - 1);
+  this->ls_mg_interface_in.resize(0, n_h_levels - 1);
+  this->ls_mg_interface_out.resize(0, n_h_levels - 1);
+  this->ls_mg_operators.resize(0, n_h_levels - 1);
 
-    unsigned int minlevel = 0;
-    unsigned int maxlevel = n_h_levels - 1;
+  // Fill the constraints
+  mg_computing_timer.enter_subsection("Set boundary conditions");
 
-    this->mg_operators.resize(0, n_h_levels - 1);
-    mg_solution.resize(0, n_h_levels - 1);
-    mg_time_derivative_previous_solutions.resize(0, n_h_levels - 1);
-    level_constraints.resize(0, n_h_levels - 1);
-    this->ls_mg_interface_in.resize(0, n_h_levels - 1);
-    this->ls_mg_interface_out.resize(0, n_h_levels - 1);
-    this->ls_mg_operators.resize(0, n_h_levels - 1);
+  mg_constrained_dofs.initialize(dof_handler);
 
-    // Fill the constraints
-    mg_computing_timer.enter_subsection("Set boundary conditions");
+  FEValuesExtractors::Vector velocities(0);
+  FEValuesExtractors::Scalar pressure(dim);
 
-    mg_constrained_dofs.initialize(dof_handler);
-
-    FEValuesExtractors::Vector velocities(0);
-    FEValuesExtractors::Scalar pressure(dim);
-
-    for (unsigned int i_bc = 0;
-         i_bc < simulation_parameters.boundary_conditions.size;
-         ++i_bc)
-      {
-        if (simulation_parameters.boundary_conditions.type[i_bc] ==
-            BoundaryConditions::BoundaryType::slip)
-          {
-            std::set<types::boundary_id> no_normal_flux_boundaries;
-            no_normal_flux_boundaries.insert(
-              simulation_parameters.boundary_conditions.id[i_bc]);
-            for (unsigned int level = minlevel; level <= maxlevel; ++level)
-              {
-                AffineConstraints<double> temp_constraints;
-                temp_constraints.clear();
-                const IndexSet locally_relevant_level_dofs =
-                  DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                                level);
-                temp_constraints.reinit(locally_relevant_level_dofs);
-                VectorTools::compute_no_normal_flux_constraints_on_level(
-                  dof_handler,
-                  0,
-                  no_normal_flux_boundaries,
-                  temp_constraints,
-                  *mapping,
-                  mg_constrained_dofs.get_refinement_edge_indices(level),
-                  level);
-                temp_constraints.close();
-                mg_constrained_dofs.add_user_constraints(level,
-                                                         temp_constraints);
-              }
-          }
-        else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::periodic)
-          {
-            /*already taken into account when mg_constrained_dofs is
-             * initialized*/
-          }
-        else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::pressure)
-          {
-            /*do nothing*/
-          }
-        else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::function_weak)
-          {
-            /*do nothing*/
-          }
-        else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::partial_slip)
-          {
-            /*do nothing*/
-          }
-        else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::outlet)
-          {
-            /*do nothing*/
-          }
-        else
-          {
-            std::set<types::boundary_id> dirichlet_boundary_id = {
-              simulation_parameters.boundary_conditions.id[i_bc]};
-            mg_constrained_dofs.make_zero_boundary_constraints(
-              dof_handler,
-              dirichlet_boundary_id,
-              fe->component_mask(velocities));
-          }
-      }
-
-    mg_computing_timer.leave_subsection("Set boundary conditions");
-
-    // Create mg operators for each level and additional operators needed only
-    // for local smoothing
-    for (unsigned int level = minlevel; level <= maxlevel; ++level)
-      {
-        level_constraints[level].clear();
-
-        const IndexSet relevant_dofs =
-          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-
-        level_constraints[level].reinit(relevant_dofs);
-
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-        mg_constrained_dofs.merge_constraints(
-          level_constraints[level], level, true, false, true, true);
-#else
-        AssertThrow(
-          false,
-          ExcMessage(
-            "The constraints for the lsmg preconditioner require a most recent version of deal.II."));
-#endif
-
-        level_constraints[level].close();
-
-        mg_computing_timer.enter_subsection("Set up operators");
-
-        this->mg_operators[level] =
-          std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
-
-        this->mg_operators[level]->reinit(
-          *mapping,
-          dof_handler,
-          level_constraints[level],
-          *cell_quadrature,
-          &(*forcing_function),
-          simulation_parameters.physical_properties_manager
-            .get_kinematic_viscosity_scale(),
-          simulation_parameters.stabilization.stabilization,
-          level,
-          simulation_control);
-
-        this->mg_operators[level]->initialize_dof_vector(mg_solution[level]);
-        this->mg_operators[level]->initialize_dof_vector(
-          mg_time_derivative_previous_solutions[level]);
-
-        this->ls_mg_operators[level].initialize(*mg_operators[level]);
-        this->ls_mg_interface_in[level].initialize(*mg_operators[level]);
-        this->ls_mg_interface_out[level].initialize(*mg_operators[level]);
-
-        partitioners[level] =
-          this->mg_operators[level]->get_vector_partitioner();
-
-        mg_computing_timer.leave_subsection("Set up operators");
-      }
-
-    // Create transfer operator and transfer solution to mg levels
-    mg_computing_timer.enter_subsection(
-      "Create transfer operator and execute relevant transfers");
-
-    this->mg_transfer_ls = std::make_shared<LSTransferType>();
-
-    this->mg_transfer_ls->initialize_constraints(mg_constrained_dofs);
-    this->mg_transfer_ls->build(dof_handler, partitioners);
-    this->mg_transfer_ls->interpolate_to_mg(dof_handler,
-                                            mg_solution,
-                                            present_solution);
-
-    if (is_bdf(simulation_control->get_assembly_method()))
-      this->mg_transfer_ls->interpolate_to_mg(
-        dof_handler,
-        mg_time_derivative_previous_solutions,
-        time_derivative_previous_solutions);
-
-    // Evaluate non linear terms for all mg operators
-    for (unsigned int level = minlevel; level <= maxlevel; ++level)
-      {
-        mg_solution[level].update_ghost_values();
-        this->mg_operators[level]->evaluate_non_linear_term(mg_solution[level]);
-
-        if (is_bdf(simulation_control->get_assembly_method()))
-          {
-            mg_time_derivative_previous_solutions[level].update_ghost_values();
-            mg_operators[level]->evaluate_time_derivative_previous_solutions(
-              mg_time_derivative_previous_solutions[level]);
-          }
-      }
-
-    mg_computing_timer.leave_subsection(
-      "Create transfer operator and execute relevant transfers");
-
-    this->mg_matrix =
-      std::make_shared<mg::Matrix<VectorType>>(this->ls_mg_operators);
-
-    // Create smoother, fill parameters for each level and intialize it
-    mg_computing_timer.enter_subsection("Set up and initialize smoother");
-
-    this->mg_smoother = std::make_shared<
-      MGSmootherPrecondition<OperatorType, SmootherType, VectorType>>();
-
-    MGLevelObject<typename SmootherType::AdditionalData> smoother_data(
-      minlevel, maxlevel);
-
-    for (unsigned int level = minlevel; level <= maxlevel; ++level)
-      {
-        VectorType diagonal_vector;
-        this->mg_operators[level]->compute_inverse_diagonal(diagonal_vector);
-        smoother_data[level].preconditioner =
-          std::make_shared<SmootherPreconditionerType>(diagonal_vector);
-        smoother_data[level].n_iterations =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .mg_smoother_iterations;
-
-        if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-              .mg_smoother_eig_estimation)
-          {
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-            // Set relaxation to zero so that eigenvalues are estimated
-            // internally
-            smoother_data[level].relaxation = 0.0;
-            smoother_data[level].smoothing_range =
-              simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-                .eig_estimation_smoothing_range;
-            smoother_data[level].eig_cg_n_iterations =
-              simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-                .eig_estimation_cg_n_iterations;
-            smoother_data[level].eigenvalue_algorithm = SmootherType::
-              AdditionalData::EigenvalueAlgorithm::power_iteration;
-            smoother_data[level].constraints.copy_from(
-              this->mg_operators[level]
-                ->get_system_matrix_free()
-                .get_affine_constraints());
-#else
-            AssertThrow(
-              false,
-              ExcMessage(
-                "The estimation of eigenvalues within LSMG requires a version of deal.II >= 9.6.0"));
-#endif
-          }
-        else
-          smoother_data[level].relaxation =
-            simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-              .mg_smoother_relaxation;
-      }
-
-    mg_smoother->initialize(this->mg_operators, smoother_data);
-
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-    if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_smoother_eig_estimation &&
-        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .eig_estimation_verbose != Parameters::Verbosity::quiet)
-      {
-        // Print eigenvalue estimation for all levels
-        for (unsigned int level = minlevel; level <= maxlevel; ++level)
-          {
-            VectorType vec;
-            this->mg_operators[level]->initialize_dof_vector(vec);
-            const auto evs =
-              mg_smoother->smoothers[level].estimate_eigenvalues(vec);
-
-            pcout << std::endl;
-            pcout << "  -Eigenvalue estimation level " << level << ":"
-                  << std::endl;
-            pcout << "    Relaxation parameter: "
-                  << mg_smoother->smoothers[level].get_relaxation()
-                  << std::endl;
-            pcout << "    Minimum eigenvalue: " << evs.min_eigenvalue_estimate
-                  << std::endl;
-            pcout << "    Maximum eigenvalue: " << evs.max_eigenvalue_estimate
-                  << std::endl;
-            pcout << std::endl;
-          }
-      }
-#else
-    AssertThrow(
-      false,
-      ExcMessage(
-        "The estimation of eigenvalues within LSMG requires a version of deal.II >= 9.6.0"));
-#endif
-
-    mg_computing_timer.leave_subsection("Set up and initialize smoother");
-
-    // If multigrid number of levels or minimum number of cells in level are
-    // specified, change the min level for the coarse-grid solver and the
-    // multigrid object, and print levels with appropriate numbering
-
-    int mg_min_level =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_min_level;
-
-    AssertThrow(
-      mg_min_level <= static_cast<int>(MGTools::max_level_for_coarse_mesh(
-                        dof_handler.get_triangulation())),
-      ExcMessage(std::string(
-        "The maximum level allowed for the coarse mesh (mg min level) is: " +
-        std::to_string(
-          MGTools::max_level_for_coarse_mesh(dof_handler.get_triangulation())) +
-        ".")));
-
-    int mg_level_min_cells =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_level_min_cells;
-
-    AssertThrow(
-      mg_level_min_cells <=
-        static_cast<int>(dof_handler.get_triangulation().n_cells(maxlevel)),
-      ExcMessage(
-        "The mg level min cells specified are larger than the cells of the finest mg level."));
-
-
-    if (mg_min_level != -1)
-      minlevel = mg_min_level;
-
-    if (mg_level_min_cells != -1)
-      {
-        for (unsigned int level = minlevel; level <= maxlevel; ++level)
-          if (static_cast<int>(dof_handler.get_triangulation().n_cells(
-                level)) >= mg_level_min_cells)
+  for (unsigned int i_bc = 0;
+       i_bc < simulation_parameters.boundary_conditions.size;
+       ++i_bc)
+    {
+      if (simulation_parameters.boundary_conditions.type[i_bc] ==
+          BoundaryConditions::BoundaryType::slip)
+        {
+          std::set<types::boundary_id> no_normal_flux_boundaries;
+          no_normal_flux_boundaries.insert(
+            simulation_parameters.boundary_conditions.id[i_bc]);
+          for (unsigned int level = minlevel; level <= maxlevel; ++level)
             {
-              minlevel = level;
-              break;
+              AffineConstraints<double> temp_constraints;
+              temp_constraints.clear();
+              const IndexSet locally_relevant_level_dofs =
+                DoFTools::extract_locally_relevant_level_dofs(dof_handler,
+                                                              level);
+              temp_constraints.reinit(locally_relevant_level_dofs);
+              VectorTools::compute_no_normal_flux_constraints_on_level(
+                dof_handler,
+                0,
+                no_normal_flux_boundaries,
+                temp_constraints,
+                *mapping,
+                mg_constrained_dofs.get_refinement_edge_indices(level),
+                level);
+              temp_constraints.close();
+              mg_constrained_dofs.add_user_constraints(level, temp_constraints);
             }
-      }
+        }
+      else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::periodic)
+        {
+          /*already taken into account when mg_constrained_dofs is
+           * initialized*/
+        }
+      else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::pressure)
+        {
+          /*do nothing*/
+        }
+      else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::function_weak)
+        {
+          /*do nothing*/
+        }
+      else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::partial_slip)
+        {
+          /*do nothing*/
+        }
+      else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::outlet)
+        {
+          /*do nothing*/
+        }
+      else
+        {
+          std::set<types::boundary_id> dirichlet_boundary_id = {
+            simulation_parameters.boundary_conditions.id[i_bc]};
+          mg_constrained_dofs.make_zero_boundary_constraints(
+            dof_handler, dirichlet_boundary_id, fe->component_mask(velocities));
+        }
+    }
 
-    if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_verbosity != Parameters::Verbosity::quiet)
-      {
-        pcout << std::endl;
-        pcout << "  -Levels of MG preconditioner:" << std::endl;
-        for (unsigned int level = minlevel; level <= maxlevel; ++level)
-          pcout << "    Level " << level - minlevel << ": "
-                << dof_handler.n_dofs(level) << " DoFs, "
-                << dof_handler.get_triangulation().n_cells(level) << " cells"
-                << std::endl;
-        pcout << std::endl;
-      }
+  mg_computing_timer.leave_subsection("Set boundary conditions");
 
-    // Create coarse-grid GMRES solver and AMG preconditioner
-    mg_computing_timer.enter_subsection("Create coarse-grid solver");
+  // Create mg operators for each level and additional operators needed only
+  // for local smoothing
+  for (unsigned int level = minlevel; level <= maxlevel; ++level)
+    {
+      level_constraints[level].clear();
 
-    const int max_iterations =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_max_iterations;
-    const double tolerance =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_tolerance;
-    const double reduce =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_reduce;
-    this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
-      max_iterations, tolerance, reduce, false, false);
-    SolverGMRES<VectorType>::AdditionalData solver_parameters;
-    solver_parameters.max_n_tmp_vectors =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_max_krylov_vectors;
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
-    this->coarse_grid_solver =
-      std::make_shared<SolverGMRES<VectorType>>(*coarse_grid_solver_control,
-                                                solver_parameters);
+      level_constraints[level].reinit(relevant_dofs);
 
-    if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_coarse_grid_preconditioner ==
-        Parameters::LinearSolver::PreconditionerType::amg)
-      {
-        TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
-        amg_data.elliptic = false;
-        if (dof_handler.get_fe().degree > 1)
-          amg_data.higher_order_elements = true;
-        amg_data.n_cycles =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_n_cycles;
-        amg_data.w_cycle =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_w_cycles;
-        amg_data.aggregation_threshold =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_aggregation_threshold;
-        amg_data.smoother_sweeps =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_smoother_sweeps;
-        amg_data.smoother_overlap =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_smoother_overlap;
-        amg_data.output_details = false;
-        amg_data.smoother_type  = "ILU";
-        amg_data.coarse_type    = "ILU";
-        // Constant modes for velocity and pressure
-        // std::vector<std::vector<bool>> constant_modes;
-        // ComponentMask                  components(dim + 1, true);
-        // DoFTools::extract_constant_modes(dof_handler,
-        //                                  components,
-        //                                  constant_modes);
-        // amg_data.constant_modes = constant_modes;
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+      mg_constrained_dofs.merge_constraints(
+        level_constraints[level], level, true, false, true, true);
+#else
+      AssertThrow(
+        false,
+        ExcMessage(
+          "The constraints for the lsmg preconditioner require a most recent version of deal.II."));
+#endif
 
-        Teuchos::ParameterList              parameter_ml;
-        std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
-        amg_data.set_parameters(parameter_ml,
-                                distributed_constant_modes,
-                                mg_operators[minlevel]->get_system_matrix());
-        const double ilu_fill =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_fill;
-        const double ilu_atol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_precond_ilu_atol;
-        const double ilu_rtol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_precond_ilu_rtol;
-        parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
-        parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
-        parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
+      level_constraints[level].close();
 
-        parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
-        parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
-        parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
+      mg_computing_timer.enter_subsection("Set up operators");
 
-        this->precondition_amg.initialize(
-          mg_operators[minlevel]->get_system_matrix(), parameter_ml);
+      this->mg_operators[level] =
+        std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
 
-        this->mg_coarse = std::make_shared<
-          MGCoarseGridIterativeSolver<VectorType,
-                                      SolverGMRES<VectorType>,
-                                      OperatorType,
-                                      decltype(this->precondition_amg)>>(
-          *coarse_grid_solver, *mg_operators[minlevel], this->precondition_amg);
-      }
-    else if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-               .mg_coarse_grid_preconditioner ==
-             Parameters::LinearSolver::PreconditionerType::ilu)
-      {
-        int current_preconditioner_fill_level =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_fill;
-        const double ilu_atol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_atol;
-        const double ilu_rtol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_rtol;
-        TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
-          current_preconditioner_fill_level, ilu_atol, ilu_rtol, 0);
-
-        precondition_ilu.initialize(
-          this->mg_operators[minlevel]->get_system_matrix(),
-          preconditionerOptions);
-
-        this->mg_coarse = std::make_shared<
-          MGCoarseGridIterativeSolver<VectorType,
-                                      SolverGMRES<VectorType>,
-                                      OperatorType,
-                                      decltype(this->precondition_ilu)>>(
-          *coarse_grid_solver, *mg_operators[minlevel], this->precondition_ilu);
-      }
-    mg_computing_timer.leave_subsection("Create coarse-grid solver");
-
-    // Create interface matrices needed for local smoothing in case of local
-    // refinement
-    this->mg_interface_matrix_in =
-      std::make_shared<mg::Matrix<VectorType>>(this->ls_mg_interface_in);
-    this->mg_interface_matrix_out =
-      std::make_shared<mg::Matrix<VectorType>>(this->ls_mg_interface_out);
-
-    // Create main MG object
-    this->mg = std::make_shared<Multigrid<VectorType>>(*mg_matrix,
-                                                       *mg_coarse,
-                                                       *mg_transfer_ls,
-                                                       *mg_smoother,
-                                                       *mg_smoother,
-                                                       minlevel);
-
-    if (dof_handler.get_triangulation().has_hanging_nodes())
-      this->mg->set_edge_matrices(*this->mg_interface_matrix_in,
-                                  *this->mg_interface_matrix_out);
-
-    // Create MG preconditioner
-    this->ls_multigrid_preconditioner =
-      std::make_shared<PreconditionMG<dim, VectorType, LSTransferType>>(
-        dof_handler, *this->mg, *this->mg_transfer_ls);
-
-    computing_timer.leave_subsection("Setup LSMG");
-  }
-
-  void
-  vmult(VectorType &dst, const VectorType &src) const
-  {
-    if (ls_multigrid_preconditioner)
-      ls_multigrid_preconditioner->vmult(dst, src);
-    else if (gc_multigrid_preconditioner)
-      gc_multigrid_preconditioner->vmult(dst, src);
-    else
-      AssertThrow(false, ExcNotImplemented());
-  }
-
-
-  void
-  initialize_gc(
-    TimerOutput                             &computing_timer,
-    const DoFHandler<dim>                   &dof_handler,
-    const SimulationParameters<dim>         &simulation_parameters,
-    const std::shared_ptr<Mapping<dim>>     &mapping,
-    const std::shared_ptr<FESystem<dim>>     fe,
-    TimerOutput                             &mg_computing_timer,
-    const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
-    const std::shared_ptr<Function<dim>>     forcing_function,
-    const VectorType                        &present_solution,
-    const VectorType                        &time_derivative_previous_solutions,
-    const ConditionalOStream                &pcout,
-    const std::shared_ptr<SimulationControl> simulation_control) const
-  {
-    computing_timer.enter_subsection("Setup GCMG");
-
-    // Create level objects
-    MGLevelObject<VectorType> mg_solution;
-    MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
-    MGLevelObject<AffineConstraints<typename VectorType::value_type>>
-      constraints;
-
-    // Create triangulations for all levels
-    std::vector<std::shared_ptr<const Triangulation<dim>>>
-      coarse_grid_triangulations;
-
-    mg_computing_timer.enter_subsection("Create level triangulations");
-
-    coarse_grid_triangulations =
-      MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
-        dof_handler.get_triangulation());
-
-    mg_computing_timer.leave_subsection("Create level triangulations");
-
-    // Modify the triangulations if multigrid number of levels or minimum number
-    // of cells in level are specified
-    std::vector<std::shared_ptr<const Triangulation<dim>>> temp;
-
-    int mg_min_level =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_min_level;
-
-    AssertThrow(
-      (mg_min_level + 1) <= static_cast<int>(coarse_grid_triangulations.size()),
-      ExcMessage(
-        "The mg min level specified is higher than the finest mg level."));
-
-    int mg_level_min_cells =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_level_min_cells;
-
-    AssertThrow(
-      mg_level_min_cells <=
-        static_cast<int>(
-          coarse_grid_triangulations[coarse_grid_triangulations.size() - 1]
-            ->n_global_active_cells()),
-      ExcMessage(
-        "The mg level min cells specified are larger than the cells of the finest mg level."));
-
-    // find first relevant coarse-grid triangulation
-    auto ptr = std::find_if(
-      coarse_grid_triangulations.begin(),
-      coarse_grid_triangulations.end() - 1,
-      [&mg_min_level, &mg_level_min_cells](const auto &tria) {
-        if (mg_min_level != -1) // minimum number of levels
-          {
-            if ((mg_min_level + 1) <= static_cast<int>(tria->n_global_levels()))
-              return true;
-          }
-        else if (mg_level_min_cells != -1) // minimum number of cells
-          {
-            if (static_cast<int>(tria->n_global_active_cells()) >=
-                mg_level_min_cells)
-              return true;
-          }
-        else
-          {
-            return true;
-          }
-        return false;
-      });
-
-    // consider all triangulations from that one
-    while (ptr != coarse_grid_triangulations.end())
-      temp.push_back(*(ptr++));
-
-    coarse_grid_triangulations = temp;
-
-    // Extract min and max levels and resize mg level objects accordingly
-    const unsigned int n_h_levels = coarse_grid_triangulations.size();
-
-    unsigned int minlevel = 0;
-    unsigned int maxlevel = n_h_levels - 1;
-
-    dof_handlers.resize(minlevel, maxlevel);
-    mg_operators.resize(minlevel, maxlevel);
-    transfers.resize(minlevel, maxlevel);
-    mg_solution.resize(minlevel, maxlevel);
-    mg_time_derivative_previous_solutions.resize(minlevel, maxlevel);
-    constraints.resize(minlevel, maxlevel);
-
-    // Distribute DoFs for each level
-    mg_computing_timer.enter_subsection(
-      "Create DoFHandlers and distribute DoFs");
-    for (unsigned int l = minlevel; l <= maxlevel; ++l)
-      {
-        dof_handlers[l].reinit(*coarse_grid_triangulations[l]);
-        dof_handlers[l].distribute_dofs(dof_handler.get_fe());
-      }
-    mg_computing_timer.leave_subsection(
-      "Create DoFHandlers and distribute DoFs");
-
-    // Apply constraints and create mg operators for each level
-    for (unsigned int level = minlevel; level <= maxlevel; ++level)
-      {
-        const auto &level_dof_handler = dof_handlers[level];
-        auto       &level_constraint  = constraints[level];
-
-        mg_computing_timer.enter_subsection("Set boundary conditions");
-
-        level_constraint.clear();
-        const IndexSet locally_relevant_dofs =
-          DoFTools::extract_locally_relevant_dofs(level_dof_handler);
-        level_constraint.reinit(locally_relevant_dofs);
-
-        DoFTools::make_hanging_node_constraints(level_dof_handler,
-                                                level_constraint);
-
-        FEValuesExtractors::Vector velocities(0);
-        FEValuesExtractors::Scalar pressure(dim);
-
-        for (unsigned int i_bc = 0;
-             i_bc < simulation_parameters.boundary_conditions.size;
-             ++i_bc)
-          {
-            if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                BoundaryConditions::BoundaryType::slip)
-              {
-                std::set<types::boundary_id> no_normal_flux_boundaries;
-                no_normal_flux_boundaries.insert(
-                  simulation_parameters.boundary_conditions.id[i_bc]);
-                VectorTools::compute_no_normal_flux_constraints(
-                  level_dof_handler,
-                  0,
-                  no_normal_flux_boundaries,
-                  level_constraint,
-                  *mapping);
-              }
-            else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                     BoundaryConditions::BoundaryType::periodic)
-              {
-                DoFTools::make_periodicity_constraints(
-                  level_dof_handler,
-                  simulation_parameters.boundary_conditions.id[i_bc],
-                  simulation_parameters.boundary_conditions.periodic_id[i_bc],
-                  simulation_parameters.boundary_conditions
-                    .periodic_direction[i_bc],
-                  level_constraint);
-              }
-            else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                     BoundaryConditions::BoundaryType::pressure)
-              {
-                /*do nothing*/
-              }
-            else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                     BoundaryConditions::BoundaryType::function_weak)
-              {
-                /*do nothing*/
-              }
-            else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                     BoundaryConditions::BoundaryType::partial_slip)
-              {
-                /*do nothing*/
-              }
-            else if (simulation_parameters.boundary_conditions.type[i_bc] ==
-                     BoundaryConditions::BoundaryType::outlet)
-              {
-                /*do nothing*/
-              }
-            else
-              {
-                VectorTools::interpolate_boundary_values(
-                  *mapping,
-                  level_dof_handler,
-                  simulation_parameters.boundary_conditions.id[i_bc],
-                  dealii::Functions::ZeroFunction<dim>(dim + 1),
-                  level_constraint,
-                  fe->component_mask(velocities));
-              }
-          }
-
-        level_constraint.close();
-
-        mg_computing_timer.leave_subsection("Set boundary conditions");
-
-        mg_computing_timer.enter_subsection("Set up operators");
-
-        this->mg_operators[level] =
-          std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
-
-        this->mg_operators[level]->reinit(
-          *mapping,
-          level_dof_handler,
-          level_constraint,
-          *cell_quadrature,
-          &(*forcing_function),
-          simulation_parameters.physical_properties_manager
-            .get_kinematic_viscosity_scale(),
-          simulation_parameters.stabilization.stabilization,
-          numbers::invalid_unsigned_int,
-          simulation_control);
-
-        mg_computing_timer.leave_subsection("Set up operators");
-      }
-
-    // Create transfer operators and transfer solution to mg levels
-    mg_computing_timer.enter_subsection(
-      "Create transfer operator and execute relevant transfers");
-
-    for (unsigned int level = minlevel; level < maxlevel; ++level)
-      transfers[level + 1].reinit(dof_handlers[level + 1],
-                                  dof_handlers[level],
-                                  constraints[level + 1],
-                                  constraints[level]);
-
-    this->mg_transfer_gc =
-      std::make_shared<GCTransferType>(transfers, [&](const auto l, auto &vec) {
-        this->mg_operators[l]->initialize_dof_vector(vec);
-      });
-
-    this->mg_transfer_gc->interpolate_to_mg(dof_handler,
-                                            mg_solution,
-                                            present_solution);
-
-    if (is_bdf(simulation_control->get_assembly_method()))
-      this->mg_transfer_gc->interpolate_to_mg(
+      this->mg_operators[level]->reinit(
+        *mapping,
         dof_handler,
-        mg_time_derivative_previous_solutions,
-        time_derivative_previous_solutions);
+        level_constraints[level],
+        *cell_quadrature,
+        &(*forcing_function),
+        simulation_parameters.physical_properties_manager
+          .get_kinematic_viscosity_scale(),
+        simulation_parameters.stabilization.stabilization,
+        level,
+        simulation_control);
 
-    // Evaluate non linear terms for all mg operators
-    for (unsigned int level = minlevel; level <= maxlevel; ++level)
-      {
-        mg_solution[level].update_ghost_values();
-        this->mg_operators[level]->evaluate_non_linear_term(mg_solution[level]);
+      this->mg_operators[level]->initialize_dof_vector(mg_solution[level]);
+      this->mg_operators[level]->initialize_dof_vector(
+        mg_time_derivative_previous_solutions[level]);
 
-        if (is_bdf(simulation_control->get_assembly_method()))
-          {
-            mg_time_derivative_previous_solutions[level].update_ghost_values();
-            this->mg_operators[level]
-              ->evaluate_time_derivative_previous_solutions(
-                mg_time_derivative_previous_solutions[level]);
-          }
-      }
+      this->ls_mg_operators[level].initialize(*mg_operators[level]);
+      this->ls_mg_interface_in[level].initialize(*mg_operators[level]);
+      this->ls_mg_interface_out[level].initialize(*mg_operators[level]);
 
-    mg_computing_timer.leave_subsection(
-      "Create transfer operator and execute relevant transfers");
+      partitioners[level] = this->mg_operators[level]->get_vector_partitioner();
 
-    if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_verbosity != Parameters::Verbosity::quiet)
-      {
-        pcout << std::endl;
-        pcout << "  -Levels of MG preconditioner:" << std::endl;
-        for (unsigned int level = minlevel; level <= maxlevel; ++level)
-          pcout << "    Level " << level << ": " << dof_handlers[level].n_dofs()
-                << " DoFs, "
-                << coarse_grid_triangulations[level]->n_global_active_cells()
-                << " cells" << std::endl;
-        pcout << std::endl;
-      }
+      mg_computing_timer.leave_subsection("Set up operators");
+    }
 
-    this->mg_matrix = std::make_shared<mg::Matrix<VectorType>>(mg_operators);
+  // Create transfer operator and transfer solution to mg levels
+  mg_computing_timer.enter_subsection(
+    "Create transfer operator and execute relevant transfers");
 
-    // Create smoother, fill parameters for each level and intialize it
-    mg_computing_timer.enter_subsection("Set up and initialize smoother");
+  this->mg_transfer_ls = std::make_shared<LSTransferType>();
 
-    this->mg_smoother = std::make_shared<
-      MGSmootherPrecondition<OperatorType, SmootherType, VectorType>>();
-    MGLevelObject<typename SmootherType::AdditionalData> smoother_data(
-      minlevel, maxlevel);
+  this->mg_transfer_ls->initialize_constraints(mg_constrained_dofs);
+  this->mg_transfer_ls->build(dof_handler, partitioners);
+  this->mg_transfer_ls->interpolate_to_mg(dof_handler,
+                                          mg_solution,
+                                          present_solution);
 
-    for (unsigned int level = minlevel; level <= maxlevel; ++level)
-      {
-        VectorType diagonal_vector;
-        this->mg_operators[level]->compute_inverse_diagonal(diagonal_vector);
-        smoother_data[level].preconditioner =
-          std::make_shared<SmootherPreconditionerType>(diagonal_vector);
-        smoother_data[level].n_iterations =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .mg_smoother_iterations;
+  if (is_bdf(simulation_control->get_assembly_method()))
+    this->mg_transfer_ls->interpolate_to_mg(
+      dof_handler,
+      mg_time_derivative_previous_solutions,
+      time_derivative_previous_solutions);
 
-        if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-              .mg_smoother_eig_estimation)
-          {
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-            // Set relaxation to zero so that eigenvalues are estimated
-            // internally
-            smoother_data[level].relaxation = 0.0;
-            smoother_data[level].smoothing_range =
-              simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-                .eig_estimation_smoothing_range;
-            smoother_data[level].eig_cg_n_iterations =
-              simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-                .eig_estimation_cg_n_iterations;
-            smoother_data[level].eigenvalue_algorithm = SmootherType::
-              AdditionalData::EigenvalueAlgorithm::power_iteration;
-            smoother_data[level].constraints.copy_from(
-              this->mg_operators[level]
-                ->get_system_matrix_free()
-                .get_affine_constraints());
-#else
-            AssertThrow(
-              false,
-              ExcMessage(
-                "The estimation of eigenvalues within GCMG requires a version of deal.II >= 9.6.0"));
-#endif
-          }
-        else
-          smoother_data[level].relaxation =
-            simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-              .mg_smoother_relaxation;
-      }
+  // Evaluate non linear terms for all mg operators
+  for (unsigned int level = minlevel; level <= maxlevel; ++level)
+    {
+      mg_solution[level].update_ghost_values();
+      this->mg_operators[level]->evaluate_non_linear_term(mg_solution[level]);
 
-    this->mg_smoother->initialize(this->mg_operators, smoother_data);
+      if (is_bdf(simulation_control->get_assembly_method()))
+        {
+          mg_time_derivative_previous_solutions[level].update_ghost_values();
+          mg_operators[level]->evaluate_time_derivative_previous_solutions(
+            mg_time_derivative_previous_solutions[level]);
+        }
+    }
 
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-    if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_smoother_eig_estimation &&
+  mg_computing_timer.leave_subsection(
+    "Create transfer operator and execute relevant transfers");
+
+  this->mg_matrix =
+    std::make_shared<mg::Matrix<VectorType>>(this->ls_mg_operators);
+
+  // Create smoother, fill parameters for each level and intialize it
+  mg_computing_timer.enter_subsection("Set up and initialize smoother");
+
+  this->mg_smoother = std::make_shared<
+    MGSmootherPrecondition<OperatorType, SmootherType, VectorType>>();
+
+  MGLevelObject<typename SmootherType::AdditionalData> smoother_data(minlevel,
+                                                                     maxlevel);
+
+  for (unsigned int level = minlevel; level <= maxlevel; ++level)
+    {
+      VectorType diagonal_vector;
+      this->mg_operators[level]->compute_inverse_diagonal(diagonal_vector);
+      smoother_data[level].preconditioner =
+        std::make_shared<SmootherPreconditionerType>(diagonal_vector);
+      smoother_data[level].n_iterations =
         simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .eig_estimation_verbose != Parameters::Verbosity::quiet)
-      {
-        // Print eigenvalue estimation for all levels
-        for (unsigned int level = minlevel; level <= maxlevel; ++level)
-          {
-            VectorType vec;
-            this->mg_operators[level]->initialize_dof_vector(vec);
-            const auto evs =
-              this->mg_smoother->smoothers[level].estimate_eigenvalues(vec);
+          .mg_smoother_iterations;
 
-            pcout << std::endl;
-            pcout << "  -Eigenvalue estimation level " << level << ":"
-                  << std::endl;
-            pcout << "    Relaxation parameter: "
-                  << this->mg_smoother->smoothers[level].get_relaxation()
-                  << std::endl;
-            pcout << "    Minimum eigenvalue: " << evs.min_eigenvalue_estimate
-                  << std::endl;
-            pcout << "    Maximum eigenvalue: " << evs.max_eigenvalue_estimate
-                  << std::endl;
-            pcout << std::endl;
-          }
-      }
+      if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_smoother_eig_estimation)
+        {
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+          // Set relaxation to zero so that eigenvalues are estimated
+          // internally
+          smoother_data[level].relaxation = 0.0;
+          smoother_data[level].smoothing_range =
+            simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+              .eig_estimation_smoothing_range;
+          smoother_data[level].eig_cg_n_iterations =
+            simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+              .eig_estimation_cg_n_iterations;
+          smoother_data[level].eigenvalue_algorithm =
+            SmootherType::AdditionalData::EigenvalueAlgorithm::power_iteration;
+          smoother_data[level].constraints.copy_from(
+            this->mg_operators[level]
+              ->get_system_matrix_free()
+              .get_affine_constraints());
 #else
-    AssertThrow(
-      false,
-      ExcMessage(
-        "The estimation of eigenvalues within GCMG requires a version of deal.II >= 9.6.0"));
+          AssertThrow(
+            false,
+            ExcMessage(
+              "The estimation of eigenvalues within LSMG requires a version of deal.II >= 9.6.0"));
+#endif
+        }
+      else
+        smoother_data[level].relaxation =
+          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_smoother_relaxation;
+    }
+
+  mg_smoother->initialize(this->mg_operators, smoother_data);
+
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+  if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_smoother_eig_estimation &&
+      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .eig_estimation_verbose != Parameters::Verbosity::quiet)
+    {
+      // Print eigenvalue estimation for all levels
+      for (unsigned int level = minlevel; level <= maxlevel; ++level)
+        {
+          VectorType vec;
+          this->mg_operators[level]->initialize_dof_vector(vec);
+          const auto evs =
+            mg_smoother->smoothers[level].estimate_eigenvalues(vec);
+
+          pcout << std::endl;
+          pcout << "  -Eigenvalue estimation level " << level << ":"
+                << std::endl;
+          pcout << "    Relaxation parameter: "
+                << mg_smoother->smoothers[level].get_relaxation() << std::endl;
+          pcout << "    Minimum eigenvalue: " << evs.min_eigenvalue_estimate
+                << std::endl;
+          pcout << "    Maximum eigenvalue: " << evs.max_eigenvalue_estimate
+                << std::endl;
+          pcout << std::endl;
+        }
+    }
+#else
+  AssertThrow(
+    false,
+    ExcMessage(
+      "The estimation of eigenvalues within LSMG requires a version of deal.II >= 9.6.0"));
 #endif
 
-    mg_computing_timer.leave_subsection("Set up and initialize smoother");
+  mg_computing_timer.leave_subsection("Set up and initialize smoother");
 
-    // Create coarse-grid GMRES solver and AMG preconditioner
-    mg_computing_timer.enter_subsection("Create coarse-grid solver");
+  // If multigrid number of levels or minimum number of cells in level are
+  // specified, change the min level for the coarse-grid solver and the
+  // multigrid object, and print levels with appropriate numbering
 
-    const int max_iterations =
+  int mg_min_level =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_min_level;
+
+  AssertThrow(
+    mg_min_level <= static_cast<int>(MGTools::max_level_for_coarse_mesh(
+                      dof_handler.get_triangulation())),
+    ExcMessage(std::string(
+      "The maximum level allowed for the coarse mesh (mg min level) is: " +
+      std::to_string(
+        MGTools::max_level_for_coarse_mesh(dof_handler.get_triangulation())) +
+      ".")));
+
+  int mg_level_min_cells =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_level_min_cells;
+
+  AssertThrow(
+    mg_level_min_cells <=
+      static_cast<int>(dof_handler.get_triangulation().n_cells(maxlevel)),
+    ExcMessage(
+      "The mg level min cells specified are larger than the cells of the finest mg level."));
+
+
+  if (mg_min_level != -1)
+    minlevel = mg_min_level;
+
+  if (mg_level_min_cells != -1)
+    {
+      for (unsigned int level = minlevel; level <= maxlevel; ++level)
+        if (static_cast<int>(dof_handler.get_triangulation().n_cells(level)) >=
+            mg_level_min_cells)
+          {
+            minlevel = level;
+            break;
+          }
+    }
+
+  if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_verbosity != Parameters::Verbosity::quiet)
+    {
+      pcout << std::endl;
+      pcout << "  -Levels of MG preconditioner:" << std::endl;
+      for (unsigned int level = minlevel; level <= maxlevel; ++level)
+        pcout << "    Level " << level - minlevel << ": "
+              << dof_handler.n_dofs(level) << " DoFs, "
+              << dof_handler.get_triangulation().n_cells(level) << " cells"
+              << std::endl;
+      pcout << std::endl;
+    }
+
+  // Create coarse-grid GMRES solver and AMG preconditioner
+  mg_computing_timer.enter_subsection("Create coarse-grid solver");
+
+  const int max_iterations =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_max_iterations;
+  const double tolerance =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_tolerance;
+  const double reduce =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_reduce;
+  this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
+    max_iterations, tolerance, reduce, false, false);
+  SolverGMRES<VectorType>::AdditionalData solver_parameters;
+  solver_parameters.max_n_tmp_vectors =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_max_krylov_vectors;
+
+  this->coarse_grid_solver =
+    std::make_shared<SolverGMRES<VectorType>>(*coarse_grid_solver_control,
+                                              solver_parameters);
+
+  if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_coarse_grid_preconditioner ==
+      Parameters::LinearSolver::PreconditionerType::amg)
+    {
+      TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+      amg_data.elliptic = false;
+      if (dof_handler.get_fe().degree > 1)
+        amg_data.higher_order_elements = true;
+      amg_data.n_cycles =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_n_cycles;
+      amg_data.w_cycle =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_w_cycles;
+      amg_data.aggregation_threshold =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_aggregation_threshold;
+      amg_data.smoother_sweeps =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_smoother_sweeps;
+      amg_data.smoother_overlap =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_smoother_overlap;
+      amg_data.output_details = false;
+      amg_data.smoother_type  = "ILU";
+      amg_data.coarse_type    = "ILU";
+      // Constant modes for velocity and pressure
+      // std::vector<std::vector<bool>> constant_modes;
+      // ComponentMask                  components(dim + 1, true);
+      // DoFTools::extract_constant_modes(dof_handler,
+      //                                  components,
+      //                                  constant_modes);
+      // amg_data.constant_modes = constant_modes;
+
+      Teuchos::ParameterList              parameter_ml;
+      std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
+      amg_data.set_parameters(parameter_ml,
+                              distributed_constant_modes,
+                              mg_operators[minlevel]->get_system_matrix());
+      const double ilu_fill =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_fill;
+      const double ilu_atol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_precond_ilu_atol;
+      const double ilu_rtol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_precond_ilu_rtol;
+      parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
+      parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
+      parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
+
+      parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
+      parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
+      parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
+
+      this->precondition_amg.initialize(
+        mg_operators[minlevel]->get_system_matrix(), parameter_ml);
+
+      this->mg_coarse = std::make_shared<
+        MGCoarseGridIterativeSolver<VectorType,
+                                    SolverGMRES<VectorType>,
+                                    OperatorType,
+                                    decltype(this->precondition_amg)>>(
+        *coarse_grid_solver, *mg_operators[minlevel], this->precondition_amg);
+    }
+  else if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+             .mg_coarse_grid_preconditioner ==
+           Parameters::LinearSolver::PreconditionerType::ilu)
+    {
+      int current_preconditioner_fill_level =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_fill;
+      const double ilu_atol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_atol;
+      const double ilu_rtol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_rtol;
+      TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
+        current_preconditioner_fill_level, ilu_atol, ilu_rtol, 0);
+
+      precondition_ilu.initialize(
+        this->mg_operators[minlevel]->get_system_matrix(),
+        preconditionerOptions);
+
+      this->mg_coarse = std::make_shared<
+        MGCoarseGridIterativeSolver<VectorType,
+                                    SolverGMRES<VectorType>,
+                                    OperatorType,
+                                    decltype(this->precondition_ilu)>>(
+        *coarse_grid_solver, *mg_operators[minlevel], this->precondition_ilu);
+    }
+  mg_computing_timer.leave_subsection("Create coarse-grid solver");
+
+  // Create interface matrices needed for local smoothing in case of local
+  // refinement
+  this->mg_interface_matrix_in =
+    std::make_shared<mg::Matrix<VectorType>>(this->ls_mg_interface_in);
+  this->mg_interface_matrix_out =
+    std::make_shared<mg::Matrix<VectorType>>(this->ls_mg_interface_out);
+
+  // Create main MG object
+  this->mg = std::make_shared<Multigrid<VectorType>>(*mg_matrix,
+                                                     *mg_coarse,
+                                                     *mg_transfer_ls,
+                                                     *mg_smoother,
+                                                     *mg_smoother,
+                                                     minlevel);
+
+  if (dof_handler.get_triangulation().has_hanging_nodes())
+    this->mg->set_edge_matrices(*this->mg_interface_matrix_in,
+                                *this->mg_interface_matrix_out);
+
+  // Create MG preconditioner
+  this->ls_multigrid_preconditioner =
+    std::make_shared<PreconditionMG<dim, VectorType, LSTransferType>>(
+      dof_handler, *this->mg, *this->mg_transfer_ls);
+
+  computing_timer.leave_subsection("Setup LSMG");
+}
+
+
+template <int dim>
+void
+MFNavierStokesPreconditionGMG<dim>::initialize_gc(
+  TimerOutput                             &computing_timer,
+  const DoFHandler<dim>                   &dof_handler,
+  const SimulationParameters<dim>         &simulation_parameters,
+  const std::shared_ptr<Mapping<dim>>     &mapping,
+  const std::shared_ptr<FESystem<dim>>     fe,
+  TimerOutput                             &mg_computing_timer,
+  const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
+  const std::shared_ptr<Function<dim>>     forcing_function,
+  const VectorType                        &present_solution,
+  const VectorType                        &time_derivative_previous_solutions,
+  const ConditionalOStream                &pcout,
+  const std::shared_ptr<SimulationControl> simulation_control) const
+{
+  computing_timer.enter_subsection("Setup GCMG");
+
+  // Create level objects
+  MGLevelObject<VectorType> mg_solution;
+  MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
+  MGLevelObject<AffineConstraints<typename VectorType::value_type>> constraints;
+
+  // Create triangulations for all levels
+  std::vector<std::shared_ptr<const Triangulation<dim>>>
+    coarse_grid_triangulations;
+
+  mg_computing_timer.enter_subsection("Create level triangulations");
+
+  coarse_grid_triangulations =
+    MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
+      dof_handler.get_triangulation());
+
+  mg_computing_timer.leave_subsection("Create level triangulations");
+
+  // Modify the triangulations if multigrid number of levels or minimum number
+  // of cells in level are specified
+  std::vector<std::shared_ptr<const Triangulation<dim>>> temp;
+
+  int mg_min_level =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_min_level;
+
+  AssertThrow(
+    (mg_min_level + 1) <= static_cast<int>(coarse_grid_triangulations.size()),
+    ExcMessage(
+      "The mg min level specified is higher than the finest mg level."));
+
+  int mg_level_min_cells =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_level_min_cells;
+
+  AssertThrow(
+    mg_level_min_cells <=
+      static_cast<int>(
+        coarse_grid_triangulations[coarse_grid_triangulations.size() - 1]
+          ->n_global_active_cells()),
+    ExcMessage(
+      "The mg level min cells specified are larger than the cells of the finest mg level."));
+
+  // find first relevant coarse-grid triangulation
+  auto ptr =
+    std::find_if(coarse_grid_triangulations.begin(),
+                 coarse_grid_triangulations.end() - 1,
+                 [&mg_min_level, &mg_level_min_cells](const auto &tria) {
+                   if (mg_min_level != -1) // minimum number of levels
+                     {
+                       if ((mg_min_level + 1) <=
+                           static_cast<int>(tria->n_global_levels()))
+                         return true;
+                     }
+                   else if (mg_level_min_cells != -1) // minimum number of cells
+                     {
+                       if (static_cast<int>(tria->n_global_active_cells()) >=
+                           mg_level_min_cells)
+                         return true;
+                     }
+                   else
+                     {
+                       return true;
+                     }
+                   return false;
+                 });
+
+  // consider all triangulations from that one
+  while (ptr != coarse_grid_triangulations.end())
+    temp.push_back(*(ptr++));
+
+  coarse_grid_triangulations = temp;
+
+  // Extract min and max levels and resize mg level objects accordingly
+  const unsigned int n_h_levels = coarse_grid_triangulations.size();
+
+  unsigned int minlevel = 0;
+  unsigned int maxlevel = n_h_levels - 1;
+
+  dof_handlers.resize(minlevel, maxlevel);
+  mg_operators.resize(minlevel, maxlevel);
+  transfers.resize(minlevel, maxlevel);
+  mg_solution.resize(minlevel, maxlevel);
+  mg_time_derivative_previous_solutions.resize(minlevel, maxlevel);
+  constraints.resize(minlevel, maxlevel);
+
+  // Distribute DoFs for each level
+  mg_computing_timer.enter_subsection("Create DoFHandlers and distribute DoFs");
+  for (unsigned int l = minlevel; l <= maxlevel; ++l)
+    {
+      dof_handlers[l].reinit(*coarse_grid_triangulations[l]);
+      dof_handlers[l].distribute_dofs(dof_handler.get_fe());
+    }
+  mg_computing_timer.leave_subsection("Create DoFHandlers and distribute DoFs");
+
+  // Apply constraints and create mg operators for each level
+  for (unsigned int level = minlevel; level <= maxlevel; ++level)
+    {
+      const auto &level_dof_handler = dof_handlers[level];
+      auto       &level_constraint  = constraints[level];
+
+      mg_computing_timer.enter_subsection("Set boundary conditions");
+
+      level_constraint.clear();
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(level_dof_handler);
+      level_constraint.reinit(locally_relevant_dofs);
+
+      DoFTools::make_hanging_node_constraints(level_dof_handler,
+                                              level_constraint);
+
+      FEValuesExtractors::Vector velocities(0);
+      FEValuesExtractors::Scalar pressure(dim);
+
+      for (unsigned int i_bc = 0;
+           i_bc < simulation_parameters.boundary_conditions.size;
+           ++i_bc)
+        {
+          if (simulation_parameters.boundary_conditions.type[i_bc] ==
+              BoundaryConditions::BoundaryType::slip)
+            {
+              std::set<types::boundary_id> no_normal_flux_boundaries;
+              no_normal_flux_boundaries.insert(
+                simulation_parameters.boundary_conditions.id[i_bc]);
+              VectorTools::compute_no_normal_flux_constraints(
+                level_dof_handler,
+                0,
+                no_normal_flux_boundaries,
+                level_constraint,
+                *mapping);
+            }
+          else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+                   BoundaryConditions::BoundaryType::periodic)
+            {
+              DoFTools::make_periodicity_constraints(
+                level_dof_handler,
+                simulation_parameters.boundary_conditions.id[i_bc],
+                simulation_parameters.boundary_conditions.periodic_id[i_bc],
+                simulation_parameters.boundary_conditions
+                  .periodic_direction[i_bc],
+                level_constraint);
+            }
+          else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+                   BoundaryConditions::BoundaryType::pressure)
+            {
+              /*do nothing*/
+            }
+          else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+                   BoundaryConditions::BoundaryType::function_weak)
+            {
+              /*do nothing*/
+            }
+          else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+                   BoundaryConditions::BoundaryType::partial_slip)
+            {
+              /*do nothing*/
+            }
+          else if (simulation_parameters.boundary_conditions.type[i_bc] ==
+                   BoundaryConditions::BoundaryType::outlet)
+            {
+              /*do nothing*/
+            }
+          else
+            {
+              VectorTools::interpolate_boundary_values(
+                *mapping,
+                level_dof_handler,
+                simulation_parameters.boundary_conditions.id[i_bc],
+                dealii::Functions::ZeroFunction<dim>(dim + 1),
+                level_constraint,
+                fe->component_mask(velocities));
+            }
+        }
+
+      level_constraint.close();
+
+      mg_computing_timer.leave_subsection("Set boundary conditions");
+
+      mg_computing_timer.enter_subsection("Set up operators");
+
+      this->mg_operators[level] =
+        std::make_shared<NavierStokesStabilizedOperator<dim, double>>();
+
+      this->mg_operators[level]->reinit(
+        *mapping,
+        level_dof_handler,
+        level_constraint,
+        *cell_quadrature,
+        &(*forcing_function),
+        simulation_parameters.physical_properties_manager
+          .get_kinematic_viscosity_scale(),
+        simulation_parameters.stabilization.stabilization,
+        numbers::invalid_unsigned_int,
+        simulation_control);
+
+      mg_computing_timer.leave_subsection("Set up operators");
+    }
+
+  // Create transfer operators and transfer solution to mg levels
+  mg_computing_timer.enter_subsection(
+    "Create transfer operator and execute relevant transfers");
+
+  for (unsigned int level = minlevel; level < maxlevel; ++level)
+    transfers[level + 1].reinit(dof_handlers[level + 1],
+                                dof_handlers[level],
+                                constraints[level + 1],
+                                constraints[level]);
+
+  this->mg_transfer_gc =
+    std::make_shared<GCTransferType>(transfers, [&](const auto l, auto &vec) {
+      this->mg_operators[l]->initialize_dof_vector(vec);
+    });
+
+  this->mg_transfer_gc->interpolate_to_mg(dof_handler,
+                                          mg_solution,
+                                          present_solution);
+
+  if (is_bdf(simulation_control->get_assembly_method()))
+    this->mg_transfer_gc->interpolate_to_mg(
+      dof_handler,
+      mg_time_derivative_previous_solutions,
+      time_derivative_previous_solutions);
+
+  // Evaluate non linear terms for all mg operators
+  for (unsigned int level = minlevel; level <= maxlevel; ++level)
+    {
+      mg_solution[level].update_ghost_values();
+      this->mg_operators[level]->evaluate_non_linear_term(mg_solution[level]);
+
+      if (is_bdf(simulation_control->get_assembly_method()))
+        {
+          mg_time_derivative_previous_solutions[level].update_ghost_values();
+          this->mg_operators[level]
+            ->evaluate_time_derivative_previous_solutions(
+              mg_time_derivative_previous_solutions[level]);
+        }
+    }
+
+  mg_computing_timer.leave_subsection(
+    "Create transfer operator and execute relevant transfers");
+
+  if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_verbosity != Parameters::Verbosity::quiet)
+    {
+      pcout << std::endl;
+      pcout << "  -Levels of MG preconditioner:" << std::endl;
+      for (unsigned int level = minlevel; level <= maxlevel; ++level)
+        pcout << "    Level " << level << ": " << dof_handlers[level].n_dofs()
+              << " DoFs, "
+              << coarse_grid_triangulations[level]->n_global_active_cells()
+              << " cells" << std::endl;
+      pcout << std::endl;
+    }
+
+  this->mg_matrix = std::make_shared<mg::Matrix<VectorType>>(mg_operators);
+
+  // Create smoother, fill parameters for each level and intialize it
+  mg_computing_timer.enter_subsection("Set up and initialize smoother");
+
+  this->mg_smoother = std::make_shared<
+    MGSmootherPrecondition<OperatorType, SmootherType, VectorType>>();
+  MGLevelObject<typename SmootherType::AdditionalData> smoother_data(minlevel,
+                                                                     maxlevel);
+
+  for (unsigned int level = minlevel; level <= maxlevel; ++level)
+    {
+      VectorType diagonal_vector;
+      this->mg_operators[level]->compute_inverse_diagonal(diagonal_vector);
+      smoother_data[level].preconditioner =
+        std::make_shared<SmootherPreconditionerType>(diagonal_vector);
+      smoother_data[level].n_iterations =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .mg_smoother_iterations;
+
+      if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_smoother_eig_estimation)
+        {
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+          // Set relaxation to zero so that eigenvalues are estimated
+          // internally
+          smoother_data[level].relaxation = 0.0;
+          smoother_data[level].smoothing_range =
+            simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+              .eig_estimation_smoothing_range;
+          smoother_data[level].eig_cg_n_iterations =
+            simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+              .eig_estimation_cg_n_iterations;
+          smoother_data[level].eigenvalue_algorithm =
+            SmootherType::AdditionalData::EigenvalueAlgorithm::power_iteration;
+          smoother_data[level].constraints.copy_from(
+            this->mg_operators[level]
+              ->get_system_matrix_free()
+              .get_affine_constraints());
+#else
+          AssertThrow(
+            false,
+            ExcMessage(
+              "The estimation of eigenvalues within GCMG requires a version of deal.II >= 9.6.0"));
+#endif
+        }
+      else
+        smoother_data[level].relaxation =
+          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_smoother_relaxation;
+    }
+
+  this->mg_smoother->initialize(this->mg_operators, smoother_data);
+
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+  if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_smoother_eig_estimation &&
       simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_max_iterations;
-    const double tolerance =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_tolerance;
-    const double reduce =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_reduce;
-    this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
-      max_iterations, tolerance, reduce, false, false);
-    SolverGMRES<VectorType>::AdditionalData solver_parameters;
-    solver_parameters.max_n_tmp_vectors =
-      simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_max_krylov_vectors;
+          .eig_estimation_verbose != Parameters::Verbosity::quiet)
+    {
+      // Print eigenvalue estimation for all levels
+      for (unsigned int level = minlevel; level <= maxlevel; ++level)
+        {
+          VectorType vec;
+          this->mg_operators[level]->initialize_dof_vector(vec);
+          const auto evs =
+            this->mg_smoother->smoothers[level].estimate_eigenvalues(vec);
 
-    this->coarse_grid_solver =
-      std::make_shared<SolverGMRES<VectorType>>(*coarse_grid_solver_control,
-                                                solver_parameters);
+          pcout << std::endl;
+          pcout << "  -Eigenvalue estimation level " << level << ":"
+                << std::endl;
+          pcout << "    Relaxation parameter: "
+                << this->mg_smoother->smoothers[level].get_relaxation()
+                << std::endl;
+          pcout << "    Minimum eigenvalue: " << evs.min_eigenvalue_estimate
+                << std::endl;
+          pcout << "    Maximum eigenvalue: " << evs.max_eigenvalue_estimate
+                << std::endl;
+          pcout << std::endl;
+        }
+    }
+#else
+  AssertThrow(
+    false,
+    ExcMessage(
+      "The estimation of eigenvalues within GCMG requires a version of deal.II >= 9.6.0"));
+#endif
 
-    if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_coarse_grid_preconditioner ==
-        Parameters::LinearSolver::PreconditionerType::amg)
-      {
-        TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
-        amg_data.elliptic = false;
-        if (dof_handler.get_fe().degree > 1)
-          amg_data.higher_order_elements = true;
-        amg_data.n_cycles =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_n_cycles;
-        amg_data.w_cycle =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_w_cycles;
-        amg_data.aggregation_threshold =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_aggregation_threshold;
-        amg_data.smoother_sweeps =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_smoother_sweeps;
-        amg_data.smoother_overlap =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_smoother_overlap;
-        amg_data.output_details = false;
-        amg_data.smoother_type  = "ILU";
-        amg_data.coarse_type    = "ILU";
-        // Constant modes for velocity
-        std::vector<std::vector<bool>> constant_modes;
-        ComponentMask                  components(dim + 1, true);
-        DoFTools::extract_constant_modes(dof_handlers[minlevel],
-                                         components,
-                                         constant_modes);
-        amg_data.constant_modes = constant_modes;
+  mg_computing_timer.leave_subsection("Set up and initialize smoother");
 
-        Teuchos::ParameterList              parameter_ml;
-        std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
-        amg_data.set_parameters(
-          parameter_ml,
-          distributed_constant_modes,
-          this->mg_operators[minlevel]->get_system_matrix());
-        const double ilu_fill =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_fill;
-        const double ilu_atol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_precond_ilu_atol;
-        const double ilu_rtol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .amg_precond_ilu_rtol;
-        parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
-        parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
-        parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
+  // Create coarse-grid GMRES solver and AMG preconditioner
+  mg_computing_timer.enter_subsection("Create coarse-grid solver");
 
-        parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
-        parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
-        parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
+  const int max_iterations =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_max_iterations;
+  const double tolerance =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_tolerance;
+  const double reduce =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_reduce;
+  this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
+    max_iterations, tolerance, reduce, false, false);
+  SolverGMRES<VectorType>::AdditionalData solver_parameters;
+  solver_parameters.max_n_tmp_vectors =
+    simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+      .mg_coarse_grid_max_krylov_vectors;
 
-        this->precondition_amg.initialize(
-          this->mg_operators[minlevel]->get_system_matrix(), parameter_ml);
+  this->coarse_grid_solver =
+    std::make_shared<SolverGMRES<VectorType>>(*coarse_grid_solver_control,
+                                              solver_parameters);
 
-        this->mg_coarse = std::make_shared<
-          MGCoarseGridIterativeSolver<VectorType,
-                                      SolverGMRES<VectorType>,
-                                      OperatorType,
-                                      decltype(this->precondition_amg)>>(
-          *coarse_grid_solver, *mg_operators[minlevel], this->precondition_amg);
-      }
-    else if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-               .mg_coarse_grid_preconditioner ==
-             Parameters::LinearSolver::PreconditionerType::ilu)
-      {
-        int current_preconditioner_fill_level =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_fill;
-        const double ilu_atol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_atol;
-        const double ilu_rtol =
-          simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-            .ilu_precond_rtol;
-        TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
-          current_preconditioner_fill_level, ilu_atol, ilu_rtol, 0);
+  if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_coarse_grid_preconditioner ==
+      Parameters::LinearSolver::PreconditionerType::amg)
+    {
+      TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+      amg_data.elliptic = false;
+      if (dof_handler.get_fe().degree > 1)
+        amg_data.higher_order_elements = true;
+      amg_data.n_cycles =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_n_cycles;
+      amg_data.w_cycle =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_w_cycles;
+      amg_data.aggregation_threshold =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_aggregation_threshold;
+      amg_data.smoother_sweeps =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_smoother_sweeps;
+      amg_data.smoother_overlap =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_smoother_overlap;
+      amg_data.output_details = false;
+      amg_data.smoother_type  = "ILU";
+      amg_data.coarse_type    = "ILU";
+      // Constant modes for velocity
+      std::vector<std::vector<bool>> constant_modes;
+      ComponentMask                  components(dim + 1, true);
+      DoFTools::extract_constant_modes(dof_handlers[minlevel],
+                                       components,
+                                       constant_modes);
+      amg_data.constant_modes = constant_modes;
 
-        this->precondition_ilu.initialize(
-          this->mg_operators[minlevel]->get_system_matrix(),
-          preconditionerOptions);
+      Teuchos::ParameterList              parameter_ml;
+      std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
+      amg_data.set_parameters(
+        parameter_ml,
+        distributed_constant_modes,
+        this->mg_operators[minlevel]->get_system_matrix());
+      const double ilu_fill =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_fill;
+      const double ilu_atol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_precond_ilu_atol;
+      const double ilu_rtol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .amg_precond_ilu_rtol;
+      parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
+      parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
+      parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
 
-        this->mg_coarse = std::make_shared<
-          MGCoarseGridIterativeSolver<VectorType,
-                                      SolverGMRES<VectorType>,
-                                      OperatorType,
-                                      decltype(this->precondition_ilu)>>(
-          *coarse_grid_solver, *mg_operators[minlevel], this->precondition_ilu);
-      }
+      parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
+      parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
+      parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
 
-    mg_computing_timer.leave_subsection("Create coarse-grid solver");
+      this->precondition_amg.initialize(
+        this->mg_operators[minlevel]->get_system_matrix(), parameter_ml);
 
-    // Create main MG object
-    this->mg = std::make_shared<Multigrid<VectorType>>(
-      *mg_matrix, *mg_coarse, *mg_transfer_gc, *mg_smoother, *mg_smoother);
+      this->mg_coarse = std::make_shared<
+        MGCoarseGridIterativeSolver<VectorType,
+                                    SolverGMRES<VectorType>,
+                                    OperatorType,
+                                    decltype(this->precondition_amg)>>(
+        *coarse_grid_solver, *mg_operators[minlevel], this->precondition_amg);
+    }
+  else if (simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+             .mg_coarse_grid_preconditioner ==
+           Parameters::LinearSolver::PreconditionerType::ilu)
+    {
+      int current_preconditioner_fill_level =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_fill;
+      const double ilu_atol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_atol;
+      const double ilu_rtol =
+        simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .ilu_precond_rtol;
+      TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
+        current_preconditioner_fill_level, ilu_atol, ilu_rtol, 0);
 
-    // Create MG preconditioner
-    this->gc_multigrid_preconditioner =
-      std::make_shared<PreconditionMG<dim, VectorType, GCTransferType>>(
-        dof_handler, *this->mg, *this->mg_transfer_gc);
+      this->precondition_ilu.initialize(
+        this->mg_operators[minlevel]->get_system_matrix(),
+        preconditionerOptions);
 
-    computing_timer.leave_subsection("Setup GCMG");
-  }
+      this->mg_coarse = std::make_shared<
+        MGCoarseGridIterativeSolver<VectorType,
+                                    SolverGMRES<VectorType>,
+                                    OperatorType,
+                                    decltype(this->precondition_ilu)>>(
+        *coarse_grid_solver, *mg_operators[minlevel], this->precondition_ilu);
+    }
 
-private:
-  // onlt GC
-  mutable MGLevelObject<DoFHandler<dim>>                     dof_handlers;
-  mutable MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers;
+  mg_computing_timer.leave_subsection("Create coarse-grid solver");
 
-  // level matrices
-  mutable MGLevelObject<std::shared_ptr<OperatorType>>
-                                                  mg_operators; // TODO: reuse
-  mutable std::shared_ptr<mg::Matrix<VectorType>> mg_matrix;
+  // Create main MG object
+  this->mg = std::make_shared<Multigrid<VectorType>>(
+    *mg_matrix, *mg_coarse, *mg_transfer_gc, *mg_smoother, *mg_smoother);
 
-  // edge matrices (only LS)
-  mutable std::shared_ptr<mg::Matrix<VectorType>> mg_interface_matrix_in;
-  mutable std::shared_ptr<mg::Matrix<VectorType>> mg_interface_matrix_out;
-  mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
-    ls_mg_operators;
-  mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
-    ls_mg_interface_in;
-  mutable MGLevelObject<MatrixFreeOperators::MGInterfaceOperator<OperatorType>>
-                                                       ls_mg_interface_out;
-  mutable MGLevelObject<std::shared_ptr<OperatorType>> mg_interface_in;
-  mutable MGLevelObject<std::shared_ptr<OperatorType>> mg_interface_out;
+  // Create MG preconditioner
+  this->gc_multigrid_preconditioner =
+    std::make_shared<PreconditionMG<dim, VectorType, GCTransferType>>(
+      dof_handler, *this->mg, *this->mg_transfer_gc);
 
-  // smoother
-  mutable std::shared_ptr<
-    MGSmootherPrecondition<OperatorType, SmootherType, VectorType>>
-    mg_smoother;
+  computing_timer.leave_subsection("Setup GCMG");
+}
 
-  // transfer operators
-  mutable MGConstrainedDoFs               mg_constrained_dofs;
-  mutable std::shared_ptr<LSTransferType> mg_transfer_ls; // TODO: reuse
-  mutable std::shared_ptr<GCTransferType> mg_transfer_gc; // TODO: reuse
 
-  // coarse-grid solvers
-  mutable TrilinosWrappers::PreconditionAMG        precondition_amg;
-  mutable TrilinosWrappers::PreconditionILU        precondition_ilu;
-  mutable std::shared_ptr<ReductionControl>        coarse_grid_solver_control;
-  mutable std::shared_ptr<SolverGMRES<VectorType>> coarse_grid_solver;
-  mutable std::shared_ptr<MGCoarseGridBase<VectorType>> mg_coarse;
 
-  // multigrid as precondtioner
-  mutable std::shared_ptr<Multigrid<VectorType>> mg;
-  mutable std::shared_ptr<PreconditionMG<dim, VectorType, LSTransferType>>
-    ls_multigrid_preconditioner;
-  mutable std::shared_ptr<PreconditionMG<dim, VectorType, GCTransferType>>
-    gc_multigrid_preconditioner;
-};
+template <int dim>
+void
+MFNavierStokesPreconditionGMG<dim>::vmult(VectorType       &dst,
+                                          const VectorType &src) const
+{
+  if (ls_multigrid_preconditioner)
+    ls_multigrid_preconditioner->vmult(dst, src);
+  else if (gc_multigrid_preconditioner)
+    gc_multigrid_preconditioner->vmult(dst, src);
+  else
+    AssertThrow(false, ExcNotImplemented());
+}
+
+
 
 template <int dim>
 MFNavierStokesSolver<dim>::MFNavierStokesSolver(
@@ -1518,7 +1458,7 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::solve_with_GMG(SolverGMRES<VectorType> &solver)
 {
-  PreconditionGMG<dim> gmg;
+  MFNavierStokesPreconditionGMG<dim> gmg;
 
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .preconditioner == Parameters::LinearSolver::PreconditionerType::lsmg)

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -63,6 +63,9 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
 {
   computing_timer.enter_subsection("Setup LSMG");
 
+  dof_handler.get_triangulation().signals.post_refinement.connect(
+    [this]() { this->clear(); });
+
   // Create level objects
   MGLevelObject<VectorType> mg_solution;
   MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
@@ -559,6 +562,9 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
 {
   computing_timer.enter_subsection("Setup GCMG");
 
+  dof_handler.get_triangulation().signals.post_refinement.connect(
+    [this]() { this->clear(); });
+
   // Create level objects
   MGLevelObject<VectorType> mg_solution;
   MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
@@ -1047,6 +1053,15 @@ MFNavierStokesPreconditionGMG<dim>::vmult(VectorType       &dst,
     gc_multigrid_preconditioner->vmult(dst, src);
   else
     AssertThrow(false, ExcNotImplemented());
+}
+
+
+
+template <int dim>
+void
+MFNavierStokesPreconditionGMG<dim>::clear() const
+{
+  AssertThrow(false, ExcNotImplemented());
 }
 
 

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -563,7 +563,7 @@ public:
   {
     if (ls_multigrid_preconditioner)
       ls_multigrid_preconditioner->vmult(dst, src);
-    if (gc_multigrid_preconditioner)
+    else if (gc_multigrid_preconditioner)
       gc_multigrid_preconditioner->vmult(dst, src);
     else
       AssertThrow(false, ExcNotImplemented());

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -59,7 +59,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
   const VectorType                        &present_solution,
   const VectorType                        &time_derivative_previous_solutions,
   const ConditionalOStream                &pcout,
-  const std::shared_ptr<SimulationControl> simulation_control) const
+  const std::shared_ptr<SimulationControl> simulation_control)
 {
   computing_timer.enter_subsection("Setup LSMG");
 
@@ -452,6 +452,13 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
       amg_data.output_details = false;
       amg_data.smoother_type  = "ILU";
       amg_data.coarse_type    = "ILU";
+      // Constant modes for velocity and pressure
+      // std::vector<std::vector<bool>> constant_modes;
+      // ComponentMask                  components(dim + 1, true);
+      // DoFTools::extract_constant_modes(dof_handler,
+      //                                  components,
+      //                                  constant_modes);
+      // amg_data.constant_modes = constant_modes;
 
       Teuchos::ParameterList              parameter_ml;
       std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
@@ -553,7 +560,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
   const VectorType                        &present_solution,
   const VectorType                        &time_derivative_previous_solutions,
   const ConditionalOStream                &pcout,
-  const std::shared_ptr<SimulationControl> simulation_control) const
+  const std::shared_ptr<SimulationControl> simulation_control)
 {
   computing_timer.enter_subsection("Setup GCMG");
 
@@ -701,10 +708,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
           else if (simulation_parameters.boundary_conditions.type[i_bc] ==
                    BoundaryConditions::BoundaryType::pressure)
             {
-              AssertThrow(
-                false,
-                ExcMessage(
-                  "The boundary conditions on pressure are not implemented."));
+              /*do nothing*/
             }
           else if (simulation_parameters.boundary_conditions.type[i_bc] ==
                    BoundaryConditions::BoundaryType::function_weak)

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -452,13 +452,6 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
       amg_data.output_details = false;
       amg_data.smoother_type  = "ILU";
       amg_data.coarse_type    = "ILU";
-      // Constant modes for velocity and pressure
-      // std::vector<std::vector<bool>> constant_modes;
-      // ComponentMask                  components(dim + 1, true);
-      // DoFTools::extract_constant_modes(dof_handler,
-      //                                  components,
-      //                                  constant_modes);
-      // amg_data.constant_modes = constant_modes;
 
       Teuchos::ParameterList              parameter_ml;
       std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
@@ -639,8 +632,8 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
   // Extract min and max levels and resize mg level objects accordingly
   const unsigned int n_h_levels = coarse_grid_triangulations.size();
 
-  unsigned int minlevel = 0;
-  unsigned int maxlevel = n_h_levels - 1;
+  const unsigned int minlevel = 0;
+  const unsigned int maxlevel = n_h_levels - 1;
 
   dof_handlers.resize(minlevel, maxlevel);
   mg_operators.resize(minlevel, maxlevel);
@@ -708,7 +701,10 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
           else if (simulation_parameters.boundary_conditions.type[i_bc] ==
                    BoundaryConditions::BoundaryType::pressure)
             {
-              /*do nothing*/
+              AssertThrow(
+                false,
+                ExcMessage(
+                  "The boundary conditions on pressure are not implemented."));
             }
           else if (simulation_parameters.boundary_conditions.type[i_bc] ==
                    BoundaryConditions::BoundaryType::function_weak)
@@ -1436,7 +1432,10 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 {
-  // TODO
+  AssertThrow(
+    false,
+    ExcMessage(
+      "The update multiphysics time average solution is not implemented yet."));
 }
 
 template <int dim>

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1097,7 +1097,7 @@ MFNavierStokesSolver<dim>::solve()
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);
-  // this->update_multiphysics_time_average_solution();
+  this->update_multiphysics_time_average_solution();
 
   while (this->simulation_control->integrate())
     {
@@ -1436,10 +1436,11 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 {
-  //AssertThrow(
-  //  false,
-  //  ExcMessage(
-  //    "The update multiphysics time average solution is not implemented yet."));
+  // AssertThrow(
+  //   false,
+  //   ExcMessage(
+  //     "The update multiphysics time average solution is not implemented
+  //     yet."));
 }
 
 template <int dim>

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1436,10 +1436,10 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 {
-  AssertThrow(
-    false,
-    ExcMessage(
-      "The update multiphysics time average solution is not implemented yet."));
+  //AssertThrow(
+  //  false,
+  //  ExcMessage(
+  //    "The update multiphysics time average solution is not implemented yet."));
 }
 
 template <int dim>

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -63,9 +63,6 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
 {
   computing_timer.enter_subsection("Setup LSMG");
 
-  dof_handler.get_triangulation().signals.post_refinement.connect(
-    [this]() { this->clear(); });
-
   // Create level objects
   MGLevelObject<VectorType> mg_solution;
   MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
@@ -567,9 +564,6 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
 {
   computing_timer.enter_subsection("Setup GCMG");
 
-  dof_handler.get_triangulation().signals.post_refinement.connect(
-    [this]() { this->clear(); });
-
   // Create level objects
   MGLevelObject<VectorType> mg_solution;
   MGLevelObject<VectorType> mg_time_derivative_previous_solutions;
@@ -1058,13 +1052,6 @@ MFNavierStokesPreconditionGMG<dim>::vmult(VectorType       &dst,
     gc_multigrid_preconditioner->vmult(dst, src);
   else
     AssertThrow(false, ExcNotImplemented());
-}
-
-template <int dim>
-void
-MFNavierStokesPreconditionGMG<dim>::clear() const
-{
-  // AssertThrow(false, ExcNotImplemented());
 }
 
 template <int dim>

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1093,7 +1093,7 @@ MFNavierStokesSolver<dim>::solve()
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);
-  this->update_multiphysics_time_average_solution();
+  // this->update_multiphysics_time_average_solution();
 
   while (this->simulation_control->integrate())
     {

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1039,8 +1039,6 @@ MFNavierStokesPreconditionGMG<dim>::initialize_gc(
   computing_timer.leave_subsection("Setup GCMG");
 }
 
-
-
 template <int dim>
 void
 MFNavierStokesPreconditionGMG<dim>::vmult(VectorType       &dst,


### PR DESCRIPTION
# Description of the problem

The GMG preconditioners were defined within two functions in the matrix-free solver. This was preventing us from reusing certain parts of the multigrid.

# Description of the solution

The GMG preconditioners now have their own class and objects. This also allows to use the inexact newton solver for the `lethe-fluid-matrix-free` application. In addition, some corrections to the local smoothing algorithm were introduced by eliminating the interface out matrix. 

# How Has This Been Tested?

All the existent matrix-free tests pass without any issue.

# Future changes

-This is the first step towards reusing parts of multigrid to improve the performance of the matrix-free solver.
