### PR TITLE
Preallocate filenames in solutions_output.cc

### DIFF
--- a/source/core/solutions_output.cc
+++ b/source/core/solutions_output.cc
@@ -116,6 +116,7 @@ write_boundaries_vtu_and_pvd(PVDHandler              &pvd_handler_boundary,
       const unsigned int n_files =
         (group_files == 0) ? n_processes : std::min(group_files, n_processes);
 
+      filenames.reserve(n_files);
       for (unsigned int i = 0; i < n_files; ++i)
         filenames.push_back(file_prefix + "." +
                             Utilities::int_to_string(iter, digits) + "." +


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The warning was about calling filenames.pushback in the for loop without preallocating it before. This is done here.

