### PR TITLE
Fix clang tidy v20 warning in dem/visualization.cc

### DIFF
--- a/source/dem/visualization.cc
+++ b/source/dem/visualization.cc
@@ -43,11 +43,11 @@ Visualization<dim, PropertiesIndex>::build_patches(
           // are part of a vector. Do not forget that since we added the ID
           // of the particles, we need to shift the field_position by 1. Hence,
           // we add 1 to field_position
-          vector_datasets.emplace_back(std::make_tuple(
+          vector_datasets.emplace_back(
             field_position + 1,
             field_position + n_components,
             field_name,
-            DataComponentInterpretation::component_is_part_of_vector));
+            DataComponentInterpretation::component_is_part_of_vector);
         }
       dataset_names.emplace_back(field_name);
     }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description
Fix clang tidy v20 warning in source/dem/visualization.cc
<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

### Testing

CI run without warning related to this file.
<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ x] Copyright headers are present and up to date
- [ x] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [ x] If parameters are modified, the tests and the documentation of examples are up to date
- [ x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [ x] No other PR is open related to this refactoring
- [ x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ x] If any future works is planned, an issue is opened
- [ x] The PR description is cleaned and ready for merge