### PR TITLE
Fix the include guards in the matrix-free solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR A missing include "deal.II/multigrid/mg_transfer_matrix_free.templates.h" was added to enable compilation on deal.II master version (9.8-pre). It will not be impossible to compile Lethe with a deal.II 9.8-pre version that predates 10/09/2025. [#1676](https://github.com/chaos-polymtl/lethe/pull/1676)
+- MINOR A missing include "deal.II/multigrid/mg_transfer_matrix_free.templates.h" was added to enable compilation on deal.II master version (9.8-pre). It will not be impossible to compile Lethe with a deal.II 9.8-pre version that predates 10/09/2025. [#1676](https://github.com/chaos-polymtl/lethe/pull/1676). The initial version of this PR was partially wrong and is updated in [#1677](https://github.com/chaos-polymtl/lethe/pull/1677) to adequately account for the 9.7 version check.
 
 ### [Master] - 2025-09-11
 

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -25,10 +25,11 @@
 #include <deal.II/multigrid/mg_smoother.h>
 #include <deal.II/multigrid/mg_tools.h>
 #include <deal.II/multigrid/mg_transfer_global_coarsening.h>
-#include <deal.II/multigrid/mg_transfer_global_coarsening.templates.h>
 #include <deal.II/multigrid/mg_transfer_matrix_free.h>
-#if DEAL_II_VERSION_GTE(9, 6, 0)
+#if DEAL_II_VERSION_GTE(9, 8, 0)
 #  include <deal.II/multigrid/mg_transfer_matrix_free.templates.h>
+#else
+#  include <deal.II/multigrid/mg_transfer_global_coarsening.templates.h>
 #endif
 #include <deal.II/multigrid/multigrid.h>
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

A mistake was made in the previous (by me) in which the include guards were not correct for deal.II 9.7 when accounting for the new matrix free include. This was rapidly found by @peterrum 

### Solution

Fix the include guard to have the correct deal.II version and add the else clause.

### Testing

Compiles on my machine. I will also try to compile it on deal.II 9.7 to double check.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge