### PR TITLE
fix clang v20 in cahn hilliard assemblers

### DIFF
--- a/source/solvers/cahn_hilliard_assemblers.cc
+++ b/source/solvers/cahn_hilliard_assemblers.cc
@@ -7,6 +7,8 @@
 #include <solvers/cahn_hilliard_assemblers.h>
 #include <solvers/copy_data.h>
 
+#include <numbers>
+
 template <int dim>
 void
 CahnHilliardAssemblerCore<dim>::assemble_matrix(


### PR DESCRIPTION
Remove the clang tidy V20 warnings in `cahn_hilliard_assemblers.cc` (replace sqrt(2) with std::numbers::sqrt2)