### PR TITLE
Mortar: Generalize linear velocity computation for 3D case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR The linear velocity computation for the rotor domain (within the mortar feature) assumed that, in 3D, the rotation axis was always z. This PR fixes this by using the complete equation to transform an angular velocity into a linear velocity. [#1967](https://github.com/chaos-polymtl/lethe/pull/1967)
+- MINOR This PR fixes the computation of cell radial distance for 3D mortar cases, and improves the indentification of the rotor/stator domains by using a material_id() flag (as opposed to comparing the radial distance of the cell center with the computed interface radius). The linear velocity computation is also generalized for 3D cases with rotation axis other than z. [#1967](https://github.com/chaos-polymtl/lethe/pull/1967)
 
 ## [Master] - 2026/04/20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR This PR fixes the computation of cell radial distance for 3D mortar cases, and improves the indentification of the rotor/stator domains by using a material_id() flag (as opposed to comparing the radial distance of the cell center with the computed interface radius). The linear velocity computation is also generalized for 3D cases with rotation axis other than z. [#1967](https://github.com/chaos-polymtl/lethe/pull/1967)
+- MINOR This PR fixes the computation of cell radial distance for 3D mortar cases, and improves the identification of the rotor/stator domains by using a material_id() flag (as opposed to comparing the radial distance between the cell center and the computed interface radius). The linear velocity computation is also generalized for 3D cases with rotation axis other than z. [#1967](https://github.com/chaos-polymtl/lethe/pull/1967)
 
 ## [Master] - 2026/04/20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/04/21
+
+### Fixed
+
+- MINOR The linear velocity computation for the rotor domain (within the mortar feature) assumed that, in 3D, the rotation axis was always z. This PR fixes this by using the complete equation to transform an angular velocity into a linear velocity. [#1967](https://github.com/chaos-polymtl/lethe/pull/1967)
+
 ## [Master] - 2026/04/20
 
 ### Added

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -402,6 +402,45 @@ namespace LetheGridTools
   };
 
   /**
+   * @brief Transform angular velocity into linear velocity considering that the
+   * angular velocity @p omega is constant in all directions.
+   *
+   * @param[in] omega Angular velocity value
+   * @param[in] point Coordinates of the point in which the linear velocity is
+   * being calculated
+   * @param[in] rotation_axis Rotation axis used in 3D cases, so that the
+   * angular velocity vector is given by omega_vec = omega * rotation_axis
+   *
+   * @return Linear velocity at @p point
+   */
+  template <int dim>
+  inline Tensor<1, dim>
+  angular_to_linear_velocity(
+    const double          omega,
+    const Tensor<1, dim> &point,
+    const Tensor<1, dim> &rotation_axis = Tensor<1, dim>())
+  {
+    Tensor<1, dim> result;
+
+    if constexpr (dim == 2)
+      {
+        result[0] = -omega * point[1];
+        result[1] = omega * point[0];
+      }
+
+    if constexpr (dim == 3)
+      {
+        // Store angular velocity according to unit vector that defines the
+        // rotation axis
+        const auto omega_vec = omega * rotation_axis;
+        // Compute cross product
+        result = cross_product_3d(omega_vec, point);
+      }
+
+    return result;
+  }
+
+  /**
    * @brief Rotate the mapping according to the rotation angle in a rotor-stator configuration
    *
    * @param[in] dof_handler DofHandler of the triangulation

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -407,7 +407,6 @@ namespace LetheGridTools
    * @param[in] dof_handler DofHandler of the triangulation
    * @param[in,out] mapping_cache Rotated mapping
    * @param[in] mapping Current mapping
-   * @param[in] radius Radius or the rotor domain which is going to be rotated
    * @param[in] rotation_angle Rotation angle of the rotor domain
    * @param[in] center_of_rotation Center of rotation of the rotor domain.
    * Default is the origin
@@ -418,7 +417,6 @@ namespace LetheGridTools
   rotate_mapping(const DoFHandler<dim> &dof_handler,
                  MappingQCache<dim>    &mapping_cache,
                  const Mapping<dim>    &mapping,
-                 const double          &radius,
                  const double          &rotation_angle,
                  const Point<dim>      &center_of_rotation = Point<dim>(),
                  const Tensor<1, dim>  &rotation_axis      = Tensor<1, dim>());

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -422,22 +422,6 @@ namespace LetheGridTools
                  const Tensor<1, dim>  &rotation_axis      = Tensor<1, dim>());
 
   /**
-   * @brief Computes the radial distance between a given point and a center of rotation
-   *
-   * @param[in] point Current point from which the radial distance is computed
-   * @param[in] rotation_axis Rotation axis of the domain
-   * @param[in] center_of_rotation Center of rotation of the domain
-   *
-   * @return Radial distance
-   */
-  template <int dim>
-  double
-  compute_radial_distance_3d(
-    const Point<dim>     &point,
-    const Tensor<1, dim> &rotation_axis,
-    const Point<dim>     &center_of_rotation = Point<dim>());
-
-  /**
    * @brief
    * A functor that provides a way to check if two cells are the same cell.
    * Used to store cells in hash sets.

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -424,6 +424,22 @@ namespace LetheGridTools
                  const Tensor<1, dim>  &rotation_axis      = Tensor<1, dim>());
 
   /**
+   * @brief Computes the radial distance between a given point and a center of rotation
+   *
+   * @param[in] point Current point from which the radial distance is computed
+   * @param[in] rotation_axis Rotation axis of the domain
+   * @param[in] center_of_rotation Center of rotation of the domain
+   *
+   * @return Radial distance
+   */
+  template <int dim>
+  double
+  compute_radial_distance_3d(
+    const Point<dim>     &point,
+    const Tensor<1, dim> &rotation_axis,
+    const Point<dim>     &center_of_rotation = Point<dim>());
+
+  /**
    * @brief
    * A functor that provides a way to check if two cells are the same cell.
    * Used to store cells in hash sets.

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -406,10 +406,11 @@ namespace LetheGridTools
    * angular velocity @p omega is constant in all directions.
    *
    * @param[in] omega Angular velocity value
-   * @param[in] point Coordinates of the point in which the linear velocity is
+   * @param[in] point Coordinates of the point at which the linear velocity is
    * being calculated
    * @param[in] rotation_axis Rotation axis used in 3D cases, so that the
-   * angular velocity vector is given by omega_vec = omega * rotation_axis
+   * angular velocity vector is given by omega_vec = omega * rotation_axis. In
+   * 2D, we apply a rotation around the z-axis.
    *
    * @return Linear velocity at @p point
    */

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -6,6 +6,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <core/lethe_grid_tools.h>
 #include <core/parameters.h>
 #include <core/utilities.h>
 

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -432,15 +432,12 @@ public:
    * when the mortar feature is enabled.
    *
    * @param[in] mapping Describes the transformations from unit to real cell.
-   * @param[in] radius Radius at the mortar interface in the direction
-   * perpendicular to the rotation axis.
    * @param[in] center_of_rotation Center of rotation of the rotor domain.
    * @param[in] rotor_angular_velocity  Angular velocity of the rotor domain.
    */
   void
   evaluate_velocity_ale(
     const Mapping<dim>                             &mapping,
-    const double                                    radius,
     const Point<dim>                                center_of_rotation,
     const Tensor<1, dim>                            rotation_axis,
     std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity);

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -442,6 +442,7 @@ public:
     const Mapping<dim>                             &mapping,
     const double                                    radius,
     const Point<dim>                                center_of_rotation,
+    const Tensor<1, dim>                            rotation_axis,
     std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity);
 
   /**

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -433,6 +433,7 @@ public:
    *
    * @param[in] mapping Describes the transformations from unit to real cell.
    * @param[in] center_of_rotation Center of rotation of the rotor domain.
+   * @param[in] rotation_axis Rotation axis of the rotor domain for 3D case.
    * @param[in] rotor_angular_velocity  Angular velocity of the rotor domain.
    */
   void

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -7,6 +7,7 @@
 #include "core/parameters_cfd_dem.h"
 #include <core/bdf.h>
 #include <core/dem_properties.h>
+#include <core/lethe_grid_tools.h>
 #include <core/parameters.h>
 #include <core/physical_property_model.h>
 #include <core/sdirk_stage_data.h>

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -1345,13 +1345,10 @@ public:
    * FeValues.
    *
    * @param[in] mortar_parameters Parameters for the mortar method
-   *
-   * @param[in] radius Radius of the rotor domain
    */
   void
   reinit_mortar(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                const Parameters::Mortar<dim> &mortar_parameters,
-                const double                  &radius);
+                const Parameters::Mortar<dim> &mortar_parameters);
 
   /**
    * @brief Calculates the physical properties. This function calculates the

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -363,8 +363,8 @@ read_mesh_and_manifolds_for_stator_and_rotor(
   Triangulation<dim> rotor_temp_tria;
   attach_grid_to_triangulation(rotor_temp_tria, *mortar_parameters.rotor_mesh);
 
-  // Add a user flag to cells on the rotor and stator triangulations; this will
-  // be needed when attributing them an angular velocity. We use the material_id
+  // Add a flag to cells on the rotor and stator triangulations; this will be
+  // needed when attributing them an angular velocity. We use the material_id
   // flag because it won't be erased when the triangulations are merged.
   for (const auto &cell : rotor_temp_tria.active_cell_iterators())
     cell->set_material_id(1);

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -363,12 +363,14 @@ read_mesh_and_manifolds_for_stator_and_rotor(
   Triangulation<dim> rotor_temp_tria;
   attach_grid_to_triangulation(rotor_temp_tria, *mortar_parameters.rotor_mesh);
 
-  // Add a user flag to cells on the rotor triangulation; this will be needed
-  // when attributing them an angular velocity. We use the material_id because
-  // it won't be erased when the triangulation is merged. After the merge, this
-  // id is copied to a user_index
+  // Add a user flag to cells on the rotor and stator triangulations; this will
+  // be needed when attributing them an angular velocity. We use the material_id
+  // flag because it won't be erased when the triangulations are merged.
   for (const auto &cell : rotor_temp_tria.active_cell_iterators())
     cell->set_material_id(1);
+
+  for (const auto &cell : stator_temp_tria.active_cell_iterators())
+    cell->set_material_id(2);
 
   if (mesh_parameters.type == Parameters::Mesh::Type::dealii)
     {
@@ -541,17 +543,6 @@ read_mesh_and_manifolds_for_stator_and_rotor(
                 mortar_parameters.stator_boundary_id)
               n_faces_stator_interface++;
           }
-
-  // Copy the flags identifying the rotor domain from material_id() to
-  // user_index()
-  for (const auto &cell : triangulation.active_cell_iterators())
-    {
-      if (cell->material_id() == 1)
-        cell->set_user_index(1);
-
-      // Return material_id() to 0, as is done in attach_grid_to_triangulation()
-      cell->set_material_id(0);
-    }
 
   // Total number of faces
   const unsigned int n_faces_rotor_interface_total =

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -370,7 +370,7 @@ read_mesh_and_manifolds_for_stator_and_rotor(
     cell->set_material_id(1);
 
   for (const auto &cell : stator_temp_tria.active_cell_iterators())
-    cell->set_material_id(2);
+    cell->set_material_id(0);
 
   if (mesh_parameters.type == Parameters::Mesh::Type::dealii)
     {

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -363,6 +363,13 @@ read_mesh_and_manifolds_for_stator_and_rotor(
   Triangulation<dim> rotor_temp_tria;
   attach_grid_to_triangulation(rotor_temp_tria, *mortar_parameters.rotor_mesh);
 
+  // Add a user flag to cells on the rotor triangulation; this will be needed
+  // when attributing them an angular velocity. We use the material_id because
+  // it won't be erased when the triangulation is merged. After the merge, this
+  // id is copied to a user_index
+  for (const auto &cell : rotor_temp_tria.active_cell_iterators())
+    cell->set_material_id(1);
+
   if (mesh_parameters.type == Parameters::Mesh::Type::dealii)
     {
       // Get stator manifold ids without flat id
@@ -534,6 +541,17 @@ read_mesh_and_manifolds_for_stator_and_rotor(
                 mortar_parameters.stator_boundary_id)
               n_faces_stator_interface++;
           }
+
+  // Copy the flags identifying the rotor domain from material_id() to
+  // user_index()
+  for (const auto &cell : triangulation.active_cell_iterators())
+    {
+      if (cell->material_id() == 1)
+        cell->set_user_index(1);
+
+      // Return material_id() to 0, as is done in attach_grid_to_triangulation()
+      cell->set_material_id(0);
+    }
 
   // Total number of faces
   const unsigned int n_faces_rotor_interface_total =

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1858,6 +1858,30 @@ LetheGridTools::rotate_mapping(const DoFHandler<3> &dof_handler,
                                const Point<3>      &center_of_rotation,
                                const Tensor<1, 3>  &rotation_axis);
 
+template <int dim>
+double
+LetheGridTools::compute_radial_distance_3d(const Point<dim>     &point,
+                                           const Tensor<1, dim> &rotation_axis,
+                                           const Point<dim> &center_of_rotation)
+{
+  // Compute distance =  ||VC x d||/||d||, where d is the rotation axis and VC
+  // is the distance between the current point and the center of rotation
+  const auto axis = rotation_axis / rotation_axis.norm();
+  const auto aux  = cross_product_3d((point - center_of_rotation), axis);
+
+  return aux.norm();
+}
+
+template double
+LetheGridTools::compute_radial_distance_3d(const Point<2>     &point,
+                                           const Tensor<1, 2> &rotation_axis,
+                                           const Point<2> &center_of_rotation);
+
+template double
+LetheGridTools::compute_radial_distance_3d(const Point<3>     &point,
+                                           const Tensor<1, 3> &rotation_axis,
+                                           const Point<3> &center_of_rotation);
+
 template <int dim, int spacedim>
 void
 LetheGridTools::vertices_cell_mapping(

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1789,7 +1789,6 @@ void
 LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
                                MappingQCache<dim>    &mapping_cache,
                                const Mapping<dim>    &mapping,
-                               const double          &radius,
                                const double          &rotation_angle,
                                const Point<dim>      &center_of_rotation,
                                const Tensor<1, dim>  &rotation_axis)
@@ -1846,7 +1845,6 @@ template void
 LetheGridTools::rotate_mapping(const DoFHandler<2> &dof_handler,
                                MappingQCache<2>    &mapping_cache,
                                const Mapping<2>    &mapping,
-                               const double        &radius,
                                const double        &rotation_angle,
                                const Point<2>      &center_of_rotation,
                                const Tensor<1, 2>  &rotation_axis);
@@ -1855,7 +1853,6 @@ template void
 LetheGridTools::rotate_mapping(const DoFHandler<3> &dof_handler,
                                MappingQCache<3>    &mapping_cache,
                                const Mapping<3>    &mapping,
-                               const double        &radius,
                                const double        &rotation_angle,
                                const Point<3>      &center_of_rotation,
                                const Tensor<1, 3>  &rotation_axis);

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1800,7 +1800,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
           // Do not rotate the point if current cell is part of the stator
-          if (cell->material_id() == 2)
+          if (cell->material_id() == 0)
             return point;
 
           // Shift point by the center of rotation
@@ -1822,7 +1822,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
           // Do not rotate point if current cell is part of the stator
-          if (cell->material_id() == 2)
+          if (cell->material_id() == 0)
             return point;
 
           // Shift point by the center of rotation
@@ -1832,7 +1832,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
             Physics::Transformations::Rotations::rotation_matrix_3d(
               rotation_axis, rotation_angle) *
             shift_point;
-          // Returnn rotated point according to the center of rotation
+          // Return rotated point according to the center of rotation
           return static_cast<Point<dim>>(rotate_point + center_of_rotation);
         },
         false);
@@ -1861,6 +1861,11 @@ LetheGridTools::compute_radial_distance_3d(const Point<dim>     &point,
                                            const Tensor<1, dim> &rotation_axis,
                                            const Point<dim> &center_of_rotation)
 {
+  Assert(
+    rotation_axis.norm() > 0,
+    ExcMessage(
+      "To compute the radial distance, the rotation axis must be non-zero."));
+
   // Compute distance =  ||VC x d||/||d||, where d is the rotation axis and VC
   // is the distance between the current point and the center of rotation
   const auto axis = rotation_axis / rotation_axis.norm();

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1799,9 +1799,9 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         mapping,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
-          // Verify if cells are part of the stator (user_index = 0) or the
-          // rotor (user_index = 1)
-          if (cell->user_index() == 0)
+          // Verify if cells are part of the rotor (material_id = 1) or the
+          // stator (material_id = 2)
+          if (cell->material_id() == 2)
             return point;
 
           // Shift point by the center of rotation
@@ -1822,9 +1822,9 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         mapping,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
-          // Verify if cells are part of the stator (user_index = 0) or the
-          // rotor (user_index = 1)
-          if (cell->user_index() == 0)
+          // Verify if cells are part of the rotor (material_id = 1) or the
+          // stator (material_id = 2)
+          if (cell->material_id() == 2)
             return point;
 
           // Shift point by the center of rotation

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1855,35 +1855,6 @@ LetheGridTools::rotate_mapping(const DoFHandler<3> &dof_handler,
                                const Point<3>      &center_of_rotation,
                                const Tensor<1, 3>  &rotation_axis);
 
-template <int dim>
-double
-LetheGridTools::compute_radial_distance_3d(const Point<dim>     &point,
-                                           const Tensor<1, dim> &rotation_axis,
-                                           const Point<dim> &center_of_rotation)
-{
-  Assert(
-    rotation_axis.norm() > 0,
-    ExcMessage(
-      "To compute the radial distance, the rotation axis must be non-zero."));
-
-  // Compute distance =  ||VC x d||/||d||, where d is the rotation axis and VC
-  // is the distance between the current point and the center of rotation
-  const auto axis = rotation_axis / rotation_axis.norm();
-  const auto aux  = cross_product_3d((point - center_of_rotation), axis);
-
-  return aux.norm();
-}
-
-template double
-LetheGridTools::compute_radial_distance_3d(const Point<2>     &point,
-                                           const Tensor<1, 2> &rotation_axis,
-                                           const Point<2> &center_of_rotation);
-
-template double
-LetheGridTools::compute_radial_distance_3d(const Point<3>     &point,
-                                           const Tensor<1, 3> &rotation_axis,
-                                           const Point<3> &center_of_rotation);
-
 template <int dim, int spacedim>
 void
 LetheGridTools::vertices_cell_mapping(

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1799,8 +1799,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         mapping,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
-          // Verify if cells are part of the rotor (material_id = 1) or the
-          // stator (material_id = 2)
+          // Do not rotate the point if current cell is part of the stator
           if (cell->material_id() == 2)
             return point;
 
@@ -1822,8 +1821,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         mapping,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
-          // Verify if cells are part of the rotor (material_id = 1) or the
-          // stator (material_id = 2)
+          // Do not rotate point if current cell is part of the stator
           if (cell->material_id() == 2)
             return point;
 

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1800,7 +1800,9 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         mapping,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
-          if ((cell->center() - center_of_rotation).norm() > radius)
+          // Verify if cells are part of the stator (user_index = 0) or the
+          // rotor (user_index = 1)
+          if (cell->user_index() == 0)
             return point;
 
           // Shift point by the center of rotation
@@ -1821,13 +1823,9 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         mapping,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
-          // Compute point radial distance with respect to the rotation axis
-          const double point_radial_distance =
-            compute_radial_distance_3d(cell->center(),
-                                       rotation_axis,
-                                       center_of_rotation);
-
-          if (point_radial_distance > radius)
+          // Verify if cells are part of the stator (user_index = 0) or the
+          // rotor (user_index = 1)
+          if (cell->user_index() == 0)
             return point;
 
           // Shift point by the center of rotation

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/dem_properties.h>
@@ -1822,19 +1822,23 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
         dof_handler.get_triangulation(),
         [&](const auto &cell, const auto &point) {
           // Compute point radial distance with respect to the rotation axis
-          const auto aux =
-            cross_product_3d((cell->center() - center_of_rotation),
-                             rotation_axis);
           const double point_radial_distance =
-            aux.norm() / rotation_axis.norm();
+            compute_radial_distance_3d(cell->center(),
+                                       rotation_axis,
+                                       center_of_rotation);
 
           if (point_radial_distance > radius)
             return point;
 
-          return static_cast<Point<dim>>(
+          // Shift point by the center of rotation
+          const auto shift_point = point - center_of_rotation;
+          // Rotate
+          const auto rotate_point =
             Physics::Transformations::Rotations::rotation_matrix_3d(
               rotation_axis, rotation_angle) *
-            point);
+            shift_point;
+          // Returnn rotated point according to the center of rotation
+          return static_cast<Point<dim>>(rotate_point + center_of_rotation);
         },
         false);
     }

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -626,22 +626,20 @@ compute_interface_dimensions_circular(
                           double     radius_current =
                             v.distance(mortar_parameters.center_of_rotation);
 
-                          // In 3D, the interface radius to be computed is
-                          // actually with respect to the rotation axis. For
-                          // this computation, we use the relation:
-                          // radius_current = ||VC x d||/||d||, where VC is the
-                          // current vertex minus the center of rotation, and d
-                          // is the rotation axis
+                          // In 3D, the interface radius is computed as the
+                          // minimum distance between the current vertex and the
+                          // rotation axis, assuming that the center of rotation
+                          // point is contained within the rotation axis line
                           if constexpr (dim == 3)
                             {
                               vertex_min = std::min(vertex_min, v[direction]);
                               vertex_max = std::max(vertex_max, v[direction]);
 
                               radius_current =
-                                LetheGridTools::compute_radial_distance_3d(
-                                  v,
+                                LetheGridTools::find_point_line_distance(
+                                  mortar_parameters.center_of_rotation,
                                   mortar_parameters.rotation_axis,
-                                  mortar_parameters.center_of_rotation);
+                                  v);
                             }
 
                           radius_min = std::min(radius_min, radius_current);

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -637,14 +637,11 @@ compute_interface_dimensions_circular(
                               vertex_min = std::min(vertex_min, v[direction]);
                               vertex_max = std::max(vertex_max, v[direction]);
 
-                              const auto aux = cross_product_3d(
-                                (v - mortar_parameters.center_of_rotation),
-                                mortar_parameters.rotation_axis /
-                                  mortar_parameters.rotation_axis.norm());
-                              const double num = aux.norm();
-                              const double den =
-                                mortar_parameters.rotation_axis.norm();
-                              radius_current = num / den;
+                              radius_current =
+                                LetheGridTools::compute_radial_distance_3d(
+                                  v,
+                                  mortar_parameters.rotation_axis,
+                                  mortar_parameters.center_of_rotation);
                             }
 
                           radius_min = std::min(radius_min, radius_current);

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -576,12 +576,12 @@ compute_interface_dimensions_circular(
   double vertex_min = std::numeric_limits<double>::max();
   double vertex_max = 0;
 
-  Assert(mortar_parameters.rotation_axis.norm() > 0,
-         ExcMessage("The rotation axis must be non-zero."));
-
   // Verify if rotation axis is a unit vector in x, y, or z
   if constexpr (dim == 3)
     {
+      Assert(mortar_parameters.rotation_axis.norm() > 0,
+             ExcMessage("The rotation axis must be non-zero."));
+
       // First check if the vector has a unit norm
       bool is_unit_axis =
         mortar_parameters.rotation_axis.norm() == 1 ? true : false;

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -576,6 +576,9 @@ compute_interface_dimensions_circular(
   double vertex_min = std::numeric_limits<double>::max();
   double vertex_max = 0;
 
+  Assert(mortar_parameters.rotation_axis.norm() > 0,
+         ExcMessage("The rotation axis must be non-zero."));
+
   // Verify if rotation axis is a unit vector in x, y, or z
   if constexpr (dim == 3)
     {

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4598,11 +4598,7 @@ namespace Parameters
       stator_boundary_id = prm.get_integer("stator boundary id");
       center_of_rotation =
         value_string_to_tensor<dim>(prm.get("center of rotation"));
-
       rotation_axis = value_string_to_tensor<dim>(prm.get("rotation axis"));
-      Assert(rotation_axis.norm() > 0,
-             ExcMessage("The rotation axis must be non-zero."));
-
       prm.enter_subsection("rotor rotation angle");
       rotor_rotation_angle->parse_parameters(prm);
       rotor_rotation_angle->set_time(0);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4598,7 +4598,11 @@ namespace Parameters
       stator_boundary_id = prm.get_integer("stator boundary id");
       center_of_rotation =
         value_string_to_tensor<dim>(prm.get("center of rotation"));
+
       rotation_axis = value_string_to_tensor<dim>(prm.get("rotation axis"));
+      Assert(rotation_axis.norm() > 0,
+             ExcMessage("The rotation axis must be non-zero."));
+
       prm.enter_subsection("rotor rotation angle");
       rotor_rotation_angle->parse_parameters(prm);
       rotor_rotation_angle->set_time(0);

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -865,8 +865,7 @@ FluidDynamicsMatrixBased<dim>::assemble_local_system_matrix(
 
   if (this->simulation_parameters.mortar_parameters.enable)
     scratch_data.reinit_mortar(cell,
-                               this->simulation_parameters.mortar_parameters,
-                               this->mortar_manager->radius[0]);
+                               this->simulation_parameters.mortar_parameters);
 
   scratch_data.calculate_physical_properties();
 
@@ -1105,8 +1104,7 @@ FluidDynamicsMatrixBased<dim>::assemble_local_system_rhs(
 
   if (this->simulation_parameters.mortar_parameters.enable)
     scratch_data.reinit_mortar(cell,
-                               this->simulation_parameters.mortar_parameters,
-                               this->mortar_manager->radius[0]);
+                               this->simulation_parameters.mortar_parameters);
 
   scratch_data.calculate_physical_properties();
 

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2552,6 +2552,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
              .mapping,
           this->mg_operators[level]->mortar_manager_mf->radius[0],
           this->simulation_parameters.mortar_parameters.center_of_rotation,
+          this->simulation_parameters.mortar_parameters.rotation_axis,
           this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
 
       this->mg_operators[level]->evaluate_non_linear_term_and_calculate_tau(
@@ -3290,6 +3291,7 @@ FluidDynamicsMatrixFree<dim>::assemble_system_rhs()
       *this->get_mapping(),
       this->system_operator->mortar_manager_mf->radius[0],
       this->simulation_parameters.mortar_parameters.center_of_rotation,
+      this->simulation_parameters.mortar_parameters.rotation_axis,
       this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
 
   this->system_operator->evaluate_non_linear_term_and_calculate_tau(
@@ -3619,6 +3621,7 @@ FluidDynamicsMatrixFree<dim>::setup_preconditioner()
       *this->get_mapping(),
       this->system_operator->mortar_manager_mf->radius[0],
       this->simulation_parameters.mortar_parameters.center_of_rotation,
+      this->simulation_parameters.mortar_parameters.rotation_axis,
       this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
 
   this->computing_timer.enter_subsection("Evaluate non linear term and tau");

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1473,21 +1473,9 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                       << std::endl;
         }
 
-      // Initialize variable needed when mortar is enabled
-      double interface_radius = 0;
+      // Create mappings for each level
       if (this->simulation_parameters.mortar_parameters.enable)
-        {
-          // Create mappings for each level
-          this->mappings.resize(this->minlevel, this->maxlevel);
-          // Compute interface radius (same for all levels)
-          if (this->simulation_parameters.mortar_parameters.interface_type ==
-              Parameters::Mortar<dim>::InterfaceType::circular)
-            interface_radius =
-              std::get<0>(compute_interface_dimensions_circular(
-                *this->coarse_grid_triangulations[0],
-                *mapping,
-                this->simulation_parameters.mortar_parameters))[0];
-        }
+        this->mappings.resize(this->minlevel, this->maxlevel);
 
       // Apply constraints and create mg operators for each level
       for (unsigned int level = this->minlevel; level <= this->maxlevel;
@@ -1513,7 +1501,6 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                   this->dof_handlers[level],
                   *this->mappings[level],
                   *mapping,
-                  interface_radius,
                   this->simulation_parameters.mortar_parameters
                     .rotor_rotation_angle->value(Point<dim>()),
                   this->simulation_parameters.mortar_parameters
@@ -2550,7 +2537,6 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
              ->get_system_matrix_free()
              .get_mapping_info()
              .mapping,
-          this->mg_operators[level]->mortar_manager_mf->radius[0],
           this->simulation_parameters.mortar_parameters.center_of_rotation,
           this->simulation_parameters.mortar_parameters.rotation_axis,
           this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
@@ -3289,7 +3275,6 @@ FluidDynamicsMatrixFree<dim>::assemble_system_rhs()
   if (this->simulation_parameters.mortar_parameters.enable)
     this->system_operator->evaluate_velocity_ale(
       *this->get_mapping(),
-      this->system_operator->mortar_manager_mf->radius[0],
       this->simulation_parameters.mortar_parameters.center_of_rotation,
       this->simulation_parameters.mortar_parameters.rotation_axis,
       this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
@@ -3619,7 +3604,6 @@ FluidDynamicsMatrixFree<dim>::setup_preconditioner()
   if (this->simulation_parameters.mortar_parameters.enable)
     this->system_operator->evaluate_velocity_ale(
       *this->get_mapping(),
-      this->system_operator->mortar_manager_mf->radius[0],
       this->simulation_parameters.mortar_parameters.center_of_rotation,
       this->simulation_parameters.mortar_parameters.rotation_axis,
       this->simulation_parameters.mortar_parameters.rotor_angular_velocity);

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1189,29 +1189,13 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
            lane < matrix_free.n_active_entries_per_cell_batch(cell);
            lane++)
         {
-          // Compute radial distance from the current cell
-          const auto cell_center =
-            matrix_free.get_cell_iterator(cell, lane)->center();
-          double radius_current;
-
-          if constexpr (dim == 2)
-            radius_current = cell_center.distance(center_of_rotation);
-
-          if constexpr (dim == 3)
-            {
-              radius_current =
-                LetheGridTools::compute_radial_distance_3d(cell_center,
-                                                           rotation_axis,
-                                                           center_of_rotation);
-            }
-
-          // Use prescribed rotor angular velocity only if cell is part of the
-          // rotor
+          // Use prescribed rotor angular velocity and verify if cells are part
+          // of the stator (user_index = 0) or the rotor (user_index = 1)
           double omega;
-          if (radius_current > radius)
-            omega = 0.0;
-          else
+          if (matrix_free.get_cell_iterator(cell, lane)->user_index() == 1)
             omega = rotor_angular_velocity_value;
+          else
+            omega = 0.0;
 
           // Compute linear velocity at quadrature points
           for (const auto q : integrator.quadrature_point_indices())

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1158,7 +1158,6 @@ template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
   const Mapping<dim>                             &mapping,
-  const double                                    radius,
   const Point<dim>                                center_of_rotation,
   const Tensor<1, dim>                            rotation_axis,
   std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity)

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1189,9 +1189,9 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
            lane++)
         {
           // Use prescribed rotor angular velocity and verify if cells are part
-          // of the stator (user_index = 0) or the rotor (user_index = 1)
+          // of the rotor (material_id = 1) or the stator (material_id = 2)
           double omega;
-          if (matrix_free.get_cell_iterator(cell, lane)->user_index() == 1)
+          if (matrix_free.get_cell_iterator(cell, lane)->material_id() == 1)
             omega = rotor_angular_velocity_value;
           else
             omega = 0.0;

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1160,6 +1160,7 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
   const Mapping<dim>                             &mapping,
   const double                                    radius,
   const Point<dim>                                center_of_rotation,
+  const Tensor<1, dim>                            rotation_axis,
   std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity)
 {
   this->timer.enter_subsection("operator::evaluate_velocity_ale");
@@ -1191,28 +1192,55 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
           // Compute radial distance from the current cell
           const auto cell_center =
             matrix_free.get_cell_iterator(cell, lane)->center();
-          const auto radius_current = cell_center.distance(center_of_rotation);
+          double radius_current;
+
+          if constexpr (dim == 2)
+            radius_current = cell_center.distance(center_of_rotation);
+
+          if constexpr (dim == 3)
+            {
+              radius_current =
+                LetheGridTools::compute_radial_distance_3d(cell_center,
+                                                           rotation_axis,
+                                                           center_of_rotation);
+            }
 
           // Use prescribed rotor angular velocity only if cell is part of the
           // rotor
-          double cell_rotor_angular_velocity;
+          double omega;
           if (radius_current > radius)
-            cell_rotor_angular_velocity = 0.0;
+            omega = 0.0;
           else
-            cell_rotor_angular_velocity = rotor_angular_velocity_value;
+            omega = rotor_angular_velocity_value;
 
           // Compute linear velocity at quadrature points
           for (const auto q : integrator.quadrature_point_indices())
             {
-              // Assumption in 3D case: rotation axis is in z
-              // TODO generalize rotation axis
               const auto x = integrator.quadrature_point(q)[0][lane];
               const auto y = integrator.quadrature_point(q)[1][lane];
 
-              this->velocity_ale[cell][q][0][lane] =
-                -cell_rotor_angular_velocity * y;
-              this->velocity_ale[cell][q][1][lane] =
-                cell_rotor_angular_velocity * x;
+              if constexpr (dim == 2)
+                {
+                  this->velocity_ale[cell][q][0][lane] = -omega * y;
+                  this->velocity_ale[cell][q][1][lane] = omega * x;
+                }
+
+              if constexpr (dim == 3)
+                {
+                  const auto z = integrator.quadrature_point(q)[2][lane];
+
+                  // Store angular velocity according to unit vector that
+                  // defines the rotation axis
+                  const auto omega_vec = omega * rotation_axis;
+
+                  // Compute terms of u_ale = omega_vec x [x, y, z]
+                  this->velocity_ale[cell][q][0][lane] =
+                    omega_vec[1] * z - omega_vec[2] * y;
+                  this->velocity_ale[cell][q][1][lane] =
+                    omega_vec[2] * x - omega_vec[0] * z;
+                  this->velocity_ale[cell][q][2][lane] =
+                    omega_vec[0] * y - omega_vec[1] * x;
+                }
             }
         }
     }

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1216,8 +1216,10 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
           // Compute linear velocity at quadrature points
           for (const auto q : integrator.quadrature_point_indices())
             {
-              const auto x = integrator.quadrature_point(q)[0][lane];
-              const auto y = integrator.quadrature_point(q)[1][lane];
+              const auto x =
+                integrator.quadrature_point(q)[0][lane] - center_of_rotation[0];
+              const auto y =
+                integrator.quadrature_point(q)[1][lane] - center_of_rotation[1];
 
               if constexpr (dim == 2)
                 {
@@ -1227,7 +1229,8 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
 
               if constexpr (dim == 3)
                 {
-                  const auto z = integrator.quadrature_point(q)[2][lane];
+                  const auto z = integrator.quadrature_point(q)[2][lane] -
+                                 center_of_rotation[2];
 
                   // Store angular velocity according to unit vector that
                   // defines the rotation axis

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1205,33 +1205,20 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
           // Compute linear velocity at quadrature points
           for (const auto q : integrator.quadrature_point_indices())
             {
-              const auto x =
-                integrator.quadrature_point(q)[0][lane] - center_of_rotation[0];
-              const auto y =
-                integrator.quadrature_point(q)[1][lane] - center_of_rotation[1];
+              // Store point coordinates in tensor format
+              Tensor<1, dim> p;
+              for (int i = 0; i < dim; i++)
+                p[i] = integrator.quadrature_point(q)[i][lane] -
+                       center_of_rotation[i];
 
-              if constexpr (dim == 2)
-                {
-                  this->velocity_ale[cell][q][0][lane] = -omega * y;
-                  this->velocity_ale[cell][q][1][lane] = omega * x;
-                }
+              // Compute terms of u_ale
+              const auto product =
+                LetheGridTools::angular_to_linear_velocity(omega,
+                                                           p,
+                                                           rotation_axis);
 
-              if constexpr (dim == 3)
-                {
-                  const auto z = integrator.quadrature_point(q)[2][lane] -
-                                 center_of_rotation[2];
-
-                  // Store angular velocity according to unit vector that
-                  // defines the rotation axis
-                  const auto omega_vec = omega * rotation_axis;
-
-                  // Compute terms of u_ale = omega_vec x [x, y, z]
-                  const auto product =
-                    cross_product_3d(omega_vec, Tensor<1, dim>({x, y, z}));
-
-                  for (int i = 0; i < dim; i++)
-                    this->velocity_ale[cell][q][i][lane] = product[i];
-                }
+              for (int i = 0; i < dim; i++)
+                this->velocity_ale[cell][q][i][lane] = product[i];
             }
         }
     }

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1193,7 +1193,8 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
           double omega;
           if (matrix_free.get_cell_iterator(cell, lane)->material_id() == 1)
             omega = rotor_angular_velocity_value;
-          else
+          else if (matrix_free.get_cell_iterator(cell, lane)->material_id() ==
+                   2)
             omega = 0.0;
 
           // Compute linear velocity at quadrature points

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1188,14 +1188,19 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
            lane < matrix_free.n_active_entries_per_cell_batch(cell);
            lane++)
         {
-          // Use prescribed rotor angular velocity and verify if cells are part
-          // of the rotor (material_id = 1) or the stator (material_id = 2)
-          double omega;
+          // Apply prescribed rotor angular velocity only at rotor cells
+          // (material_id = 1)
+          double omega = 0.0;
           if (matrix_free.get_cell_iterator(cell, lane)->material_id() == 1)
             omega = rotor_angular_velocity_value;
-          else if (matrix_free.get_cell_iterator(cell, lane)->material_id() ==
-                   2)
-            omega = 0.0;
+
+          // The mortar implementation is not defined for more than two
+          // materials. Throw when running debug mode as a security measure to
+          // prevent this case
+          Assert(
+            matrix_free.get_cell_iterator(cell, lane)->material_id() < 2,
+            ExcMessage(
+              "The material id in a cell was identified as equal or greater than 2, however the mortar implementation is not defined for more than two materials."));
 
           // Compute linear velocity at quadrature points
           for (const auto q : integrator.quadrature_point_indices())

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1226,12 +1226,11 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
                   const auto omega_vec = omega * rotation_axis;
 
                   // Compute terms of u_ale = omega_vec x [x, y, z]
-                  this->velocity_ale[cell][q][0][lane] =
-                    omega_vec[1] * z - omega_vec[2] * y;
-                  this->velocity_ale[cell][q][1][lane] =
-                    omega_vec[2] * x - omega_vec[0] * z;
-                  this->velocity_ale[cell][q][2][lane] =
-                    omega_vec[0] * y - omega_vec[1] * x;
+                  const auto product =
+                    cross_product_3d(omega_vec, Tensor<1, dim>({x, y, z}));
+
+                  for (int i = 0; i < dim; i++)
+                    this->velocity_ale[cell][q][i][lane] = product[i];
                 }
             }
         }

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1292,13 +1292,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_adaptive()
 
   // If mortar is enabled, update mapping cache with refined triangulation
   if (this->simulation_parameters.mortar_parameters.enable)
-    {
-      this->mapping_cache->initialize(*this->mapping, tria);
-      // Propagate cell index to refined cells
-      for (const auto &cell : tria.active_cell_iterators())
-        if (cell->level() > 0)
-          cell->set_user_index(cell->parent()->user_index());
-    }
+    this->mapping_cache->initialize(*this->mapping, tria);
 
   setup_dofs();
 
@@ -1364,13 +1358,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
 
   // If mortar is enabled, update mapping cache with refined triangulation
   if (this->simulation_parameters.mortar_parameters.enable)
-    {
-      this->mapping_cache->initialize(*this->mapping, *this->triangulation);
-      // Propagate cell index to refined cells
-      for (const auto &cell : this->triangulation->active_cell_iterators())
-        if (cell->level() > 0)
-          cell->set_user_index(cell->parent()->user_index());
-    }
+    this->mapping_cache->initialize(*this->mapping, *this->triangulation);
 
   setup_dofs();
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1289,6 +1289,17 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_adaptive()
     average_velocities->prepare_for_mesh_adaptation();
 
   tria.execute_coarsening_and_refinement();
+
+  // If mortar is enabled, update mapping cache with refined triangulation
+  if (this->simulation_parameters.mortar_parameters.enable)
+    {
+      this->mapping_cache->initialize(*this->mapping, tria);
+      // Propagate cell index to refined cells
+      for (const auto &cell : tria.active_cell_iterators())
+        if (cell->level() > 0)
+          cell->set_user_index(cell->parent()->user_index());
+    }
+
   setup_dofs();
 
   // Transfer solution
@@ -1353,7 +1364,13 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
 
   // If mortar is enabled, update mapping cache with refined triangulation
   if (this->simulation_parameters.mortar_parameters.enable)
-    this->mapping_cache->initialize(*this->mapping, *this->triangulation);
+    {
+      this->mapping_cache->initialize(*this->mapping, *this->triangulation);
+      // Propagate cell index to refined cells
+      for (const auto &cell : this->triangulation->active_cell_iterators())
+        if (cell->level() > 0)
+          cell->set_user_index(cell->parent()->user_index());
+    }
 
   setup_dofs();
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2239,10 +2239,6 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_rotor_mapping(
       *this->dof_handler,
       *this->mapping_cache,
       *this->mapping,
-      std::get<0>(compute_interface_dimensions_circular(
-        *this->triangulation,
-        *this->mapping,
-        this->simulation_parameters.mortar_parameters))[0],
       rotation_angle,
       this->simulation_parameters.mortar_parameters.center_of_rotation,
       this->simulation_parameters.mortar_parameters.rotation_axis);

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -423,7 +423,7 @@ NavierStokesScratchData<dim>::reinit_mortar(
   double omega;
   if (cell->material_id() == 1)
     omega = rotor_angular_velocity;
-  else
+  else if (cell->material_id() == 2)
     omega = 0.0;
 
   // Compute rotor linear velocity at quadrature points

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -418,13 +418,19 @@ NavierStokesScratchData<dim>::reinit_mortar(
   const double rotor_angular_velocity =
     mortar_parameters.rotor_angular_velocity->value(Point<dim>());
 
-  // Use prescribed rotor angular velocity and verify if cells are part of the
-  // the rotor (material_id = 1) or the stator (material_id = 2)
-  double omega;
+  // Apply prescribed rotor angular velocity only at rotor cells
+  // (material_id = 1)
+  double omega = 0.0;
   if (cell->material_id() == 1)
     omega = rotor_angular_velocity;
-  else if (cell->material_id() == 2)
-    omega = 0.0;
+
+  // The mortar implementation is not defined for more than two
+  // materials. Throw when running debug mode as a security measure to prevent
+  // this case
+  Assert(
+    cell->material_id() < 2,
+    ExcMessage(
+      "The material id in a cell was identified as equal or greater than 2, however the mortar implementation is not defined for more than two materials."));
 
   // Compute rotor linear velocity at quadrature points
   rotor_linear_velocity_values = std::vector<Tensor<1, dim>>(this->n_q_points);

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -426,22 +426,41 @@ NavierStokesScratchData<dim>::reinit_mortar(
     cell_center.distance(mortar_parameters.center_of_rotation);
 
   // Use prescribed rotor angular velocity only if cell is part of the rotor
-  double cell_rotor_angular_velocity;
+  double omega;
   if (radius_current > radius)
-    cell_rotor_angular_velocity = 0.0;
+    omega = 0.0;
   else
-    cell_rotor_angular_velocity = rotor_angular_velocity;
+    omega = rotor_angular_velocity;
 
   // Compute rotor linear velocity at quadrature points
   rotor_linear_velocity_values = std::vector<Tensor<1, dim>>(this->n_q_points);
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      // Assumption in 3D case: rotation axis is in z
-      // TODO generalize rotation axis
-      const auto x                       = fe_values.quadrature_point(q)[0];
-      const auto y                       = fe_values.quadrature_point(q)[1];
-      rotor_linear_velocity_values[q][0] = -cell_rotor_angular_velocity * y;
-      rotor_linear_velocity_values[q][1] = cell_rotor_angular_velocity * x;
+      const auto x = fe_values.quadrature_point(q)[0];
+      const auto y = fe_values.quadrature_point(q)[1];
+
+      if constexpr (dim == 2)
+        {
+          rotor_linear_velocity_values[q][0] = -omega * y;
+          rotor_linear_velocity_values[q][1] = omega * x;
+        }
+
+      if constexpr (dim == 3)
+        {
+          const auto z = fe_values.quadrature_point(q)[2];
+
+          // Store angular velocity according to unit vector that defines the
+          // rotation axis
+          const auto omega_vec = omega * mortar_parameters.rotation_axis;
+
+          // Compute terms of u = omega_vec x [x, y, z]
+          rotor_linear_velocity_values[q][0] =
+            omega_vec[1] * z - omega_vec[2] * y;
+          rotor_linear_velocity_values[q][1] =
+            omega_vec[2] * x - omega_vec[0] * z;
+          rotor_linear_velocity_values[q][2] =
+            omega_vec[0] * y - omega_vec[1] * x;
+        }
 
       // Update velocity for stabilization
       this->velocity_for_stabilization[q] -= rotor_linear_velocity_values[q];

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -453,12 +453,7 @@ NavierStokesScratchData<dim>::reinit_mortar(
           const auto omega_vec = omega * mortar_parameters.rotation_axis;
 
           // Compute terms of u_ale = omega_vec x [x, y, z]
-          rotor_linear_velocity_values[q][0] =
-            omega_vec[1] * p[2] - omega_vec[2] * p[1];
-          rotor_linear_velocity_values[q][1] =
-            omega_vec[2] * p[0] - omega_vec[0] * p[2];
-          rotor_linear_velocity_values[q][2] =
-            omega_vec[0] * p[1] - omega_vec[1] * p[0];
+          rotor_linear_velocity_values[q] = cross_product_3d(omega_vec, p);
         }
 
       // Update velocity for stabilization

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -419,9 +419,9 @@ NavierStokesScratchData<dim>::reinit_mortar(
     mortar_parameters.rotor_angular_velocity->value(Point<dim>());
 
   // Use prescribed rotor angular velocity and verify if cells are part of the
-  // stator (user_index = 0) or the rotor (user_index = 1)
+  // the rotor (material_id = 1) or the stator (material_id = 2)
   double omega;
-  if (cell->user_index() == 1)
+  if (cell->material_id() == 1)
     omega = rotor_angular_velocity;
   else
     omega = 0.0;

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -422,8 +422,16 @@ NavierStokesScratchData<dim>::reinit_mortar(
     mortar_parameters.rotor_angular_velocity->value(Point<dim>());
 
   // Compute radius between center of rotation and current cell center
-  const double radius_current =
-    cell_center.distance(mortar_parameters.center_of_rotation);
+  double radius_current;
+
+  if constexpr (dim == 2)
+    radius_current = cell_center.distance(mortar_parameters.center_of_rotation);
+
+  if constexpr (dim == 3)
+    radius_current = LetheGridTools::compute_radial_distance_3d(
+      cell_center,
+      mortar_parameters.rotation_axis,
+      mortar_parameters.center_of_rotation);
 
   // Use prescribed rotor angular velocity only if cell is part of the rotor
   double omega;
@@ -453,7 +461,7 @@ NavierStokesScratchData<dim>::reinit_mortar(
           // rotation axis
           const auto omega_vec = omega * mortar_parameters.rotation_axis;
 
-          // Compute terms of u = omega_vec x [x, y, z]
+          // Compute terms of u_ale = omega_vec x [x, y, z]
           rotor_linear_velocity_values[q][0] =
             omega_vec[1] * z - omega_vec[2] * y;
           rotor_linear_velocity_values[q][1] =

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -413,32 +413,19 @@ NavierStokesScratchData<dim>::reinit_mortar(
   const Parameters::Mortar<dim>                        &mortar_parameters,
   const double                                         &radius)
 {
-  const auto cell_center = cell->center();
-
   // Get updated rotor angular velocity
   mortar_parameters.rotor_angular_velocity->set_time(
     this->simulation_control->get_current_time());
   const double rotor_angular_velocity =
     mortar_parameters.rotor_angular_velocity->value(Point<dim>());
 
-  // Compute radius between center of rotation and current cell center
-  double radius_current;
-
-  if constexpr (dim == 2)
-    radius_current = cell_center.distance(mortar_parameters.center_of_rotation);
-
-  if constexpr (dim == 3)
-    radius_current = LetheGridTools::compute_radial_distance_3d(
-      cell_center,
-      mortar_parameters.rotation_axis,
-      mortar_parameters.center_of_rotation);
-
-  // Use prescribed rotor angular velocity only if cell is part of the rotor
+  // Use prescribed rotor angular velocity and verify if cells are part of the
+  // stator (user_index = 0) or the rotor (user_index = 1)
   double omega;
-  if (radius_current > radius)
-    omega = 0.0;
-  else
+  if (cell->user_index() == 1)
     omega = rotor_angular_velocity;
+  else
+    omega = 0.0;
 
   // Compute rotor linear velocity at quadrature points
   rotor_linear_velocity_values = std::vector<Tensor<1, dim>>(this->n_q_points);

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -440,21 +440,10 @@ NavierStokesScratchData<dim>::reinit_mortar(
       const auto p =
         fe_values.quadrature_point(q) - mortar_parameters.center_of_rotation;
 
-      if constexpr (dim == 2)
-        {
-          rotor_linear_velocity_values[q][0] = -omega * p[1];
-          rotor_linear_velocity_values[q][1] = omega * p[0];
-        }
-
-      if constexpr (dim == 3)
-        {
-          // Store angular velocity according to unit vector that defines the
-          // rotation axis
-          const auto omega_vec = omega * mortar_parameters.rotation_axis;
-
-          // Compute terms of u_ale = omega_vec x [x, y, z]
-          rotor_linear_velocity_values[q] = cross_product_3d(omega_vec, p);
-        }
+      // Compute terms of u_ale
+      rotor_linear_velocity_values[q] =
+        LetheGridTools::angular_to_linear_velocity(
+          omega, p, mortar_parameters.rotation_axis);
 
       // Update velocity for stabilization
       this->velocity_for_stabilization[q] -= rotor_linear_velocity_values[q];

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -444,30 +444,29 @@ NavierStokesScratchData<dim>::reinit_mortar(
   rotor_linear_velocity_values = std::vector<Tensor<1, dim>>(this->n_q_points);
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
-      const auto x = fe_values.quadrature_point(q)[0];
-      const auto y = fe_values.quadrature_point(q)[1];
+      // Shift quadrature point by the center of rotation
+      const auto p =
+        fe_values.quadrature_point(q) - mortar_parameters.center_of_rotation;
 
       if constexpr (dim == 2)
         {
-          rotor_linear_velocity_values[q][0] = -omega * y;
-          rotor_linear_velocity_values[q][1] = omega * x;
+          rotor_linear_velocity_values[q][0] = -omega * p[1];
+          rotor_linear_velocity_values[q][1] = omega * p[0];
         }
 
       if constexpr (dim == 3)
         {
-          const auto z = fe_values.quadrature_point(q)[2];
-
           // Store angular velocity according to unit vector that defines the
           // rotation axis
           const auto omega_vec = omega * mortar_parameters.rotation_axis;
 
           // Compute terms of u_ale = omega_vec x [x, y, z]
           rotor_linear_velocity_values[q][0] =
-            omega_vec[1] * z - omega_vec[2] * y;
+            omega_vec[1] * p[2] - omega_vec[2] * p[1];
           rotor_linear_velocity_values[q][1] =
-            omega_vec[2] * x - omega_vec[0] * z;
+            omega_vec[2] * p[0] - omega_vec[0] * p[2];
           rotor_linear_velocity_values[q][2] =
-            omega_vec[0] * y - omega_vec[1] * x;
+            omega_vec[0] * p[1] - omega_vec[1] * p[0];
         }
 
       // Update velocity for stabilization

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -410,8 +410,7 @@ template <int dim>
 void
 NavierStokesScratchData<dim>::reinit_mortar(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
-  const Parameters::Mortar<dim>                        &mortar_parameters,
-  const double                                         &radius)
+  const Parameters::Mortar<dim>                        &mortar_parameters)
 {
   // Get updated rotor angular velocity
   mortar_parameters.rotor_angular_velocity->set_time(

--- a/tests/mortar/rotate_mapping.cc
+++ b/tests/mortar/rotate_mapping.cc
@@ -111,8 +111,10 @@ test()
   Assert(prerotation == 0.0, ExcInternalError());
 
   // Rotate mapping
-  LetheGridTools::rotate_mapping(
-    dof_handler, mapping_cache, mapping, radius[0], rotation_angle);
+  LetheGridTools::rotate_mapping(dof_handler,
+                                 mapping_cache,
+                                 mapping,
+                                 rotation_angle);
 
   // Print information
   if (Utilities::MPI::this_mpi_process(comm) == 0)
@@ -123,8 +125,10 @@ test()
       deallog << "Radius : " << radius[0] << std::endl;
     }
   // Rotate mapping
-  LetheGridTools::rotate_mapping(
-    dof_handler, mapping_cache, mapping, radius[0] * 10, rotation_angle);
+  LetheGridTools::rotate_mapping(dof_handler,
+                                 mapping_cache,
+                                 mapping,
+                                 rotation_angle);
 
   const auto n_subdivisions1 =
     compute_number_interface_cells(triangulation, mortar_parameters);

--- a/tests/mortar/rotate_mapping.cc
+++ b/tests/mortar/rotate_mapping.cc
@@ -124,23 +124,6 @@ test()
               << std::endl;
       deallog << "Radius : " << radius[0] << std::endl;
     }
-  // Rotate mapping
-  LetheGridTools::rotate_mapping(dof_handler,
-                                 mapping_cache,
-                                 mapping,
-                                 rotation_angle);
-
-  const auto n_subdivisions1 =
-    compute_number_interface_cells(triangulation, mortar_parameters);
-
-  const auto [radius1, prerotation1] =
-    compute_interface_dimensions_circular(triangulation,
-                                          mapping_cache,
-                                          mortar_parameters);
-
-  AssertDimension(n_subdivisions[0], n_subdivisions1[0]);
-  AssertDimension(radius[0], radius[0]);
-  Assert(std::abs(rotation_angle - prerotation1) < 1.e-8, ExcInternalError());
 }
 
 int

--- a/tests/mortar/rotate_mapping_3d.cc
+++ b/tests/mortar/rotate_mapping_3d.cc
@@ -118,7 +118,6 @@ test()
   LetheGridTools::rotate_mapping(dof_handler,
                                  mapping_cache,
                                  mapping,
-                                 radius[0],
                                  rotation_angle,
                                  mortar_parameters.center_of_rotation,
                                  mortar_parameters.rotation_axis);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

This PR fixes the computation of cell radial distance for 3D mortar cases, and improves the indentification of the rotor/stator domains by using a material_id() flag (as opposed to comparing the radial distance of the cell center with the computed interface radius). The linear velocity computation is also generalized for 3D cases with rotation axis other than z.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The computation of the radial distance for 3D cases is fixed, and the corresponding function has been added in `lethe_grid_tools`.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

No changes in tests.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge