### PR TITLE
Add instructions to multiple ids to the same boundary type

### DIFF
--- a/doc/source/parameters/cfd/boundary_conditions_cfd.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_cfd.rst
@@ -59,7 +59,7 @@ where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot \mathbf{n})_{-}` 
     end
   end
 
-* ``number`` specifies the number of boundary conditions of the problem. Hence, ``set number`` refers to the number of bc subsections, and not the number of boundary ids in the mesh. For instance, periodicity between 2 boundaries counts as 1 condition even if it requires two distinct boundary ids.
+* ``number`` specifies the number of boundary conditions of the problem. Hence, ``set number`` refers to the number of ``bc`` subsections, and not the number of boundary ids in the mesh. For instance, periodicity between 2 boundaries counts as 1 condition even if it requires two distinct boundary ids.
 
 .. warning::
     The ``number`` of boundary conditions must be specified explicitly. This is often a source of error.
@@ -74,7 +74,7 @@ where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot \mathbf{n})_{-}` 
 * ``fix pressure constant`` specifies if a zero pressure constraint should be applied on a single node of the coarse grid solver when using geometric multigrid preconditioning combined with the **lethe-fluid-matrix-free** solver. Essentially, this condition should be set to true whenever a user is using the **lethe-fluid-matrix-free** solver and simulating the flow within a closed domain (that is a domain on which all boundaries are either periodic or Dirichlet boundary conditions).
 
 * Each fluid dynamics boundary condition is stored in a ``bc #`` subsection :
-    * ``id``  is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number ``#`` of the bc. The parameter also accepts a list of boundary ids, in which case the same boundary condition will be applied. In this case, id numbers should be separated by commas, for example: ``set id = 0,1,2``.
+    * ``id``  is the number associated with the boundary condition. By default, Lethe assumes that the id is equivalent to the number ``#`` of the bc. The parameter also accepts a list of boundary ids, to which the same boundary condition will be applied. In this case, id numbers should be separated by commas, for example: ``set id = 0,1,2``.
     
     * ``type`` is the type of the boundary condition.
     


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of this documentation
       Is it related to Lethe documentation (simulation parameters or theory guide) or in-code documentation? -->

Very minor addition. The `set id` instruction did not mention we could pass multiple id. I just added it.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge