### PR TITLE
Fix CI-V20 Mortar Stokes tests

### DIFF
--- a/tests/mortar/stokes_01.cc
+++ b/tests/mortar/stokes_01.cc
@@ -231,7 +231,7 @@ main(int argc, char **argv)
                 const auto point = fe_values.quadrature_point(q);
 
                 Tensor<1, dim> source;
-                for (int d = 0; d < dim; ++d)
+                for (unsigned int d = 0; d < dim; ++d)
                   source[d] = rhs_func->value(point, d);
 
                 for (const unsigned int i : fe_values.dof_indices())

--- a/tests/mortar/stokes_02.cc
+++ b/tests/mortar/stokes_02.cc
@@ -317,7 +317,7 @@ run(const std::string &formulation,
                 const auto point = fe_values.quadrature_point(q);
 
                 Tensor<1, dim> source;
-                for (int d = 0; d < dim; ++d)
+                for (unsigned int d = 0; d < dim; ++d)
                   source[d] = rhs_func->value(point, d);
 
                 for (const unsigned int i : fe_values.dof_indices())

--- a/tests/mortar/stokes_03.cc
+++ b/tests/mortar/stokes_03.cc
@@ -247,7 +247,7 @@ run(const std::string &formulation)
                 const auto point = fe_values.quadrature_point(q);
 
                 Tensor<1, dim> source;
-                for (int d = 0; d < dim; ++d)
+                for (unsigned int d = 0; d < dim; ++d)
                   source[d] = rhs_func->value(point, d);
 
                 for (const unsigned int i : fe_values.dof_indices())


### PR DESCRIPTION
Fix the Clang Tidy V20 warnings in the three mortar stokes tests

