### PR TITLE
FIx clang tidy v20 warning in dem/insertion.cc

### DIFF
--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -22,7 +22,7 @@ Insertion<dim, PropertiesIndex>::Insertion(
   this->change_to_triangulation = triangulation.signals.any_change.connect(
     [&] { this->mark_for_update = true; });
 
-  for (unsigned int i = 0; i < dim; ++i)
+  for (int i = 0; i < dim; ++i)
     {
       if (dem_parameters.insertion_info.clear_box_point_1[i] <=
           dem_parameters.insertion_info.clear_box_point_2[i])


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description
Fix clang tidy v20 warning in source/dem/insertion.cc file

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

### Testing

CI run without warning related to this file.
<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ x] Copyright headers are present and up to date
- [ x] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [ x] If parameters are modified, the tests and the documentation of examples are up to date
- [ x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [ x] No other PR is open related to this refactoring
- [ x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ x] If any future works is planned, an issue is opened
- [ x] The PR description is cleaned and ready for merge