### PR TITLE
Clang V20 - Mortar, Parameter and SDirk

### DIFF
--- a/include/core/sdirk_stage_data.h
+++ b/include/core/sdirk_stage_data.h
@@ -97,8 +97,8 @@ public:
    *
    * where \( s \) is the total number of stages.
    *
-   * Pay attention that the stage indices start from 1, but the but indicices
-   * for the matrix and the vectors when coding start from 0.
+   * Pay attention that the stage indices start from 1, but the indices
+   * for the matrix and the vectors start at 0.
    *
    *
    * @param[in] table The SDIRK Butcher tableau (structure containing A, b, and

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -325,6 +325,7 @@ MortarManagerBase<dim>::get_weights(const Point<dim> &face_center,
   if (type == 0) // aligned
     {
       std::vector<double> weights;
+      weights.reserve(n_quadrature_points);
 
       for (unsigned int q = 0; q < n_quadrature_points; ++q)
         weights.emplace_back(radius[0] * quadrature.weight(q) * delta_0 *

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -261,9 +261,7 @@ namespace Parameters
 
       output_folder = prm.get("output path");
       output_name   = prm.get("output name");
-      output_name.erase(std::remove(output_name.begin(),
-                                    output_name.end(),
-                                    '/'),
+      output_name.erase(std::ranges::remove(output_name, '/').begin(),
                         output_name.end());
       output_iteration_frequency = prm.get_integer("output frequency");
       output_time_frequency      = prm.get_double("output time frequency");

--- a/source/core/sdirk_stage_data.cc
+++ b/source/core/sdirk_stage_data.cc
@@ -30,7 +30,7 @@ sdirk_table(const Parameters::SimulationControl::TimeSteppingMethod method)
 
       // alpha is a constant coefficient chosen to ensure the method is stable
       // and consistent
-      const double alpha = (2. - std::sqrt(2.)) / 2.;
+      constexpr double alpha = (2. - std::numbers::sqrt2) / 2.;
 
       table.A.reinit(2, 2);
       table.A(0, 0) = alpha;


### PR DESCRIPTION
Fixed Clang Tidy warnings in mortar.cc, parameters.cc and sdirk related files. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge