### PR TITLE
CHNS Free Energy Postprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Added computation of the energies involved in the Cahn-Hilliard equations and updated related documentation. [#1095](https://github.com/lethe-cfd/lethe/pull/1095)
+- MINOR Added Cahn-Hilliard equations energy computation and output. The documentation was updated accordingly. [#1095](https://github.com/lethe-cfd/lethe/pull/1095)
 
 ## [Master] - 2024-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-04-17
+
+### Added
+
+- MINOR Added computation of the energies involved in the Cahn-Hilliard equations and updated related documentation. [#1094](future PR link)
+
 ## [Master] - 2024-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Added computation of the energies involved in the Cahn-Hilliard equations and updated related documentation. [#1094](future PR link)
+- MINOR Added computation of the energies involved in the Cahn-Hilliard equations and updated related documentation. [#1095](https://github.com/lethe-cfd/lethe/pull/1095)
 
 ## [Master] - 2024-04-16
 

--- a/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.output
+++ b/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.output
@@ -1,0 +1,58 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       64
+   Number of degrees of freedom: 243
+   Volume of triangulation:      4
+   Number of Cahn-Hilliard degrees of freedom: 162
+-----------------
+Phase statistics
+-----------------
+Min: -0.994529
+Max: 1
+Average: 0.607051
+Integral: 2.4282
+Volume phase 0: 3.2141
+Volume phase 1: 0.785898
+-------------
+Phase energy
+-------------
+Bulk energy: 0.667619
+Interface energy: 1.74433
+Total energy: 2.41195
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.5      Time step: 0.5      CFL: 0
+*******************************************************************************
+-----------------
+Phase statistics
+-----------------
+Min: -1.01453
+Max: 1.00534
+Average: 0.60706
+Integral: 2.42824
+Volume phase 0: 3.21412
+Volume phase 1: 0.78588
+-------------
+Phase energy
+-------------
+Bulk energy: 0.687751
+Interface energy: 1.66703
+Total energy: 2.35478
+
+*******************************************************************************
+Transient iteration: 2        Time: 1        Time step: 0.5      CFL: 0.967317
+*******************************************************************************
+-----------------
+Phase statistics
+-----------------
+Min: -0.891115
+Max: 1.0132
+Average: 0.61502
+Integral: 2.46008
+Volume phase 0: 3.23004
+Volume phase 1: 0.76996
+-------------
+Phase energy
+-------------
+Bulk energy: 1.08564
+Interface energy: 1.19563
+Total energy: 2.28127

--- a/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.prm
+++ b/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.prm
@@ -1,0 +1,127 @@
+set dimension = 2
+
+subsection simulation control
+  set method           = bdf1
+  set time end         = 1
+  set time step        = 0.5
+  set output name      = out
+  set output frequency = 0
+end
+
+subsection initial conditions
+  set type = L2projection
+  subsection cahn hilliard
+    set Function constants  = nbr_refs=5
+    set Function expression = -tanh(sqrt(2*0.25)*(0.5 - sqrt(x*x+y*y))/(2^(-nbr_refs+1))); 0
+  end
+end
+
+subsection boundary conditions
+  set number         = 4
+  set time dependent = false
+  subsection bc 0
+    set id   = 0
+    set type = slip
+  end
+  subsection bc 1
+    set id   = 1
+    set type = slip
+  end
+  subsection bc 2
+    set id   = 2
+    set type = slip
+  end
+  subsection bc 3
+    set id   = 3
+    set type = slip
+  end
+end
+
+subsection boundary conditions cahn hilliard
+  set number         = 1
+  subsection bc 0
+    set id   = 0
+    set type = dirichlet
+    subsection phi
+      set Function constants  = nbr_refs=5
+      set Function expression = -tanh(sqrt(2*0.25)*(0.5 - sqrt(x*x+y*y))/(2^(-nbr_refs+1)))
+    end
+  end
+end
+
+subsection multiphysics
+  set fluid dynamics = true
+  set cahn hilliard  = true
+end
+
+subsection cahn hilliard
+  set potential smoothing coefficient = 0.0
+
+  subsection epsilon
+    set method = automatic
+  end
+end
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 0
+    set density             = 1000
+    set kinematic viscosity = 0.01
+  end
+  subsection fluid 1
+    set density             = 100
+    set kinematic viscosity = 0.01
+  end
+  set number of material interactions = 1
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set first fluid id              = 0
+      set second fluid id             = 1
+      set surface tension model       = constant
+      set surface tension coefficient = 24.5
+      # Mobility Cahn-Hilliard
+      set cahn hilliard mobility model    = constant
+      set cahn hilliard mobility constant = 1e-6
+    end
+  end
+end
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_cube
+  set grid arguments     = -1 : 1 : true
+  set initial refinement = 3
+end
+
+subsection post-processing
+  set verbosity                  = verbose
+  set calculate phase statistics = true
+  set phase statistics name      = phase_statistics
+  set calculate phase energy     = true
+end
+
+subsection FEM
+  set phase cahn hilliard order     = 1
+  set potential cahn hilliard order = 1
+  set velocity order                = 1
+  set pressure order                = 1
+end
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection cahn hilliard
+    set verbosity = quiet
+  end
+end
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection cahn hilliard
+    set verbosity = quiet
+  end
+end

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_ch.output
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_ch.output
@@ -10,9 +10,11 @@ Min: -0.994529
 Max: 1
 Average: 0.544551
 Integral: 2.1782
+Volume phase 0: 3.0891
+Volume phase 1: 0.910898
 
 *******************************************************************************
-Transient iteration: 1        Time: 0.5      Time step: 0.5      CFL: 0       
+Transient iteration: 1        Time: 0.5      Time step: 0.5      CFL: 0
 *******************************************************************************
 -----------------
 Phase statistics
@@ -21,6 +23,8 @@ Min: -0.786164
 Max: 0.781734
 Average: 0.423636
 Integral: 1.69454
+Volume phase 0: 2.84727
+Volume phase 1: 1.15273
 
 *******************************************************************************
 Transient iteration: 2        Time: 1        Time step: 0.5      CFL: 0.533525
@@ -32,3 +36,5 @@ Min: -0.780241
 Max: 0.794182
 Average: 0.427977
 Integral: 1.71191
+Volume phase 0: 2.85595
+Volume phase 1: 1.14405

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -67,7 +67,7 @@ This subsection controls the post-processing other than the forces and torque on
     # Other Cahn-Hilliard postprocessing
     set calculate phase statistics       = false
     set phase statistics name            = phase_statistics
-    set calculate phase energy           = true
+    set calculate phase energy           = false
     set phase energy name                = phase_energy
     
   end
@@ -221,11 +221,15 @@ This subsection controls the post-processing other than the forces and torque on
 
 * ``mass conservation name``: name of the output file containing the mass of both fluids for VOF simulations. The default file name is ``mass_conservation_information``.
   
-* ``calculate phase statistics``: outputs phase statistics from the solution of the Cahn-Hilliard equations, including minimum, maximum, average, integral of the phase order parameter. Also includes the volume of each phase. This works only with the :doc:`cahn_hilliard` solver.
+* ``calculate phase statistics``: outputs Cahn-Hilliard phase statistics, including minimum, maximum, average, integral of the phase order parameter, and the volume of each phase.
 
-* ``phase statistics name``: name of the output file containing phase order parameter statistics from Cahn-Hilliard simulations. The default file name is ``phase_statistics``.
+  .. warning ::
 
-* ``calculate phase energy``:  outputs phase energies from the solution of the Cahn-Hilliard equations : bulk energy, interface energy and total energy. This works only with the :doc:`cahn_hilliard` solver. The energies are computed as follow:
+      ``calculate phase statistics = true`` only works with the :doc:`cahn_hilliard` solver.
+
+* ``phase statistics name``: name of the output file containing phase order parameter statistics from Cahn-Hilliard simulations. The default file name is ``phase_statistics``. It is stored in the output folder with in a  ``.dat`` file.
+
+* ``calculate phase energy``: outputs Cahn-Hilliard phase energies, including bulk energy, interface energy and total energy. The energies are computed as follow:
 
   .. math::
 
@@ -239,7 +243,11 @@ This subsection controls the post-processing other than the forces and torque on
 
      E_{total} = E_{bulk} + E_{interface}  
     
-  where :math:`\epsilon` is the numerical interface thickness. Note that these energies are not homogeneous to physical energies, but they give nonetheless a good insight on the system's evolution.
+  where :math:`\epsilon` is the numerical interface thickness. Note that these energies are not homogeneous to physical energies. Nonetheless, they are a convenient way to track the system's evolution.
+  
+  .. warning ::
+
+      ``calculate phase energy = true`` only works with the :doc:`cahn_hilliard` solver.
 
 
 * ``phase energy name``: name of the output file containing phase energies from Cahn-Hilliard simulations. The default file name is ``phase_energy``.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -221,7 +221,7 @@ This subsection controls the post-processing other than the forces and torque on
 
 * ``mass conservation name``: name of the output file containing the mass of both fluids for VOF simulations. The default file name is ``mass_conservation_information``.
   
-* ``calculate phase statistics``: outputs phase statistics from the solution of the Cahn-Hilliard equations, including minimum, maximum, average, and standard deviation of the phase order parameter. This works only with the :doc:`cahn_hilliard` solver.
+* ``calculate phase statistics``: outputs phase statistics from the solution of the Cahn-Hilliard equations, including minimum, maximum, average, integral of the phase order parameter. Also includes the volume of each phase. This works only with the :doc:`cahn_hilliard` solver.
 
 * ``phase statistics name``: name of the output file containing phase order parameter statistics from Cahn-Hilliard simulations. The default file name is ``phase_statistics``.
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -67,6 +67,8 @@ This subsection controls the post-processing other than the forces and torque on
     # Other Cahn-Hilliard postprocessing
     set calculate phase statistics       = false
     set phase statistics name            = phase_statistics
+    set calculate phase energy           = true
+    set phase energy name                = phase_energy
     
   end
 
@@ -222,5 +224,25 @@ This subsection controls the post-processing other than the forces and torque on
 * ``calculate phase statistics``: outputs phase statistics from the solution of the Cahn-Hilliard equations, including minimum, maximum, average, and standard deviation of the phase order parameter. This works only with the :doc:`cahn_hilliard` solver.
 
 * ``phase statistics name``: name of the output file containing phase order parameter statistics from Cahn-Hilliard simulations. The default file name is ``phase_statistics``.
+
+* ``calculate phase energy``:  outputs phase energies from the solution of the Cahn-Hilliard equations : bulk energy, interface energy and total energy. This works only with the :doc:`cahn_hilliard` solver. The energies are computed as follow:
+
+  .. math::
+
+     E_{bulk} = \int_{\Omega} (1-\phi^2)^2 \mathrm{d}\Omega 
+      
+  .. math::
+
+     E_{interface} = \int_{\Omega} 0.5\epsilon^2|\nabla \phi |^2 \mathrm{d}\Omega 
+      
+  .. math::
+
+     E_{total} = E_{bulk} + E_{interface}  
+    
+  where :math:`\epsilon` is the numerical interface thickness. Note that these energies are not homogeneous to physical energies, but they give nonetheless a good insight on the system's evolution.
+
+
+* ``phase energy name``: name of the output file containing phase energies from Cahn-Hilliard simulations. The default file name is ``phase_energy``.
+
 
         

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -907,6 +907,12 @@ namespace Parameters
     /// Prefix for the VOF mass conservation output
     std::string mass_conservation_output_name;
 
+    /// Enable energies calculation on the domain in Cahn-Hilliard simulations
+    bool calculate_phase_energy;
+
+    /// Prefix for the energy output in Cahn-Hilliard simulations
+    std::string phase_energy_output_name;
+
     static void
     declare_parameters(ParameterHandler &prm);
     void

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -402,10 +402,23 @@ private:
   calculate_phase_statistics();
 
   /**
-   * @brief Writes the phase integral to an output file
+   * @brief Writes the phase statistics to an output file
    */
   void
   write_phase_statistics();
+
+  /**
+   *
+   * @return A pointer to an array of double containing the energies. First element is bulk energy, second is interface energy and third is total energy
+   */
+  void
+  calculate_phase_energy();
+
+  /*
+   * @brief Write the energy to an output file
+   */
+  void
+  write_phase_energy();
 
   /**
    * @brief Calculates the barycenter of fluid 1 and its velocity
@@ -482,6 +495,9 @@ private:
 
   // Phase statistics table
   TableHandler statistics_table;
+
+  // Phase energy table
+  TableHandler phase_energy_table;
 
   // Phase fraction filter
   std::shared_ptr<CahnHilliardFilterBase> filter;

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -396,7 +396,7 @@ private:
   copy_local_rhs_to_global_rhs(const StabilizedMethodsCopyData &copy_data);
 
   /**
-   * @brief Calculate phase order parameter integral for monitoring purposes
+   * @brief Calculate phase statistics for monitoring purposes
    */
   void
   calculate_phase_statistics();
@@ -409,7 +409,7 @@ private:
 
   /**
    *
-   * @return A pointer to an array of double containing the energies. First element is bulk energy, second is interface energy and third is total energy
+   * @brief Calculate the phase energies :  bulk energy, interface energy and total energy.
    */
   void
   calculate_phase_energy();

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1833,13 +1833,13 @@ namespace Parameters
         "calculate phase energy",
         "false",
         Patterns::Bool(),
-        "Enable calculation of phase energies : total energy, bulk energy and interface energy");
+        "Enable calculation of phase energies, including: total energy, bulk energy, and interface energy");
 
       prm.declare_entry(
         "phase energy name",
         "phase_energy",
         Patterns::FileName(),
-        "Name of energy output file in Cahn-Hilliard simulations.");
+        "Name of energy output file in Cahn-Hilliard simulations. The file is stored in the output folder specified in the simulation control subsection");
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1828,6 +1828,18 @@ namespace Parameters
         "mass_conservation_information",
         Patterns::FileName(),
         "Name of mass conservation output file in VOF simulations");
+
+      prm.declare_entry(
+        "calculate phase energy",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of phase energies : total energy, bulk energy and interface energy");
+
+      prm.declare_entry(
+        "phase energy name",
+        "phase_energy",
+        Patterns::FileName(),
+        "Name of energy output file in Cahn-Hilliard simulations.");
     }
     prm.leave_subsection();
   }
@@ -1875,6 +1887,8 @@ namespace Parameters
       barycenter_output_name      = prm.get("barycenter name");
       calculate_mass_conservation = prm.get_bool("calculate mass conservation");
       mass_conservation_output_name = prm.get("mass conservation name");
+      calculate_phase_energy        = prm.get_bool("calculate phase energy");
+      phase_energy_output_name      = prm.get("phase energy name");
 
       // Viscous dissipative fluid
       const std::string op_fluid = prm.get("postprocessed fluid");

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -419,6 +419,107 @@ CahnHilliard<dim>::calculate_phase_statistics()
   double min_phase_value(std::numeric_limits<double>::max());
   double volume_0(0.);
   double volume_1(0.);
+
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+          fe_values[phase_order].get_function_values(present_solution,
+                                                     local_phase_order_values);
+          fe_values[phase_order].get_function_gradients(
+            present_solution, local_phase_order_gradients);
+          for (unsigned int q = 0; q < n_q_points; q++)
+            {
+              integral += local_phase_order_values[q] * fe_values.JxW(q);
+              max_phase_value =
+                std::max(local_phase_order_values[q], max_phase_value);
+              min_phase_value =
+                std::min(local_phase_order_values[q], min_phase_value);
+              volume_0 +=
+                (1 + local_phase_order_values[q]) * 0.5 * fe_values.JxW(q);
+              volume_1 +=
+                (1 - local_phase_order_values[q]) * 0.5 * fe_values.JxW(q);
+            }
+        }
+    }
+
+  min_phase_value = Utilities::MPI::min(min_phase_value, mpi_communicator);
+  max_phase_value = Utilities::MPI::max(max_phase_value, mpi_communicator);
+
+  integral = Utilities::MPI::sum(integral, mpi_communicator);
+  volume_0 = Utilities::MPI::sum(volume_0, mpi_communicator);
+  volume_1 = Utilities::MPI::sum(volume_1, mpi_communicator);
+
+  double global_volume = GridTools::volume(*triangulation, *mapping);
+  double phase_average = integral / global_volume;
+
+
+  // Console output
+  if (simulation_parameters.post_processing.verbosity ==
+      Parameters::Verbosity::verbose)
+    {
+      announce_string(this->pcout, "Phase statistics");
+      this->pcout << "Min: " << min_phase_value << std::endl;
+      this->pcout << "Max: " << max_phase_value << std::endl;
+      this->pcout << "Average: " << phase_average << std::endl;
+      this->pcout << "Integral: " << integral << std::endl;
+      this->pcout << "Volume phase 0: " << volume_0 << std::endl;
+      this->pcout << "Volume phase 1: " << volume_1 << std::endl;
+    }
+
+  statistics_table.add_value("time", simulation_control->get_current_time());
+  statistics_table.set_scientific("time", true);
+  statistics_table.add_value("min", min_phase_value);
+  statistics_table.set_scientific("min", true);
+  statistics_table.add_value("max", max_phase_value);
+  statistics_table.set_scientific("max", true);
+  statistics_table.add_value("average", phase_average);
+  statistics_table.set_scientific("average", true);
+  statistics_table.add_value("integral", integral);
+  statistics_table.set_scientific("integral", true);
+  statistics_table.add_value("volume_0", volume_0);
+  statistics_table.set_scientific("volume_0", true);
+  statistics_table.add_value("volume_1", volume_1);
+  statistics_table.set_scientific("volume_1", true);
+}
+
+template <int dim>
+void
+CahnHilliard<dim>::write_phase_statistics()
+{
+  auto mpi_communicator = triangulation->get_communicator();
+
+  if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
+    {
+      std::string filename =
+        simulation_parameters.simulation_control.output_folder +
+        simulation_parameters.post_processing.phase_output_name + ".dat";
+      std::ofstream output(filename.c_str());
+
+      statistics_table.write_text(output);
+    }
+}
+
+template <int dim>
+void
+CahnHilliard<dim>::calculate_phase_energy()
+{
+  auto mpi_communicator = triangulation->get_communicator();
+
+  FEValues<dim> fe_values(*mapping,
+                          *fe,
+                          *cell_quadrature,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+  const FEValuesExtractors::Scalar phase_order(0);
+
+  const unsigned int          n_q_points = cell_quadrature->size();
+  std::vector<double>         local_phase_order_values(n_q_points);
+  std::vector<Tensor<1, dim>> local_phase_order_gradients(n_q_points);
+
   double bulk_energy(0.);
   double interface_energy(0.);
   double total_energy(0.);
@@ -441,15 +542,6 @@ CahnHilliard<dim>::calculate_phase_statistics()
             present_solution, local_phase_order_gradients);
           for (unsigned int q = 0; q < n_q_points; q++)
             {
-              integral += local_phase_order_values[q] * fe_values.JxW(q);
-              max_phase_value =
-                std::max(local_phase_order_values[q], max_phase_value);
-              min_phase_value =
-                std::min(local_phase_order_values[q], min_phase_value);
-              volume_0 +=
-                (1 + local_phase_order_values[q]) * 0.5 * fe_values.JxW(q);
-              volume_1 +=
-                (1 - local_phase_order_values[q]) * 0.5 * fe_values.JxW(q);
               bulk_energy += (1 - local_phase_order_values[q] *
                                     local_phase_order_values[q]) *
                              (1 - local_phase_order_values[q] *
@@ -463,60 +555,39 @@ CahnHilliard<dim>::calculate_phase_statistics()
         }
     }
 
-  min_phase_value = Utilities::MPI::min(min_phase_value, mpi_communicator);
-  max_phase_value = Utilities::MPI::max(max_phase_value, mpi_communicator);
-
-  integral         = Utilities::MPI::sum(integral, mpi_communicator);
-  volume_0         = Utilities::MPI::sum(volume_0, mpi_communicator);
-  volume_1         = Utilities::MPI::sum(volume_1, mpi_communicator);
   bulk_energy      = Utilities::MPI::sum(bulk_energy, mpi_communicator);
   interface_energy = Utilities::MPI::sum(interface_energy, mpi_communicator);
   total_energy     = bulk_energy + interface_energy;
-  double global_volume = GridTools::volume(*triangulation, *mapping);
-  double phase_average = integral / global_volume;
 
+  phase_energy_table.add_value("time", simulation_control->get_current_time());
+  phase_energy_table.set_scientific("time", true);
+  phase_energy_table.add_value("bulk_energy", bulk_energy);
+  phase_energy_table.set_scientific("bulk_energy", true);
+  phase_energy_table.add_value("interface_energy", interface_energy);
+  phase_energy_table.set_scientific("interface_energy", true);
+  phase_energy_table.add_value("total_energy", total_energy);
+  phase_energy_table.set_scientific("total_energy", true);
 
   // Console output
   if (simulation_parameters.post_processing.verbosity ==
       Parameters::Verbosity::verbose)
     {
-      announce_string(this->pcout, "Phase statistics");
-      this->pcout << "Min: " << min_phase_value << std::endl;
-      this->pcout << "Max: " << max_phase_value << std::endl;
-      this->pcout << "Average: " << phase_average << std::endl;
-      this->pcout << "Integral: " << integral << std::endl;
-      this->pcout << "Volume phase 0: " << volume_0 << std::endl;
-      this->pcout << "Volume phase 1: " << volume_1 << std::endl;
-      this->pcout << "Bulk energy: " << bulk_energy << std::endl;
-      this->pcout << "Interface energy: " << interface_energy << std::endl;
-      this->pcout << "Total energy: " << total_energy << std::endl;
+      announce_string(this->pcout, "Phase energy");
+      this->pcout << "Bulk energy: "
+                  << std::setprecision(simulation_control->get_log_precision())
+                  << bulk_energy << std::endl;
+      this->pcout << "Interface energy: "
+                  << std::setprecision(simulation_control->get_log_precision())
+                  << interface_energy << std::endl;
+      this->pcout << "Total energy: "
+                  << std::setprecision(simulation_control->get_log_precision())
+                  << total_energy << std::endl;
     }
-
-  statistics_table.add_value("time", simulation_control->get_current_time());
-  statistics_table.set_scientific("time", true);
-  statistics_table.add_value("min", min_phase_value);
-  statistics_table.set_scientific("min", true);
-  statistics_table.add_value("max", max_phase_value);
-  statistics_table.set_scientific("max", true);
-  statistics_table.add_value("average", phase_average);
-  statistics_table.set_scientific("average", true);
-  statistics_table.add_value("integral", integral);
-  statistics_table.set_scientific("integral", true);
-  statistics_table.add_value("volume_0", volume_0);
-  statistics_table.set_scientific("volume_0", true);
-  statistics_table.add_value("volume_1", volume_1);
-  statistics_table.set_scientific("volume_1", true);
-  statistics_table.add_value("bulk_energy", bulk_energy);
-  statistics_table.set_scientific("bulk_energy", true);
-  statistics_table.add_value("interface_energy", interface_energy);
-  statistics_table.set_scientific("interface_energy", true);
-  statistics_table.add_value("total_energy", total_energy);
-  statistics_table.set_scientific("total_energy", true);
 }
 
 template <int dim>
 void
-CahnHilliard<dim>::write_phase_statistics()
+CahnHilliard<dim>::write_phase_energy()
 {
   auto mpi_communicator = triangulation->get_communicator();
 
@@ -524,10 +595,14 @@ CahnHilliard<dim>::write_phase_statistics()
     {
       std::string filename =
         simulation_parameters.simulation_control.output_folder +
-        simulation_parameters.post_processing.phase_output_name + ".dat";
+        simulation_parameters.post_processing.phase_energy_output_name + ".dat";
       std::ofstream output(filename.c_str());
+      phase_energy_table.set_precision("time", 12);
+      phase_energy_table.set_precision("bulk_energy", 12);
+      phase_energy_table.set_precision("interface_energy", 12);
+      phase_energy_table.set_precision("total_energy", 12);
 
-      statistics_table.write_text(output);
+      phase_energy_table.write_text(output);
     }
 }
 
@@ -626,6 +701,18 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_phase_statistics();
+    }
+
+  if (this->simulation_parameters.post_processing.calculate_phase_energy)
+    {
+      calculate_phase_energy();
+      // Output phase energies to a text file from processor 0
+      if (simulation_control->get_step_number() %
+            this->simulation_parameters.post_processing.output_frequency ==
+          0)
+        {
+          this->write_phase_energy();
+        }
     }
 
   if (this->simulation_parameters.timer.type ==


### PR DESCRIPTION
# Description of the problem

The Cahn-Hilliard equations are energy based equations for solving multiphase flows : the interface is the result of two energies in competition, bulk and interface energy. The system, which starts from a non-equilibrium state, lowers its total energy (bulk + interface) to reach equilibrium. In order to visualize this process I added the energy computation into the postprocessing section.
Very minor : added the computation of the volume of each phases.

# Description of the solution

- New functions `calculate_phase_energy()` and `write_phase_energy` were implemented as well as new parameter entries in the postprocess subsection : `compute phase energy` (boolean) and `phase energy name`

# How Has This Been Tested?

- A new test was added : `cahn_hilliard_navier_stokes_energy_postprocessing`

# Documentation

- Postprocessing documentation was updated to include this new feature

- File modified : `post_processing.rst`