### PR TITLE
Flow rates postprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Simulations with adaptive time-stepping would checkpoint correctly, but would not restart with the correct time-step due to the way the time-step was read from the checkpointing files. This is now fixed and tested. [#1093](https://github.com/lethe-cfd/lethe/pull/1093)
 
+## [Master] - 2024-04-15
+
+### Fixed
+
+- MINOR The previous flow rate post processing tool would add a line to the .dat file for each defined boundary (in the boundary condition subsection of the .prm file) for every time iteration. This is not the expected output as one would expect a single line to be added for each time step with the flow rates of every boundary. This is now fixed. [#1092](https://github.com/lethe-cfd/lethe/pull/1092)
+
 ## [Master] - 2024-04-07
 
 ### Added

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1386,7 +1386,18 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
   // Calculate flow rate at every boundary
   if (this->simulation_parameters.post_processing.calculate_flow_rate)
     {
+      this->flow_rate_table.add_value("time",
+                                      simulation_control->get_current_time());
+      this->flow_rate_table.set_scientific("time", true);
+
       TimerOutput::Scope t(this->computing_timer, "flow_rate_calculation");
+
+      if (this->simulation_parameters.post_processing.verbosity ==
+          Parameters::Verbosity::verbose)
+        {
+          announce_string(this->pcout, "Flow rates");
+        }
+
       for (unsigned int boundary_id = 0;
            boundary_id < simulation_parameters.boundary_conditions.size;
            ++boundary_id)
@@ -1399,9 +1410,13 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
                                 *this->mapping);
           this->flow_rate_table.add_value(
             "time", simulation_control->get_current_time());
+
           this->flow_rate_table.add_value("flow-rate-" +
                                             std::to_string(boundary_id),
                                           boundary_flow_rate.first);
+          this->flow_rate_table.set_scientific("flow-rate-" +
+                                                 std::to_string(boundary_id),
+                                               true);
           if (this->simulation_parameters.post_processing.verbosity ==
               Parameters::Verbosity::verbose)
             {
@@ -1424,13 +1439,13 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
             simulation_parameters.post_processing.flow_rate_output_name +
             ".dat";
           std::ofstream output(filename.c_str());
-          flow_rate_table.set_precision("time", 12);
+          flow_rate_table.set_precision("time", 4);
           for (unsigned int boundary_id = 0;
                boundary_id < simulation_parameters.boundary_conditions.size;
                ++boundary_id)
             flow_rate_table.set_precision("flow-rate-" +
                                             std::to_string(boundary_id),
-                                          12);
+                                          4);
           this->flow_rate_table.write_text(output);
         }
     }

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1408,8 +1408,6 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
                                 boundary_id,
                                 *this->face_quadrature,
                                 *this->mapping);
-          this->flow_rate_table.add_value(
-            "time", simulation_control->get_current_time());
 
           this->flow_rate_table.add_value("flow-rate-" +
                                             std::to_string(boundary_id),

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1409,12 +1409,11 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
                                 *this->face_quadrature,
                                 *this->mapping);
 
-          this->flow_rate_table.add_value("flow-rate-" +
-                                            std::to_string(boundary_id),
-                                          boundary_flow_rate.first);
-          this->flow_rate_table.set_scientific("flow-rate-" +
-                                                 std::to_string(boundary_id),
-                                               true);
+          this->flow_rate_table.add_value(
+            "flow-rate-" + Utilities::int_to_string(boundary_id, 2),
+            boundary_flow_rate.first);
+          this->flow_rate_table.set_scientific(
+            "flow-rate-" + Utilities::int_to_string(boundary_id, 2), true);
           if (this->simulation_parameters.post_processing.verbosity ==
               Parameters::Verbosity::verbose)
             {
@@ -1437,13 +1436,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
             simulation_parameters.post_processing.flow_rate_output_name +
             ".dat";
           std::ofstream output(filename.c_str());
-          flow_rate_table.set_precision("time", 4);
+          flow_rate_table.set_precision("time", 12);
           for (unsigned int boundary_id = 0;
                boundary_id < simulation_parameters.boundary_conditions.size;
                ++boundary_id)
-            flow_rate_table.set_precision("flow-rate-" +
-                                            std::to_string(boundary_id),
-                                          4);
+            flow_rate_table.set_precision(
+              "flow-rate-" + Utilities::int_to_string(boundary_id, 2), 12);
           this->flow_rate_table.write_text(output);
         }
     }


### PR DESCRIPTION
# Description of the problem

- The previous flow rate post processing tool would add a line to the `.dat` file for each defined boundary (in the boundary condition subsection of the `.prm` file) for every time iteration. This is not the expected output as one would expect a single line to be added for each time step with the flow rates of every boundary.
- Also, the values of the flow rates were added with a 12 digits precision. Instead, a 4 digits precision in **scientific notation** was chosen, which seems like a reasonable precision. 

# Description of the solution

- The value of time is now added outside of the loop on the boundary conditions.

# Comments
- At the moment there is no unified output format : with/without scientific notation, different numbers of digits. This could be the work of a future PR.
