### PR TITLE
fix clang v20 in parameters

### DIFF
--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -6,6 +6,8 @@
 
 #include <deal.II/base/exceptions.h>
 
+#include <algorithm>
+
 DeclException2(
   PhaseChangeIntervalError,
   double,
@@ -261,10 +263,7 @@ namespace Parameters
 
       output_folder = prm.get("output path");
       output_name   = prm.get("output name");
-      output_name.erase(std::remove(output_name.begin(),
-                                    output_name.end(),
-                                    '/'),
-                        output_name.end());
+      std::erase(output_name, '/');
       output_iteration_frequency = prm.get_integer("output frequency");
       output_time_frequency      = prm.get_double("output time frequency");
       output_times_vector =

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1916,7 +1916,7 @@ namespace Parameters
         insertion_directions_units_vector.reserve(3);
         n_photons_each_directions.reserve(3);
         step_between_photons_each_directions.reserve(3);
-        for (unsigned int i = 0; i < dim; i++)
+        for (int i = 0; i < dim; i++)
           {
             Tensor<1, dim> temp_direction_tensor =
               value_string_to_tensor<dim>(insertion_unit_tensors_string.at(i));
@@ -1965,8 +1965,8 @@ namespace Parameters
     template class GridMotion<3>;
     template class InsertionInfo<2>;
     template class InsertionInfo<3>;
-    template class ParticleRayTracing<2>;
-    template class ParticleRayTracing<3>;
+    template struct ParticleRayTracing<2>;
+    template struct ParticleRayTracing<3>;
 
   } // namespace Lagrangian
 } // namespace Parameters


### PR DESCRIPTION
Remove the clang tidy V20 warnings in `parameters.cc` and `parameters_lagrangian.cc`