### PR TITLE
Fix ASC issue and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/04/10
+
+### Fixed
+
+- MINOR The dynamic_with_sparse_contacts load balance method could crash if load balancing was triggered at the first iteration of a restart (yes this is oddly specific). This PR fixes this by refreshing the ASC structures when the DEM is restarted. [#1964](https://github.com/chaos-polymtl/lethe/pull/1964)
+
+
 ## [Master] - 2026/04/09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR The dynamic_with_sparse_contacts load balance method could crash if load balancing was triggered at the first iteration of a restart (yes this is oddly specific). This PR fixes this by refreshing the ASC structures when the DEM is restarted. [#1964](https://github.com/chaos-polymtl/lethe/pull/1964)
 
-
 ## [Master] - 2026/04/09
 
 ### Added

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -890,6 +890,16 @@ DEMSolver<dim, PropertiesIndex>::solve()
       find_floating_mesh_mapping_step(smallest_solid_object_mapping_criterion,
                                       this->solid_surfaces);
 
+      // If this is a restart simulation, force compute the cell mobility
+      // for ASC. Otherwise this will crash if it a load balancing
+      // including ASC is tried.
+      if (DEMActionManager::get_action_manager()->check_restart_simulation())
+        sparse_contacts_object.identify_mobility_status(
+          background_dh,
+          particle_handler,
+          triangulation.n_active_cells(),
+          mpi_communicator);
+
       // Map solid objects if the action was triggered (if solid object)
       if (action_manager->check_solid_object_search())
         {

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -384,8 +384,6 @@ DEMSolver<dim, PropertiesIndex>::load_balance()
     triangulation, periodic_boundaries_cells_information);
 
   // If ASC is enabled, update the local and ghost cell set
-
-
   sparse_contacts_object.update_local_and_ghost_cell_set(background_dh);
 
   // Update neighbors of cells after load balance

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -357,6 +357,18 @@ DEMSolver<dim, PropertiesIndex>::load_balance()
     return;
 
   TimerOutput::Scope t(this->computing_timer, "Load balancing");
+
+  // If the load balancing uses the sparse_contact object to calculate the
+  // weight, make sure that the sparse contact object has all mobility status
+  // correctly identified and refreshed.
+  if (parameters.model_parameters.load_balance_method ==
+      ModelParameters<dim>::LoadBalanceMethod::dynamic_with_sparse_contacts)
+    sparse_contacts_object.identify_mobility_status(
+      background_dh,
+      particle_handler,
+      triangulation.n_active_cells(),
+      mpi_communicator);
+
   // Prepare particle handler for the adaptation of the triangulation to the
   // load
   particle_handler.prepare_for_coarsening_and_refinement();
@@ -372,6 +384,8 @@ DEMSolver<dim, PropertiesIndex>::load_balance()
     triangulation, periodic_boundaries_cells_information);
 
   // If ASC is enabled, update the local and ghost cell set
+
+
   sparse_contacts_object.update_local_and_ghost_cell_set(background_dh);
 
   // Update neighbors of cells after load balance
@@ -889,16 +903,6 @@ DEMSolver<dim, PropertiesIndex>::solve()
       // (if solid object)
       find_floating_mesh_mapping_step(smallest_solid_object_mapping_criterion,
                                       this->solid_surfaces);
-
-      // If this is a restart simulation, force compute the cell mobility
-      // for ASC. Otherwise this will crash if it a load balancing
-      // including ASC is tried.
-      if (DEMActionManager::get_action_manager()->check_restart_simulation())
-        sparse_contacts_object.identify_mobility_status(
-          background_dh,
-          particle_handler,
-          triangulation.n_active_cells(),
-          mpi_communicator);
 
       // Map solid objects if the action was triggered (if solid object)
       if (action_manager->check_solid_object_search())


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The dynamic_with_sparse_contacts load balance method could crash if load balancing was triggered at the first iteration of a restart (yes this is oddly specific).

### Solution

 This PR fixes this by refreshing the ASC structures when the DEM is restarted. Although it's not the cutest fix, it is durable and stable.

### Testing

Testing on the pneumatic conveying example and it works just fine !

### Documentation

Nothing to document

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge