### PR TITLE
Fix clang v20 warning for dem i*.cc

### DIFF
--- a/source/dem/input_parameter_inspection.cc
+++ b/source/dem/input_parameter_inspection.cc
@@ -13,7 +13,7 @@ input_parameter_inspection(const DEMSolverParameters<dim> &dem_parameters,
                              &size_distribution_object_container)
 {
   // Getting the input parameters as local variable
-  auto   parameters          = dem_parameters;
+  const auto &parameters     = dem_parameters;
   auto   physical_properties = dem_parameters.lagrangian_physical_properties;
   double rayleigh_time_step  = DBL_MAX;
   for (unsigned int i = 0; i < physical_properties.particle_type_number; ++i)

--- a/source/dem/insertion_plane.cc
+++ b/source/dem/insertion_plane.cc
@@ -5,6 +5,8 @@
 
 #include <dem/insertion_plane.h>
 
+#include <algorithm>
+
 using namespace DEM;
 
 // The constructor of plane insertion class. In the constructor, we find which
@@ -226,9 +228,8 @@ InsertionPlane<dim, PropertiesIndex>::insert(
               starting_IDs_on_every_proc[i] = starting_id_on_proc;
               starting_id_on_proc += number_of_particles_to_insert_per_core[i];
             }
-          std::fill(remained_particles_for_every_proc.begin(),
-                    remained_particles_for_every_proc.end(),
-                    particles_of_each_type_remaining);
+          std::ranges::fill(remained_particles_for_every_proc,
+                            particles_of_each_type_remaining);
         }
 
       // Now, processor zero knows how many particles will be inserted by every


### PR DESCRIPTION
Remove the clang tidy V20 warnings in input_parameter_inspection.cc and insertion_place.cc