### PR TITLE
Fix issue with boundary pvd file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR  Two of the files using the std::numbers namespace were actually missing the "numbers" include. Ths created a compilation issue on Apple CLANG. This has been fixed by adding the correct include in the sdirk and dem files. [#1750](https://github.com/chaos-polymtl/lethe/pull/1750)
 
+- MINOR Fixes a bug introduced in [#1731]. Essentially, the wrong function was used to write the boundaries checkpoint pvd file (read instead of save) and this would crash the simulation when trying to write a new checkpoint file from zero. This PR fixes this by calling the correct function. [](https://github.com/chaos-polymtl/lethe/pull/)
+
+
 ### [Master] - 2025-10-13
 
 ### Fixed

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -3196,7 +3196,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
             this->simulation_parameters.restart_parameters.filename +
             ".boundary";
 
-          this->pvdhandler_boundary.read(prefix_boundary);
+          this->pvdhandler_boundary.save(prefix_boundary);
         }
     }
 


### PR DESCRIPTION
Fix the call to the write checkpoint to use the correct call instead of a read call. This fixes the bug encountered

<!-- Please, fill in the description as completely as possible.-->

### Description

The writing of a PVD for the boundary (introduced in #1731 ) introduced a bug identified in #1749 that prevents the simulation from adequately writing checkpoint files. This is caused by an incorrect call to read instead of write in the write_checkpoint routine.

### Solution

Call the save instead of the read functionality at this location.

### Testing

Tested it on my machine and it works just fine. This is a one liner so I don't think this requires a new test.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge