### PR TITLE
Fix non-initialized parameters in two unit tests

### DIFF
--- a/tests/mortar/read_mortar_data_01.cc
+++ b/tests/mortar/read_mortar_data_01.cc
@@ -51,13 +51,15 @@ test()
   Parameters::Mortar<dim> mortar;
 
   // Stator mesh parameters
-  stator_mesh.type                     = Parameters::Mesh::Type::dealii;
-  stator_mesh.grid_type                = "hyper_shell";
-  stator_mesh.grid_arguments           = "0, 0 : 0.5 : 1.0 : 6 : true";
-  stator_mesh.scale                    = 1;
-  stator_mesh.simplex                  = false;
-  stator_mesh.initial_refinement       = n_global_refinements;
-  stator_mesh.refine_until_target_size = false;
+  stator_mesh.type                             = Parameters::Mesh::Type::dealii;
+  stator_mesh.grid_type                        = "hyper_shell";
+  stator_mesh.grid_arguments                   = "0, 0 : 0.5 : 1.0 : 6 : true";
+  stator_mesh.scale                            = 1;
+  stator_mesh.simplex                          = false;
+  stator_mesh.initial_refinement               = n_global_refinements;
+  stator_mesh.refine_until_target_size         = false;
+  stator_mesh.boundaries_to_refine             = std::vector<int>();
+  stator_mesh.initial_refinement_at_boundaries = 0;
 
   // Rotor mesh parameters
   mortar.enable                     = "true";

--- a/tests/mortar/read_mortar_data_02.cc
+++ b/tests/mortar/read_mortar_data_02.cc
@@ -57,6 +57,8 @@ test()
   stator_mesh.simplex                  = false;
   stator_mesh.initial_refinement       = n_global_refinements;
   stator_mesh.refine_until_target_size = false;
+  stator_mesh.boundaries_to_refine     = std::vector<int>();
+  stator_mesh.initial_refinement_at_boundaries = 0;
 
   // Rotor mesh parameters
   mortar.enable                     = "true";


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Two parameters in unit tests were not initialized and on some machines this could cause the tests to stall.

### Solution

Fix this by giving the parameters default values.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge