### PR TITLE
Optimize NS-VOF assembler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-07-05
+
+### Changed
+
+- MINOR  The NS-VOF assembler was not optimized as the NS assembler. The if conditions on the dof components were added to not compute multiplications that are a priori 0 in the matrix and rhs assembly. [#1188](https://github.com/chaos-polymtl/lethe/pull/1188)
+
 ## [Master] - 2024-07-04
 
 ### Changed

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -135,7 +135,7 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
           const unsigned int component_i = scratch_data.components[i];
-          
+
           const auto &phi_u_i      = scratch_data.phi_u[q][i];
           const auto &grad_phi_u_i = scratch_data.grad_phi_u[q][i];
           const auto &div_phi_u_i  = scratch_data.div_phi_u[q][i];
@@ -150,11 +150,11 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
               const unsigned int component_j = scratch_data.components[j];
-              
+
               const auto &phi_u_j      = scratch_data.phi_u[q][j];
               const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
               // const auto &div_phi_u_j  = scratch_data.div_phi_u[q][j];
-              const auto  shear_rate_j = grad_phi_u_j + transpose(grad_phi_u_j);
+              const auto shear_rate_j = grad_phi_u_j + transpose(grad_phi_u_j);
 
               const auto &phi_p_j =
                 scratch_data.phi_p[q][j] * pressure_scaling_factor;
@@ -166,21 +166,23 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_matrix(
 
               if (component_i == dim)
                 {
-                  const auto &div_phi_u_j  = scratch_data.div_phi_u[q][j];
-                  
+                  const auto &div_phi_u_j = scratch_data.div_phi_u[q][j];
+
                   local_matrix_ij += phi_p_i * div_phi_u_j;
-                  
-                  local_matrix_ij += tau / density_eq * (strong_jac * grad_phi_p_i);
+
+                  local_matrix_ij +=
+                    tau / density_eq * (strong_jac * grad_phi_p_i);
                 }
 
               if (component_i < dim && component_j < dim)
                 {
-                  local_matrix_ij += dynamic_viscosity_eq *
-                  scalar_product(shear_rate_j, grad_phi_u_i) + density_eq * velocity_gradient_x_phi_u_j[j] * phi_u_i +
-                density_eq * grad_phi_u_j_x_velocity[j] * phi_u_i;
-                
+                  local_matrix_ij +=
+                    dynamic_viscosity_eq *
+                      scalar_product(shear_rate_j, grad_phi_u_i) +
+                    density_eq * velocity_gradient_x_phi_u_j[j] * phi_u_i +
+                    density_eq * grad_phi_u_j_x_velocity[j] * phi_u_i;
                 }
-                
+
               if (component_i < dim)
                 {
                   // Jacobian is currently incomplete
@@ -307,7 +309,7 @@ GLSNavierStokesVOFAssemblerCore<dim>::assemble_rhs(
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
           const unsigned int component_i = scratch_data.components[i];
-          
+
           const auto phi_u_i      = scratch_data.phi_u[q][i];
           const auto grad_phi_u_i = scratch_data.grad_phi_u[q][i];
           const auto phi_p_i      = scratch_data.phi_p[q][i];


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

The NS-VOF assembler was not optimized as the NS assembler. The if conditions on the dof components were added to not compute multiplications that are a priori 0.

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

None of the application tests have changed. The computational time gain is about 20% by iteration on the 3D lpbf benchmark case for a simulation of about 300 iterations. I can do it for a complete simulation if you thing it is worth doing it :)  

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

No new documentation needed.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge