### PR TITLE
Clang tidy V20 warning KINSOL non-linear solver

### DIFF
--- a/tests/core/kinsol_newton_non_linear_solver_01.cc
+++ b/tests/core/kinsol_newton_non_linear_solver_01.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2021, 2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2019-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**


### PR DESCRIPTION
Remove the clang tidy V20 warning in the kinsol non-linear solver by using the correct initializer list.
