### PR TITLE
Fix 2 warnings clang v20 in fluid dynamics matrix free 

### DIFF
--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -827,12 +827,15 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
               "The mg level min cells specified are larger than the cells of the finest mg level."));
 
           for (unsigned int level = min_h_level; level <= max_h_level; ++level)
-            if (n_cells_on_levels[level] >=
-                static_cast<unsigned int>(mg_level_min_cells))
-              {
-                min_h_level = level;
-                break;
-              }
+            {
+              const int n_cells_on_level =
+                static_cast<int>(n_cells_on_levels[level]);
+              if (n_cells_on_level >= mg_level_min_cells)
+                {
+                  min_h_level = level;
+                  break;
+                }
+            }
         }
 
       // p-multigrid


### PR DESCRIPTION
Remove 3 clang tidy V20 warnings in fluid_dynamics_matrix_free.cc. 