### PR TITLE
Explicitly set max num of threads

### DIFF
--- a/applications/initial_conditions/initial_conditions.cc
+++ b/applications/initial_conditions/initial_conditions.cc
@@ -118,8 +118,7 @@ main(int argc, char *argv[])
 
 
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       const Parameters::SizeOfSubsections size_of_subsections =
         Parameters::get_size_of_subsections(argv[1]);

--- a/applications/initial_conditions/initial_conditions.cc
+++ b/applications/initial_conditions/initial_conditions.cc
@@ -119,7 +119,7 @@ main(int argc, char *argv[])
 
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       const Parameters::SizeOfSubsections size_of_subsections =
         Parameters::get_size_of_subsections(argv[1]);

--- a/applications/lethe-fluid-block/gd_navier_stokes.cc
+++ b/applications/lethe-fluid-block/gd_navier_stokes.cc
@@ -7,8 +7,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-block/gd_navier_stokes.cc
+++ b/applications/lethe-fluid-block/gd_navier_stokes.cc
@@ -8,7 +8,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-matrix-free/mf_navier_stokes.cc
+++ b/applications/lethe-fluid-matrix-free/mf_navier_stokes.cc
@@ -21,7 +21,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-matrix-free/mf_navier_stokes.cc
+++ b/applications/lethe-fluid-matrix-free/mf_navier_stokes.cc
@@ -20,8 +20,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-nitsche/nitsche_navier_stokes.cc
+++ b/applications/lethe-fluid-nitsche/nitsche_navier_stokes.cc
@@ -22,7 +22,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-nitsche/nitsche_navier_stokes.cc
+++ b/applications/lethe-fluid-nitsche/nitsche_navier_stokes.cc
@@ -21,8 +21,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-particles/cfd_dem_coupling.cc
+++ b/applications/lethe-fluid-particles/cfd_dem_coupling.cc
@@ -24,7 +24,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, dealii::numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
 
       if (argc != 2)

--- a/applications/lethe-fluid-particles/cfd_dem_coupling.cc
+++ b/applications/lethe-fluid-particles/cfd_dem_coupling.cc
@@ -23,8 +23,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
 
       if (argc != 2)

--- a/applications/lethe-fluid-sharp/gls_sharp_navier_stokes.cc
+++ b/applications/lethe-fluid-sharp/gls_sharp_navier_stokes.cc
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, dealii::numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-sharp/gls_sharp_navier_stokes.cc
+++ b/applications/lethe-fluid-sharp/gls_sharp_navier_stokes.cc
@@ -24,8 +24,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-vans/gls_vans.cc
+++ b/applications/lethe-fluid-vans/gls_vans.cc
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, dealii::numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid-vans/gls_vans.cc
+++ b/applications/lethe-fluid-vans/gls_vans.cc
@@ -24,8 +24,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid/gls_navier_stokes.cc
+++ b/applications/lethe-fluid/gls_navier_stokes.cc
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-fluid/gls_navier_stokes.cc
+++ b/applications/lethe-fluid/gls_navier_stokes.cc
@@ -24,8 +24,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 2)
         {

--- a/applications/lethe-parameter-check/lethe_parameter_check.cc
+++ b/applications/lethe-parameter-check/lethe_parameter_check.cc
@@ -14,7 +14,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       if (argc != 3)
         {

--- a/applications/lethe-parameter-check/lethe_parameter_check.cc
+++ b/applications/lethe-parameter-check/lethe_parameter_check.cc
@@ -13,8 +13,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       if (argc != 3)
         {

--- a/applications/lethe-particles/dem.cc
+++ b/applications/lethe-particles/dem.cc
@@ -9,8 +9,7 @@ main(int argc, char *argv[])
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
 
       if (argc != 2)

--- a/applications/lethe-particles/dem.cc
+++ b/applications/lethe-particles/dem.cc
@@ -10,7 +10,7 @@ main(int argc, char *argv[])
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, dealii::numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
 
       if (argc != 2)

--- a/applications/lethe-rpt-cell-reconstruction-3d/rpt_cell_reconstruction_3d.cc
+++ b/applications/lethe-rpt-cell-reconstruction-3d/rpt_cell_reconstruction_3d.cc
@@ -17,8 +17,7 @@ main(int argc, char *argv[])
           std::exit(1);
         }
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;

--- a/applications/lethe-rpt-cell-reconstruction-3d/rpt_cell_reconstruction_3d.cc
+++ b/applications/lethe-rpt-cell-reconstruction-3d/rpt_cell_reconstruction_3d.cc
@@ -18,7 +18,7 @@ main(int argc, char *argv[])
         }
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;

--- a/applications/lethe-rpt-fem-reconstruction-3d/rpt_fem_reconstruction_3d.cc
+++ b/applications/lethe-rpt-fem-reconstruction-3d/rpt_fem_reconstruction_3d.cc
@@ -18,7 +18,7 @@ main(int argc, char *argv[])
         }
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       // Check the number of MPI processes
       int number_of_processes;

--- a/applications/lethe-rpt-fem-reconstruction-3d/rpt_fem_reconstruction_3d.cc
+++ b/applications/lethe-rpt-fem-reconstruction-3d/rpt_fem_reconstruction_3d.cc
@@ -17,8 +17,7 @@ main(int argc, char *argv[])
           std::exit(1);
         }
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       // Check the number of MPI processes
       int number_of_processes;

--- a/applications/lethe-rpt-l2-projection-3d/rpt_l2_projection_3d.cc
+++ b/applications/lethe-rpt-l2-projection-3d/rpt_l2_projection_3d.cc
@@ -17,8 +17,7 @@ main(int argc, char *argv[])
           std::exit(1);
         }
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;

--- a/applications/lethe-rpt-l2-projection-3d/rpt_l2_projection_3d.cc
+++ b/applications/lethe-rpt-l2-projection-3d/rpt_l2_projection_3d.cc
@@ -18,7 +18,7 @@ main(int argc, char *argv[])
         }
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1529,10 +1529,6 @@ template <int dim>
 void
 CFDDEMSolver<dim>::solve()
 {
-  // This is enforced to 1 right now because it does not provide
-  // better speed-up than using MPI. This could be eventually changed...
-  MultithreadInfo::set_thread_limit(1);
-
   read_mesh_and_manifolds(
     *this->triangulation,
     this->cfd_dem_simulation_parameters.cfd_parameters.mesh,

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -4869,7 +4869,6 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::solve()
 {
-  MultithreadInfo::set_thread_limit(1);
   read_mesh_and_manifolds(
     *this->triangulation,
     this->simulation_parameters.mesh,

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -1940,10 +1940,6 @@ template <int dim>
 void
 GLSVANSSolver<dim>::solve()
 {
-  // This is enforced to 1 right now because it does not provide
-  // better speed-up than using MPI. This could be eventually changed...
-  MultithreadInfo::set_thread_limit(1);
-
   read_mesh_and_manifolds(
     *this->triangulation,
     this->cfd_dem_simulation_parameters.cfd_parameters.mesh,

--- a/source/solvers/gd_navier_stokes.cc
+++ b/source/solvers/gd_navier_stokes.cc
@@ -1242,10 +1242,6 @@ template <int dim>
 void
 GDNavierStokesSolver<dim>::solve()
 {
-  // This is enforced to 1 right now because it does not provide
-  // better speed-up than using MPI. This could be eventually changed...
-  MultithreadInfo::set_thread_limit(1);
-
   read_mesh_and_manifolds(
     *this->triangulation,
     this->simulation_parameters.mesh,

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1789,10 +1789,6 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::solve()
 {
-  // This is enforced to 1 right now because it does not provide
-  // better speed-up than using MPI. This could be eventually changed...
-  MultithreadInfo::set_thread_limit(1);
-
   read_mesh_and_manifolds(
     *this->triangulation,
     this->simulation_parameters.mesh,

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -702,8 +702,6 @@ template <int dim, int spacedim>
 void
 GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
 {
-  MultithreadInfo::set_thread_limit(1);
-
   // Fluid setup
   read_mesh_and_manifolds(
     *this->triangulation,

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -76,8 +76,6 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::solve()
 {
-  MultithreadInfo::set_thread_limit(1);
-
   read_mesh_and_manifolds(
     *this->triangulation,
     this->simulation_parameters.mesh,

--- a/tests/TEMPLATE
+++ b/tests/TEMPLATE
@@ -45,7 +45,7 @@ main(/* int argc, char *argv[] */)
       initlog();
       /*
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       */
       test();
     }

--- a/tests/core/inexact_newton_non_linear_solver_01.cc
+++ b/tests/core/inexact_newton_non_linear_solver_01.cc
@@ -50,8 +50,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/inexact_newton_non_linear_solver_01.cc
+++ b/tests/core/inexact_newton_non_linear_solver_01.cc
@@ -51,7 +51,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/inexact_newton_non_linear_solver_02.cc
+++ b/tests/core/inexact_newton_non_linear_solver_02.cc
@@ -57,7 +57,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/inexact_newton_non_linear_solver_02.cc
+++ b/tests/core/inexact_newton_non_linear_solver_02.cc
@@ -56,8 +56,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/kinsol_newton_non_linear_solver_01.cc
+++ b/tests/core/kinsol_newton_non_linear_solver_01.cc
@@ -46,7 +46,7 @@ main(int argc, char **argv)
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       initlog();
       test();
     }

--- a/tests/core/kinsol_newton_non_linear_solver_01.cc
+++ b/tests/core/kinsol_newton_non_linear_solver_01.cc
@@ -45,8 +45,7 @@ main(int argc, char **argv)
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       initlog();
       test();
     }

--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_2.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_2.cc
@@ -142,7 +142,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_2.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_2.cc
@@ -141,8 +141,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
@@ -142,8 +142,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/newton_non_linear_solver_01.cc
+++ b/tests/core/newton_non_linear_solver_01.cc
@@ -51,8 +51,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/newton_non_linear_solver_01.cc
+++ b/tests/core/newton_non_linear_solver_01.cc
@@ -52,7 +52,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -120,7 +120,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -119,8 +119,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -100,8 +100,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -101,7 +101,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -100,7 +100,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -99,8 +99,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -100,7 +100,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -99,8 +99,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -121,8 +121,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -122,7 +122,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -147,7 +147,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -146,8 +146,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/table_read.cc
+++ b/tests/core/table_read.cc
@@ -75,7 +75,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/core/table_read.cc
+++ b/tests/core/table_read.cc
@@ -74,8 +74,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/dem/boundary_cells_and_faces.cc
+++ b/tests/dem/boundary_cells_and_faces.cc
@@ -82,8 +82,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/boundary_cells_and_faces.cc
+++ b/tests/dem/boundary_cells_and_faces.cc
@@ -83,7 +83,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/find_cell_neighbors.cc
+++ b/tests/dem/find_cell_neighbors.cc
@@ -85,7 +85,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/find_cell_neighbors.cc
+++ b/tests/dem/find_cell_neighbors.cc
@@ -84,8 +84,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/find_full_cell_neighbors.cc
+++ b/tests/dem/find_full_cell_neighbors.cc
@@ -79,8 +79,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/find_full_cell_neighbors.cc
+++ b/tests/dem/find_full_cell_neighbors.cc
@@ -80,7 +80,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/particle_point_contact.cc
+++ b/tests/dem/particle_point_contact.cc
@@ -191,7 +191,7 @@ main(int argc, char **argv)
   try
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
 
       initlog();
       test<2>();

--- a/tests/dem/particle_point_contact.cc
+++ b/tests/dem/particle_point_contact.cc
@@ -190,8 +190,7 @@ main(int argc, char **argv)
 {
   try
     {
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       initlog();
       test<2>();

--- a/tests/dem/particle_wall_contact_pairs.cc
+++ b/tests/dem/particle_wall_contact_pairs.cc
@@ -147,7 +147,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/dem/particle_wall_contact_pairs.cc
+++ b/tests/dem/particle_wall_contact_pairs.cc
@@ -146,8 +146,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test<3>();
     }
   catch (std::exception &exc)

--- a/tests/solvers/average_velocities_01.cc
+++ b/tests/solvers/average_velocities_01.cc
@@ -142,8 +142,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/average_velocities_01.cc
+++ b/tests/solvers/average_velocities_01.cc
@@ -143,7 +143,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/average_velocities_02.cc
+++ b/tests/solvers/average_velocities_02.cc
@@ -154,7 +154,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/average_velocities_02.cc
+++ b/tests/solvers/average_velocities_02.cc
@@ -153,8 +153,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/average_velocities_03.cc
+++ b/tests/solvers/average_velocities_03.cc
@@ -144,8 +144,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/average_velocities_03.cc
+++ b/tests/solvers/average_velocities_03.cc
@@ -145,7 +145,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/multiphysics_interface_01.cc
+++ b/tests/solvers/multiphysics_interface_01.cc
@@ -124,7 +124,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test<2>();
       test<3>();
     }

--- a/tests/solvers/multiphysics_interface_01.cc
+++ b/tests/solvers/multiphysics_interface_01.cc
@@ -123,8 +123,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test<2>();
       test<3>();
     }

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -186,8 +186,7 @@ main(int argc, char *argv[])
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -187,7 +187,7 @@ main(int argc, char *argv[])
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/reynolds_stress_01.cc
+++ b/tests/solvers/reynolds_stress_01.cc
@@ -165,8 +165,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/reynolds_stress_01.cc
+++ b/tests/solvers/reynolds_stress_01.cc
@@ -166,7 +166,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/reynolds_stress_02.cc
+++ b/tests/solvers/reynolds_stress_02.cc
@@ -179,7 +179,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/reynolds_stress_02.cc
+++ b/tests/solvers/reynolds_stress_02.cc
@@ -178,8 +178,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/reynolds_stress_03.cc
+++ b/tests/solvers/reynolds_stress_03.cc
@@ -164,7 +164,7 @@ main(int argc, char **argv)
     {
       initlog();
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, numbers::invalid_unsigned_int);
+        argc, argv, 1);
       test();
     }
   catch (std::exception &exc)

--- a/tests/solvers/reynolds_stress_03.cc
+++ b/tests/solvers/reynolds_stress_03.cc
@@ -163,8 +163,7 @@ main(int argc, char **argv)
   try
     {
       initlog();
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(
-        argc, argv, 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       test();
     }
   catch (std::exception &exc)


### PR DESCRIPTION
# Description of the problem

The third argument of the [`MPI_InitFinalize(...)` ](https://www.dealii.org/developer/doxygen/deal.II/classUtilities_1_1MPI_1_1MPI__InitFinalize.html#a71954ff48c33b1101b8a4d64d9c685db) call in all applications in Lethe was set to `numbers::invalid_unsigned_int`; if this is the case, then the number of threads is determined automatically according to the system and set via `MultithreadInfo::set_thread_limit(...)`.

Due to confusions this week in the lab, I though that it would be a good idea to set it explicitly to 1, which guarantees that it will start as many MPI processes per node as there are cores on each node avoiding multi-threading.

For the main applications, there was a call `MultithreadInfo::set_thread_limit(1)` in the respective `solve()` function, however, according to deal.II, it only works if it is called before any threads are created, therefore, it is safer to call it at the beginning of `main()` instead.

# Description of the solution

Removed `MultithreadInfo::set_thread_limit(1)` from the applications and set the third argument of `MPI_InitFinalize(...)` to 1 in all cases across the library.

# How Has This Been Tested?

All the tests pass without any issue. 
