### PR TITLE
Fix interface_tools_sphere_reconstruction.cc warning

### DIFF
--- a/tests/core/interface_tools_sphere_reconstruction.cc
+++ b/tests/core/interface_tools_sphere_reconstruction.cc
@@ -95,7 +95,8 @@ test()
           triangulation) in the intersected volume cell */
           const std::vector<Point<3>> &surface_vertices =
             interface_reconstruction_vertices.at(cell_index);
-          const std::vector<CellData<2>> &surface_cells = intersected_cell.second;
+          const std::vector<CellData<2>> &surface_cells =
+            intersected_cell.second;
 
           Triangulation<2, 3> surface_triangulation;
           surface_triangulation.create_triangulation(surface_vertices,


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The warning in ``tests/core/interface_tools_sphere_reconstruction.cc`` was because we are creating variable ``surface_cells`` by copy and using it as read-only. To fix it, it is created now as a const reference. 
The variable ``surface_cells`` looks like it is read-only but does not have a similar warning. I made a const reference anyway.