### PR TITLE
Fix bug with particle output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+### [Master] - 2025-11-14
+
+### Fixed
+
+- MAJOR A bug had been introduced in [#1752] that prevented paraview from opening the vtu, pvtu and pvd files for the particle results in the CFD-DEM solver. This was because the new property (momentum_transfer_coefficient) was not given a name and this prevented the output from being adequately named. This PR fixes it by giving an appropriate name to that property which fixes the output of the particles. [#1800](https://github.com/chaos-polymtl/lethe/pull/1800)
+
 ### [Master] - 2025-11-04
 
 ### Added
 
-- MAJOR The residual displayed in the non-linear and linear solver are affected by the total volume of the triangulation (mesh). Consequently, if a simulation is carried out on a triangulation with a small volume, very small residuals are obtained at the initial solution step. This complicates the choice of the linear and non-linear tolerances since they need to be adjusted in a case-dependent fashion. This change introduces a new parameter ("rescale residual") to the linear solver subsection. When the parameter is true, all residuals (linear and non-linear) are rescaled by the squared root of the volume of the triangulation. This is very convenient because, when activated, tolerances are independent of the domain size. [1728](https://github.com/chaos-polymtl/lethe/pull/1728)
+- MAJOR The residual displayed in the non-linear and linear solver are affected by the total volume of the triangulation (mesh). Consequently, if a simulation is carried out on a triangulation with a small volume, very small residuals are obtained at the initial solution step. This complicates the choice of the linear and non-linear tolerances since they need to be adjusted in a case-dependent fashion. This change introduces a new parameter ("rescale residual") to the linear solver subsection. When the parameter is true, all residuals (linear and non-linear) are rescaled by the squared root of the volume of the triangulation. This is very convenient because, when activated, tolerances are independent of the domain size. [#1728](https://github.com/chaos-polymtl/lethe/pull/1728)
 
 ### [Master] - 2025-11-08
 

--- a/source/core/dem_properties.cc
+++ b/source/core/dem_properties.cc
@@ -50,6 +50,8 @@ namespace DEM
           std::make_pair("fem_torque", 1);
         properties[PropertiesIndex::volumetric_contribution] =
           std::make_pair("volumetric_contribution", 1);
+        properties[PropertiesIndex::momentum_transfer_coefficient] =
+          std::make_pair("momentum_transfer_coefficient", 1);
       }
 
     if constexpr (std::is_same_v<PropertiesIndex,


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

A bug had been introduced in [#1752] that prevented paraview from opening the vtu, pvtu and pvd files for the particle results in the CFD-DEM solver. This was because the new property (momentum_transfer_coefficient) was not given a name and this prevented the output from being adequately named. 

### Solution

This PR fixes this issue by adding the name to the new property. Which in turns fixes the output for the paraview file. It is a one-line change, but that has been consequences.

### Testing

Tested by running a few cases on my machine. All is fine. This is relatively hard to test automatically regrettably.

### Documentation

Nothing to change here.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge