### PR TITLE
Partial fix for unresolved CFD-DEM restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-04-18
+
+### Fixed
+
+- MINOR Checkpoints were not established correctly with the lethe-fluid-particles solver. The void fraction was delayed in time and the restart file would not yield the same result because of this, resulting in crashes when the time derivative of the void fraction was used in the calculations. [#1096](https://github.com/lethe-cfd/lethe/pull/1096)
+
 ## [Master] - 2024-04-17
 
 ### Added

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -166,9 +166,11 @@ template <int dim>
 void
 GLSVANSSolver<dim>::finish_time_step_fd()
 {
-  GLSNavierStokesSolver<dim>::finish_time_step();
-
+  // Void fraction percolation must be done before the time step is finished to
+  // ensure that the checkpointed information is correct
   percolate_void_fraction();
+
+  GLSNavierStokesSolver<dim>::finish_time_step();
 }
 
 template <int dim>


### PR DESCRIPTION
# Description of the problem

- Unresolved CFD-DEM restart had jump in the residual

# Description of the solution

- There was a bug where the percolation of the void fraction was taking place after the checkpointing which is wrong.

# How Has This Been Tested?

- The results of the tests won't be affected because the restart files have not been remade. 

# Comments

- The code needs major cleanup...
