### PR TITLE
Fix clang tidy non-linear solver

### DIFF
--- a/tests/core/newton_non_linear_solver_01.cc
+++ b/tests/core/newton_non_linear_solver_01.cc
@@ -18,19 +18,20 @@ void
 test()
 {
   Parameters::NonLinearSolver params{
-    Parameters::Verbosity::verbose,
-    Parameters::NonLinearSolver::SolverType::newton,
-    Parameters::NonLinearSolver::KinsolStrategy::
-      normal_newton, // kinsol strategy, not used in this case
-    1e-8,            // tolerance
-    10,              // maxIter
-    4,               // display precision
-    false,           // force rhs calculation
-    0.1,             // matrix tolerance
-    0.99,            // step_tolerance
-    false            // reuse matrix accross problems
-
-  };
+    .verbosity = Parameters::Verbosity::verbose,
+    .solver    = Parameters::NonLinearSolver::SolverType::newton,
+    .kinsol_strategy =
+      Parameters::NonLinearSolver::KinsolStrategy::normal_newton, // not used in
+                                                                  // this case
+    .tolerance                    = 1e-8,
+    .max_iterations               = 10,
+    .display_precision            = 4,
+    .force_rhs_calculation        = false,
+    .matrix_tolerance             = 0.1,
+    .step_tolerance               = 0.99,
+    .reuse_matrix                 = false,
+    .reuse_preconditioner         = false,
+    .abort_at_convergence_failure = false};
 
   deallog << "Creating solver" << std::endl;
 


### PR DESCRIPTION
Remove the clang tidy V20 warning on the Newton
non-linear solver by using the correct initializer for the non-linear solver parameter struct

