### PR TITLE
Fix output of number of cells on levels for LSMG

### DIFF
--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -419,7 +419,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
   if (mg_level_min_cells != -1)
     {
       for (unsigned int level = minlevel; level <= maxlevel; ++level)
-        if (static_cast<int>(n_cells_on_levels[maxlevel]) >= mg_level_min_cells)
+        if (static_cast<int>(n_cells_on_levels[level]) >= mg_level_min_cells)
           {
             minlevel = level;
             break;

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -434,7 +434,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_ls(
       for (unsigned int level = minlevel; level <= maxlevel; ++level)
         pcout << "    Level " << level - minlevel << ": "
               << dof_handler.n_dofs(level) << " DoFs, "
-              << n_cells_on_levels[maxlevel] << " cells" << std::endl;
+              << n_cells_on_levels[level] << " cells" << std::endl;
       pcout << std::endl;
     }
 


### PR DESCRIPTION
The output of the number of cells for each level when using local smoothing was not correct.  This was a minor bug introduced in the last GMG PR. Now the correct level is passed to the vector containing the information.

