### PR TITLE
Removed deprecated lines of code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-05-29
+
+### Removed
+
+- MINOR Remove deprecated functions `enable_projected_phase_fraction_gradient` and `reinit_projected_phase_fraction_gradient` with their related variables in `NavierStokesScratchData` were removed. [#1543](https://github.com/chaos-polymtl/lethe/pull/1543)
+
 ## Release of Lethe v1.0.1 - 2024-05-28
 The Lethe v1.0.1 release introduces some key new features including:
 
@@ -52,7 +58,7 @@ The particle_wall_contact_info has been changed to a struct instead of a class a
 
 ### Added
 
-- MINOR Mortar: the matrix-based solver is now able to read 'gmsh' files, and a function to compute the rotor radius and the number of subdivisions at the rotor-stator interface has been added. [#1526] (https://github.com/chaos-polymtl/lethe/pull/1526)
+- MINOR Mortar: the matrix-based solver is now able to read 'gmsh' files, and a function to compute the rotor radius and the number of subdivisions at the rotor-stator interface has been added. [#1526](https://github.com/chaos-polymtl/lethe/pull/1526)
 
 ### Added
 
@@ -60,7 +66,7 @@ The particle_wall_contact_info has been changed to a struct instead of a class a
 
 ### Added
 
-- MINOR Some of the functions related to the mortar coupling have been refactored, and new functionalities have been added. For instance, the matrix-based solver is able to read 'gmsh' files, and the matrix-free solver is able to read data from the mortar subsection. A new coupling operator has been added. [#] (https://github.com/chaos-polymtl/lethe/pull/)
+- MINOR Some of the functions related to the mortar coupling have been refactored, and new functionalities have been added. For instance, the matrix-based solver is able to read 'gmsh' files, and the matrix-free solver is able to read data from the mortar subsection. A new coupling operator has been added. [#1526](https://github.com/chaos-polymtl/lethe/pull/1526)
 
 ## [Master] - 2024-05-07
 

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_navier_stokes_scratch_data_h

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2019-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/bdf.h>

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/bdf.h>


### PR DESCRIPTION
### Description

This PR simply cleans up deprecated functions `enable_projected_phase_fraction_gradient` and `reinit_projected_phase_fraction_gradient` with their related variables in `NavierStokesScratchData`. 

### Testing

- Waiting for CI; all tests passed locally in DEBUG
- Tested with the 2D rising-bubble case (a case with surface tension force). The results are visually similar to the previous ones.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this one
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge