### PR TITLE
Add preprint of article to Lethe documentation

### DIFF
--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -9,7 +9,9 @@ Preprints
 
 This section regroups preprints of journal articles already submitted, but which are still under review.
 
-* `H. Papillon-Laroche, A. Alphonius, M. Schreter-Fleischhacker, J.-P. Harvey and B. Blais. "Geometric Reinitialization for Capillary Flows: a Comparative Study with State-of-the-Art Conservative Level-Set Methods," arXiv preprint arXiv:2602.00275, 2026. <https://doi.org/10.48550/arXiv.2602.00275>`_.
+* `H. Papillon-Laroche, A. Alphonius, M. Schreter-Fleischhacker, J.-P. Harvey, and B. Blais. "Geometric Reinitialization for Capillary Flows: a Comparative Study with State-of-the-Art Conservative Level-Set Methods," arXiv preprint arXiv:2602.00275, 2026. <https://doi.org/10.48550/arXiv.2602.00275>`_.
+
+* `O. Guévremont, O. Gazil, F. Galli, N. Virgilio, and B Blais. "Surface-access limitation in catalytic porous monoliths: Performance diagnosis using pore-resolved CFD," arXiv preprint arXiv:2604.03514, 2026. <https://doi.org/10.48550/arXiv.2604.03514>`_.
 
 2026
 ----


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The recent submission O. Guévremont, O. Gazil, F. Galli, N. Virgilio, and B Blais. "Surface-access limitation in catalytic porous monoliths: Performance diagnosis using pore-resolved CFD," (2026) and its preprint on arXiv were not reflected in the Lethe documentation. This PR adds the publication.

<!-- Explain the content of this documentation
       Is it related to Lethe documentation (simulation parameters or theory guide) or in-code documentation? -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge