### PR TITLE
Clang tidy v20 fluid_dynamics_sharp.cc

### DIFF
--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -2684,11 +2684,11 @@ FluidDynamicsSharp<dim>::Visualization_IB::build_patches(
       // Check to see if the property is a vector
       if (components_number == 3)
         {
-          vector_datasets.emplace_back(std::make_tuple(
+          vector_datasets.emplace_back(
             field_position,
             field_position + components_number - 1,
             field_name,
-            DataComponentInterpretation::component_is_part_of_vector));
+            DataComponentInterpretation::component_is_part_of_vector);
         }
       dataset_names.push_back(field_name);
       ++field_position;


### PR DESCRIPTION
Fix comparison between unsigned int and int, pre-allocate container size instead of pushing back, use sqrt2 instead of sqrt(2)